### PR TITLE
feat: improve thermal and ambient indicators

### DIFF
--- a/main/ui/nina_allsky.c
+++ b/main/ui/nina_allsky.c
@@ -32,8 +32,8 @@ typedef struct {
     lv_obj_t *bar;
     lv_obj_t *lbl_sub1;
     lv_obj_t *lbl_sub2;
-    lv_obj_t *dot1;   /* AMBIENT only */
-    lv_obj_t *dot2;   /* AMBIENT only */
+    lv_obj_t *dot1;   /* THERMAL only — fan symbol (LV_SYMBOL_REFRESH) */
+    lv_obj_t *dot2;   /* AMBIENT only — heater symbol (LV_SYMBOL_CHARGE) */
 } allsky_quadrant_t;
 
 static lv_obj_t *allsky_page = NULL;
@@ -282,30 +282,27 @@ static void create_quadrant(allsky_quadrant_t *qd, lv_obj_t *parent,
             lv_color_hex(app_config_apply_brightness(current_theme->label_color, gb)), 0);
     }
 
-    /* Indicator dots for AMBIENT quadrant */
-    if (quad_index == 2) {
-        lv_obj_t *dot_cont = lv_obj_create(title_row);
-        lv_obj_remove_style_all(dot_cont);
-        lv_obj_clear_flag(dot_cont, LV_OBJ_FLAG_CLICKABLE);
-        lv_obj_set_size(dot_cont, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-        lv_obj_set_flex_flow(dot_cont, LV_FLEX_FLOW_ROW);
-        lv_obj_set_style_pad_column(dot_cont, 6, 0);
+    /* Fan indicator symbol — top-right of THERMAL quadrant */
+    if (quad_index == 0) {
+        qd->dot1 = lv_label_create(title_row);
+        lv_label_set_text(qd->dot1, LV_SYMBOL_REFRESH);
+        lv_obj_set_style_text_font(qd->dot1, &lv_font_montserrat_22, 0);
+        if (current_theme) {
+            int gb = app_config_get()->color_brightness;
+            lv_obj_set_style_text_color(qd->dot1,
+                lv_color_hex(app_config_apply_brightness(current_theme->bento_border, gb)), 0);
+        }
+    }
 
-        for (int d = 0; d < 2; d++) {
-            lv_obj_t *dot = lv_obj_create(dot_cont);
-            lv_obj_remove_style_all(dot);
-            lv_obj_clear_flag(dot, LV_OBJ_FLAG_CLICKABLE);
-            lv_obj_set_size(dot, 20, 20);
-            lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
-            lv_obj_set_style_border_width(dot, 2, 0);
-            lv_obj_set_style_bg_opa(dot, LV_OPA_TRANSP, 0);
-            if (current_theme) {
-                int gb = app_config_get()->color_brightness;
-                lv_obj_set_style_border_color(dot,
-                    lv_color_hex(app_config_apply_brightness(current_theme->label_color, gb)), 0);
-            }
-            if (d == 0) qd->dot1 = dot;
-            else        qd->dot2 = dot;
+    /* Heater indicator symbol — top-right of AMBIENT quadrant */
+    if (quad_index == 2) {
+        qd->dot2 = lv_label_create(title_row);
+        lv_label_set_text(qd->dot2, LV_SYMBOL_CHARGE);
+        lv_obj_set_style_text_font(qd->dot2, &lv_font_montserrat_22, 0);
+        if (current_theme) {
+            int gb = app_config_get()->color_brightness;
+            lv_obj_set_style_text_color(qd->dot2,
+                lv_color_hex(app_config_apply_brightness(current_theme->bento_border, gb)), 0);
         }
     }
 
@@ -478,12 +475,14 @@ void allsky_page_update(const allsky_data_t *data) {
                     lv_color_hex(app_config_apply_brightness(current_theme->text_color, gb)), 0);
             }
 
-            /* Reset dots */
-            if (qd->dot1) {
-                lv_obj_set_style_bg_opa(qd->dot1, LV_OPA_TRANSP, 0);
+            /* Reset indicator symbols to dim */
+            if (qd->dot1 && current_theme) {
+                lv_obj_set_style_text_color(qd->dot1,
+                    lv_color_hex(app_config_apply_brightness(current_theme->bento_border, gb)), 0);
             }
-            if (qd->dot2) {
-                lv_obj_set_style_bg_opa(qd->dot2, LV_OPA_TRANSP, 0);
+            if (qd->dot2 && current_theme) {
+                lv_obj_set_style_text_color(qd->dot2,
+                    lv_color_hex(app_config_apply_brightness(current_theme->bento_border, gb)), 0);
             }
             continue;
         }
@@ -582,34 +581,26 @@ void allsky_page_update(const allsky_data_t *data) {
             }
         }
 
-        /* Indicator dots (ambient quadrant) */
-        if (q == 2) {
+        /* Fan indicator symbol (on thermal quadrant, data from ambient config) */
+        if (qd->dot1 && current_theme) {
+            const char *dot1_val = data->field_values[ALLSKY_F_AMBIENT_DOT1];
+            bool dot1_on = (dot1_val[0] != '\0' && qcfg[2].dot1_on_value[0] != '\0'
+                            && strcmp(dot1_val, qcfg[2].dot1_on_value) == 0);
+            uint32_t c = dot1_on ? current_theme->progress_color
+                                 : current_theme->bento_border;
+            lv_obj_set_style_text_color(qd->dot1,
+                lv_color_hex(app_config_apply_brightness(c, gb)), 0);
+        }
 
-            /* Indicator dots */
-            if (qd->dot1) {
-                const char *dot1_val = data->field_values[ALLSKY_F_AMBIENT_DOT1];
-                bool dot1_on = (dot1_val[0] != '\0' && qcfg[2].dot1_on_value[0] != '\0'
-                                && strcmp(dot1_val, qcfg[2].dot1_on_value) == 0);
-                if (dot1_on && current_theme) {
-                    lv_obj_set_style_bg_color(qd->dot1,
-                        lv_color_hex(app_config_apply_brightness(current_theme->progress_color, gb)), 0);
-                    lv_obj_set_style_bg_opa(qd->dot1, LV_OPA_COVER, 0);
-                } else {
-                    lv_obj_set_style_bg_opa(qd->dot1, LV_OPA_TRANSP, 0);
-                }
-            }
-            if (qd->dot2) {
-                const char *dot2_val = data->field_values[ALLSKY_F_AMBIENT_DOT2];
-                bool dot2_on = (dot2_val[0] != '\0' && qcfg[2].dot2_on_value[0] != '\0'
-                                && strcmp(dot2_val, qcfg[2].dot2_on_value) == 0);
-                if (dot2_on && current_theme) {
-                    lv_obj_set_style_bg_color(qd->dot2,
-                        lv_color_hex(app_config_apply_brightness(current_theme->progress_color, gb)), 0);
-                    lv_obj_set_style_bg_opa(qd->dot2, LV_OPA_COVER, 0);
-                } else {
-                    lv_obj_set_style_bg_opa(qd->dot2, LV_OPA_TRANSP, 0);
-                }
-            }
+        /* Heater indicator symbol (on ambient quadrant) */
+        if (qd->dot2 && current_theme) {
+            const char *dot2_val = data->field_values[ALLSKY_F_AMBIENT_DOT2];
+            bool dot2_on = (dot2_val[0] != '\0' && qcfg[2].dot2_on_value[0] != '\0'
+                            && strcmp(dot2_val, qcfg[2].dot2_on_value) == 0);
+            uint32_t c = dot2_on ? current_theme->progress_color
+                                 : current_theme->bento_border;
+            lv_obj_set_style_text_color(qd->dot2,
+                lv_color_hex(app_config_apply_brightness(c, gb)), 0);
         }
     }
 }
@@ -653,14 +644,14 @@ void allsky_page_apply_theme(void) {
             lv_obj_set_style_bg_opa(qd->bar, LV_OPA_30, 0);
         }
 
-        /* Indicator dots border */
+        /* Indicator symbols — reset to dim on theme change */
         if (qd->dot1) {
-            lv_obj_set_style_border_color(qd->dot1,
-                lv_color_hex(app_config_apply_brightness(current_theme->label_color, gb)), 0);
+            lv_obj_set_style_text_color(qd->dot1,
+                lv_color_hex(app_config_apply_brightness(current_theme->bento_border, gb)), 0);
         }
         if (qd->dot2) {
-            lv_obj_set_style_border_color(qd->dot2,
-                lv_color_hex(app_config_apply_brightness(current_theme->label_color, gb)), 0);
+            lv_obj_set_style_text_color(qd->dot2,
+                lv_color_hex(app_config_apply_brightness(current_theme->bento_border, gb)), 0);
         }
     }
 


### PR DESCRIPTION
### Summary
The UI now uses symbols for thermal and ambient quadrant indicators, replacing generic dots. This makes the status of these quadrants clearer and easier to understand at a glance.

### Changes
*   Thermal and ambient quadrant indicators display symbols.
*   Indicator dots for thermal and ambient quadrants have specific roles.

---
<sub>Analyzed **3** commit(s) | Updated: 2026-03-04T02:16:40.741Z | Generated by GitHub Actions</sub>