### PR TITLE
feat: add first-run setup wizard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ bootloader.bin
 partition-table.bin
 ota_data_initial.bin
 .playwright-mcp/
+.superpowers/
 
 # Compilation artifacts
 *.o
@@ -108,6 +109,9 @@ cleanup_log_*.txt
 # Documentation and plans (local only)
 docs/
 plans/
+
+# Generated tool output
+repomix-output.xml
 
 # Python cache (if using Python scripts)
 __pycache__/

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,7 +5,7 @@ idf_component_register(
     SRCS main.c tasks.c power_mgmt.c jpeg_utils.c stb_image.c perf_monitor.c ota_github.c
          nina_connection.c nina_client.c nina_api_fetchers.c nina_sequence.c nina_websocket.c
          allsky_client.c weather_client.c spotify_auth.c spotify_client.c demo_data.c
-         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_auth.c mqtt_ha.c
+         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_auth.c web_handlers_wifi.c mqtt_ha.c
          ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
          ui/nina_toast.c ui/nina_event_log.c ui/nina_alerts.c ui/nina_safety.c ui/nina_session_stats.c ui/lv_font_material_safety.c ui/lv_font_superscript_24.c ui/lv_font_playfair_228.c ui/lv_font_playfair_90.c ui/lv_font_overpass_27.c ui/lv_font_overpass_16.c
          ui/nina_idle_indicator.c

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -8,13 +8,13 @@ idf_component_register(
          app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_auth.c web_handlers_wifi.c mqtt_ha.c
          ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
          ui/nina_toast.c ui/nina_event_log.c ui/nina_alerts.c ui/nina_safety.c ui/nina_session_stats.c ui/lv_font_material_safety.c ui/lv_font_superscript_24.c ui/lv_font_playfair_228.c ui/lv_font_playfair_90.c ui/lv_font_overpass_27.c ui/lv_font_overpass_16.c
-         ui/nina_idle_indicator.c
+         ui/nina_setup_screen.c ui/nina_idle_indicator.c
          ui/nina_info_overlay.c ui/nina_info_camera.c ui/nina_info_mount.c
          ui/nina_info_imagestats.c ui/nina_info_sequence.c ui/nina_info_filter.c ui/nina_info_autofocus.c ui/nina_info_session_stats.c
          ui/nina_ota_prompt.c
          ${LV_DEMOS_SOURCES}
     INCLUDE_DIRS . ui ${LV_DEMO_DIR}
-    EMBED_TXTFILES config_ui.html login.html
+    EMBED_TXTFILES config_ui.html login.html setup_ui.html
     EMBED_FILES favicon.png logo.jpg spotify_logo.png)
 
 idf_component_get_property(LVGL_LIB lvgl__lvgl COMPONENT_LIB)

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -484,6 +484,33 @@
       .toast { top: auto; bottom: calc(68px + 64px + 16px); right: 16px; }
       .row.stack-mobile { flex-direction: column; }
     }
+
+    /* === WIFI SCAN PANEL === */
+    .wifi-scan-panel{border:1px solid rgba(var(--accent-rgb),0.25);border-radius:10px;padding:14px;margin-bottom:18px;background:rgba(var(--accent-rgb),0.04)}
+    .wifi-scan-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;cursor:pointer}
+    .wifi-scan-title{color:var(--accent);font-weight:600;font-size:0.82rem;display:flex;align-items:center;gap:6px}
+    .wifi-scan-title .chevron{transition:transform 0.2s;display:inline-block}
+    .wifi-scan-title .chevron.collapsed{transform:rotate(-90deg)}
+    .wifi-scan-rescan{color:var(--accent);font-size:0.72rem;cursor:pointer;border:1px solid rgba(var(--accent-rgb),0.35);padding:3px 10px;border-radius:5px;background:rgba(var(--accent-rgb),0.08);transition:background 0.2s}
+    .wifi-scan-rescan:hover{background:rgba(var(--accent-rgb),0.15)}
+    .wifi-scan-list{overflow:hidden;transition:max-height 0.3s ease,opacity 0.3s ease;max-height:500px;opacity:1}
+    .wifi-scan-list.collapsed{max-height:0;opacity:0;margin:0}
+    .wifi-scan-row{padding:10px 12px;border-radius:8px;background:rgba(255,255,255,0.06);margin-bottom:4px;display:flex;justify-content:space-between;align-items:center;transition:background 0.15s}
+    .wifi-scan-row:hover{background:rgba(255,255,255,0.1)}
+    .wifi-scan-row.incompatible{opacity:0.45;cursor:default}
+    .wifi-scan-row.incompatible:hover{background:rgba(255,255,255,0.06)}
+    .wifi-scan-row-left{display:flex;align-items:center;gap:10px;min-width:0}
+    .wifi-scan-ssid{color:#f4f4f5;font-size:0.82rem;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+    .wifi-scan-row.incompatible .wifi-scan-ssid{color:#888;text-decoration:line-through}
+    .wifi-scan-meta{color:#666;font-size:0.68rem}
+    .wifi-scan-select{background:var(--accent);color:#0a0a1a;border:none;padding:5px 14px;border-radius:6px;font-size:0.68rem;font-weight:700;cursor:pointer;letter-spacing:0.5px;text-transform:uppercase;box-shadow:0 0 8px rgba(var(--accent-rgb),0.3);transition:transform 0.1s,box-shadow 0.15s;flex-shrink:0}
+    .wifi-scan-select:hover{transform:scale(1.05);box-shadow:0 0 14px rgba(var(--accent-rgb),0.5)}
+    .wifi-scan-select:active{transform:scale(0.97)}
+    .wifi-scan-badge{color:#f44336;font-size:0.62rem;font-weight:600;border:1px solid rgba(244,67,54,0.3);padding:3px 8px;border-radius:4px;background:rgba(244,67,54,0.08);flex-shrink:0}
+    .wifi-scan-signal{display:flex;align-items:flex-end;gap:2px;width:20px;height:16px;flex-shrink:0}
+    .wifi-scan-signal span{width:3px;border-radius:1px}
+    .wifi-scan-status{color:var(--text-muted);font-size:0.75rem;text-align:center;padding:16px 0}
+    .wifi-scan-footer{color:#555;font-size:0.68rem;margin-top:6px;padding-left:2px}
   </style>
 </head>
 <body>
@@ -868,6 +895,15 @@
 
       <div class="card">
         <div class="card-title">Network</div>
+        <div class="wifi-scan-panel" id="wifiScanPanel">
+          <div class="wifi-scan-header" onclick="toggleScanPanel()">
+            <span class="wifi-scan-title"><span class="chevron" id="scanChevron">&#x25BC;</span> Available Networks</span>
+            <span class="wifi-scan-rescan" id="scanRescanBtn" onclick="event.stopPropagation();scanWifi()">&#x21bb; Rescan</span>
+          </div>
+          <div class="wifi-scan-list" id="wifiScanList">
+            <div class="wifi-scan-status" id="wifiScanStatus">Scanning for networks...</div>
+          </div>
+        </div>
         <div class="field">
           <label class="field-label">Device hostname</label>
           <input type="text" class="input" id="hostname" placeholder="NINA-DISPLAY" maxlength="31" pattern="[A-Za-z0-9\-]+" style="max-width:320px">
@@ -2254,8 +2290,98 @@
       $('idle_target_field').style.display=enabled?'':'none';
     }
 
+    function scanWifi(){
+      var list=$('wifiScanList');
+      var status=$('wifiScanStatus');
+      list.classList.remove('collapsed');
+      $('scanChevron').classList.remove('collapsed');
+      status.style.display='';
+      status.textContent='Scanning for networks...';
+      var rows=list.querySelectorAll('.wifi-scan-row');
+      for(var i=0;i<rows.length;i++) rows[i].remove();
+      var old=$('wifiScanFooter');if(old)old.remove();
+      fetch('/api/wifi/scan').then(function(r){return r.json()}).then(function(data){
+        renderScanResults(data);
+      }).catch(function(e){
+        status.textContent='Scan failed. Try again.';
+        status.style.display='';
+      });
+    }
+
+    function renderScanResults(data){
+      var list=$('wifiScanList');
+      var status=$('wifiScanStatus');
+      var rows=list.querySelectorAll('.wifi-scan-row');
+      for(var i=0;i<rows.length;i++) rows[i].remove();
+      var old=$('wifiScanFooter');if(old)old.remove();
+      if(!data.networks||data.networks.length===0){
+        status.textContent='No networks found.';
+        status.style.display='';
+        return;
+      }
+      status.style.display='none';
+      for(var i=0;i<data.networks.length;i++){
+        var n=data.networks[i];
+        var row=document.createElement('div');
+        row.className='wifi-scan-row'+(n.compatible?'':' incompatible');
+        var bars=getSignalBars(n.rssi,n.compatible);
+        var left='<div class="wifi-scan-row-left">'+bars+'<div><div class="wifi-scan-ssid">'+escHtml(n.ssid)+'</div><div class="wifi-scan-meta">'+escHtml(n.auth)+' &middot; Ch '+n.channel+' &middot; '+n.rssi+' dBm</div></div></div>';
+        if(n.compatible){
+          row.innerHTML=left;
+          var btn=document.createElement('button');
+          btn.className='wifi-scan-select';
+          btn.textContent='Select';
+          (function(ssid){btn.addEventListener('click',function(){selectNetwork(ssid)})})(n.ssid);
+          row.appendChild(btn);
+        }else{
+          row.innerHTML=left+'<span class="wifi-scan-badge">INCOMPATIBLE</span>';
+        }
+        list.appendChild(row);
+      }
+      var footer=document.createElement('div');
+      footer.className='wifi-scan-footer';
+      footer.id='wifiScanFooter';
+      var txt=data.count+' network'+(data.count!==1?'s':'')+' found';
+      if(data.incompatible_count>0) txt+=' &middot; '+data.incompatible_count+' incompatible';
+      footer.innerHTML=txt;
+      list.appendChild(footer);
+    }
+
+    function getSignalBars(rssi,compatible){
+      var bars=rssi>=-50?4:rssi>=-70?3:2;
+      var color=!compatible?'#666':bars>=4?'#4caf50':bars>=3?'#ff9800':'#f44336';
+      var inactive='rgba(255,255,255,0.15)';
+      var heights=[4,8,12,16];
+      var html='<div class="wifi-scan-signal">';
+      for(var i=0;i<4;i++){
+        html+='<span style="height:'+heights[i]+'px;background:'+(i<bars?color:inactive)+'"></span>';
+      }
+      return html+'</div>';
+    }
+
+    function selectNetwork(ssid){
+      var slots=['ssid1','ssid2','ssid3'];
+      var target=null;
+      for(var i=0;i<slots.length;i++){
+        if(!$(slots[i]).value.trim()){target=i;break;}
+      }
+      if(target===null) target=2;
+      $(slots[target]).value=ssid;
+      $('pass'+(target+1)).value='';
+      $('pass'+(target+1)).focus();
+      checkDirty();
+    }
+
+    function toggleScanPanel(){
+      var list=$('wifiScanList');
+      var chev=$('scanChevron');
+      list.classList.toggle('collapsed');
+      chev.classList.toggle('collapsed');
+    }
+
     function loadConfig(){
       fetch('/api/config').then(r=>r.json()).then(populateConfig).catch(e=>console.error('Failed to load config',e));
+      scanWifi();
     }
 
     /* === Version Load === */

--- a/main/login.html
+++ b/main/login.html
@@ -27,11 +27,16 @@
     <input id="p" type="password" autocomplete="current-password" autofocus required>
     <button id="b" type="submit">Sign in</button>
     <div class="err" id="e"></div>
+    <div id="hint" style="display:none;font-size:12px;color:#9ca3af;margin-top:10px">Default password: <code style="color:#d1d5db;background:#1f2937;padding:2px 6px;border-radius:3px;font-size:12px">changeme123!</code></div>
   </form>
 <script>
 (function(){
   var f=document.getElementById('f'),p=document.getElementById('p'),
-      b=document.getElementById('b'),e=document.getElementById('e');
+      b=document.getElementById('b'),e=document.getElementById('e'),
+      h=document.getElementById('hint');
+  fetch('/api/auth/status').then(function(r){return r.json()}).then(function(d){
+    if(d.default_password) h.style.display='';
+  }).catch(function(){});
   f.addEventListener('submit',function(ev){
     ev.preventDefault();
     e.textContent='';

--- a/main/main.c
+++ b/main/main.c
@@ -398,11 +398,13 @@ static void wifi_init(void)
     memcpy(wifi_config_ap.ap.ssid, ap_name, ap_len);
     wifi_config_ap.ap.ssid_len = ap_len;
 
-    /* Load STA credentials from app_config wifi_networks[0] (highest priority) */
+    /* Load STA credentials from app_config wifi_networks[0] (highest priority).
+     * Always call esp_wifi_set_config to override any credentials the C6
+     * coprocessor may have stored in its own NVS. */
     {
         const app_config_t *cfg = app_config_get();
+        wifi_config_t sta_cfg = {0};
         if (cfg->wifi_networks[0].ssid[0] != '\0') {
-            wifi_config_t sta_cfg = {0};
             sta_cfg.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
             sta_cfg.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
             sta_cfg.sta.threshold.rssi = -90;
@@ -415,8 +417,8 @@ static void wifi_init(void)
                     sizeof(sta_cfg.sta.ssid));
             strlcpy((char *)sta_cfg.sta.password, cfg->wifi_networks[0].password,
                     sizeof(sta_cfg.sta.password));
-            esp_wifi_set_config(WIFI_IF_STA, &sta_cfg);
         }
+        esp_wifi_set_config(WIFI_IF_STA, &sta_cfg);
     }
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
@@ -483,26 +485,6 @@ void app_main(void)
 
     wifi_init();
 
-    /* One-time migration: copy WiFi credentials from ESP-IDF NVS to app_config
-     * wifi_networks[0] if it's empty (first boot after upgrade to v24). */
-    {
-        app_config_t *cfg = app_config_get();
-        if (cfg->wifi_networks[0].ssid[0] == '\0') {
-            wifi_config_t sta_cfg = {0};
-            if (esp_wifi_get_config(WIFI_IF_STA, &sta_cfg) == ESP_OK &&
-                sta_cfg.sta.ssid[0] != '\0') {
-                strlcpy(cfg->wifi_networks[0].ssid,
-                        (const char *)sta_cfg.sta.ssid,
-                        sizeof(cfg->wifi_networks[0].ssid));
-                strlcpy(cfg->wifi_networks[0].password,
-                        (const char *)sta_cfg.sta.password,
-                        sizeof(cfg->wifi_networks[0].password));
-                app_config_save(cfg);
-                ESP_LOGI(TAG, "Migrated WiFi credentials to wifi_networks[0]: %s",
-                         cfg->wifi_networks[0].ssid);
-            }
-        }
-    }
 
     // Enable Dynamic Frequency Scaling — CPU scales 360 MHz (active) to 40 MHz (idle)
     power_mgmt_init();

--- a/main/main.c
+++ b/main/main.c
@@ -42,6 +42,7 @@
 #include "wifi_manager.h"
 #include "ui/nina_settings_tabview.h"
 #include "ui/nina_thumbnail.h"
+#include "ui/nina_setup_screen.h"
 
 /* Embedded splash logo (JPEG, hardware-decoded at boot) */
 extern const uint8_t logo_jpg_start[] asm("_binary_logo_jpg_start");
@@ -163,7 +164,7 @@ static bool wifi_advance_to_next_network(void)
     return false;
 }
 
-static void wifi_connect_to_slot(int index)
+void wifi_connect_to_slot(int index)
 {
     const app_config_t *cfg = app_config_get();
     wifi_config_t sta_cfg = {0};
@@ -305,6 +306,34 @@ static void event_handler(void *arg, esp_event_base_t event_base,
         if (mode == WIFI_MODE_APSTA) {
             ESP_LOGI(TAG, "STA connected, disabling AP");
             esp_wifi_set_mode(WIFI_MODE_STA);
+        }
+
+        if (is_setup_mode()) {
+            set_setup_mode(false);
+            ESP_LOGI(TAG, "WiFi connected during setup — transitioning to dashboard");
+            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                nina_setup_screen_destroy();
+                lv_obj_t *scr = lv_scr_act();
+                create_nina_dashboard(scr, instance_count);
+                nina_toast_init(scr);
+                nina_event_log_overlay_create(scr);
+                nina_alerts_init(scr);
+                nina_safety_create(scr);
+                bsp_display_unlock();
+            }
+            nina_dashboard_set_page_change_cb(on_page_changed);
+            nina_client_init();
+            nina_client_init_image_buffers();
+            nina_thumbnail_init();
+            spotify_auth_init();
+            spotify_client_init();
+
+            xTaskCreatePinnedToCore(input_task, "input_task", 6144, NULL, 5, NULL, 0);
+            xTaskCreatePinnedToCore(data_update_task, "data_task", 12288, NULL, 4, &data_task_handle, 1);
+            if (app_config_get()->spotify_enabled) {
+                spotify_ensure_task_running();
+            }
+            weather_client_start();
         }
 
         /* Apply timezone before SNTP so localtime_r works as soon as time is set */
@@ -494,6 +523,12 @@ void app_main(void)
     /* Pre-allocate JPEG encoder DMA channel before display init claims DMA resources */
     screenshot_encoder_init();
 
+    bool setup_mode = (app_config_get()->wifi_networks[0].ssid[0] == '\0');
+    if (setup_mode) {
+        set_setup_mode(true);
+        ESP_LOGI(TAG, "No WiFi configured — entering setup mode");
+    }
+
     bsp_display_cfg_t cfg = {
         .lvgl_port_cfg = ESP_LVGL_PORT_INIT_CONFIG(),
         .buffer_size = BSP_LCD_DRAW_BUFF_SIZE,
@@ -608,9 +643,12 @@ void app_main(void)
         lv_obj_t *scr = lv_scr_act();
         lv_obj_set_style_bg_color(scr, lv_color_hex(0x000000), 0);
 
-        create_nina_dashboard(scr, instance_count);
+        if (setup_mode) {
+            nina_setup_screen_create(scr);
+        } else {
+            create_nina_dashboard(scr, instance_count);
 
-        /* Create splash ON TOP of dashboard — last child draws on top */
+            /* Create splash ON TOP of dashboard — last child draws on top */
         if (splash_ready) {
             lv_obj_t *splash_cont = lv_obj_create(scr);
             lv_obj_remove_style_all(splash_cont);
@@ -658,57 +696,61 @@ void app_main(void)
             nina_dashboard_show_page(saved_page, 0);
         }
 
+        } /* end else (normal mode) */
+
         bsp_display_unlock();
     } else {
         ESP_LOGE(TAG, "Failed to acquire display lock during init!");
     }
 
-    nina_dashboard_set_page_change_cb(on_page_changed);
+    if (!setup_mode) {
+        nina_dashboard_set_page_change_cb(on_page_changed);
 
-    nina_client_init();  // DNS cache mutex — must be called before poll tasks spawn
-    nina_client_init_image_buffers();  // Pre-allocate PSRAM image fetch buffer
-    nina_thumbnail_init();  // Pre-allocate PSRAM zoom buffer
+        nina_client_init();  // DNS cache mutex — must be called before poll tasks spawn
+        nina_client_init_image_buffers();  // Pre-allocate PSRAM image fetch buffer
+        nina_thumbnail_init();  // Pre-allocate PSRAM zoom buffer
 
-    /* Spotify init — always called so web handlers (config, login) work even when disabled */
-    spotify_auth_init();
-    spotify_client_init();
+        /* Spotify init — always called so web handlers (config, login) work even when disabled */
+        spotify_auth_init();
+        spotify_client_init();
 
-    /* weather_client_init() already called above, before dashboard creation */
+        /* weather_client_init() already called above, before dashboard creation */
 
-    /* Allocate task stacks in PSRAM to save internal heap; TCBs stay internal */
-    {
-        StackType_t *input_stack = heap_caps_malloc(6144 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
-        StaticTask_t *input_tcb  = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-        if (input_stack && input_tcb) {
-            xTaskCreateStaticPinnedToCore(input_task, "input_task", 6144, NULL, 5,
-                                          input_stack, input_tcb, 0);
-        } else {
-            ESP_LOGE(TAG, "Failed to alloc input_task stack from PSRAM, falling back");
-            if (input_stack) heap_caps_free(input_stack);
-            if (input_tcb) heap_caps_free(input_tcb);
-            xTaskCreatePinnedToCore(input_task, "input_task", 6144, NULL, 5, NULL, 0);
+        /* Allocate task stacks in PSRAM to save internal heap; TCBs stay internal */
+        {
+            StackType_t *input_stack = heap_caps_malloc(6144 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
+            StaticTask_t *input_tcb  = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+            if (input_stack && input_tcb) {
+                xTaskCreateStaticPinnedToCore(input_task, "input_task", 6144, NULL, 5,
+                                              input_stack, input_tcb, 0);
+            } else {
+                ESP_LOGE(TAG, "Failed to alloc input_task stack from PSRAM, falling back");
+                if (input_stack) heap_caps_free(input_stack);
+                if (input_tcb) heap_caps_free(input_tcb);
+                xTaskCreatePinnedToCore(input_task, "input_task", 6144, NULL, 5, NULL, 0);
+            }
+
+            StackType_t *data_stack = heap_caps_malloc(12288 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
+            StaticTask_t *data_tcb  = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+            if (data_stack && data_tcb) {
+                data_task_handle = xTaskCreateStaticPinnedToCore(data_update_task, "data_task", 12288, NULL, 4,
+                                                                 data_stack, data_tcb, 1);
+            } else {
+                ESP_LOGE(TAG, "Failed to alloc data_task stack from PSRAM, falling back");
+                if (data_stack) heap_caps_free(data_stack);
+                if (data_tcb) heap_caps_free(data_tcb);
+                xTaskCreatePinnedToCore(data_update_task, "data_task", 12288, NULL, 4, &data_task_handle, 1);
+            }
         }
 
-        StackType_t *data_stack = heap_caps_malloc(12288 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
-        StaticTask_t *data_tcb  = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
-        if (data_stack && data_tcb) {
-            data_task_handle = xTaskCreateStaticPinnedToCore(data_update_task, "data_task", 12288, NULL, 4,
-                                                             data_stack, data_tcb, 1);
-        } else {
-            ESP_LOGE(TAG, "Failed to alloc data_task stack from PSRAM, falling back");
-            if (data_stack) heap_caps_free(data_stack);
-            if (data_tcb) heap_caps_free(data_tcb);
-            xTaskCreatePinnedToCore(data_update_task, "data_task", 12288, NULL, 4, &data_task_handle, 1);
+        /* Spotify poll task — only when enabled (Core 0, 10KB PSRAM stack for HTTPS+JSON) */
+        if (app_config_get()->spotify_enabled) {
+            spotify_ensure_task_running();
         }
-    }
 
-    /* Spotify poll task — only when enabled (Core 0, 10KB PSRAM stack for HTTPS+JSON) */
-    if (app_config_get()->spotify_enabled) {
-        spotify_ensure_task_running();
-    }
-
-    /* Weather poll task — always start; task sleeps when no location configured */
-    weather_client_start();
+        /* Weather poll task — always start; task sleeps when no location configured */
+        weather_client_start();
+    } /* end if (!setup_mode) */
 
     /* Mark this firmware as valid so the bootloader won't roll back.
      * This must come after successful init — if we crash before here,

--- a/main/setup_ui.html
+++ b/main/setup_ui.html
@@ -1,0 +1,354 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>WiFi Setup - NINA Display</title>
+<style>
+  html,body{margin:0;padding:0;height:100%;background:#0b0f17;color:#e5e7eb;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  body{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:16px;box-sizing:border-box}
+  .card{background:#111827;border:1px solid #1f2937;border-radius:10px;padding:28px;width:100%;max-width:420px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+  h1{font-size:18px;margin:0 0 4px;font-weight:600;letter-spacing:.2px}
+  .sub{font-size:14px;color:#9ca3af;margin:0 0 20px}
+
+  /* Scan panel */
+  .scan-panel{background:#0b0f17;border:1px solid #1f2937;border-radius:8px;margin-bottom:20px;overflow:hidden}
+  .scan-header{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid #1f2937}
+  .scan-label{font-size:13px;font-weight:600;color:#e5e7eb}
+  .btn-rescan{background:transparent;color:#3b82f6;border:1px solid #3b82f6;border-radius:5px;padding:4px 10px;font-size:11px;font-weight:600;cursor:pointer;font-family:inherit;text-transform:uppercase;letter-spacing:.3px}
+  .btn-rescan:hover{background:rgba(59,130,246,.1)}
+  .btn-rescan:disabled{opacity:.5;cursor:not-allowed}
+  .scan-list{max-height:260px;overflow-y:auto;scrollbar-width:thin;scrollbar-color:#273142 transparent}
+  .scan-list::-webkit-scrollbar{width:6px}
+  .scan-list::-webkit-scrollbar-track{background:transparent}
+  .scan-list::-webkit-scrollbar-thumb{background:#273142;border-radius:3px}
+  .scan-empty{padding:20px;text-align:center;color:#9ca3af;font-size:13px}
+  .scan-footer{padding:8px 14px;border-top:1px solid #1f2937;font-size:11px;color:#6b7280;text-align:center}
+
+  /* Spinner */
+  .spinner-wrap{display:flex;align-items:center;justify-content:center;padding:24px;gap:10px;color:#9ca3af;font-size:13px}
+  .spinner{width:18px;height:18px;border:2px solid #273142;border-top-color:#3b82f6;border-radius:50%;animation:spin .8s linear infinite;flex-shrink:0}
+  @keyframes spin{to{transform:rotate(360deg)}}
+
+  /* Network row */
+  .net-row{display:flex;align-items:center;padding:10px 14px;border-bottom:1px solid #1a1f2e;gap:10px;transition:background .15s}
+  .net-row:last-child{border-bottom:none}
+  .net-row:hover{background:rgba(59,130,246,.04)}
+  .net-row.incompatible{opacity:.45}
+  .net-row.incompatible:hover{background:transparent}
+  .net-info{flex:1;min-width:0}
+  .net-ssid{font-size:13px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .net-ssid.struck{text-decoration:line-through}
+  .net-meta{font-size:11px;color:#6b7280;margin-top:2px}
+  .badge-incompat{display:inline-block;background:rgba(244,67,54,.15);color:#f44336;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;text-transform:uppercase;letter-spacing:.3px;margin-left:6px;vertical-align:middle}
+  .btn-select{background:#3b82f6;color:#0b0f17;border:none;border-radius:5px;padding:5px 12px;font-size:11px;font-weight:700;cursor:pointer;font-family:inherit;text-transform:uppercase;letter-spacing:.3px;flex-shrink:0;white-space:nowrap}
+  .btn-select:hover{background:#60a5fa}
+
+  /* Signal bars */
+  .signal-bars{display:flex;align-items:flex-end;gap:2px;flex-shrink:0;width:18px;height:16px}
+  .signal-bars .bar{width:3px;border-radius:1px;background:#273142}
+  .signal-bars .bar:nth-child(1){height:4px}
+  .signal-bars .bar:nth-child(2){height:7px}
+  .signal-bars .bar:nth-child(3){height:11px}
+  .signal-bars .bar:nth-child(4){height:16px}
+  .signal-bars.bars-4 .bar{background:#4caf50}
+  .signal-bars.bars-3 .bar:nth-child(1),.signal-bars.bars-3 .bar:nth-child(2),.signal-bars.bars-3 .bar:nth-child(3){background:#ff9800}
+  .signal-bars.bars-2 .bar:nth-child(1),.signal-bars.bars-2 .bar:nth-child(2){background:#f44336}
+
+  /* Form */
+  .form-group{margin-bottom:14px}
+  .form-group label{display:block;font-size:12px;color:#9ca3af;margin-bottom:6px}
+  .form-group input{width:100%;box-sizing:border-box;background:#0b0f17;color:#e5e7eb;border:1px solid #273142;border-radius:6px;padding:10px 12px;font-size:14px;outline:none;font-family:inherit}
+  .form-group input:focus{border-color:#3b82f6}
+  .btn-connect{margin-top:6px;width:100%;background:#2563eb;color:#fff;border:0;border-radius:6px;padding:10px 12px;font-size:14px;font-weight:600;cursor:pointer;font-family:inherit}
+  .btn-connect:hover{background:#1d4ed8}
+  .btn-connect:disabled{background:#374151;cursor:not-allowed}
+
+  /* Status area */
+  .status-area{margin-top:16px;text-align:center;display:none}
+  .status-connecting{display:flex;align-items:center;justify-content:center;gap:10px;color:#9ca3af;font-size:13px;padding:8px 0}
+  .status-success{color:#4caf50;font-size:14px;font-weight:500}
+  .status-success .ip{display:block;font-size:12px;color:#9ca3af;margin-top:4px;font-weight:400}
+  .status-success a{display:inline-block;margin-top:12px;color:#3b82f6;font-size:13px;font-weight:600;text-decoration:none}
+  .status-success a:hover{text-decoration:underline}
+  .status-fail{color:#f87171;font-size:13px}
+  .btn-retry{margin-top:10px;background:transparent;color:#3b82f6;border:1px solid #3b82f6;border-radius:6px;padding:8px 16px;font-size:13px;font-weight:600;cursor:pointer;font-family:inherit}
+  .btn-retry:hover{background:rgba(59,130,246,.1)}
+  .err{color:#f87171;font-size:12px;margin-top:8px;min-height:16px;text-align:center}
+</style>
+</head>
+<body>
+  <div class="card">
+    <h1>NINA Display</h1>
+    <p class="sub">WiFi Setup</p>
+
+    <!-- Scan panel -->
+    <div class="scan-panel">
+      <div class="scan-header">
+        <span class="scan-label">Available Networks</span>
+        <button class="btn-rescan" id="btnRescan" type="button">Rescan</button>
+      </div>
+      <div id="scanBody">
+        <div class="spinner-wrap"><div class="spinner"></div>Scanning...</div>
+      </div>
+      <div class="scan-footer" id="scanFooter" style="display:none"></div>
+    </div>
+
+    <!-- Network form -->
+    <form id="wifiForm" autocomplete="off">
+      <div class="form-group">
+        <label for="ssid">SSID</label>
+        <input id="ssid" type="text" autocomplete="off" placeholder="Network name" required>
+      </div>
+      <div class="form-group">
+        <label for="pass">Password</label>
+        <input id="pass" type="password" autocomplete="off" placeholder="Network password">
+      </div>
+      <button class="btn-connect" id="btnConnect" type="submit">Connect</button>
+      <div class="err" id="formErr"></div>
+    </form>
+
+    <!-- Status area -->
+    <div class="status-area" id="statusArea">
+      <div class="status-connecting" id="statusConnecting">
+        <div class="spinner"></div>Connecting...
+      </div>
+      <div class="status-success" id="statusSuccess" style="display:none"></div>
+      <div class="status-fail" id="statusFail" style="display:none"></div>
+    </div>
+  </div>
+
+<script>
+(function(){
+  var btnRescan=document.getElementById('btnRescan');
+  var scanBody=document.getElementById('scanBody');
+  var scanFooter=document.getElementById('scanFooter');
+  var wifiForm=document.getElementById('wifiForm');
+  var ssidInput=document.getElementById('ssid');
+  var passInput=document.getElementById('pass');
+  var btnConnect=document.getElementById('btnConnect');
+  var formErr=document.getElementById('formErr');
+  var statusArea=document.getElementById('statusArea');
+  var statusConnecting=document.getElementById('statusConnecting');
+  var statusSuccess=document.getElementById('statusSuccess');
+  var statusFail=document.getElementById('statusFail');
+  var pollTimer=null;
+  var pollStart=0;
+
+  function escHtml(s){
+    var d=document.createElement('div');
+    d.appendChild(document.createTextNode(s));
+    return d.innerHTML;
+  }
+
+  function getSignalBars(rssi,compatible){
+    var bars;
+    if(rssi>=-50) bars=4;
+    else if(rssi>=-70) bars=3;
+    else bars=2;
+    var cls='signal-bars';
+    if(compatible) cls+=' bars-'+bars;
+    return '<div class="'+cls+'">'
+      +'<div class="bar"></div><div class="bar"></div>'
+      +'<div class="bar"></div><div class="bar"></div></div>';
+  }
+
+  function selectNetwork(ssid){
+    ssidInput.value=ssid;
+    passInput.value='';
+    passInput.focus();
+    formErr.textContent='';
+  }
+
+  function renderResults(data){
+    var networks=data.networks||data||[];
+    if(!networks.length){
+      scanBody.innerHTML='<div class="scan-empty">No networks found</div>';
+      scanFooter.style.display='none';
+      return;
+    }
+    // Sort: compatible first, then by RSSI descending
+    networks.sort(function(a,b){
+      var ac=a.compatible!==false?1:0;
+      var bc=b.compatible!==false?1:0;
+      if(ac!==bc) return bc-ac;
+      return(b.rssi||0)-(a.rssi||0);
+    });
+    var total=networks.length;
+    var incompat=0;
+    var list=document.createElement('div');
+    list.className='scan-list';
+    for(var i=0;i<networks.length;i++){
+      var n=networks[i];
+      var compat=n.compatible!==false;
+      if(!compat) incompat++;
+      var row=document.createElement('div');
+      row.className='net-row'+(compat?'':' incompatible');
+      // Signal bars
+      var barsDiv=document.createElement('span');
+      barsDiv.innerHTML=getSignalBars(n.rssi||0,compat);
+      row.appendChild(barsDiv.firstChild);
+      // Info
+      var info=document.createElement('div');
+      info.className='net-info';
+      var ssidSpan=document.createElement('div');
+      ssidSpan.className='net-ssid'+(compat?'':' struck');
+      ssidSpan.textContent=n.ssid||'(hidden)';
+      if(!compat){
+        var badge=document.createElement('span');
+        badge.className='badge-incompat';
+        badge.textContent='INCOMPATIBLE';
+        ssidSpan.appendChild(badge);
+      }
+      info.appendChild(ssidSpan);
+      var meta=document.createElement('div');
+      meta.className='net-meta';
+      var parts=[];
+      if(n.auth!==undefined) parts.push(escHtml(String(n.auth)));
+      if(n.channel!==undefined) parts.push('Ch '+n.channel);
+      if(n.rssi!==undefined) parts.push(n.rssi+' dBm');
+      meta.innerHTML=parts.join(' &middot; ');
+      info.appendChild(meta);
+      row.appendChild(info);
+      // Select button (only for compatible)
+      if(compat){
+        var btn=document.createElement('button');
+        btn.className='btn-select';
+        btn.type='button';
+        btn.textContent='Select';
+        (function(ssid){
+          btn.addEventListener('click',function(){selectNetwork(ssid);});
+        })(n.ssid||'');
+        row.appendChild(btn);
+      }
+      list.appendChild(row);
+    }
+    scanBody.innerHTML='';
+    scanBody.appendChild(list);
+    var footerText=total+' network'+(total!==1?'s':'')+' found';
+    if(incompat>0) footerText+=' · '+incompat+' incompatible';
+    scanFooter.textContent=footerText;
+    scanFooter.style.display='';
+  }
+
+  function scanWifi(){
+    btnRescan.disabled=true;
+    scanBody.innerHTML='<div class="spinner-wrap"><div class="spinner"></div>Scanning...</div>';
+    scanFooter.style.display='none';
+    fetch('/api/wifi/scan').then(function(r){
+      if(!r.ok) throw new Error('HTTP '+r.status);
+      return r.json();
+    }).then(function(data){
+      renderResults(data);
+      btnRescan.disabled=false;
+    }).catch(function(e){
+      scanBody.innerHTML='<div class="scan-empty">Scan failed: '+escHtml(e.message)+'</div>';
+      scanFooter.style.display='none';
+      btnRescan.disabled=false;
+    });
+  }
+
+  function resetForm(){
+    statusArea.style.display='none';
+    statusConnecting.style.display='';
+    statusSuccess.style.display='none';
+    statusFail.style.display='none';
+    wifiForm.style.display='';
+    btnConnect.disabled=false;
+    formErr.textContent='';
+    if(pollTimer){clearInterval(pollTimer);pollTimer=null;}
+  }
+
+  function pollStatus(){
+    fetch('/api/wifi/status').then(function(r){
+      if(!r.ok) throw new Error('HTTP '+r.status);
+      return r.json();
+    }).then(function(d){
+      if(d.connected){
+        if(pollTimer){clearInterval(pollTimer);pollTimer=null;}
+        statusConnecting.style.display='none';
+        var ip=escHtml(d.ip||'');
+        var ssid=escHtml(d.ssid||ssidInput.value);
+        statusSuccess.innerHTML='Connected to '+ssid+'!'
+          +'<span class="ip">IP Address: '+ip+'</span>'
+          +'<a href="http://'+ip+'/">Open NINA Display &rarr;</a>';
+        statusSuccess.style.display='';
+      } else if(Date.now()-pollStart>=15000){
+        if(pollTimer){clearInterval(pollTimer);pollTimer=null;}
+        statusConnecting.style.display='none';
+        statusFail.innerHTML='Connection failed.';
+        var retryBtn=document.createElement('button');
+        retryBtn.className='btn-retry';
+        retryBtn.type='button';
+        retryBtn.textContent='Try Again';
+        retryBtn.addEventListener('click',function(){resetForm();});
+        statusFail.appendChild(document.createElement('br'));
+        statusFail.appendChild(retryBtn);
+        statusFail.style.display='';
+      }
+    }).catch(function(){
+      // Network error during poll: keep trying until timeout
+      if(Date.now()-pollStart>=15000){
+        if(pollTimer){clearInterval(pollTimer);pollTimer=null;}
+        statusConnecting.style.display='none';
+        statusFail.innerHTML='Connection failed.';
+        var retryBtn=document.createElement('button');
+        retryBtn.className='btn-retry';
+        retryBtn.type='button';
+        retryBtn.textContent='Try Again';
+        retryBtn.addEventListener('click',function(){resetForm();});
+        statusFail.appendChild(document.createElement('br'));
+        statusFail.appendChild(retryBtn);
+        statusFail.style.display='';
+      }
+    });
+  }
+
+  function connectWifi(){
+    var ssid=ssidInput.value.trim();
+    if(!ssid){
+      formErr.textContent='Enter a network name.';
+      ssidInput.focus();
+      return;
+    }
+    formErr.textContent='';
+    btnConnect.disabled=true;
+    wifiForm.style.display='none';
+    statusArea.style.display='';
+    statusConnecting.style.display='';
+    statusSuccess.style.display='none';
+    statusFail.style.display='none';
+    fetch('/api/wifi/setup',{
+      method:'POST',
+      headers:{'Content-Type':'application/json'},
+      body:JSON.stringify({ssid:ssid,password:passInput.value})
+    }).then(function(r){
+      if(!r.ok) throw new Error('HTTP '+r.status);
+      pollStart=Date.now();
+      pollTimer=setInterval(pollStatus,2000);
+    }).catch(function(e){
+      statusConnecting.style.display='none';
+      statusFail.innerHTML='Setup request failed: '+escHtml(e.message);
+      var retryBtn=document.createElement('button');
+      retryBtn.className='btn-retry';
+      retryBtn.type='button';
+      retryBtn.textContent='Try Again';
+      retryBtn.addEventListener('click',function(){resetForm();});
+      statusFail.appendChild(document.createElement('br'));
+      statusFail.appendChild(retryBtn);
+      statusFail.style.display='';
+    });
+  }
+
+  wifiForm.addEventListener('submit',function(ev){
+    ev.preventDefault();
+    connectWifi();
+  });
+  btnRescan.addEventListener('click',function(){scanWifi();});
+
+  // Auto-scan on load
+  scanWifi();
+})();
+</script>
+</body>
+</html>

--- a/main/ui/nina_setup_screen.c
+++ b/main/ui/nina_setup_screen.c
@@ -1,0 +1,122 @@
+#include "nina_setup_screen.h"
+#include "app_config.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/portmacro.h"
+
+static const char *TAG = "setup_screen";
+
+static lv_obj_t *s_setup_cont = NULL;
+static volatile bool s_setup_mode = false;
+
+bool is_setup_mode(void)
+{
+    return s_setup_mode;
+}
+
+void set_setup_mode(bool enabled)
+{
+    s_setup_mode = enabled;
+}
+
+void nina_setup_screen_create(lv_obj_t *parent)
+{
+    ESP_LOGI(TAG, "Creating setup screen");
+
+    /* Full-screen background */
+    s_setup_cont = lv_obj_create(parent);
+    lv_obj_remove_style_all(s_setup_cont);
+    lv_obj_set_size(s_setup_cont, 720, 720);
+    lv_obj_set_style_bg_color(s_setup_cont, lv_color_hex(0x000000), 0);
+    lv_obj_set_style_bg_opa(s_setup_cont, LV_OPA_COVER, 0);
+    lv_obj_set_style_pad_all(s_setup_cont, 40, 0);
+    lv_obj_set_style_pad_top(s_setup_cont, 100, 0);
+    lv_obj_set_style_pad_row(s_setup_cont, 12, 0);
+    lv_obj_set_flex_flow(s_setup_cont, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(s_setup_cont, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_add_flag(s_setup_cont, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
+    lv_obj_clear_flag(s_setup_cont, LV_OBJ_FLAG_SCROLLABLE);
+
+    /* Title */
+    lv_obj_t *title = lv_label_create(s_setup_cont);
+    lv_label_set_text(title, "WiFi Setup Required");
+    lv_obj_set_width(title, lv_pct(100));
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(title, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, 0);
+
+    /* Subtitle */
+    lv_obj_t *subtitle = lv_label_create(s_setup_cont);
+    lv_label_set_text(subtitle, "Connect to this device's WiFi network\nand open the setup page in your browser.");
+    lv_obj_set_width(subtitle, lv_pct(90));
+    lv_obj_set_style_text_font(subtitle, &lv_font_montserrat_20, 0);
+    lv_obj_set_style_text_color(subtitle, lv_color_hex(0xCCCCCC), 0);
+    lv_obj_set_style_text_align(subtitle, LV_TEXT_ALIGN_CENTER, 0);
+
+    /* First divider */
+    lv_obj_t *div1 = lv_obj_create(s_setup_cont);
+    lv_obj_remove_style_all(div1);
+    lv_obj_set_size(div1, lv_pct(80), 1);
+    lv_obj_set_style_bg_color(div1, lv_color_hex(0x444444), 0);
+    lv_obj_set_style_bg_opa(div1, LV_OPA_60, 0);
+
+    /* Info rows */
+    const app_config_t *cfg = app_config_get();
+    const char *ap_name = (cfg && cfg->hostname[0] != '\0') ? cfg->hostname : "NINA-DISPLAY";
+
+    const char *labels[] = {"Network:", "Password:", "Open in browser:"};
+    const char *values[] = {ap_name, "12345678", "http://192.168.4.1"};
+
+    for (int i = 0; i < 3; i++) {
+        lv_obj_t *row = lv_obj_create(s_setup_cont);
+        lv_obj_remove_style_all(row);
+        lv_obj_set_width(row, lv_pct(85));
+        lv_obj_set_height(row, LV_SIZE_CONTENT);
+        lv_obj_set_flex_flow(row, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+
+        lv_obj_t *lbl = lv_label_create(row);
+        lv_label_set_text(lbl, labels[i]);
+        lv_obj_set_style_text_font(lbl, &lv_font_montserrat_18, 0);
+        lv_obj_set_style_text_color(lbl, lv_color_hex(0xCCCCCC), 0);
+
+        lv_obj_t *val = lv_label_create(row);
+        lv_label_set_text(val, values[i]);
+        lv_obj_set_style_text_font(val, &lv_font_montserrat_22, 0);
+        lv_obj_set_style_text_color(val, lv_color_hex(0x3b82f6), 0);
+    }
+
+    /* Second divider */
+    lv_obj_t *div2 = lv_obj_create(s_setup_cont);
+    lv_obj_remove_style_all(div2);
+    lv_obj_set_size(div2, lv_pct(80), 1);
+    lv_obj_set_style_bg_color(div2, lv_color_hex(0x444444), 0);
+    lv_obj_set_style_bg_opa(div2, LV_OPA_60, 0);
+
+    /* Waiting text */
+    lv_obj_t *waiting = lv_label_create(s_setup_cont);
+    lv_label_set_text(waiting, "Waiting for configuration...");
+    lv_obj_set_style_text_font(waiting, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(waiting, lv_color_hex(0x555555), 0);
+    lv_obj_set_style_text_align(waiting, LV_TEXT_ALIGN_CENTER, 0);
+
+    /* Spinner */
+    lv_obj_t *spinner = lv_spinner_create(s_setup_cont);
+    lv_obj_set_size(spinner, 40, 40);
+    lv_spinner_set_anim_params(spinner, 1000, 270);
+    lv_obj_set_style_arc_color(spinner, lv_color_hex(0x3b82f6), LV_PART_INDICATOR);
+    lv_obj_set_style_arc_color(spinner, lv_color_hex(0x222222), LV_PART_MAIN);
+    lv_obj_set_style_arc_width(spinner, 4, LV_PART_INDICATOR);
+    lv_obj_set_style_arc_width(spinner, 4, LV_PART_MAIN);
+
+    ESP_LOGI(TAG, "Setup screen created");
+}
+
+void nina_setup_screen_destroy(void)
+{
+    if (s_setup_cont) {
+        lv_obj_del(s_setup_cont);
+        s_setup_cont = NULL;
+        ESP_LOGI(TAG, "Setup screen destroyed");
+    }
+}

--- a/main/ui/nina_setup_screen.h
+++ b/main/ui/nina_setup_screen.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "lvgl.h"
+
+void nina_setup_screen_create(lv_obj_t *parent);
+void nina_setup_screen_destroy(void);
+bool is_setup_mode(void);
+void set_setup_mode(bool enabled);

--- a/main/web_handlers_auth.c
+++ b/main/web_handlers_auth.c
@@ -28,6 +28,21 @@ esp_err_t login_page_get_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
+esp_err_t auth_status_get_handler(httpd_req_t *req)
+{
+    const app_config_t *cfg = app_config_get();
+    bool is_default = (strcmp(cfg->admin_password, "changeme123!") == 0);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "default_password", is_default);
+    char *json = cJSON_PrintUnformatted(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, json);
+    free(json);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
 /* POST /api/login — verify password, issue session cookie. Unauthenticated. */
 esp_err_t login_post_handler(httpd_req_t *req)
 {

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -5,15 +5,24 @@
 #include "esp_heap_caps.h"
 #include "build_version.h"
 #include "esp_mac.h"
+#include "ui/nina_setup_screen.h"
 
 extern const uint8_t config_html_start[] asm("_binary_config_ui_html_start");
 extern const uint8_t config_html_end[]   asm("_binary_config_ui_html_end");
+extern const uint8_t setup_html_start[] asm("_binary_setup_ui_html_start");
+extern const uint8_t setup_html_end[]   asm("_binary_setup_ui_html_end");
 extern const uint8_t favicon_png_start[] asm("_binary_favicon_png_start");
 extern const uint8_t favicon_png_end[]   asm("_binary_favicon_png_end");
 
 // Handler for root URL
 esp_err_t root_get_handler(httpd_req_t *req)
 {
+    if (is_setup_mode()) {
+        httpd_resp_set_type(req, "text/html");
+        httpd_resp_send(req, (const char *)setup_html_start,
+                        setup_html_end - setup_html_start);
+        return ESP_OK;
+    }
     REQUIRE_AUTH(req);
     httpd_resp_set_type(req, "text/html");
     httpd_resp_send(req, (const char *)config_html_start,

--- a/main/web_handlers_wifi.c
+++ b/main/web_handlers_wifi.c
@@ -2,6 +2,8 @@
 #include "esp_wifi.h"
 #include "esp_heap_caps.h"
 #include <string.h>
+#include "esp_netif.h"
+#include "ui/nina_setup_screen.h"
 
 #define MAX_SCAN_AP_RECORDS  30
 #define MAX_SCAN_RESULTS     20
@@ -47,7 +49,9 @@ static int compare_rssi_desc(const void *a, const void *b)
 
 esp_err_t wifi_scan_get_handler(httpd_req_t *req)
 {
-    REQUIRE_AUTH(req);
+    if (!is_setup_mode()) {
+        REQUIRE_AUTH(req);
+    }
 
     wifi_scan_config_t scan_cfg = {
         .ssid = NULL,
@@ -146,5 +150,83 @@ esp_err_t wifi_scan_get_handler(httpd_req_t *req)
     free(json);
     cJSON_Delete(root);
     heap_caps_free(ap_records);
+    return ESP_OK;
+}
+
+esp_err_t wifi_setup_post_handler(httpd_req_t *req)
+{
+    if (!is_setup_mode()) {
+        REQUIRE_AUTH(req);
+    }
+
+    char buf[256] = {0};
+    int ret = httpd_req_recv(req, buf, sizeof(buf) - 1);
+    if (ret <= 0) return send_400(req, "Empty request body");
+
+    cJSON *root = cJSON_Parse(buf);
+    if (!root) return send_400(req, "Invalid JSON");
+
+    cJSON *ssid_item = cJSON_GetObjectItem(root, "ssid");
+    cJSON *pass_item = cJSON_GetObjectItem(root, "password");
+
+    if (!cJSON_IsString(ssid_item) || ssid_item->valuestring[0] == '\0') {
+        cJSON_Delete(root);
+        return send_400(req, "SSID is required");
+    }
+
+    app_config_t *cfg = app_config_get();
+    strlcpy(cfg->wifi_networks[0].ssid, ssid_item->valuestring,
+            sizeof(cfg->wifi_networks[0].ssid));
+    if (cJSON_IsString(pass_item)) {
+        strlcpy(cfg->wifi_networks[0].password, pass_item->valuestring,
+                sizeof(cfg->wifi_networks[0].password));
+    } else {
+        cfg->wifi_networks[0].password[0] = '\0';
+    }
+    app_config_save(cfg);
+
+    cJSON_Delete(root);
+
+    extern void wifi_connect_to_slot(int index);
+    esp_wifi_disconnect();
+    wifi_connect_to_slot(0);
+
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, "{\"ok\":true}");
+    return ESP_OK;
+}
+
+esp_err_t wifi_status_get_handler(httpd_req_t *req)
+{
+    if (!is_setup_mode()) {
+        REQUIRE_AUTH(req);
+    }
+
+    esp_netif_t *sta = esp_netif_get_handle_from_ifkey("WIFI_STA_DEF");
+    esp_netif_ip_info_t ip_info = {0};
+    bool connected = false;
+    char ip_str[16] = "";
+    char ssid_str[33] = "";
+
+    if (sta && esp_netif_get_ip_info(sta, &ip_info) == ESP_OK && ip_info.ip.addr != 0) {
+        connected = true;
+        snprintf(ip_str, sizeof(ip_str), IPSTR, IP2STR(&ip_info.ip));
+
+        wifi_config_t wcfg = {0};
+        if (esp_wifi_get_config(WIFI_IF_STA, &wcfg) == ESP_OK) {
+            strlcpy(ssid_str, (const char *)wcfg.sta.ssid, sizeof(ssid_str));
+        }
+    }
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON_AddBoolToObject(root, "connected", connected);
+    cJSON_AddStringToObject(root, "ssid", ssid_str);
+    cJSON_AddStringToObject(root, "ip", ip_str);
+
+    char *json = cJSON_PrintUnformatted(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, json);
+    free(json);
+    cJSON_Delete(root);
     return ESP_OK;
 }

--- a/main/web_handlers_wifi.c
+++ b/main/web_handlers_wifi.c
@@ -1,0 +1,150 @@
+#include "web_server_internal.h"
+#include "esp_wifi.h"
+#include "esp_heap_caps.h"
+#include <string.h>
+
+#define MAX_SCAN_AP_RECORDS  30
+#define MAX_SCAN_RESULTS     20
+
+static const char *auth_mode_to_string(wifi_auth_mode_t auth)
+{
+    switch (auth) {
+        case WIFI_AUTH_OPEN:            return "Open";
+        case WIFI_AUTH_WEP:             return "WEP";
+        case WIFI_AUTH_WPA_PSK:         return "WPA";
+        case WIFI_AUTH_WPA2_PSK:        return "WPA2";
+        case WIFI_AUTH_WPA_WPA2_PSK:    return "WPA/WPA2";
+        case WIFI_AUTH_WPA3_PSK:        return "WPA3";
+        case WIFI_AUTH_WPA2_WPA3_PSK:   return "WPA2/WPA3";
+        case WIFI_AUTH_WPA2_ENTERPRISE: return "WPA2-Enterprise";
+        case WIFI_AUTH_WPA3_ENT_192:    return "WPA3-Enterprise";
+        case WIFI_AUTH_WAPI_PSK:        return "WAPI";
+        default:                        return "Unknown";
+    }
+}
+
+static bool is_auth_compatible(wifi_auth_mode_t auth)
+{
+    switch (auth) {
+        case WIFI_AUTH_OPEN:
+        case WIFI_AUTH_WPA_PSK:
+        case WIFI_AUTH_WPA2_PSK:
+        case WIFI_AUTH_WPA_WPA2_PSK:
+        case WIFI_AUTH_WPA3_PSK:
+        case WIFI_AUTH_WPA2_WPA3_PSK:
+            return true;
+        default:
+            return false;
+    }
+}
+
+static int compare_rssi_desc(const void *a, const void *b)
+{
+    const wifi_ap_record_t *ap_a = (const wifi_ap_record_t *)a;
+    const wifi_ap_record_t *ap_b = (const wifi_ap_record_t *)b;
+    return ap_b->rssi - ap_a->rssi;
+}
+
+esp_err_t wifi_scan_get_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    wifi_scan_config_t scan_cfg = {
+        .ssid = NULL,
+        .bssid = NULL,
+        .channel = 0,
+        .show_hidden = false,
+        .scan_type = WIFI_SCAN_TYPE_ACTIVE,
+        .scan_time.active.min = 120,
+        .scan_time.active.max = 300,
+    };
+
+    esp_err_t err = esp_wifi_scan_start(&scan_cfg, true);
+    if (err != ESP_OK) {
+        cJSON *root = cJSON_CreateObject();
+        cJSON_AddStringToObject(root, "error", "WiFi scan failed");
+        cJSON_AddNumberToObject(root, "code", err);
+        char *json = cJSON_PrintUnformatted(root);
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_set_status(req, "500 Internal Server Error");
+        httpd_resp_sendstr(req, json);
+        free(json);
+        cJSON_Delete(root);
+        return ESP_OK;
+    }
+
+    uint16_t ap_count = 0;
+    esp_wifi_scan_get_ap_num(&ap_count);
+    if (ap_count > MAX_SCAN_AP_RECORDS) {
+        ap_count = MAX_SCAN_AP_RECORDS;
+    }
+
+    wifi_ap_record_t *ap_records = heap_caps_malloc(ap_count * sizeof(wifi_ap_record_t), MALLOC_CAP_SPIRAM);
+    if (!ap_records) {
+        esp_wifi_clear_ap_list();
+        cJSON *root = cJSON_CreateObject();
+        cJSON_AddStringToObject(root, "error", "Out of memory for scan results");
+        cJSON_AddNumberToObject(root, "code", ESP_ERR_NO_MEM);
+        char *json = cJSON_PrintUnformatted(root);
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_set_status(req, "500 Internal Server Error");
+        httpd_resp_sendstr(req, json);
+        free(json);
+        cJSON_Delete(root);
+        return ESP_OK;
+    }
+
+    esp_wifi_scan_get_ap_records(&ap_count, ap_records);
+
+    qsort(ap_records, ap_count, sizeof(wifi_ap_record_t), compare_rssi_desc);
+
+    cJSON *root = cJSON_CreateObject();
+    cJSON *networks = cJSON_AddArrayToObject(root, "networks");
+    int result_count = 0;
+    int incompatible_count = 0;
+    char seen_ssids[MAX_SCAN_RESULTS][33];
+    int seen_count = 0;
+
+    for (int i = 0; i < ap_count && result_count < MAX_SCAN_RESULTS; i++) {
+        const char *ssid = (const char *)ap_records[i].ssid;
+
+        if (ssid[0] == '\0') continue;
+
+        bool duplicate = false;
+        for (int j = 0; j < seen_count; j++) {
+            if (strcmp(seen_ssids[j], ssid) == 0) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (duplicate) continue;
+
+        strncpy(seen_ssids[seen_count], ssid, 32);
+        seen_ssids[seen_count][32] = '\0';
+        seen_count++;
+
+        bool compatible = is_auth_compatible(ap_records[i].authmode);
+        if (!compatible) incompatible_count++;
+
+        cJSON *net = cJSON_CreateObject();
+        cJSON_AddStringToObject(net, "ssid", ssid);
+        cJSON_AddNumberToObject(net, "rssi", ap_records[i].rssi);
+        cJSON_AddNumberToObject(net, "channel", ap_records[i].primary);
+        cJSON_AddStringToObject(net, "auth", auth_mode_to_string(ap_records[i].authmode));
+        cJSON_AddBoolToObject(net, "compatible", compatible);
+        cJSON_AddItemToArray(networks, net);
+        result_count++;
+    }
+
+    cJSON_AddNumberToObject(root, "count", result_count);
+    cJSON_AddNumberToObject(root, "incompatible_count", incompatible_count);
+
+    char *json = cJSON_PrintUnformatted(root);
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, json);
+
+    free(json);
+    cJSON_Delete(root);
+    heap_caps_free(ap_records);
+    return ESP_OK;
+}

--- a/main/web_handlers_wifi.h
+++ b/main/web_handlers_wifi.h
@@ -3,3 +3,5 @@
 #include "esp_http_server.h"
 
 esp_err_t wifi_scan_get_handler(httpd_req_t *req);
+esp_err_t wifi_setup_post_handler(httpd_req_t *req);
+esp_err_t wifi_status_get_handler(httpd_req_t *req);

--- a/main/web_handlers_wifi.h
+++ b/main/web_handlers_wifi.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "esp_http_server.h"
+
+esp_err_t wifi_scan_get_handler(httpd_req_t *req);

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -196,7 +196,7 @@ void start_web_server(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 16384;
-    config.max_uri_handlers = 43;
+    config.max_uri_handlers = 44;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -253,6 +253,7 @@ void start_web_server(void)
         { "/login",                      HTTP_GET,  login_page_get_handler, NULL },
         { "/api/login",                  HTTP_POST, login_post_handler, NULL },
         { "/api/logout",                 HTTP_POST, logout_post_handler, NULL },
+        { "/api/wifi/scan",              HTTP_GET,  wifi_scan_get_handler, NULL },
     };
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -196,7 +196,7 @@ void start_web_server(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 16384;
-    config.max_uri_handlers = 44;
+    config.max_uri_handlers = 47;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -254,6 +254,9 @@ void start_web_server(void)
         { "/api/login",                  HTTP_POST, login_post_handler, NULL },
         { "/api/logout",                 HTTP_POST, logout_post_handler, NULL },
         { "/api/wifi/scan",              HTTP_GET,  wifi_scan_get_handler, NULL },
+        { "/api/wifi/setup",         HTTP_POST, wifi_setup_post_handler, NULL },
+        { "/api/wifi/status",        HTTP_GET,  wifi_status_get_handler, NULL },
+        { "/api/auth/status",        HTTP_GET,  auth_status_get_handler, NULL },
     };
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -104,4 +104,5 @@ esp_err_t admin_password_post_handler(httpd_req_t *req);
 esp_err_t login_page_get_handler(httpd_req_t *req);
 esp_err_t login_post_handler(httpd_req_t *req);
 esp_err_t logout_post_handler(httpd_req_t *req);
+esp_err_t wifi_scan_get_handler(httpd_req_t *req);
 void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t *new_cfg);

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -105,4 +105,7 @@ esp_err_t login_page_get_handler(httpd_req_t *req);
 esp_err_t login_post_handler(httpd_req_t *req);
 esp_err_t logout_post_handler(httpd_req_t *req);
 esp_err_t wifi_scan_get_handler(httpd_req_t *req);
+esp_err_t wifi_setup_post_handler(httpd_req_t *req);
+esp_err_t wifi_status_get_handler(httpd_req_t *req);
+esp_err_t auth_status_get_handler(httpd_req_t *req);
 void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t *new_cfg);


### PR DESCRIPTION
### Summary
This PR introduces a new first-run setup wizard that guides users through initial WiFi configuration when no network is set up. It also adds a WiFi network scanner to the web interface and ensures that stored WiFi credentials on the ESP32-C6 coprocessor are properly cleared when no SSID is configured.

### Changes
*   A new first-run setup wizard now guides users through initial WiFi configuration when the device has no network configured.
*   The web interface includes a new WiFi network scanner, allowing users to view available networks and select one for connection.
*   The device explicitly clears any stored WiFi credentials on the ESP32-C6 coprocessor when no SSID is configured in the application, preventing unintended auto-connections.
*   The login page now provides a hint about the default password if it has not been changed.
*   Removed obsolete code for migrating v24 WiFi credentials from ESP-IDF NVS.
*   New HTML files (`setup_ui.html`, `config_ui.html`) and C source files (`nina_setup_screen.c`, `web_handlers_wifi.c`) provide the user interface and backend logic for the new setup wizard and WiFi scanner.
*   `main.c` manages the setup flow, WiFi configuration, and integrates the new web handlers.
*   `web_handlers_auth.c` and `web_handlers_config.c` handle the new UI elements and authentication hints.

---
<sub>Analyzed **3** commit(s) | Updated: 2026-05-27T08:48:28.180Z | Generated by GitHub Actions</sub>