### PR TITLE
feat: adopt bundled /equipment/info endpoint (ninaAPI 2.2.15+)

### DIFF
--- a/main/nina_api_fetchers.h
+++ b/main/nina_api_fetchers.h
@@ -19,6 +19,18 @@ void fetch_focuser_robust(const char *base_url, nina_client_t *data);
 void fetch_switch_info(const char *base_url, nina_client_t *data);
 void fetch_safety_monitor_info(const char *base_url, nina_client_t *data);
 
+/**
+ * @brief Fetch all equipment info from the bundled /equipment/info endpoint (ninaAPI 2.2.15+).
+ * Populates camera, filter wheel, focuser, guider, mount, switch, and safety monitor
+ * fields in nina_client_t from a single HTTP request.
+ *
+ * @param base_url          NINA API base URL
+ * @param data              Client data structure to populate
+ * @param fetch_filter_list If true, also parse AvailableFilters[] (use on first connect)
+ * @return 0 on success, -1 on HTTP failure (offline), -2 if endpoint unavailable (404/error)
+ */
+int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool fetch_filter_list);
+
 /* Info overlay detail fetchers — on-demand, not part of normal polling */
 #include "ui/info_overlay_types.h"
 void fetch_camera_details(const char *base_url, camera_detail_data_t *out);

--- a/main/nina_client.h
+++ b/main/nina_client.h
@@ -147,6 +147,9 @@ typedef struct {
 
     // Persistent HTTP client handle for keep-alive reuse (esp_http_client_handle_t)
     void *http_client;
+
+    // Set true if /equipment/info returned 404 (old ninaAPI); disables bundled fetch
+    bool bundle_not_available;
 } nina_poll_state_t;
 
 // Initialize polling state (call once before polling loop)

--- a/main/perf_monitor.c
+++ b/main/perf_monitor.c
@@ -303,6 +303,7 @@ void perf_monitor_report(void)
     log_timer("effective_interval", &g_perf.effective_cycle_interval);
 
     ESP_LOGI(TAG, "── Endpoint Fetchers ──");
+    log_timer("equipment_bundle", &g_perf.poll_equipment_bundle);
     log_timer("camera",        &g_perf.poll_camera);
     log_timer("guider",        &g_perf.poll_guider);
     log_timer("mount",         &g_perf.poll_mount);
@@ -457,6 +458,7 @@ char *perf_monitor_report_json(void)
 
     // Endpoints
     cJSON *endpoints = cJSON_CreateObject();
+    cJSON_AddItemToObject(endpoints, "equipment_bundle", timer_to_json(&g_perf.poll_equipment_bundle));
     cJSON_AddItemToObject(endpoints, "camera_info",    timer_to_json(&g_perf.poll_camera));
     cJSON_AddItemToObject(endpoints, "guider_info",    timer_to_json(&g_perf.poll_guider));
     cJSON_AddItemToObject(endpoints, "mount_info",     timer_to_json(&g_perf.poll_mount));

--- a/main/perf_monitor.h
+++ b/main/perf_monitor.h
@@ -79,6 +79,7 @@ typedef struct {
     perf_timer_t poll_image_history;      // fetch_image_history_robust duration
     perf_timer_t poll_filter;             // fetch_filter_robust_ex duration
     perf_timer_t poll_profile;            // fetch_profile_robust duration
+    perf_timer_t poll_equipment_bundle;   // fetch_equipment_info_bundled duration
 
     // UI update timing
     perf_timer_t ui_update_total;         // Total time in bsp_display_lock for UI updates

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -322,8 +322,9 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     lv_obj_t *seq_left = lv_obj_create(box_seq);
     lv_obj_remove_style_all(seq_left);
     lv_obj_clear_flag(seq_left, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_size(seq_left, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+    lv_obj_set_height(seq_left, LV_SIZE_CONTENT);
     lv_obj_set_flex_flow(seq_left, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_grow(seq_left, 1);
 
     lv_obj_t *lbl_seq_title = create_small_label(seq_left, "SEQUENCE");
     lv_obj_set_style_text_font(lbl_seq_title, &lv_font_montserrat_14, 0);
@@ -333,11 +334,22 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     lv_obj_set_style_text_font(p->lbl_seq_container, &lv_font_montserrat_24, 0);
     lv_label_set_text(p->lbl_seq_container, "----");
 
+    // Safety monitor icon (centered in sequence row)
+    extern const lv_font_t lv_font_material_safety;
+    p->safety_icon = lv_label_create(box_seq);
+    lv_obj_set_style_text_font(p->safety_icon, &lv_font_material_safety, 0);
+    lv_obj_set_style_text_color(p->safety_icon, lv_color_hex(0x999999), 0);
+    lv_label_set_text(p->safety_icon, "");
+    lv_obj_clear_flag(p->safety_icon, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_clear_flag(p->safety_icon, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_flag(p->safety_icon, LV_OBJ_FLAG_HIDDEN);
+
     lv_obj_t *seq_right = lv_obj_create(box_seq);
     lv_obj_remove_style_all(seq_right);
     lv_obj_clear_flag(seq_right, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_size(seq_right, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+    lv_obj_set_height(seq_right, LV_SIZE_CONTENT);
     lv_obj_set_flex_flow(seq_right, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_grow(seq_right, 1);
     lv_obj_set_flex_align(seq_right, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_END);
 
     lv_obj_t *lbl_step_title = create_small_label(seq_right, "STEP");
@@ -400,19 +412,6 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     lv_obj_set_style_pad_top(p->lbl_loop_count, 8, 0);
     lv_label_set_text(p->lbl_loop_count, "-- / --");
 
-    // Safety monitor icon (floating, bottom-left of exposure box)
-    extern const lv_font_t lv_font_material_safety;
-    p->safety_icon = lv_label_create(box_exposure);
-    lv_obj_set_style_text_font(p->safety_icon, &lv_font_material_safety, 0);
-    lv_obj_set_style_text_color(p->safety_icon, lv_color_hex(0x999999), 0);
-    lv_label_set_text(p->safety_icon, "");
-    lv_obj_add_flag(p->safety_icon, LV_OBJ_FLAG_FLOATING);
-    lv_obj_clear_flag(p->safety_icon, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_clear_flag(p->safety_icon, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_set_align(p->safety_icon, LV_ALIGN_BOTTOM_LEFT);
-    lv_obj_set_style_translate_x(p->safety_icon, 6, 0);
-    lv_obj_set_style_translate_y(p->safety_icon, -6, 0);
-    lv_obj_add_flag(p->safety_icon, LV_OBJ_FLAG_HIDDEN);
 
     // RMS + HFR (col 1, row 2)
     lv_obj_t *box_rms_hfr = create_bento_box(p->page);


### PR DESCRIPTION
Replace 5-7 individual equipment HTTP requests per poll cycle with a single GET /equipment/info call. Falls back to individual fetchers automatically if the endpoint is unavailable (older ninaAPI versions).

- Add fetch_equipment_info_bundled() parsing Camera, Guider, FilterWheel, Focuser, Mount, Switch, and SafetyMonitor from one response
- Refactor switch parsing into reusable parse_switch_response() helper
- Add bundle_not_available flag for automatic legacy fallback
- Add poll_equipment_bundle perf timer to serial and JSON reports
- Update nina_client_poll() and nina_client_poll_background() to use bundled endpoint with tiered fallback
- HTTP requests per interval reduced from ~33 to ~4