### PR TITLE
feat: add HTTP unreachable counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ A touchscreen dashboard for [N.I.N.A. astrophotography software](https://nightti
   </tr>
 </table>
 
-### Spotify Player
+### Spotify Slbum Art Display
 
 <table align="center">
   <tr>

--- a/main/nina_client.c
+++ b/main/nina_client.c
@@ -188,6 +188,7 @@ cJSON *http_get_json(const char *url) {
 
     perf_timer_start(&g_perf.http_request);
     perf_counter_increment(&g_perf.http_request_count);
+    bool ever_connected = false;
     for (int attempt = 0; attempt < HTTP_MAX_ATTEMPTS; attempt++) {
         if (attempt > 0) {
             perf_counter_increment(&g_perf.http_retry_count);
@@ -219,6 +220,7 @@ cJSON *http_get_json(const char *url) {
             if (reusing && reuse_slot) *reuse_slot = NULL;
             continue;  // Transport error — retryable
         }
+        ever_connected = true;
 
         int content_length = esp_http_client_fetch_headers(client);
         if (content_length < 0) {
@@ -322,7 +324,11 @@ cJSON *http_get_json(const char *url) {
     int host_len = host_end ? (int)(host_end - host) : (int)strlen(host);
     ESP_LOGW(TAG, "%.*s unreachable", host_len, host);
 
-    perf_counter_increment(&g_perf.http_failure_count);
+    if (ever_connected) {
+        perf_counter_increment(&g_perf.http_failure_count);
+    } else {
+        perf_counter_increment(&g_perf.http_unreachable_count);
+    }
     perf_timer_stop(&g_perf.http_request);
     return NULL;  // All attempts exhausted
 }

--- a/main/perf_monitor.c
+++ b/main/perf_monitor.c
@@ -390,6 +390,8 @@ void perf_monitor_report(void)
              g_perf.http_retry_count.per_interval, g_perf.http_retry_count.total);
     ESP_LOGI(TAG, "  HTTP failures:  %"PRIu32" (interval) / %"PRIu32" (total)",
              g_perf.http_failure_count.per_interval, g_perf.http_failure_count.total);
+    ESP_LOGI(TAG, "  HTTP unreachable:%"PRIu32" (interval) / %"PRIu32" (total)",
+             g_perf.http_unreachable_count.per_interval, g_perf.http_unreachable_count.total);
     ESP_LOGI(TAG, "  WS events:      %"PRIu32" (interval) / %"PRIu32" (total)",
              g_perf.ws_event_count.per_interval, g_perf.ws_event_count.total);
 
@@ -493,6 +495,7 @@ void perf_monitor_report(void)
     perf_counter_reset_interval(&g_perf.http_request_count);
     perf_counter_reset_interval(&g_perf.http_retry_count);
     perf_counter_reset_interval(&g_perf.http_failure_count);
+    perf_counter_reset_interval(&g_perf.http_unreachable_count);
     perf_counter_reset_interval(&g_perf.ws_event_count);
     perf_counter_reset_interval(&g_perf.json_parse_count);
     perf_counter_reset_interval(&g_perf.spotify_poll_count);
@@ -591,6 +594,7 @@ char *perf_monitor_report_json(void)
     cJSON_AddItemToObject(network, "http_request_count", counter_to_json(&g_perf.http_request_count));
     cJSON_AddItemToObject(network, "http_retry_count",   counter_to_json(&g_perf.http_retry_count));
     cJSON_AddItemToObject(network, "http_failure_count", counter_to_json(&g_perf.http_failure_count));
+    cJSON_AddItemToObject(network, "http_unreachable_count", counter_to_json(&g_perf.http_unreachable_count));
     cJSON_AddItemToObject(network, "ws_event_count",     counter_to_json(&g_perf.ws_event_count));
     cJSON_AddItemToObject(root, "network", network);
 

--- a/main/perf_monitor.h
+++ b/main/perf_monitor.h
@@ -84,7 +84,8 @@ typedef struct {
     perf_timer_t http_request;            // Individual HTTP request duration (per-request)
     perf_counter_t http_request_count;    // Total HTTP requests per reporting interval
     perf_counter_t http_retry_count;      // HTTP retries per interval
-    perf_counter_t http_failure_count;    // HTTP failures per interval
+    perf_counter_t http_failure_count;    // HTTP failures per interval (connected but failed)
+    perf_counter_t http_unreachable_count;// Host unreachable (connection refused/timeout)
     perf_counter_t ws_event_count;        // WebSocket events received per interval
 
     // JSON parsing


### PR DESCRIPTION
### Summary
This PR adds a new counter to distinguish between HTTP connection failures and request failures. This helps diagnose network issues by providing clearer insights into whether a server is unreachable or if requests are failing for other reasons.

### Changes
*   Adds an HTTP unreachable counter to track when a server cannot be reached.
*   Updates the performance monitoring system to track and report the new HTTP unreachable counter.
*   Increments the HTTP unreachable counter when the client fails to establish a connection.
*   Updates the `README.md` file.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-05-02T13:52:54.253Z | Generated by GitHub Actions</sub>