### PR TITLE
feat: add session-cookie authentication to web server

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,23 @@ Save settings. The device reconnects to your network and starts polling immediat
 
 ---
 
+## Security
+
+The device web interface uses a session cookie for authentication. Open the web UI and you will be redirected to a login page. Enter the admin password (default: `changeme123!`). There is no username, only a password. Sessions expire after 12 hours.
+
+- Default admin password: `changeme123!`
+- Change the password on first boot. Open the web UI, navigate to Settings, select the System tab, and use the Admin Password section. The same section includes a Sign out button.
+- Authentication covers `/` and all configuration, reboot, factory reset, OTA, and secret-returning endpoints.
+- Unauthenticated entry points: `/login`, `/api/login`.
+- Other unauthenticated endpoints: `/favicon.ico`, `/api/version`, `/api/status`, `/api/nina/status`, `/api/check-update-json`, `/api/spotify/callback` (OAuth redirect target), `/api/allsky-proxy`, `/api/screenshot`, `/api/crash`.
+- Unauthenticated HTML requests to protected paths redirect to `/login`. Unauthenticated `/api/*` requests return HTTP 401 with a JSON body, and the UI redirects the browser to `/login`.
+- The admin password is stored in NVS. The transport is HTTP, not HTTPS. Treat the LAN segment as the trust boundary. Session tokens are 256-bit random values held in RAM and cleared on reboot.
+- Secrets (WiFi password, MQTT password, Spotify client ID) are redacted in `GET /api/config` and returned as `********`. The configuration backup endpoint returns real values to authenticated users.
+- The password field accepts 4 to 32 characters. Changing the password requires the current password.
+- Authentication can be disabled. Settings, System tab, Authentication card contains a "Require login to access the web UI" toggle. Default is enabled. When disabled, every endpoint becomes open to any client on the LAN, which includes reboot, factory reset, OTA, and configuration change. Secrets remain redacted in every API response regardless of the toggle state: `GET /api/config` returns `********` for sensitive fields, and `GET /api/config/backup?include_sensitive=1` is downgraded to a redacted backup when authentication is off. Use this only on trusted networks.
+
+---
+
 ## Display Interface
 
 ### Summary Page

--- a/build_firmware.ps1
+++ b/build_firmware.ps1
@@ -8,11 +8,14 @@
 #   .\build_firmware.ps1 -OTA         # Build + OTA flash to both devices
 #   .\build_firmware.ps1 -OTA -Devices "NinaDash1.lan","NinaDash2.lan"
 
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'Password',
+    Justification='Dev tool: password sourced from env var or interactive prompt; not persisted.')]
 param(
     [string]$IdfPath = "C:\Espressif\frameworks\esp-idf-v5.5.2",
     [switch]$FullClean,
     [switch]$OTA,
-    [string[]]$Devices = @("NinaDash2.lan")
+    [string[]]$Devices = @("NinaDash2.lan"),
+    [string]$Password = $(if ($env:NINADASH_PASSWORD) { $env:NINADASH_PASSWORD } else { "changeme123!" })
 )
 
 $ErrorActionPreference = "Stop"
@@ -150,17 +153,47 @@ Write-Host "              $OtaSizeMB MB ($OtaSize bytes)" -ForegroundColor Green
 
 # OTA flash to devices if requested (parallel)
 if ($OTA) {
+    # Device auth: /api/ota requires a valid session cookie.
+    if ([string]::IsNullOrEmpty($Password)) {
+        $sec = Read-Host -Prompt "Admin password for $($Devices -join ', ')" -AsSecureString
+        $bstr = [System.Runtime.InteropServices.Marshal]::SecureStringToBSTR($sec)
+        try { $Password = [System.Runtime.InteropServices.Marshal]::PtrToStringBSTR($bstr) }
+        finally { [System.Runtime.InteropServices.Marshal]::ZeroFreeBSTR($bstr) }
+    }
+
     Write-Host "`nUploading OTA firmware to $($Devices.Count) devices in parallel ..." -ForegroundColor Cyan
 
     [array]$jobs = foreach ($Device in $Devices) {
-        Start-Job -ArgumentList $Device, $AppBin -ScriptBlock {
-            param($Device, $AppBin)
+        Start-Job -ArgumentList $Device, $AppBin, $Password -ScriptBlock {
+            param($Device, $AppBin, $Password)
+
+            # 1. Login to get session cookie
+            $LoginUrl = "http://${Device}/api/login"
+            $loginBody = @{ password = $Password } | ConvertTo-Json -Compress
+            $loginResp = Invoke-WebRequest -Uri $LoginUrl -Method Post `
+                -Body $loginBody -ContentType "application/json" -TimeoutSec 15 `
+                -UseBasicParsing
+            if ($loginResp.StatusCode -ne 200) {
+                throw "login failed: HTTP $($loginResp.StatusCode)"
+            }
+            $setCookie = $loginResp.Headers['Set-Cookie']
+            if ($setCookie -is [array]) { $setCookie = $setCookie[0] }
+            if (-not $setCookie -or $setCookie -notmatch 'session=([^;]+)') {
+                throw "login succeeded but no session cookie returned"
+            }
+            $sessionCookie = "session=$($Matches[1])"
+
+            # 2. Upload firmware with session cookie
             $OtaUrl = "http://${Device}/api/ota"
             $fileBytes = [System.IO.File]::ReadAllBytes($AppBin)
-            $null = Invoke-WebRequest -Uri $OtaUrl -Method Post `
+            $otaResp = Invoke-WebRequest -Uri $OtaUrl -Method Post `
                 -Body $fileBytes `
                 -ContentType "application/octet-stream" `
-                -TimeoutSec 600
+                -Headers @{ Cookie = $sessionCookie } `
+                -TimeoutSec 600 -UseBasicParsing
+            if ($otaResp.StatusCode -lt 200 -or $otaResp.StatusCode -ge 300) {
+                throw "ota upload failed: HTTP $($otaResp.StatusCode)"
+            }
         }
     }
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,7 +5,7 @@ idf_component_register(
     SRCS main.c tasks.c power_mgmt.c jpeg_utils.c stb_image.c perf_monitor.c ota_github.c
          nina_connection.c nina_client.c nina_api_fetchers.c nina_sequence.c nina_websocket.c
          allsky_client.c weather_client.c spotify_auth.c spotify_client.c demo_data.c
-         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c mqtt_ha.c
+         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_auth.c mqtt_ha.c
          ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
          ui/nina_toast.c ui/nina_event_log.c ui/nina_alerts.c ui/nina_safety.c ui/nina_session_stats.c ui/lv_font_material_safety.c ui/lv_font_superscript_24.c ui/lv_font_playfair_228.c ui/lv_font_playfair_90.c ui/lv_font_overpass_27.c ui/lv_font_overpass_16.c
          ui/nina_idle_indicator.c
@@ -14,7 +14,7 @@ idf_component_register(
          ui/nina_ota_prompt.c
          ${LV_DEMOS_SOURCES}
     INCLUDE_DIRS . ui ${LV_DEMO_DIR}
-    EMBED_TXTFILES config_ui.html
+    EMBED_TXTFILES config_ui.html login.html
     EMBED_FILES favicon.png logo.jpg spotify_logo.png)
 
 idf_component_get_property(LVGL_LIB lvgl__lvgl COMPONENT_LIB)

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -767,6 +767,12 @@ static void set_defaults(app_config_t *cfg) {
     cfg->idle_page_override_target = IDLE_TARGET_SUMMARY;
     cfg->idle_page_persistent = false;
     cfg->idle_indicator_enabled = true;
+
+    // Admin password default — change via web UI on first boot
+    strcpy(cfg->admin_password, "changeme123!");
+
+    // Auth is on by default — protects device from open-LAN access
+    cfg->auth_enabled = true;
 }
 
 /**
@@ -1730,15 +1736,47 @@ static void migrate_from_v23(const app_config_v23_t *old, app_config_t *cfg) {
     ESP_LOGI(TAG, "Migrated config from v23 to v%d", APP_CONFIG_VERSION);
 }
 
-/* --- v29 → v30 migration (added idle_indicator_enabled) --- */
+/* --- v31 → v32 migration (added auth_enabled) --- */
+static void migrate_from_v31(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v31_t) ? raw_size : sizeof(app_config_v31_t);
+    memcpy(cfg, raw, copy);
+
+    /* auth_enabled: existing devices default to ON so upgrade stays locked down */
+    cfg->auth_enabled = true;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v31 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v30 → v32 migration (added admin_password, auth_enabled) --- */
+static void migrate_from_v30(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v30_t) ? raw_size : sizeof(app_config_v30_t);
+    memcpy(cfg, raw, copy);
+
+    /* admin_password gets default ("changeme123!") from set_defaults() */
+    strcpy(cfg->admin_password, "changeme123!");
+    /* auth_enabled defaults to true from set_defaults() */
+    cfg->auth_enabled = true;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v30 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v29 → v32 migration (added idle_indicator_enabled, admin_password, auth_enabled) --- */
 static void migrate_from_v29(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
     size_t copy = raw_size < sizeof(app_config_v29_t) ? raw_size : sizeof(app_config_v29_t);
     memcpy(cfg, raw, copy);
 
-    /* New field gets its default from set_defaults() (true) */
+    /* New fields get their defaults from set_defaults() */
     cfg->idle_indicator_enabled = true;
+    strcpy(cfg->admin_password, "changeme123!");
+    cfg->auth_enabled = true;
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v29 to v%d", APP_CONFIG_VERSION);
@@ -2255,8 +2293,20 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 31) {
+        /* v31 → v32: added auth_enabled */
+        migrate_from_v31(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
+    } else if (version_check == 30) {
+        /* v30 → v32: added admin_password, auth_enabled */
+        migrate_from_v30(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 29) {
-        /* v29 → v30: added idle_indicator_enabled */
+        /* v29 → v32: added idle_indicator_enabled, admin_password, auth_enabled */
         migrate_from_v29(raw, stored_size, &s_config);
         validate_config(&s_config);
         nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
@@ -2514,6 +2564,12 @@ void app_config_init(void) {
 
     free(raw);
     nvs_close(handle);
+
+    /* Warn at boot if admin password is still the factory default. */
+    if (strcmp(s_config.admin_password, "changeme123!") == 0) {
+        ESP_LOGW(TAG, "Admin password is set to factory default. "
+                      "Change it via the web UI (Settings -> System -> Admin Password).");
+    }
 }
 
 app_config_t *app_config_get(void) {

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,7 +13,7 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 30
+#define APP_CONFIG_VERSION 32
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -124,6 +124,12 @@ typedef struct {
     int8_t   idle_page_override_target; // idle_target_t enum value
     bool     idle_page_persistent;      // Return to idle page after manual navigation
     bool     idle_indicator_enabled;    // Show idle indicator on display (default true)
+
+    // Added after v30 — must stay at end to preserve NVS binary compatibility
+    char     admin_password[33];        // HTTP Basic auth password for web UI (default "changeme123!")
+
+    // Added after v31 — must stay at end to preserve NVS binary compatibility
+    bool     auth_enabled;              // When false, all endpoints are open; secrets still redacted (default true)
 } app_config_t;
 
 // v17 snapshot — AllSky fields without allsky_enabled
@@ -711,6 +717,161 @@ typedef struct {
     int8_t   idle_page_override_target;
     bool     idle_page_persistent;
 } app_config_v29_t;
+
+// v30 snapshot — layout before admin_password was added
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+} app_config_v30_t;
+
+// v31 snapshot — layout before auth_enabled was added
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+} app_config_v31_t;
 
 // WiFi credentials are stored in app_config_t.wifi_networks[3] (up to 3
 // priority-ordered networks). The AP provides headless access for initial

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1026,6 +1026,43 @@
           <img id="ssImage" style="width:100%;border-radius:var(--radius-sm);border:1px solid var(--border)">
         </div>
       </div>
+
+      <div class="card">
+        <div class="card-title">Authentication</div>
+        <div class="toggle-row">
+          <span class="toggle-label">Require login to access the web UI</span>
+          <label class="toggle"><input type="checkbox" id="auth_enabled"><span class="toggle-track"></span></label>
+        </div>
+        <p style="color:#888;font-size:0.85em;margin:8px 0 0 0;">
+          When disabled, anyone on the network can control the device (reboot, factory reset, OTA, config change).
+          Secrets (passwords, API keys, tokens) remain redacted in API responses either way.
+        </p>
+        <button class="btn btn-primary" style="margin-top:12px" onclick="saveAuthEnabled()">Save</button>
+        <div id="auth_enabled_status" style="margin-top:10px;font-size:0.9em;"></div>
+      </div>
+
+      <div class="card" id="adminPasswordCard">
+        <div class="card-title">Admin Password</div>
+        <p style="color:#888;font-size:0.85em;margin:2px 0 12px 0;">
+          Default password is <code>changeme123!</code>. Change it now to secure this device's web interface.
+        </p>
+        <div class="field">
+          <label for="admin_pw_current">Current password</label>
+          <input type="password" id="admin_pw_current" autocomplete="current-password">
+        </div>
+        <div class="field">
+          <label for="admin_pw_new">New password (4-32 chars)</label>
+          <input type="password" id="admin_pw_new" autocomplete="new-password">
+        </div>
+        <div class="field">
+          <label for="admin_pw_confirm">Confirm new password</label>
+          <input type="password" id="admin_pw_confirm" autocomplete="new-password">
+        </div>
+        <button class="btn btn-primary" onclick="changeAdminPassword()">Save Password</button>
+        <div id="admin_pw_status" style="margin-top:10px;font-size:0.9em;"></div>
+        <hr style="border:0;border-top:1px solid var(--border);margin:16px 0">
+        <button class="btn" id="signOutBtn" onclick="signOut()">Sign out</button>
+      </div>
     </div>
 
     <!-- ==================== TAB 5: ALLSKY ==================== -->
@@ -2061,6 +2098,11 @@
       if($('idle_indicator_enabled')) $('idle_indicator_enabled').checked=data.idle_indicator_enabled!==false;
       toggleIdleOverride();
 
+      // Authentication toggle — reflect in UI and hide sign-out button when off
+      var authOn = (data.auth_enabled!==false);
+      if($('auth_enabled')) $('auth_enabled').checked = authOn;
+      if($('signOutBtn')) $('signOutBtn').style.display = authOn ? '' : 'none';
+
       /* Backup tab version info */
       if ($('backupCurrentVersion')) $('backupCurrentVersion').textContent = 'v' + (data.config_version || '?');
       if ($('backupFirmwareVersion')) {
@@ -2299,6 +2341,59 @@
       });
     }
 
+    function saveAuthEnabled(){
+      var cb=$('auth_enabled');
+      var status=$('auth_enabled_status');
+      if(!cb) return;
+      if(status){ status.textContent=''; status.style.color=''; }
+      var want = !!cb.checked;
+      if(!want){
+        if(!confirm('Disable authentication?\n\nAnyone on your network will be able to reboot, reconfigure, and update this device. Secrets will remain redacted.\n\nContinue?')){
+          cb.checked = true;
+          return;
+        }
+      }
+      fetch('/api/config',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({auth_enabled:want})
+      }).then(function(r){
+        if(!r.ok) throw new Error('HTTP '+r.status);
+        if(status){
+          status.textContent = want ? 'Authentication enabled.' : 'Authentication disabled.';
+          status.style.color = '#6c6';
+        }
+        if($('signOutBtn')) $('signOutBtn').style.display = want ? '' : 'none';
+        showToast(want ? 'Authentication enabled' : 'Authentication disabled','success');
+      }).catch(function(e){
+        if(status){ status.textContent='Save failed: '+e.message; status.style.color='#f66'; }
+        showToast('Save failed: '+e.message,'error');
+      });
+    }
+
+    function signOut(){
+      fetch('/api/logout',{method:'POST'}).then(function(){
+        window.location='/login';
+      }).catch(function(){
+        window.location='/login';
+      });
+    }
+
+    /* Global fetch wrapper: redirect to /login on any 401 from protected APIs. */
+    (function(){
+      var _fetch=window.fetch;
+      window.fetch=function(input,init){
+        var url='';
+        try{ url=(typeof input==='string')?input:(input&&input.url)||''; }catch(e){}
+        return _fetch.call(this,input,init).then(function(resp){
+          if(resp && resp.status===401 && url.indexOf('/api/login')===-1){
+            window.location='/login';
+          }
+          return resp;
+        });
+      };
+    })();
+
     function factoryReset(){
       if(!confirm('Wipe all settings?')) return;
       if(!confirm('Confirm Reset?')) return;
@@ -2306,6 +2401,39 @@
         showToast('Factory reset. Rebooting...','success');
       }).catch(e=>{
         showToast('Reset failed: '+e.message,'error');
+      });
+    }
+
+    function changeAdminPassword(){
+      var cur=$('admin_pw_current').value;
+      var nw=$('admin_pw_new').value;
+      var cf=$('admin_pw_confirm').value;
+      var status=$('admin_pw_status');
+      status.textContent='';
+      if(!cur){ status.textContent='Enter current password.'; status.style.color='#f66'; return; }
+      if(nw.length<4||nw.length>32){ status.textContent='New password must be 4-32 characters.'; status.style.color='#f66'; return; }
+      if(nw!==cf){ status.textContent='New passwords do not match.'; status.style.color='#f66'; return; }
+      fetch('/api/admin-password',{
+        method:'POST',
+        headers:{'Content-Type':'application/json'},
+        body:JSON.stringify({current:cur, new:nw})
+      }).then(r=>r.json().then(j=>({ok:r.ok,status:r.status,body:j}))).then(res=>{
+        if(res.ok){
+          status.textContent='Password updated. Existing session remains active; new sign-ins require the new password.';
+          status.style.color='#6c6';
+          $('admin_pw_current').value='';
+          $('admin_pw_new').value='';
+          $('admin_pw_confirm').value='';
+          showToast('Admin password updated','success');
+        }else{
+          var msg=(res.body&&res.body.error)?res.body.error:('HTTP '+res.status);
+          status.textContent='Failed: '+msg;
+          status.style.color='#f66';
+          showToast('Password change failed: '+msg,'error');
+        }
+      }).catch(e=>{
+        status.textContent='Error: '+e.message;
+        status.style.color='#f66';
       });
     }
 

--- a/main/login.html
+++ b/main/login.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Sign in - NINA Display</title>
+<style>
+  html,body{margin:0;padding:0;height:100%;background:#0b0f17;color:#e5e7eb;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  body{display:flex;align-items:center;justify-content:center;min-height:100vh}
+  .card{background:#111827;border:1px solid #1f2937;border-radius:10px;padding:28px 28px 24px;width:320px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+  h1{font-size:18px;margin:0 0 4px;font-weight:600;letter-spacing:.2px}
+  .sub{font-size:12px;color:#9ca3af;margin:0 0 20px}
+  label{display:block;font-size:12px;color:#9ca3af;margin:0 0 6px}
+  input[type=password]{width:100%;box-sizing:border-box;background:#0b0f17;color:#e5e7eb;border:1px solid #273142;border-radius:6px;padding:10px 12px;font-size:14px;outline:none}
+  input[type=password]:focus{border-color:#3b82f6}
+  button{margin-top:14px;width:100%;background:#2563eb;color:#fff;border:0;border-radius:6px;padding:10px 12px;font-size:14px;font-weight:600;cursor:pointer}
+  button:hover{background:#1d4ed8}
+  button:disabled{background:#374151;cursor:not-allowed}
+  .err{color:#f87171;font-size:12px;margin-top:10px;min-height:16px}
+</style>
+</head>
+<body>
+  <form class="card" id="f" autocomplete="on">
+    <h1>NINA Display</h1>
+    <p class="sub">Sign in to access the configuration interface.</p>
+    <label for="p">Password</label>
+    <input id="p" type="password" autocomplete="current-password" autofocus required>
+    <button id="b" type="submit">Sign in</button>
+    <div class="err" id="e"></div>
+  </form>
+<script>
+(function(){
+  var f=document.getElementById('f'),p=document.getElementById('p'),
+      b=document.getElementById('b'),e=document.getElementById('e');
+  f.addEventListener('submit',function(ev){
+    ev.preventDefault();
+    e.textContent='';
+    b.disabled=true;
+    fetch('/api/login',{method:'POST',headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({password:p.value})})
+      .then(function(r){
+        if(r.ok){window.location='/';return;}
+        if(r.status===401){e.textContent='Incorrect password';}
+        else{e.textContent='Sign in failed (HTTP '+r.status+')';}
+        b.disabled=false;
+        p.select();
+      })
+      .catch(function(){e.textContent='Network error';b.disabled=false;});
+  });
+})();
+</script>
+</body>
+</html>

--- a/main/web_handlers_auth.c
+++ b/main/web_handlers_auth.c
@@ -1,0 +1,158 @@
+#include "web_server_internal.h"
+#include <string.h>
+#include <stdio.h>
+#include "esp_heap_caps.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/portmacro.h"
+
+/* ---- Login rate limiting (global, not per-IP) ---- */
+#define LOGIN_MAX_FAILURES 5
+#define LOGIN_LOCKOUT_SEC  30
+
+static int s_login_failures = 0;
+static int64_t s_login_lockout_until_us = 0;
+static portMUX_TYPE s_login_mux = portMUX_INITIALIZER_UNLOCKED;
+
+extern const uint8_t login_html_start[] asm("_binary_login_html_start");
+extern const uint8_t login_html_end[]   asm("_binary_login_html_end");
+
+/* GET /login — serves the static login page (unauthenticated). */
+esp_err_t login_page_get_handler(httpd_req_t *req)
+{
+    httpd_resp_set_type(req, "text/html");
+    /* No caching: avoids stale copy after logout/password change */
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store");
+    httpd_resp_send(req, (const char *)login_html_start,
+                    login_html_end - login_html_start);
+    return ESP_OK;
+}
+
+/* POST /api/login — verify password, issue session cookie. Unauthenticated. */
+esp_err_t login_post_handler(httpd_req_t *req)
+{
+    /* Rate limit: if globally locked out, reject without checking password.
+     * Skip rate-limit when auth is disabled — there's no security value, and
+     * a prank flood of bad passwords would otherwise lock the legitimate user
+     * out of re-enabling auth. */
+    const app_config_t *cfg_rl = app_config_get();
+    bool auth_off = (cfg_rl && !cfg_rl->auth_enabled);
+    int64_t now_us = esp_timer_get_time();
+    int64_t lockout_remaining_us = 0;
+    portENTER_CRITICAL(&s_login_mux);
+    if (!auth_off && now_us < s_login_lockout_until_us) {
+        lockout_remaining_us = s_login_lockout_until_us - now_us;
+    }
+    portEXIT_CRITICAL(&s_login_mux);
+    if (lockout_remaining_us > 0) {
+        int retry_s = (int)((lockout_remaining_us + 999999) / 1000000);
+        if (retry_s < 1) retry_s = 1;
+        char body[96];
+        snprintf(body, sizeof(body),
+                 "{\"error\":\"too many failed attempts, try again later\","
+                 "\"retry_after_s\":%d}", retry_s);
+        char retry_hdr[16];
+        snprintf(retry_hdr, sizeof(retry_hdr), "%d", retry_s);
+        httpd_resp_set_status(req, "429 Too Many Requests");
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_set_hdr(req, "Retry-After", retry_hdr);
+        httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    int remaining = req->content_len;
+    if (remaining <= 0 || remaining > 256) {
+        return send_400(req, "Invalid payload size");
+    }
+    char *buf = heap_caps_malloc(remaining + 1, MALLOC_CAP_SPIRAM);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+    int received = 0;
+    while (received < remaining) {
+        int ret = httpd_req_recv(req, buf + received, remaining - received);
+        if (ret <= 0) {
+            heap_caps_free(buf);
+            httpd_resp_send_408(req);
+            return ESP_OK;
+        }
+        received += ret;
+    }
+    buf[received] = '\0';
+
+    cJSON *root = cJSON_Parse(buf);
+    heap_caps_free(buf);
+    if (!root) return send_400(req, "Invalid JSON");
+
+    cJSON *pw_item = cJSON_GetObjectItem(root, "password");
+    if (!cJSON_IsString(pw_item)) {
+        cJSON_Delete(root);
+        return send_400(req, "Missing 'password' string");
+    }
+
+    const char *pw = pw_item->valuestring;
+    const app_config_t *cfg = app_config_get();
+
+    /* Constant-time compare */
+    size_t a = strlen(pw);
+    size_t b = strlen(cfg->admin_password);
+    unsigned char diff = (a != b) ? 1 : 0;
+    size_t n = (a < b) ? a : b;
+    for (size_t i = 0; i < n; i++) {
+        diff |= (unsigned char)pw[i] ^ (unsigned char)cfg->admin_password[i];
+    }
+    cJSON_Delete(root);
+
+    if (diff != 0 || cfg->admin_password[0] == '\0') {
+        /* Failed attempt: bump counter, engage lockout at threshold. */
+        bool engaged = false;
+        portENTER_CRITICAL(&s_login_mux);
+        s_login_failures++;
+        if (s_login_failures >= LOGIN_MAX_FAILURES) {
+            s_login_lockout_until_us =
+                esp_timer_get_time() + (int64_t)LOGIN_LOCKOUT_SEC * 1000000LL;
+            s_login_failures = 0;
+            engaged = true;
+        }
+        portEXIT_CRITICAL(&s_login_mux);
+        if (engaged) {
+            ESP_LOGW(TAG, "login lockout engaged for %d seconds", LOGIN_LOCKOUT_SEC);
+        }
+        httpd_resp_set_status(req, "401 Unauthorized");
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send(req, "{\"error\":\"invalid password\"}", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    /* Successful login: clear failure counter and any lockout. */
+    portENTER_CRITICAL(&s_login_mux);
+    s_login_failures = 0;
+    s_login_lockout_until_us = 0;
+    portEXIT_CRITICAL(&s_login_mux);
+
+    const char *token = session_create();
+    char cookie[160];
+    snprintf(cookie, sizeof(cookie),
+             "session=%s; Path=/; HttpOnly; Max-Age=43200; SameSite=Lax",
+             token);
+    httpd_resp_set_hdr(req, "Set-Cookie", cookie);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}
+
+/* POST /api/logout — destroy session, clear cookie. Requires auth. */
+esp_err_t logout_post_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+    char tok[80];
+    if (session_extract_cookie(req, tok, sizeof(tok))) {
+        session_destroy(tok);
+    }
+    httpd_resp_set_hdr(req, "Set-Cookie",
+                       "session=; Path=/; HttpOnly; Max-Age=0; SameSite=Lax");
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -14,6 +14,7 @@ extern const uint8_t favicon_png_end[]   asm("_binary_favicon_png_end");
 // Handler for root URL
 esp_err_t root_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     httpd_resp_set_type(req, "text/html");
     httpd_resp_send(req, (const char *)config_html_start,
                     config_html_end - config_html_start);
@@ -137,12 +138,16 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     cJSON_AddBoolToObject(obj, "idle_page_persistent", cfg->idle_page_persistent);
     cJSON_AddBoolToObject(obj, "idle_indicator_enabled", cfg->idle_indicator_enabled);
 
+    // Authentication
+    cJSON_AddBoolToObject(obj, "auth_enabled", cfg->auth_enabled);
+
     return obj;
 }
 
 // Handler for getting config
 esp_err_t config_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     app_config_t *cfg = app_config_get();
     cJSON *root = serialize_config_to_json(cfg);
     if (root == NULL) {
@@ -150,16 +155,35 @@ esp_err_t config_get_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    /* WiFi networks: serialize from app_config. Passwords never exposed. */
+    /* Redact secrets. Real values are never exposed via GET /api/config.
+     * The UI round-trips the "********" sentinel via POST and the server
+     * preserves the existing NVS value when it sees that sentinel. */
+    #define REDACT_STRING_FIELD(key) do { \
+        cJSON_DeleteItemFromObject(root, #key); \
+        if (cfg->key[0] != '\0') cJSON_AddStringToObject(root, #key, "********"); \
+        else                     cJSON_AddStringToObject(root, #key, ""); \
+    } while (0)
+    REDACT_STRING_FIELD(mqtt_password);
+    REDACT_STRING_FIELD(spotify_client_id);
+    #undef REDACT_STRING_FIELD
+    /* admin_password is never serialized by serialize_config_to_json() at all. */
+
+    /* WiFi networks: serialize from app_config. SSIDs exposed; passwords
+     * replaced with "********" (sentinel) when present so the UI can
+     * round-trip without knowing the real value. */
     {
         cJSON *wifi_arr = cJSON_AddArrayToObject(root, "wifi_networks");
         for (int i = 0; i < 3; i++) {
             cJSON *net = cJSON_CreateObject();
             cJSON_AddStringToObject(net, "ssid", cfg->wifi_networks[i].ssid);
+            cJSON_AddStringToObject(net, "password",
+                cfg->wifi_networks[i].password[0] != '\0' ? "********" : "");
             cJSON_AddItemToArray(wifi_arr, net);
         }
         /* Backward compat: expose primary SSID as top-level "ssid" */
         cJSON_AddStringToObject(root, "ssid", cfg->wifi_networks[0].ssid);
+        cJSON_AddStringToObject(root, "wifi_password",
+            cfg->wifi_networks[0].password[0] != '\0' ? "********" : "");
     }
 
     cJSON_AddBoolToObject(root, "_dirty", app_config_is_dirty());
@@ -282,6 +306,7 @@ static const backup_field_t s_backup_fields[] = {
     {"idle_page_override_target", "Idle Override Target",   "Behavior", false, false},
     {"idle_page_persistent",     "Idle Page Persistent",   "Behavior", false, false},
     {"idle_indicator_enabled",   "Idle Indicator Enabled", "Behavior", false, false},
+    {"auth_enabled",             "Authentication Enabled", "System",   false, false},
 
     /* Sensitive */
     {"weather_api_key",    "Weather API Key",    "Weather", true, false},
@@ -590,7 +615,14 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_BOOL  (root, "mqtt_enabled",   cfg->mqtt_enabled);
     JSON_TO_STRING(root, "mqtt_broker_url", cfg->mqtt_broker_url);
     JSON_TO_STRING(root, "mqtt_username",  cfg->mqtt_username);
-    JSON_TO_STRING(root, "mqtt_password",  cfg->mqtt_password);
+    /* mqtt_password: skip write if value equals "********" sentinel */
+    {
+        cJSON *_mp = cJSON_GetObjectItem(root, "mqtt_password");
+        if (cJSON_IsString(_mp) && strcmp(_mp->valuestring, "********") != 0) {
+            strncpy(cfg->mqtt_password, _mp->valuestring, sizeof(cfg->mqtt_password) - 1);
+            cfg->mqtt_password[sizeof(cfg->mqtt_password) - 1] = '\0';
+        }
+    }
     JSON_TO_STRING(root, "mqtt_topic_prefix", cfg->mqtt_topic_prefix);
 
     // Clamped int fields
@@ -774,7 +806,15 @@ static app_config_t *parse_config_from_json(cJSON *root)
     }
 
     JSON_TO_BOOL  (root, "spotify_enabled",           cfg->spotify_enabled);
-    JSON_TO_STRING(root, "spotify_client_id",          cfg->spotify_client_id);
+    /* spotify_client_id: skip write if value equals "********" sentinel */
+    {
+        cJSON *_scid = cJSON_GetObjectItem(root, "spotify_client_id");
+        if (cJSON_IsString(_scid) && strcmp(_scid->valuestring, "********") != 0) {
+            strncpy(cfg->spotify_client_id, _scid->valuestring, sizeof(cfg->spotify_client_id) - 1);
+            cfg->spotify_client_id[sizeof(cfg->spotify_client_id) - 1] = '\0';
+        }
+    }
+    /* admin_password is never accepted via /api/config — use /api/admin-password. */
     JSON_TO_INT   (root, "spotify_poll_interval_ms",   cfg->spotify_poll_interval_ms);
     JSON_TO_BOOL  (root, "spotify_show_progress_bar",  cfg->spotify_show_progress_bar);
     JSON_TO_BOOL  (root, "spotify_minimal_mode",       cfg->spotify_minimal_mode);
@@ -827,6 +867,9 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_BOOL(root, "idle_page_persistent", cfg->idle_page_persistent);
     JSON_TO_BOOL(root, "idle_indicator_enabled", cfg->idle_indicator_enabled);
 
+    // Authentication toggle
+    JSON_TO_BOOL(root, "auth_enabled", cfg->auth_enabled);
+
     return cfg;
 }
 
@@ -876,6 +919,7 @@ static cJSON *receive_json_body(httpd_req_t *req, int max_size)
 // Handler for saving config (persists to NVS)
 esp_err_t config_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     cJSON *root = receive_json_body(req, CONFIG_MAX_PAYLOAD);
     if (!root) return ESP_OK;
 
@@ -924,11 +968,15 @@ esp_err_t config_post_handler(httpd_req_t *req)
                             sizeof(cfg->wifi_networks[i].ssid) - 1);
                     cfg->wifi_networks[i].ssid[sizeof(cfg->wifi_networks[i].ssid) - 1] = '\0';
 
-                    if (cJSON_IsString(pass_item) && pass_item->valuestring[0] != '\0') {
+                    if (cJSON_IsString(pass_item) && pass_item->valuestring[0] != '\0' &&
+                        strcmp(pass_item->valuestring, "********") != 0) {
                         memset(cfg->wifi_networks[i].password, 0,
                                sizeof(cfg->wifi_networks[i].password));
                         strncpy(cfg->wifi_networks[i].password, pass_item->valuestring,
                                 sizeof(cfg->wifi_networks[i].password) - 1);
+                    } else if (cJSON_IsString(pass_item) &&
+                               strcmp(pass_item->valuestring, "********") == 0) {
+                        /* Sentinel: preserve existing password. */
                     } else if (ssid_changed) {
                         memset(cfg->wifi_networks[i].password, 0,
                                sizeof(cfg->wifi_networks[i].password));
@@ -955,7 +1003,8 @@ esp_err_t config_post_handler(httpd_req_t *req)
             strncpy(cfg->wifi_networks[0].ssid, ssid_item->valuestring,
                     sizeof(cfg->wifi_networks[0].ssid) - 1);
             cfg->wifi_networks[0].ssid[sizeof(cfg->wifi_networks[0].ssid) - 1] = '\0';
-            if (cJSON_IsString(pass_item) && pass_item->valuestring[0] != '\0') {
+            if (cJSON_IsString(pass_item) && pass_item->valuestring[0] != '\0' &&
+                strcmp(pass_item->valuestring, "********") != 0) {
                 memset(cfg->wifi_networks[0].password, 0,
                        sizeof(cfg->wifi_networks[0].password));
                 strncpy(cfg->wifi_networks[0].password, pass_item->valuestring,
@@ -988,6 +1037,7 @@ esp_err_t config_post_handler(httpd_req_t *req)
 // Handler for live-applying config (in-memory only, no NVS)
 esp_err_t config_apply_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     cJSON *root = receive_json_body(req, CONFIG_MAX_PAYLOAD);
     if (!root) return ESP_OK;
 
@@ -1023,6 +1073,7 @@ esp_err_t config_apply_handler(httpd_req_t *req)
 // Handler for reverting config to NVS-saved state
 esp_err_t config_revert_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     app_config_t *old_cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
     if (!old_cfg) {
         ESP_LOGE(TAG, "config_revert: malloc failed for old_cfg");
@@ -1049,6 +1100,7 @@ esp_err_t config_revert_handler(httpd_req_t *req)
 
 esp_err_t backup_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     /* Check include_sensitive query param */
     bool include_sensitive = false;
     {
@@ -1061,6 +1113,16 @@ esp_err_t backup_get_handler(httpd_req_t *req)
         }
     }
 
+    /* Safety rail: if authentication is disabled, secrets must NEVER be
+     * returned in any API response — including this backup endpoint. A caller
+     * that explicitly requests include_sensitive=1 on an open device still
+     * gets a redacted backup. */
+    app_config_t *cfg = app_config_get();
+    if (!cfg->auth_enabled && include_sensitive) {
+        ESP_LOGI(TAG, "backup: include_sensitive forced off (auth disabled)");
+        include_sensitive = false;
+    }
+
     /* Build root JSON */
     cJSON *root = cJSON_CreateObject();
     if (!root) { httpd_resp_send_500(req); return ESP_FAIL; }
@@ -1070,9 +1132,6 @@ esp_err_t backup_get_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(meta, "config_version", APP_CONFIG_VERSION);
     cJSON_AddStringToObject(meta, "firmware_version", BUILD_GIT_TAG);
     cJSON_AddStringToObject(meta, "git_sha", BUILD_GIT_SHA);
-
-    /* Hostname */
-    app_config_t *cfg = app_config_get();
     cJSON_AddStringToObject(meta, "hostname", cfg->hostname);
 
     /* MAC address */
@@ -1126,6 +1185,33 @@ esp_err_t backup_get_handler(httpd_req_t *req)
         }
     }
 
+    /* Inject fields that serialize_config_to_json() does NOT emit (admin_password,
+     * wifi_networks array, wifi_password legacy). Without these, a restore from
+     * a "full" backup would wipe device credentials. Only included when
+     * include_sensitive=1 (matches the existing sensitive-section gating). */
+    if (sensitive_section) {
+        cJSON_AddStringToObject(sensitive_section, "admin_password", cfg->admin_password);
+        /* mqtt_password, spotify_client_id, weather_api_key already emitted by
+         * serialize_config_to_json() and routed into sensitive_section by the
+         * s_backup_fields registry above. */
+
+        /* wifi_networks: full array with real ssid + password per entry */
+        cJSON *wifi_arr = cJSON_CreateArray();
+        for (int i = 0; i < 3; i++) {
+            cJSON *net = cJSON_CreateObject();
+            cJSON_AddStringToObject(net, "ssid", cfg->wifi_networks[i].ssid);
+            cJSON_AddStringToObject(net, "password", cfg->wifi_networks[i].password);
+            /* Mirror as "pass" too — config_post handler reads "pass" key */
+            cJSON_AddStringToObject(net, "pass", cfg->wifi_networks[i].password);
+            cJSON_AddItemToArray(wifi_arr, net);
+        }
+        cJSON_AddItemToObject(sensitive_section, "wifi_networks", wifi_arr);
+
+        /* Legacy top-level wifi_password = wifi_networks[0].password */
+        cJSON_AddStringToObject(sensitive_section, "wifi_password",
+                                cfg->wifi_networks[0].password);
+    }
+
     cJSON_AddItemToObject(root, "config", config_section);
     if (sensitive_section) {
         cJSON_AddItemToObject(root, "sensitive", sensitive_section);
@@ -1171,6 +1257,7 @@ esp_err_t backup_get_handler(httpd_req_t *req)
 
 esp_err_t restore_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     cJSON *root = receive_json_body(req, CONFIG_MAX_RESTORE_PAYLOAD);
     if (!root) return ESP_OK;  /* error already sent */
 
@@ -1245,6 +1332,14 @@ esp_err_t restore_post_handler(httpd_req_t *req)
                 for (const backup_field_t *f = s_backup_fields; f->json_key; f++) {
                     if (strcmp(f->json_key, item->string) == 0) { known = true; break; }
                 }
+                /* Also allow credential fields not in the registry (admin_password,
+                 * wifi_networks array, wifi_password legacy compat). */
+                if (!known && item->string &&
+                    (strcmp(item->string, "admin_password") == 0 ||
+                     strcmp(item->string, "wifi_networks") == 0 ||
+                     strcmp(item->string, "wifi_password") == 0)) {
+                    known = true;
+                }
                 if (known) {
                     cJSON_DeleteItemFromObject(merged, item->string);
                     cJSON_AddItemToObject(merged, item->string, cJSON_Duplicate(item, true));
@@ -1261,13 +1356,73 @@ esp_err_t restore_post_handler(httpd_req_t *req)
 
         /* Parse into config struct using existing parse_config_from_json */
         app_config_t *new_cfg = parse_config_from_json(merged);
-        cJSON_Delete(merged);
-        cJSON_Delete(root);
 
         if (!new_cfg) {
+            cJSON_Delete(merged);
+            cJSON_Delete(root);
             httpd_resp_send_500(req);
             return ESP_OK;
         }
+
+        /* parse_config_from_json() does not handle admin_password or the
+         * wifi_networks[] array. Apply them here from the merged backup. */
+        {
+            cJSON *ap = cJSON_GetObjectItem(merged, "admin_password");
+            if (cJSON_IsString(ap) && ap->valuestring[0] != '\0' &&
+                strcmp(ap->valuestring, "********") != 0) {
+                strncpy(new_cfg->admin_password, ap->valuestring,
+                        sizeof(new_cfg->admin_password) - 1);
+                new_cfg->admin_password[sizeof(new_cfg->admin_password) - 1] = '\0';
+            }
+
+            cJSON *warr = cJSON_GetObjectItem(merged, "wifi_networks");
+            if (cJSON_IsArray(warr)) {
+                int count = cJSON_GetArraySize(warr);
+                if (count > 3) count = 3;
+                for (int i = 0; i < count; i++) {
+                    cJSON *net = cJSON_GetArrayItem(warr, i);
+                    if (!cJSON_IsObject(net)) continue;
+                    cJSON *sid = cJSON_GetObjectItem(net, "ssid");
+                    /* Accept either "password" (backup format) or "pass" (legacy). */
+                    cJSON *pwd = cJSON_GetObjectItem(net, "password");
+                    if (!cJSON_IsString(pwd)) pwd = cJSON_GetObjectItem(net, "pass");
+
+                    if (cJSON_IsString(sid)) {
+                        if (sid->valuestring[0] == '\0') {
+                            memset(&new_cfg->wifi_networks[i], 0,
+                                   sizeof(wifi_network_t));
+                        } else {
+                            strncpy(new_cfg->wifi_networks[i].ssid,
+                                    sid->valuestring,
+                                    sizeof(new_cfg->wifi_networks[i].ssid) - 1);
+                            new_cfg->wifi_networks[i].ssid[
+                                sizeof(new_cfg->wifi_networks[i].ssid) - 1] = '\0';
+                            if (cJSON_IsString(pwd) &&
+                                strcmp(pwd->valuestring, "********") != 0) {
+                                memset(new_cfg->wifi_networks[i].password, 0,
+                                       sizeof(new_cfg->wifi_networks[i].password));
+                                strncpy(new_cfg->wifi_networks[i].password,
+                                        pwd->valuestring,
+                                        sizeof(new_cfg->wifi_networks[i].password) - 1);
+                            }
+                        }
+                    }
+                }
+            } else {
+                /* Legacy top-level wifi_password (maps to wifi_networks[0]) */
+                cJSON *wp = cJSON_GetObjectItem(merged, "wifi_password");
+                if (cJSON_IsString(wp) && wp->valuestring[0] != '\0' &&
+                    strcmp(wp->valuestring, "********") != 0) {
+                    memset(new_cfg->wifi_networks[0].password, 0,
+                           sizeof(new_cfg->wifi_networks[0].password));
+                    strncpy(new_cfg->wifi_networks[0].password, wp->valuestring,
+                            sizeof(new_cfg->wifi_networks[0].password) - 1);
+                }
+            }
+        }
+
+        cJSON_Delete(merged);
+        cJSON_Delete(root);
 
         /* Save to NVS and trigger side effects */
         app_config_t *old_cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -104,6 +104,7 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
 // Handler for live brightness adjustment (no reboot needed)
 esp_err_t brightness_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[128];
     int ret, remaining = req->content_len;
 
@@ -146,6 +147,7 @@ esp_err_t brightness_post_handler(httpd_req_t *req)
 // Handler for live color brightness adjustment (no reboot needed)
 esp_err_t color_brightness_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[128];
     int ret, remaining = req->content_len;
 
@@ -197,6 +199,7 @@ esp_err_t color_brightness_post_handler(httpd_req_t *req)
 // Handler for live theme switching (no reboot needed)
 esp_err_t theme_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[128];
     int ret, remaining = req->content_len;
 
@@ -244,6 +247,7 @@ esp_err_t theme_post_handler(httpd_req_t *req)
 // Handler for live widget style switching (no reboot needed)
 esp_err_t widget_style_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[128];
     int ret, remaining = req->content_len;
 
@@ -291,6 +295,7 @@ esp_err_t widget_style_post_handler(httpd_req_t *req)
 // Handler for live page switching (saves override and switches immediately)
 esp_err_t page_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[64];
     int ret, remaining = req->content_len;
 
@@ -343,6 +348,7 @@ esp_err_t page_post_handler(httpd_req_t *req)
 // Handler for live screen rotation adjustment (no reboot needed)
 esp_err_t screen_rotation_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[64];
     int ret, remaining = req->content_len;
 
@@ -411,6 +417,7 @@ void screenshot_encoder_init(void)
 // Handler for screenshot capture - serves a JPEG image via hardware encoder
 esp_err_t screenshot_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     ESP_LOGI(TAG, "Screenshot requested");
 
     if (!s_jpeg_encoder) {

--- a/main/web_handlers_spotify.c
+++ b/main/web_handlers_spotify.c
@@ -8,6 +8,7 @@
  */
 esp_err_t spotify_config_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     app_config_t *cfg = app_config_get();
     cJSON *root = cJSON_CreateObject();
     if (root == NULL) {
@@ -43,6 +44,7 @@ esp_err_t spotify_config_get_handler(httpd_req_t *req)
  */
 esp_err_t spotify_config_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[CONFIG_MAX_PAYLOAD];
     int received = httpd_req_recv(req, buf, sizeof(buf) - 1);
     if (received <= 0) {
@@ -139,6 +141,7 @@ esp_err_t spotify_callback_get_handler(httpd_req_t *req)
  */
 esp_err_t spotify_token_exchange_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[CONFIG_MAX_PAYLOAD];
     int received = httpd_req_recv(req, buf, sizeof(buf) - 1);
     if (received <= 0) {
@@ -181,6 +184,7 @@ esp_err_t spotify_token_exchange_post_handler(httpd_req_t *req)
  */
 esp_err_t spotify_logout_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     spotify_auth_logout();
 
     httpd_resp_set_type(req, "application/json");
@@ -193,6 +197,7 @@ esp_err_t spotify_logout_post_handler(httpd_req_t *req)
  */
 esp_err_t spotify_status_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     cJSON *root = cJSON_CreateObject();
     if (root == NULL) {
         httpd_resp_send_500(req);
@@ -233,6 +238,7 @@ esp_err_t spotify_status_get_handler(httpd_req_t *req)
  */
 esp_err_t spotify_control_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     char buf[256];
     int received = httpd_req_recv(req, buf, sizeof(buf) - 1);
     if (received <= 0) {

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -26,6 +26,7 @@
 // Handler for reboot
 esp_err_t reboot_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     httpd_resp_send(req, "Rebooting...", HTTPD_RESP_USE_STRLEN);
     // Delay slightly to let the response go out
     vTaskDelay(pdMS_TO_TICKS(100));
@@ -36,6 +37,7 @@ esp_err_t reboot_post_handler(httpd_req_t *req)
 // Handler for check-update (triggers on-demand OTA check on device)
 esp_err_t check_update_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     ota_check_requested = true;
     httpd_resp_send(req, "OK", HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
@@ -44,6 +46,7 @@ esp_err_t check_update_post_handler(httpd_req_t *req)
 // Handler for factory reset
 esp_err_t factory_reset_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     ESP_LOGW(TAG, "Factory reset requested via web interface");
     httpd_resp_send(req, "Factory reset initiated...", HTTPD_RESP_USE_STRLEN);
 
@@ -202,6 +205,7 @@ static void ota_restore_network(void) {
 
 esp_err_t ota_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     ESP_LOGI(TAG, "OTA update started, content length: %d", req->content_len);
 
     if (req->content_len <= 0) {
@@ -407,6 +411,7 @@ esp_err_t check_update_json_handler(httpd_req_t *req)
 // Handler for GitHub OTA download (triggered from web UI)
 esp_err_t ota_github_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     /* Read JSON body with release tag to install */
     char body[64];
     int received = httpd_req_recv(req, body, sizeof(body) - 1);
@@ -461,6 +466,7 @@ esp_err_t ota_github_post_handler(httpd_req_t *req)
 // Handler for performance profiling data
 esp_err_t perf_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     httpd_resp_set_type(req, "application/json");
     if (!g_perf.enabled) {
         httpd_resp_sendstr(req, "{\"enabled\":false}");
@@ -480,6 +486,7 @@ esp_err_t perf_get_handler(httpd_req_t *req)
 // Handler for resetting performance metrics
 esp_err_t perf_reset_post_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     httpd_resp_set_type(req, "application/json");
     if (!g_perf.enabled) {
         httpd_resp_sendstr(req, "{\"error\":\"Debug mode not enabled\"}");
@@ -529,6 +536,7 @@ esp_err_t status_get_handler(httpd_req_t *req)
 // Handler for per-instance NINA connection health (test automation)
 esp_err_t nina_status_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     const app_config_t *cfg = app_config_get();
 
     cJSON *root = cJSON_CreateObject();
@@ -625,5 +633,90 @@ esp_err_t crash_get_handler(httpd_req_t *req)
     httpd_resp_send(req, json_str, HTTPD_RESP_USE_STRLEN);
     free((void *)json_str);
     cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// Handler for changing the admin password. Requires the current password.
+esp_err_t admin_password_post_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    int remaining = req->content_len;
+    if (remaining <= 0 || remaining > 512) {
+        return send_400(req, "Invalid payload size");
+    }
+    char *buf = heap_caps_malloc(remaining + 1, MALLOC_CAP_SPIRAM);
+    if (!buf) {
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+    int received = 0;
+    while (received < remaining) {
+        int ret = httpd_req_recv(req, buf + received, remaining - received);
+        if (ret <= 0) {
+            free(buf);
+            httpd_resp_send_408(req);
+            return ESP_OK;
+        }
+        received += ret;
+    }
+    buf[received] = '\0';
+
+    cJSON *root = cJSON_Parse(buf);
+    free(buf);
+    if (!root) return send_400(req, "Invalid JSON");
+
+    cJSON *cur_item = cJSON_GetObjectItem(root, "current");
+    cJSON *new_item = cJSON_GetObjectItem(root, "new");
+    if (!cJSON_IsString(cur_item) || !cJSON_IsString(new_item)) {
+        cJSON_Delete(root);
+        return send_400(req, "Missing 'current' or 'new' string");
+    }
+    const char *cur_pw = cur_item->valuestring;
+    const char *new_pw = new_item->valuestring;
+
+    /* Validate new password length (4-32 chars) */
+    size_t new_len = strlen(new_pw);
+    if (new_len < 4 || new_len > 32) {
+        cJSON_Delete(root);
+        return send_400(req, "New password must be 4-32 characters");
+    }
+
+    /* Constant-time compare of current against stored */
+    const app_config_t *live = app_config_get();
+    size_t a = strlen(cur_pw);
+    size_t b = strlen(live->admin_password);
+    unsigned char diff = (a != b) ? 1 : 0;
+    size_t n = (a < b) ? a : b;
+    for (size_t i = 0; i < n; i++) {
+        diff |= (unsigned char)cur_pw[i] ^ (unsigned char)live->admin_password[i];
+    }
+    if (diff != 0) {
+        cJSON_Delete(root);
+        httpd_resp_set_status(req, "403 Forbidden");
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send(req, "{\"error\":\"current password incorrect\"}", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    /* Apply + persist */
+    app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+    if (!cfg) {
+        cJSON_Delete(root);
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+    memcpy(cfg, live, sizeof(app_config_t));
+    memset(cfg->admin_password, 0, sizeof(cfg->admin_password));
+    strncpy(cfg->admin_password, new_pw, sizeof(cfg->admin_password) - 1);
+
+    app_config_apply(cfg);
+    app_config_save(cfg);
+    free(cfg);
+    cJSON_Delete(root);
+
+    ESP_LOGI(TAG, "Admin password updated");
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -1,6 +1,162 @@
 #include "web_server.h"
 #include "web_server_internal.h"
 #include <string.h>
+#include "esp_random.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+
+/* ---- Session store ---- */
+#define MAX_SESSIONS 8
+#define SESSION_TOKEN_BYTES 32                         /* raw bytes */
+#define SESSION_TOKEN_HEX_LEN (SESSION_TOKEN_BYTES * 2) /* 64 hex chars */
+#define SESSION_TTL_SEC (12 * 3600)
+
+typedef struct {
+    char token[SESSION_TOKEN_HEX_LEN + 1];
+    int64_t expires_us;
+} session_t;
+
+static session_t s_sessions[MAX_SESSIONS];
+static portMUX_TYPE s_sessions_mux = portMUX_INITIALIZER_UNLOCKED;
+
+static void hex_encode(const uint8_t *in, size_t in_len, char *out) {
+    static const char hex[] = "0123456789abcdef";
+    for (size_t i = 0; i < in_len; i++) {
+        out[i * 2]     = hex[(in[i] >> 4) & 0xF];
+        out[i * 2 + 1] = hex[ in[i]       & 0xF];
+    }
+    out[in_len * 2] = '\0';
+}
+
+const char *session_create(void) {
+    uint8_t raw[SESSION_TOKEN_BYTES];
+    esp_fill_random(raw, sizeof(raw));
+    char hex[SESSION_TOKEN_HEX_LEN + 1];
+    hex_encode(raw, sizeof(raw), hex);
+
+    int64_t now_us = esp_timer_get_time();
+    int64_t expiry = now_us + (int64_t)SESSION_TTL_SEC * 1000000LL;
+
+    const char *result = NULL;
+    taskENTER_CRITICAL(&s_sessions_mux);
+    /* Prefer empty slot; otherwise oldest */
+    int target = -1;
+    int64_t oldest = INT64_MAX;
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (s_sessions[i].token[0] == '\0') { target = i; break; }
+        if (s_sessions[i].expires_us < oldest) {
+            oldest = s_sessions[i].expires_us;
+            target = i;
+        }
+    }
+    memcpy(s_sessions[target].token, hex, sizeof(hex));
+    s_sessions[target].expires_us = expiry;
+    result = s_sessions[target].token;
+    taskEXIT_CRITICAL(&s_sessions_mux);
+    return result;
+}
+
+bool session_valid(const char *token) {
+    if (!token || token[0] == '\0') return false;
+    size_t len = strlen(token);
+    if (len != SESSION_TOKEN_HEX_LEN) return false;
+    int64_t now_us = esp_timer_get_time();
+    bool ok = false;
+    taskENTER_CRITICAL(&s_sessions_mux);
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (s_sessions[i].token[0] == '\0') continue;
+        if (s_sessions[i].expires_us <= now_us) {
+            /* Opportunistic purge */
+            memset(&s_sessions[i], 0, sizeof(s_sessions[i]));
+            continue;
+        }
+        /* Constant-time compare */
+        unsigned char diff = 0;
+        for (size_t k = 0; k < SESSION_TOKEN_HEX_LEN; k++) {
+            diff |= (unsigned char)s_sessions[i].token[k] ^ (unsigned char)token[k];
+        }
+        if (diff == 0) { ok = true; /* keep scanning to purge, but can break */ break; }
+    }
+    taskEXIT_CRITICAL(&s_sessions_mux);
+    return ok;
+}
+
+void session_destroy(const char *token) {
+    if (!token || token[0] == '\0') return;
+    taskENTER_CRITICAL(&s_sessions_mux);
+    for (int i = 0; i < MAX_SESSIONS; i++) {
+        if (s_sessions[i].token[0] == '\0') continue;
+        if (strncmp(s_sessions[i].token, token, SESSION_TOKEN_HEX_LEN) == 0) {
+            memset(&s_sessions[i], 0, sizeof(s_sessions[i]));
+            break;
+        }
+    }
+    taskEXIT_CRITICAL(&s_sessions_mux);
+}
+
+bool session_extract_cookie(httpd_req_t *req, char *out, size_t out_len) {
+    if (out_len < SESSION_TOKEN_HEX_LEN + 1) return false;
+    size_t hdr_len = httpd_req_get_hdr_value_len(req, "Cookie");
+    if (hdr_len == 0 || hdr_len > 1024) return false;
+    char *buf = malloc(hdr_len + 1);
+    if (!buf) return false;
+    if (httpd_req_get_hdr_value_str(req, "Cookie", buf, hdr_len + 1) != ESP_OK) {
+        free(buf);
+        return false;
+    }
+    bool ok = false;
+    /* Scan for "session=" allowing leading whitespace/semicolons */
+    const char *p = buf;
+    while (p && *p) {
+        while (*p == ' ' || *p == ';') p++;
+        if (strncmp(p, "session=", 8) == 0) {
+            p += 8;
+            size_t n = 0;
+            while (p[n] && p[n] != ';' && n < out_len - 1) { out[n] = p[n]; n++; }
+            out[n] = '\0';
+            ok = (n == SESSION_TOKEN_HEX_LEN);
+            break;
+        }
+        /* Skip to next cookie */
+        const char *next = strchr(p, ';');
+        if (!next) break;
+        p = next + 1;
+    }
+    free(buf);
+    return ok;
+}
+
+bool check_session(httpd_req_t *req) {
+    /* When auth is disabled, every request is granted. Secrets are still
+     * redacted in API responses (see backup_get_handler, config_get_handler). */
+    const app_config_t *cfg = app_config_get();
+    if (cfg && !cfg->auth_enabled) return true;
+
+    char tok[SESSION_TOKEN_HEX_LEN + 1];
+    if (!session_extract_cookie(req, tok, sizeof(tok))) return false;
+    return session_valid(tok);
+}
+
+/**
+ * @brief Send an auth-required response.
+ *
+ * For browser page requests (URI does not start with /api/), issue a 302 redirect
+ * to /login so the user lands on the login page. For API requests, return 401
+ * with a JSON body so fetch() callers can detect and redirect client-side.
+ */
+esp_err_t send_auth_required(httpd_req_t *req) {
+    if (strncmp(req->uri, "/api/", 5) != 0) {
+        httpd_resp_set_status(req, "302 Found");
+        httpd_resp_set_hdr(req, "Location", "/login");
+        httpd_resp_send(req, NULL, 0);
+        return ESP_OK;
+    }
+    httpd_resp_set_status(req, "401 Unauthorized");
+    httpd_resp_set_type(req, "application/json");
+    const char *body = "{\"error\":\"authentication required\"}";
+    httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}
 
 /**
  * @brief Send an HTTP 400 response with a JSON error message.
@@ -40,7 +196,7 @@ void start_web_server(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 16384;
-    config.max_uri_handlers = 39;
+    config.max_uri_handlers = 43;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -93,6 +249,10 @@ void start_web_server(void)
         { "/api/status",                 HTTP_GET,  status_get_handler, NULL },
         { "/api/nina/status",            HTTP_GET,  nina_status_get_handler, NULL },
         { "/api/crash",                  HTTP_GET,  crash_get_handler, NULL },
+        { "/api/admin-password",         HTTP_POST, admin_password_post_handler, NULL },
+        { "/login",                      HTTP_GET,  login_page_get_handler, NULL },
+        { "/api/login",                  HTTP_POST, login_post_handler, NULL },
+        { "/api/logout",                 HTTP_POST, logout_post_handler, NULL },
     };
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -45,6 +45,24 @@ esp_err_t send_400(httpd_req_t *req, const char *message);
 bool validate_string_len(cJSON *root, const char *key, size_t max_len);
 bool validate_url_format(const char *url);
 
+/* ---- Session cookie auth (defined in web_server.c) ---- */
+bool check_session(httpd_req_t *req);
+esp_err_t send_auth_required(httpd_req_t *req);
+
+/* Session API used by login/logout handlers */
+const char *session_create(void);
+bool session_valid(const char *token);
+void session_destroy(const char *token);
+/* Extract session token from the request's Cookie header. Returns true if present.
+ * out buffer must hold at least 65 bytes (64 hex + NUL). */
+bool session_extract_cookie(httpd_req_t *req, char *out, size_t out_len);
+
+/**
+ * @brief Guard handler entry with session auth. Returns 401/302 if missing/invalid.
+ * Must be the first statement in the handler body.
+ */
+#define REQUIRE_AUTH(req) do { if (!check_session(req)) return send_auth_required(req); } while (0)
+
 /* ---- Handler forward declarations (registered by start_web_server) ---- */
 esp_err_t root_get_handler(httpd_req_t *req);
 esp_err_t favicon_get_handler(httpd_req_t *req);
@@ -82,4 +100,8 @@ esp_err_t restore_post_handler(httpd_req_t *req);
 esp_err_t status_get_handler(httpd_req_t *req);
 esp_err_t nina_status_get_handler(httpd_req_t *req);
 esp_err_t crash_get_handler(httpd_req_t *req);
+esp_err_t admin_password_post_handler(httpd_req_t *req);
+esp_err_t login_page_get_handler(httpd_req_t *req);
+esp_err_t login_post_handler(httpd_req_t *req);
+esp_err_t logout_post_handler(httpd_req_t *req);
 void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t *new_cfg);


### PR DESCRIPTION
### Summary
This PR adds a login screen and session-cookie authentication to the built-in web server, protecting sensitive data and actions. It redacts secrets from public API endpoints and provides an option to disable authentication while still keeping secrets hidden.

### Changes
*   Add session-cookie authentication to the web server, protecting all mutating endpoints and secret-bearing GET requests.
*   Introduce a login screen and a new settings page for managing authentication and changing the admin password.
*   Redact sensitive configuration values, such as passwords and API keys, from public API responses.
*   Allow users to disable authentication via system settings, though secret redaction remains active even when authentication is off.
*   Implement a login rate limit that locks out users for 30 seconds after five failed attempts.
*   Update the configuration structure to include settings for the admin password and authentication status.
*   Migrate existing devices to enable authentication with a default password, and the serial log warns if the default password is still in use.
*   Modify the firmware build script to support authenticated OTA updates.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-04-15T04:11:20.357Z | Generated by GitHub Actions</sub>