### PR TITLE
feat: add AllSky enable/disable toggle

### DIFF
--- a/main/allsky_client.c
+++ b/main/allsky_client.c
@@ -135,6 +135,7 @@ static const field_map_entry_t s_field_map[] = {
     { "ambient", "sub2", ALLSKY_F_AMBIENT_SUB2  },
     { "ambient", "dot1", ALLSKY_F_AMBIENT_DOT1  },
     { "ambient", "dot2", ALLSKY_F_AMBIENT_DOT2  },
+    { "sqm",     "dot1", ALLSKY_F_SQM_DOT1      },
     { "power",   "main", ALLSKY_F_POWER_MAIN    },
     { "power",   "sub1", ALLSKY_F_POWER_SUB1    },
     { "power",   "sub2", ALLSKY_F_POWER_SUB2    },

--- a/main/allsky_client.h
+++ b/main/allsky_client.h
@@ -31,6 +31,7 @@
 #define ALLSKY_F_POWER_MAIN    11
 #define ALLSKY_F_POWER_SUB1    12
 #define ALLSKY_F_POWER_SUB2    13
+#define ALLSKY_F_SQM_DOT1      14
 
 typedef struct {
     bool connected;

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -729,6 +729,7 @@ static void set_defaults(app_config_t *cfg) {
     cfg->allsky_field_config[sizeof(cfg->allsky_field_config) - 1] = '\0';
     strncpy(cfg->allsky_thresholds, DEFAULT_ALLSKY_THRESHOLDS, sizeof(cfg->allsky_thresholds) - 1);
     cfg->allsky_thresholds[sizeof(cfg->allsky_thresholds) - 1] = '\0';
+    cfg->allsky_enabled = true;
 }
 
 /**
@@ -1388,6 +1389,64 @@ static void migrate_from_v15(const app_config_v15_t *old, app_config_t *cfg) {
 }
 
 /**
+ * @brief Migrate a v17 config blob into the current struct layout.
+ *
+ * v17 → v18 adds: allsky_enabled flag (default true).
+ */
+static void migrate_from_v17(const app_config_v17_t *old, app_config_t *cfg) {
+    set_defaults(cfg);
+
+    memcpy(cfg->api_url, old->api_url, sizeof(cfg->api_url));
+    memcpy(cfg->ntp_server, old->ntp_server, sizeof(cfg->ntp_server));
+    memcpy(cfg->tz_string, old->tz_string, sizeof(cfg->tz_string));
+    memcpy(cfg->filter_colors, old->filter_colors, sizeof(cfg->filter_colors));
+    memcpy(cfg->rms_thresholds, old->rms_thresholds, sizeof(cfg->rms_thresholds));
+    memcpy(cfg->hfr_thresholds, old->hfr_thresholds, sizeof(cfg->hfr_thresholds));
+    cfg->theme_index = old->theme_index;
+    cfg->brightness = old->brightness;
+    cfg->color_brightness = old->color_brightness;
+    cfg->mqtt_enabled = old->mqtt_enabled;
+    memcpy(cfg->mqtt_broker_url, old->mqtt_broker_url, sizeof(cfg->mqtt_broker_url));
+    memcpy(cfg->mqtt_username, old->mqtt_username, sizeof(cfg->mqtt_username));
+    memcpy(cfg->mqtt_password, old->mqtt_password, sizeof(cfg->mqtt_password));
+    memcpy(cfg->mqtt_topic_prefix, old->mqtt_topic_prefix, sizeof(cfg->mqtt_topic_prefix));
+    cfg->mqtt_port = old->mqtt_port;
+    cfg->active_page_override = old->active_page_override;
+    cfg->auto_rotate_enabled = old->auto_rotate_enabled;
+    cfg->auto_rotate_interval_s = old->auto_rotate_interval_s;
+    cfg->auto_rotate_effect = old->auto_rotate_effect;
+    cfg->auto_rotate_skip_disconnected = old->auto_rotate_skip_disconnected;
+    cfg->auto_rotate_pages = old->auto_rotate_pages;
+    cfg->update_rate_s = old->update_rate_s;
+    cfg->graph_update_interval_s = old->graph_update_interval_s;
+    cfg->connection_timeout_s = old->connection_timeout_s;
+    cfg->toast_duration_s = old->toast_duration_s;
+    cfg->debug_mode = old->debug_mode;
+    memcpy(cfg->instance_enabled, old->instance_enabled, sizeof(cfg->instance_enabled));
+    cfg->screen_sleep_enabled = old->screen_sleep_enabled;
+    cfg->screen_sleep_timeout_s = old->screen_sleep_timeout_s;
+    cfg->alert_flash_enabled = old->alert_flash_enabled;
+    cfg->idle_poll_interval_s = old->idle_poll_interval_s;
+    cfg->wifi_power_save = old->wifi_power_save;
+    cfg->widget_style = old->widget_style;
+    cfg->auto_update_check = old->auto_update_check;
+    cfg->update_channel = old->update_channel;
+    cfg->deep_sleep_enabled = old->deep_sleep_enabled;
+    cfg->deep_sleep_wake_timer_s = old->deep_sleep_wake_timer_s;
+    cfg->deep_sleep_on_idle = old->deep_sleep_on_idle;
+    cfg->screen_rotation = old->screen_rotation;
+    memcpy(cfg->hostname, old->hostname, sizeof(cfg->hostname));
+    memcpy(cfg->allsky_hostname, old->allsky_hostname, sizeof(cfg->allsky_hostname));
+    cfg->allsky_update_interval_s = old->allsky_update_interval_s;
+    cfg->allsky_dew_offset = old->allsky_dew_offset;
+    memcpy(cfg->allsky_field_config, old->allsky_field_config, sizeof(cfg->allsky_field_config));
+    memcpy(cfg->allsky_thresholds, old->allsky_thresholds, sizeof(cfg->allsky_thresholds));
+    cfg->allsky_enabled = true;  /* new in v18 — default on for existing users */
+
+    ESP_LOGI(TAG, "Migrated config from v17 → v%d", APP_CONFIG_VERSION);
+}
+
+/**
  * @brief Migrate a v16 config blob into the current struct layout.
  *
  * v16 → v17 adds: AllSky integration fields.
@@ -1600,6 +1659,15 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 17 && stored_size >= sizeof(app_config_v17_t)) {
+        /* Version 17 blob — migrate to v18 */
+        app_config_v17_t old;
+        memcpy(&old, raw, sizeof(app_config_v17_t));
+        migrate_from_v17(&old, &s_config);
+        validate_config(&s_config);
+
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 16 && stored_size >= sizeof(app_config_v16_t)) {
         /* Version 16 blob — migrate to v17 */
         app_config_v16_t old;

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,7 +13,7 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 17
+#define APP_CONFIG_VERSION 18
 
 #define WIDGET_STYLE_COUNT 7
 
@@ -68,7 +68,58 @@ typedef struct {
     float    allsky_dew_offset;             // °C above ambient for dew alert (default 5.0)
     char     allsky_field_config[1536];     // JSON key mappings per quadrant
     char     allsky_thresholds[1024];       // JSON threshold configs per field
+    bool     allsky_enabled;                // Enable AllSky feature (page + poll task); default true
 } app_config_t;
+
+// v17 snapshot — AllSky fields without allsky_enabled
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+} app_config_v17_t;
 
 // WiFi credentials are NOT stored in app_config_t. They are managed by
 // ESP-IDF's WiFi NVS subsystem via esp_wifi_set_config() and auto-restored

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -842,7 +842,12 @@
 
       <div class="card">
         <div class="card-title">Connection</div>
-        <div class="field">
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable AllSky</span>
+          <label class="toggle"><input type="checkbox" id="allsky_enabled" onchange="updateAllSkyEnabledUI()"><span class="toggle-track"></span></label>
+        </div>
+        <div id="allskyConnectionFields">
+        <div class="field" style="margin-top:16px">
           <label class="field-label">AllSky Hostname</label>
           <input type="text" class="input" id="allskyHostname" placeholder="allskypi5.lan:8080">
           <div class="field-hint">Host:port of the AllSky API (e.g., allskypi5.lan:8080)</div>
@@ -867,9 +872,10 @@
             <div class="field-hint">Dew point colored safe when below ambient &minus; this offset</div>
           </div>
         </div>
+        </div>
       </div>
 
-      <div class="card">
+      <div class="card" id="allskyFieldMappingsCard">
         <div class="card-title">Field Mappings</div>
         <div class="field-hint" style="margin-bottom:16px">Configure which AllSky API JSON values appear in each display quadrant. Click a key path input, then click "Use" on a JSON leaf to fill it. Use the color controls to set gradient ranges per field.</div>
 
@@ -1127,7 +1133,8 @@
       var enabled=[$('instance_enabled_0').checked,$('instance_enabled_1').checked,$('instance_enabled_2').checked];
       var prev=sel.value;
       sel.innerHTML='';
-      sel.add(new Option('AllSky','0'));
+      var allskyOn=$('allsky_enabled')?$('allsky_enabled').checked:false;
+      if(allskyOn) sel.add(new Option('AllSky','0'));
       sel.add(new Option('Summary','1'));
       var pageIdx=2;
       for(var i=0;i<3;i++){
@@ -1787,10 +1794,24 @@
       return config;
     }
 
+    function updateAllSkyEnabledUI(){
+      var on=$('allsky_enabled').checked;
+      var d=on?'':'none';
+      $('allskyConnectionFields').style.display=d;
+      $('allskyFieldMappingsCard').style.display=on?'block':'none';
+      var arpAllsky=$('arp_allsky');
+      if(arpAllsky){
+        var row=arpAllsky.parentNode;
+        if(row) row.style.display=on?'':'none';
+      }
+      updatePageSelectOptions();
+    }
+
     function loadAllSkyConfig(){
       fetch('/api/allsky-config')
         .then(function(r){ return r.json(); })
         .then(function(cfg){
+          $('allsky_enabled').checked=cfg.allsky_enabled!==false;
           $('allskyHostname').value=cfg.hostname||'';
           $('allskyInterval').value=cfg.update_interval_s||5;
           $('allskyDewOffset').value=cfg.dew_offset!=null?cfg.dew_offset:5.0;
@@ -1799,15 +1820,18 @@
           var fieldCfg={};
           try{ fieldCfg=JSON.parse(cfg.field_config||'{}'); }catch(e){}
           populateAllSkyFieldMappings(fieldCfg,thresholds);
+          updateAllSkyEnabledUI();
         })
         .catch(function(e){
           console.error('Failed to load AllSky config',e);
           populateAllSkyFieldMappings({},{});
+          updateAllSkyEnabledUI();
         });
     }
 
     function saveAllSkyConfig(){
       var data={
+        allsky_enabled:!!$('allsky_enabled').checked,
         hostname:$('allskyHostname').value.trim(),
         update_interval_s:parseInt($('allskyInterval').value)||5,
         dew_offset:parseFloat($('allskyDewOffset').value)||5.0,

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -528,7 +528,7 @@ void data_update_task(void *arg) {
 
     /* Spawn AllSky poll task (pinned to Core 0, networking) */
     allsky_data_init(&allsky_data);
-    {
+    if (app_config_get()->allsky_enabled) {
         StackType_t *as_stack = heap_caps_malloc(6144 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
         StaticTask_t *as_tcb = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
         if (as_stack && as_tcb) {
@@ -781,8 +781,10 @@ void data_update_task(void *arg) {
                          * Bitmask bits 1-3 refer to instance indices (not page indices),
                          * so use the page-to-instance mapping for NINA pages. */
                         bool in_mask = false;
-                        if (candidate == 0)
+                        if (candidate == 0) {
                             in_mask = (page_mask & 0x20) != 0;             /* AllSky (bit 5) */
+                            if (!app_config_get()->allsky_enabled) in_mask = false;
+                        }
                         else if (candidate == 1)
                             in_mask = (page_mask & 0x01) != 0;             /* Summary (bit 0) */
                         else if (candidate >= 2 && candidate <= ena_page_count + 1) {

--- a/main/ui/nina_allsky.c
+++ b/main/ui/nina_allsky.c
@@ -294,6 +294,18 @@ static void create_quadrant(allsky_quadrant_t *qd, lv_obj_t *parent,
         }
     }
 
+    /* GPS indicator symbol — top-right of SQM quadrant */
+    if (quad_index == 1) {
+        qd->dot1 = lv_label_create(title_row);
+        lv_label_set_text(qd->dot1, LV_SYMBOL_GPS);
+        lv_obj_set_style_text_font(qd->dot1, &lv_font_montserrat_22, 0);
+        if (current_theme) {
+            int gb = app_config_get()->color_brightness;
+            lv_obj_set_style_text_color(qd->dot1,
+                lv_color_hex(app_config_apply_brightness(current_theme->bento_border, gb)), 0);
+        }
+    }
+
     /* Heater indicator symbol — top-right of AMBIENT quadrant */
     if (quad_index == 2) {
         qd->dot2 = lv_label_create(title_row);
@@ -581,11 +593,21 @@ void allsky_page_update(const allsky_data_t *data) {
             }
         }
 
-        /* Fan indicator symbol (on thermal quadrant, data from ambient config) */
+        /* Dot 1 indicator: thermal=fan (ambient config), sqm=GPS (sqm config) */
         if (qd->dot1 && current_theme) {
-            const char *dot1_val = data->field_values[ALLSKY_F_AMBIENT_DOT1];
-            bool dot1_on = (dot1_val[0] != '\0' && qcfg[2].dot1_on_value[0] != '\0'
-                            && strcmp(dot1_val, qcfg[2].dot1_on_value) == 0);
+            const char *dot1_val;
+            bool dot1_on;
+            if (q == 1) {
+                /* SQM quadrant: use sqm.dot1 key/on_value */
+                dot1_val = data->field_values[ALLSKY_F_SQM_DOT1];
+                dot1_on = (dot1_val[0] != '\0' && qcfg[1].dot1_on_value[0] != '\0'
+                           && strcmp(dot1_val, qcfg[1].dot1_on_value) == 0);
+            } else {
+                /* Thermal quadrant: fan (controlled via ambient.dot1 config) */
+                dot1_val = data->field_values[ALLSKY_F_AMBIENT_DOT1];
+                dot1_on = (dot1_val[0] != '\0' && qcfg[2].dot1_on_value[0] != '\0'
+                           && strcmp(dot1_val, qcfg[2].dot1_on_value) == 0);
+            }
             uint32_t c = dot1_on ? current_theme->progress_color
                                  : current_theme->bento_border;
             lv_obj_set_style_text_color(qd->dot1,

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -240,7 +240,7 @@ void nina_dashboard_apply_theme(int theme_index) {
         apply_theme_to_page(&pages[i]);
     }
 
-    allsky_page_apply_theme();
+    if (allsky_obj) allsky_page_apply_theme();
     summary_page_apply_theme();
     if (settings_obj) settings_tabview_apply_theme();
     sysinfo_page_apply_theme();
@@ -643,13 +643,16 @@ static void gesture_event_cb(lv_event_t *e) {
     int new_page = active_page;
 
     int settings_idx = page_count + 2;  /* settings page — skip in swipe navigation */
+    int allsky_idx = (allsky_obj == NULL) ? 0 : -1;  /* allsky page — skip when disabled */
 
     if (dir == LV_DIR_LEFT) {
         new_page = (active_page + 1) % total_page_count;
         if (new_page == settings_idx) new_page = (new_page + 1) % total_page_count;
+        if (new_page == allsky_idx) new_page = (new_page + 1) % total_page_count;
     } else if (dir == LV_DIR_RIGHT) {
         new_page = (active_page - 1 + total_page_count) % total_page_count;
         if (new_page == settings_idx) new_page = (new_page - 1 + total_page_count) % total_page_count;
+        if (new_page == allsky_idx) new_page = (new_page - 1 + total_page_count) % total_page_count;
     } else {
         return;
     }
@@ -744,9 +747,13 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
     lv_obj_set_style_bg_opa(main_cont, LV_OPA_COVER, 0);
     lv_obj_set_style_pad_all(main_cont, OUTER_PADDING, 0);
 
-    /* AllSky page — always first (page index 0), hidden initially */
-    allsky_obj = allsky_page_create(main_cont);
-    lv_obj_add_flag(allsky_obj, LV_OBJ_FLAG_HIDDEN);
+    /* AllSky page — page index 0, hidden initially (skipped entirely when disabled) */
+    if (app_config_get()->allsky_enabled) {
+        allsky_obj = allsky_page_create(main_cont);
+        lv_obj_add_flag(allsky_obj, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        allsky_obj = NULL;
+    }
 
     /* Summary page — page index 1, visible by default */
     summary_obj = summary_page_create(main_cont, page_count);
@@ -800,6 +807,7 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
 
 void nina_dashboard_show_page(int page_index, int instance_count) {
     if (page_index < 0 || page_index >= total_page_count) return;
+    if (page_index == 0 && allsky_obj == NULL) return;  /* allsky disabled */
     if (page_index == active_page) return;
 
     hide_page_at(active_page);
@@ -818,7 +826,7 @@ int nina_dashboard_get_active_page(void) {
 }
 
 bool nina_dashboard_is_allsky_page(void) {
-    return active_page == 0;
+    return allsky_obj != NULL && active_page == 0;
 }
 
 bool nina_dashboard_is_settings_page(void) {
@@ -939,6 +947,7 @@ static void slide_new_ready_cb(lv_anim_t *a)
 void nina_dashboard_show_page_animated(int page_index, int instance_count, int effect)
 {
     if (page_index < 0 || page_index >= total_page_count) return;
+    if (page_index == 0 && allsky_obj == NULL) return;  /* allsky disabled */
     if (page_index == active_page) return;
 
     lv_obj_t *old_obj = get_page_obj(active_page);

--- a/main/web_handlers_allsky.c
+++ b/main/web_handlers_allsky.c
@@ -29,6 +29,7 @@ esp_err_t allsky_config_get_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "dew_offset",       (double)cfg->allsky_dew_offset);
     cJSON_AddStringToObject(root, "field_config",     cfg->allsky_field_config);
     cJSON_AddStringToObject(root, "thresholds",       cfg->allsky_thresholds);
+    cJSON_AddBoolToObject(root, "allsky_enabled",    cfg->allsky_enabled);
 
     const char *json_str = cJSON_PrintUnformatted(root);
     if (json_str == NULL) {
@@ -102,6 +103,11 @@ esp_err_t allsky_config_post_handler(httpd_req_t *req)
     cJSON *item = cJSON_GetObjectItem(root, "dew_offset");
     if (cJSON_IsNumber(item)) {
         cfg->allsky_dew_offset = (float)item->valuedouble;
+    }
+
+    cJSON *ena = cJSON_GetObjectItem(root, "allsky_enabled");
+    if (cJSON_IsBool(ena)) {
+        cfg->allsky_enabled = cJSON_IsTrue(ena);
     }
 
     cJSON_Delete(root);


### PR DESCRIPTION
### Summary
This PR adds a toggle to enable or disable the AllSky camera functionality, allowing users to control its operation and hide related UI elements. It also fixes a bug where the GPS dot indicator was missing from the SQM dashboard.

### Changes
*   `app_config_t` now includes an `allsky_enabled` boolean, with existing configurations migrating to this new setting.
*   AllSky poll task and its LVGL page are created only when AllSky functionality is enabled.
*   Auto-rotate, swipe navigation, and theme application related to AllSky are now conditional on AllSky being enabled.
*   The `allsky_enabled` setting is available through the `/api/allsky-config` API.
*   The configuration UI dynamically hides AllSky-specific fields and options when AllSky is disabled.
*   A new field index `ALLSKY_F_SQM_DOT1` and `sqm.dot1` mapping were added for AllSky data extraction.
*   The SQM dashboard now displays the previously missing GPS symbol dot widget.
*   The GPS dot update logic correctly distinguishes between SQM and thermal data sources.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-03-04T20:56:59.012Z | Generated by GitHub Actions</sub>