### PR TITLE
feat: pin ESP component versions and start Spotify immediately on first setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,7 +143,7 @@ jobs:
           # Hash is only saved after a successful build, so missing hash = no prior success
           if [ -f build/.build_config_hash ]; then
             OLD_HASH=$(cat build/.build_config_hash)
-            NEW_HASH=$(cat sdkconfig.defaults main/idf_component.yml main/CMakeLists.txt CMakeLists.txt version.txt 2>/dev/null | sha256sum | cut -d' ' -f1)
+            NEW_HASH=$(cat sdkconfig.defaults main/idf_component.yml main/CMakeLists.txt CMakeLists.txt dependencies.lock 2>/dev/null | sha256sum | cut -d' ' -f1)
             if [ "$OLD_HASH" != "$NEW_HASH" ]; then
               echo "Build config changed, cleaning"
               NEEDS_CLEAN=true
@@ -171,7 +171,7 @@ jobs:
       - name: Save build config hash
         if: steps.check_skip.outputs.skip != 'true'
         run: |
-          cat sdkconfig.defaults main/idf_component.yml main/CMakeLists.txt CMakeLists.txt version.txt 2>/dev/null | sha256sum | cut -d' ' -f1 > build/.build_config_hash
+          cat sdkconfig.defaults main/idf_component.yml main/CMakeLists.txt CMakeLists.txt dependencies.lock 2>/dev/null | sha256sum | cut -d' ' -f1 > build/.build_config_hash
 
       - name: Show ccache stats
         if: steps.check_skip.outputs.skip != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,6 @@ build/
 build/
 sdkconfig
 sdkconfig.old
-dependencies.lock
 
 # ESP32 specific
 *.elf

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,0 +1,200 @@
+dependencies:
+  espressif/cmake_utilities:
+    component_hash: 351350613ceafba240b761b4ea991e0f231ac7a9f59a9ee901f751bddc0bb18f
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.1'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 0.5.3
+  espressif/eppp_link:
+    component_hash: 04f7f31868b8ae6014c96132740a192d09611a6e46aaa7038c865ffc7e26b38f
+    dependencies:
+    - name: espressif/esp_serial_slave_link
+      registry_url: https://components.espressif.com
+      require: private
+      version: ^1.1.0
+    - name: idf
+      require: private
+      version: '>=5.2'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 1.1.5
+  espressif/esp_codec_dev:
+    component_hash: 014948481bda426cd46714f297fe1891711246c62bea288863a8cc8cf13ef1f0
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.2.0
+  espressif/esp_hosted:
+    component_hash: e23eb702781c804a62909e5394da0641a2bff9adccec6673a7bff60ce8c8b756
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.3'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 2.12.3
+  espressif/esp_lcd_touch:
+    component_hash: 3f85a7d95af876f1a6ecca8eb90a81614890d0f03a038390804e5a77e2caf862
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.4.2'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 1.2.1
+  espressif/esp_lcd_touch_gt911:
+    component_hash: 6029febef66eefd0910d527d7f30292779ccbf22a8dedd2bd69466acf0068a7b
+    dependencies:
+    - name: espressif/esp_lcd_touch
+      registry_url: https://components.espressif.com
+      require: public
+      version: ^1.2.0
+    - name: idf
+      require: private
+      version: '>=5.2'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.2.0~2
+  espressif/esp_lvgl_port:
+    component_hash: fb6c1fdfe70d4ca39a035d63ca394a35f17ec84ce16ff98ecb13a54155d75da4
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.2'
+    - name: lvgl/lvgl
+      registry_url: https://components.espressif.com
+      require: public
+      version: '>=8,<10'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 2.8.0~1
+  espressif/esp_serial_slave_link:
+    component_hash: ac1776806de0a6e371c84e87898bb983e19ce62aa7f1e2e5c4a3b0234a575d2c
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 1.1.2
+  espressif/esp_websocket_client:
+    component_hash: c5a067a9fddea370c478017e66fac302f4b79c3d4027e9bdd42a019786cceb92
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.6.1
+  espressif/esp_wifi_remote:
+    component_hash: 40876fa6a37677b0159b9203e7d5ea0d64219cf8f3fc65e3ff92ff8d142396ba
+    dependencies:
+    - name: espressif/esp_hosted
+      registry_url: https://components.espressif.com
+      require: private
+      rules:
+      - if: target in [esp32h2, esp32p4]
+      version: '>=0.0.6'
+    - name: espressif/wifi_remote_over_eppp
+      registry_url: https://components.espressif.com
+      require: private
+      version: '>=0.1'
+    - name: idf
+      require: private
+      version: '>=5.3'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 0.16.3
+  espressif/wifi_remote_over_eppp:
+    component_hash: 06d8bc15348bbd21f1390daace36ed5adcf6026c93c5b69decc55fa04df2711a
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.3'
+    - name: espressif/eppp_link
+      registry_url: https://components.espressif.com
+      require: private
+      version: '>=0.1'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 0.3.2
+  idf:
+    source:
+      type: idf
+    version: 5.5.2
+  lvgl/lvgl:
+    component_hash: 184e532558c1c45fefed631f3e235423d22582aafb4630f3e8885c35281a49ae
+    dependencies: []
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 9.5.0
+  waveshare/esp32_p4_wifi6_touch_lcd_4b:
+    dependencies:
+    - name: espressif/esp_codec_dev
+      public: true
+      version: 1.2.*
+    - name: espressif/esp_lcd_touch_gt911
+      version: ^1
+    - name: espressif/esp_lvgl_port
+      public: true
+      version: ^2
+    - name: idf
+      version: '>=5.4'
+    - name: lvgl/lvgl
+      version: '>=8,<10'
+    - name: waveshare/esp_lcd_st7703
+      version: '*'
+    source:
+      path: C:\Users\Kumar\git\ESP32-P4-NINA-Display\components\esp32_p4_wifi6_touch_lcd_4b
+      type: local
+    targets:
+    - esp32p4
+    version: 1.0.1
+  waveshare/esp_lcd_st7703:
+    component_hash: 0ee99c4d38d5742f554fa10f0cc17a74529d623fb0ebdb0e9bfac1703f1d4442
+    dependencies:
+    - name: espressif/cmake_utilities
+      registry_url: https://components.espressif.com
+      require: private
+      version: 0.*
+    - name: idf
+      require: private
+      version: '>=5.3'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    targets:
+    - esp32p4
+    version: 1.0.5
+direct_dependencies:
+- espressif/esp_codec_dev
+- espressif/esp_hosted
+- espressif/esp_lcd_touch_gt911
+- espressif/esp_lvgl_port
+- espressif/esp_websocket_client
+- espressif/esp_wifi_remote
+- idf
+- lvgl/lvgl
+- waveshare/esp32_p4_wifi6_touch_lcd_4b
+- waveshare/esp_lcd_st7703
+manifest_hash: 553b726d4b934eca3f1e80e40c5f9ff2caa96358302536ab0d7110079803539c
+target: esp32p4
+version: 2.0.0

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -1,7 +1,8 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  espressif/esp_wifi_remote: "0.*"
-  espressif/esp_websocket_client: "1.*"
+  espressif/esp_hosted: ">=2.12.3,<2.12.4"
+  espressif/esp_wifi_remote: "~0.16.3"
+  espressif/esp_websocket_client: "~1.6.1"
   lvgl/lvgl:
     version: "~9.5.0"
     public: true

--- a/main/main.c
+++ b/main/main.c
@@ -722,19 +722,7 @@ void app_main(void)
 
     /* Spotify poll task — only when enabled (Core 0, 10KB PSRAM stack for HTTPS+JSON) */
     if (app_config_get()->spotify_enabled) {
-        StackType_t *sp_stack = heap_caps_malloc(10240 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
-        StaticTask_t *sp_tcb  = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-        if (sp_stack && sp_tcb) {
-            spotify_task_handle = xTaskCreateStaticPinnedToCore(
-                spotify_poll_task, "spotify_poll", 10240, NULL, 4,
-                sp_stack, sp_tcb, 0);
-        } else {
-            ESP_LOGE(TAG, "Failed to alloc spotify_poll stack from PSRAM, falling back");
-            if (sp_stack) heap_caps_free(sp_stack);
-            if (sp_tcb) heap_caps_free(sp_tcb);
-            xTaskCreatePinnedToCore(spotify_poll_task, "spotify_poll", 10240, NULL, 4,
-                                    &spotify_task_handle, 0);
-        }
+        spotify_ensure_task_running();
     }
 
     /* Weather poll task — always start; task sleeps when no location configured */

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -804,6 +804,30 @@ void spotify_poll_task(void *arg)
 }
 
 // =============================================================================
+// Spotify task lifecycle
+// =============================================================================
+
+void spotify_ensure_task_running(void)
+{
+    if (spotify_task_handle != NULL) return;
+
+    StackType_t  *sp_stack = heap_caps_malloc(10240 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
+    StaticTask_t *sp_tcb   = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (sp_stack && sp_tcb) {
+        spotify_task_handle = xTaskCreateStaticPinnedToCore(
+            spotify_poll_task, "spotify_poll", 10240, NULL, 4,
+            sp_stack, sp_tcb, 0);
+    } else {
+        ESP_LOGE(TAG, "Failed to alloc spotify_poll stack from PSRAM, falling back");
+        if (sp_stack) heap_caps_free(sp_stack);
+        if (sp_tcb) heap_caps_free(sp_tcb);
+        xTaskCreatePinnedToCore(spotify_poll_task, "spotify_poll", 10240, NULL, 4,
+                                &spotify_task_handle, 0);
+    }
+    ESP_LOGI(TAG, "Spotify poll task created dynamically");
+}
+
+// =============================================================================
 // Async Fetch Worker — runs HTTP fetches on Core 0 to keep Core 1 free for UI
 // =============================================================================
 

--- a/main/tasks.h
+++ b/main/tasks.h
@@ -73,6 +73,9 @@ extern _Atomic bool nina_pages_active;
 /** FreeRTOS task: Spotify API poller — fetches currently-playing, album art on track change. */
 void spotify_poll_task(void *arg);
 
+/** Create the Spotify poll task if it isn't already running. Safe to call multiple times. */
+void spotify_ensure_task_running(void);
+
 /** FreeRTOS task: UI coordinator — reads cached data, updates LVGL, handles auto-rotate. */
 void data_update_task(void *arg);
 

--- a/main/web_handlers_spotify.c
+++ b/main/web_handlers_spotify.c
@@ -1,6 +1,7 @@
 #include "web_server_internal.h"
 #include "spotify_auth.h"
 #include "spotify_client.h"
+#include "tasks.h"
 #include <string.h>
 
 /**
@@ -77,6 +78,10 @@ esp_err_t spotify_config_post_handler(httpd_req_t *req)
     cJSON_Delete(root);
 
     app_config_save(cfg);
+
+    if (cfg->spotify_enabled) {
+        spotify_ensure_task_running();
+    }
 
     httpd_resp_set_type(req, "application/json");
     httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);


### PR DESCRIPTION
### Summary
Spotify now starts immediately after its initial setup, removing the need for a device reboot. This update also ensures more consistent firmware builds by explicitly pinning component versions and tracking dependencies.

### Changes
*   Firmware component versions are explicitly pinned, and a `dependencies.lock` file tracks exact versions for consistent builds across environments.
*   Spotify starts immediately after its initial setup, removing the need for a device reboot.
*   New logic in `tasks.c` and `web_handlers_spotify.c` enables Spotify's immediate startup.
*   Old reboot-related setup logic is removed from `main.c`.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-05-25T07:35:30.274Z | Generated by GitHub Actions</sub>