### PR TITLE
perf: lazy load and destroy settings tab

### DIFF
--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -132,9 +132,10 @@ static void hide_page_at(int idx) {
         lv_obj_add_flag(summary_obj, LV_OBJ_FLAG_HIDDEN);
     else if (idx >= 1 && idx <= page_count)
         lv_obj_add_flag(pages[idx - 1].page, LV_OBJ_FLAG_HIDDEN);
-    else if (idx == page_count + 1 && settings_obj)
-        lv_obj_add_flag(settings_obj, LV_OBJ_FLAG_HIDDEN);
-    else if (idx == page_count + 2 && sysinfo_obj)
+    else if (idx == page_count + 1 && settings_obj) {
+        settings_tabview_destroy();
+        settings_obj = NULL;
+    } else if (idx == page_count + 2 && sysinfo_obj)
         lv_obj_add_flag(sysinfo_obj, LV_OBJ_FLAG_HIDDEN);
 }
 
@@ -144,7 +145,10 @@ static void show_page_at(int idx) {
         lv_obj_clear_flag(summary_obj, LV_OBJ_FLAG_HIDDEN);
     else if (idx >= 1 && idx <= page_count)
         lv_obj_clear_flag(pages[idx - 1].page, LV_OBJ_FLAG_HIDDEN);
-    else if (idx == page_count + 1 && settings_obj) {
+    else if (idx == page_count + 1) {
+        if (!settings_obj) {
+            settings_obj = settings_tabview_create(main_cont);
+        }
         lv_obj_clear_flag(settings_obj, LV_OBJ_FLAG_HIDDEN);
         settings_tabview_refresh();
     }
@@ -227,7 +231,7 @@ void nina_dashboard_apply_theme(int theme_index) {
     }
 
     summary_page_apply_theme();
-    settings_tabview_apply_theme();
+    if (settings_obj) settings_tabview_apply_theme();
     sysinfo_page_apply_theme();
     nina_graph_overlay_apply_theme();
     nina_info_overlay_apply_theme();
@@ -739,9 +743,9 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
         lv_obj_add_flag(pages[i].page, LV_OBJ_FLAG_HIDDEN);
     }
 
-    /* Settings page — page index page_count+1, hidden initially */
-    settings_obj = settings_tabview_create(main_cont);
-    lv_obj_add_flag(settings_obj, LV_OBJ_FLAG_HIDDEN);
+    /* Settings page — lazy-loaded on demand (page index page_count+1).
+     * NOT created at boot to save internal heap for OTA task. */
+    settings_obj = NULL;
 
     /* System info page — always last (page index page_count+2), hidden initially */
     sysinfo_obj = sysinfo_page_create(main_cont);

--- a/main/ui/nina_settings_tabview.c
+++ b/main/ui/nina_settings_tabview.c
@@ -634,6 +634,43 @@ lv_obj_t *settings_tabview_create(lv_obj_t *parent) {
 }
 
 /* ════════════════════════════════════════════════════════════════════════
+ *  Destroy — tear down all settings widgets to reclaim internal heap
+ * ════════════════════════════════════════════════════════════════════════ */
+
+void settings_tabview_destroy(void) {
+    /* Color picker is parented to lv_layer_top(), not st_root */
+    color_picker_hide();
+
+    /* Cancel any pending save feedback timer (not parented to any object) */
+    if (save_feedback_timer) {
+        lv_timer_delete(save_feedback_timer);
+        save_feedback_timer = NULL;
+    }
+
+    /* Tell each tab module to NULL out its static pointers */
+    settings_tab_display_destroy();
+    settings_tab_nodes_destroy();
+    settings_tab_behavior_destroy();
+    settings_tab_system_destroy();
+
+    /* Delete the root LVGL object — recursively frees tabview,
+     * keyboard, save bar, back button, and all tab contents */
+    if (st_root) {
+        lv_obj_delete(st_root);
+    }
+
+    /* NULL out all module-level statics */
+    st_root      = NULL;
+    tabview      = NULL;
+    keyboard     = NULL;
+    save_bar     = NULL;
+    lbl_save_btn = NULL;
+    kb_visible   = false;
+    needs_reboot = false;
+    dirty        = false;
+}
+
+/* ════════════════════════════════════════════════════════════════════════
  *  Refresh
  * ════════════════════════════════════════════════════════════════════════ */
 

--- a/main/ui/nina_settings_tabview.h
+++ b/main/ui/nina_settings_tabview.h
@@ -9,6 +9,9 @@
  */
 lv_obj_t *settings_tabview_create(lv_obj_t *parent);
 
+/** Destroy all settings widgets and free memory. Call when leaving settings page. */
+void settings_tabview_destroy(void);
+
 /** Refresh all tab contents from current config. */
 void settings_tabview_refresh(void);
 

--- a/main/ui/settings_tab_behavior.c
+++ b/main/ui/settings_tab_behavior.c
@@ -318,6 +318,27 @@ static void make_labeled_stepper(lv_obj_t *card, const char *text,
  *  Tab Creation
  * ════════════════════════════════════════════════════════════════════════ */
 
+void settings_tab_behavior_destroy(void) {
+    tab_root = NULL;
+    dd_rotation = NULL;
+    slider_backlight = NULL;
+    lbl_backlight_val = NULL;
+    sw_screen_sleep = NULL;
+    cont_sleep_opts = NULL;
+    lbl_sleep_timeout = NULL;
+    lbl_idle_poll = NULL;
+    sw_wifi_power_save = NULL;
+    sw_deep_sleep = NULL;
+    cont_deep_sleep_opts = NULL;
+    lbl_wake_timer = NULL;
+    sw_auto_power_off = NULL;
+    lbl_data_rate = NULL;
+    lbl_graph_rate = NULL;
+    lbl_conn_timeout = NULL;
+    lbl_toast_duration = NULL;
+    sw_alert_flash = NULL;
+}
+
 void settings_tab_behavior_create(lv_obj_t *parent) {
     tab_root = parent;
     app_config_t *cfg = app_config_get();

--- a/main/ui/settings_tab_behavior.h
+++ b/main/ui/settings_tab_behavior.h
@@ -3,5 +3,6 @@
 #include "lvgl.h"
 
 void settings_tab_behavior_create(lv_obj_t *parent);
+void settings_tab_behavior_destroy(void);
 void settings_tab_behavior_refresh(void);
 void settings_tab_behavior_apply_theme(void);

--- a/main/ui/settings_tab_display.c
+++ b/main/ui/settings_tab_display.c
@@ -642,6 +642,24 @@ static void page_checkbox_changed_cb(lv_event_t *e)
  *  Public API
  * ═══════════════════════════════════════════════════════════════════════ */
 
+void settings_tab_display_destroy(void) {
+    tab_root = NULL;
+    dd_theme = NULL;
+    dd_widget_style = NULL;
+    slider_text_bright = NULL;
+    lbl_text_bright_val = NULL;
+    seg_mode = NULL;
+    cont_fixed = NULL;
+    dd_pinned_page = NULL;
+    cont_cycle = NULL;
+    lbl_interval_val = NULL;
+    btn_interval_minus = NULL;
+    btn_interval_plus = NULL;
+    dd_transition = NULL;
+    sw_skip_offline = NULL;
+    memset(cb_pages, 0, sizeof(cb_pages));
+}
+
 void settings_tab_display_create(lv_obj_t *parent)
 {
     tab_root = parent;

--- a/main/ui/settings_tab_display.h
+++ b/main/ui/settings_tab_display.h
@@ -3,5 +3,6 @@
 #include "lvgl.h"
 
 void settings_tab_display_create(lv_obj_t *parent);
+void settings_tab_display_destroy(void);
 void settings_tab_display_refresh(void);
 void settings_tab_display_apply_theme(void);

--- a/main/ui/settings_tab_nodes.c
+++ b/main/ui/settings_tab_nodes.c
@@ -833,6 +833,12 @@ static void create_node_accordion(lv_obj_t *parent, int idx)
  *  Public API
  * ══════════════════════════════════════════════════════════════════════ */
 
+void settings_tab_nodes_destroy(void) {
+    tab_root = NULL;
+    expanded_node = -1;
+    memset(nodes, 0, sizeof(nodes));
+}
+
 void settings_tab_nodes_create(lv_obj_t *parent)
 {
     tab_root = parent;

--- a/main/ui/settings_tab_nodes.h
+++ b/main/ui/settings_tab_nodes.h
@@ -3,5 +3,6 @@
 #include "lvgl.h"
 
 void settings_tab_nodes_create(lv_obj_t *parent);
+void settings_tab_nodes_destroy(void);
 void settings_tab_nodes_refresh(void);
 void settings_tab_nodes_apply_theme(void);

--- a/main/ui/settings_tab_system.c
+++ b/main/ui/settings_tab_system.c
@@ -793,6 +793,30 @@ static void factory_reset_btn_cb(lv_event_t *e) {
  *  Public API — Create
  * ════════════════════════════════════════════════════════════════════════ */
 
+void settings_tab_system_destroy(void) {
+    tab_root = NULL;
+    ta_ssid = NULL;
+    ta_password = NULL;
+    ta_ntp = NULL;
+    dd_timezone = NULL;
+    sw_mqtt_enabled = NULL;
+    cont_mqtt_fields = NULL;
+    ta_mqtt_broker = NULL;
+    lbl_mqtt_port = NULL;
+    ta_mqtt_prefix = NULL;
+    ta_mqtt_user = NULL;
+    ta_mqtt_pass = NULL;
+    lbl_fw_version = NULL;
+    lbl_fw_built = NULL;
+    lbl_fw_idf = NULL;
+    lbl_fw_partition = NULL;
+    sw_auto_update = NULL;
+    dd_update_channel = NULL;
+    btn_check_update = NULL;
+    lbl_check_update = NULL;
+    sw_debug_mode = NULL;
+}
+
 void settings_tab_system_create(lv_obj_t *parent) {
     tab_root = parent;
 

--- a/main/ui/settings_tab_system.h
+++ b/main/ui/settings_tab_system.h
@@ -3,5 +3,6 @@
 #include "lvgl.h"
 
 void settings_tab_system_create(lv_obj_t *parent);
+void settings_tab_system_destroy(void);
 void settings_tab_system_refresh(void);
 void settings_tab_system_apply_theme(void);


### PR DESCRIPTION
### Summary
The application now loads and unloads the settings tab components on demand. This change reduces memory consumption by only creating settings elements when the tab is active and destroying them when it's closed.

### Changes
*   The main settings tab view now creates and destroys its components dynamically when opened or closed.
*   Each individual settings sub-tab (Behavior, Display, Nodes, System) now has dedicated functions to create and destroy its UI elements.
*   The dashboard manages the lifecycle of the settings tab, creating it only when needed and destroying it to free up memory.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-03-01T21:40:44.645Z | Generated by GitHub Actions</sub>