### PR TITLE
fix: simplify exposure arc animation

### DIFF
--- a/main/ui/nina_dashboard_update.c
+++ b/main/ui/nina_dashboard_update.c
@@ -70,6 +70,8 @@ static void auto_fit_value_font(lv_obj_t *label) {
         lv_obj_set_style_text_font(label, pick, 0);
 }
 
+static void arc_start_exposure_anim(dashboard_page_t *p);
+
 void arc_interp_timer_cb(lv_timer_t *timer) {
     dashboard_page_t *p = (dashboard_page_t *)lv_timer_get_user_data(timer);
     if (!p || !p->arc_exposure || p->arc_completing) return;
@@ -81,30 +83,29 @@ void arc_interp_timer_cb(lv_timer_t *timer) {
     double remaining = (double)p->cached_end_epoch - now;
 
     if (remaining <= 0) {
+        lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
         if (p->cached_is_exposing && lv_arc_get_value(p->arc_exposure) != ARC_RANGE)
             lv_arc_set_value(p->arc_exposure, ARC_RANGE);
         return;
     }
 
-    if (!p->cached_is_exposing) return;
+    if (!p->cached_is_exposing) {
+        lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
+        return;
+    }
 
     double elapsed = (double)p->cached_total - remaining;
     if (elapsed < 0) elapsed = 0;
-
-    int progress = (int)((elapsed * ARC_RANGE) / (double)p->cached_total);
-    if (progress > ARC_RANGE) progress = ARC_RANGE;
-    if (progress < 0) progress = 0;
+    int expected = (int)((elapsed * ARC_RANGE) / (double)p->cached_total);
+    if (expected > ARC_RANGE) expected = ARC_RANGE;
+    if (expected < 0) expected = 0;
 
     int current = lv_arc_get_value(p->arc_exposure);
-    if (progress != current) {
-        lv_anim_t a;
-        lv_anim_init(&a);
-        lv_anim_set_var(&a, p->arc_exposure);
-        lv_anim_set_values(&a, current, progress);
-        lv_anim_set_time(&a, ARC_TIMER_MS);
-        lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t)lv_arc_set_value);
-        lv_anim_set_path_cb(&a, lv_anim_path_linear);
-        lv_anim_start(&a);
+    lv_anim_t *existing = lv_anim_get(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
+
+    int drift = abs(current - expected);
+    if (!existing || drift > 20) {
+        arc_start_exposure_anim(p);
     }
 }
 
@@ -227,10 +228,26 @@ static void update_sequence_info(dashboard_page_t *p, const nina_client_t *d) {
         d->container_step[0] != '\0' ? d->container_step : "----");
 }
 
-static void arc_transition_complete_cb(lv_anim_t *a) {
-    dashboard_page_t *p = (dashboard_page_t *)a->user_data;
-    if (!p) return;
-    p->arc_completing = false;
+static void arc_start_exposure_anim(dashboard_page_t *p) {
+    if (p->cached_end_epoch == 0 || p->cached_total <= 0 || !p->cached_is_exposing) return;
+
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    double now = (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
+    double remaining = (double)p->cached_end_epoch - now;
+    if (remaining <= 0.1) return;
+
+    int current = lv_arc_get_value(p->arc_exposure);
+    int remaining_ms = (int)(remaining * 1000);
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, p->arc_exposure);
+    lv_anim_set_values(&a, current, ARC_RANGE);
+    lv_anim_set_time(&a, remaining_ms);
+    lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t)lv_arc_set_value);
+    lv_anim_set_path_cb(&a, lv_anim_path_linear);
+    lv_anim_start(&a);
 }
 
 static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
@@ -280,56 +297,11 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
         p->cached_end_epoch = d->exposure_end_epoch;
         p->cached_total = d->exposure_total;
 
-        if (new_exposure && !p->arc_completing) {
-            int current_val = lv_arc_get_value(p->arc_exposure);
-
-            // Calculate where the new exposure currently is
-            double remaining = difftime((time_t)d->exposure_end_epoch, now);
-            double elapsed = (double)d->exposure_total - remaining;
-            if (elapsed < 0) elapsed = 0;
-            int new_progress = (int)((elapsed * ARC_RANGE) / (double)d->exposure_total);
-            if (new_progress > ARC_RANGE) new_progress = ARC_RANGE;
-            if (new_progress < 0) new_progress = 0;
-
-            if (current_val > ARC_RANGE / 2) {
-                // Arc is in upper half — animate to full, then shrink to new progress
-                p->arc_completing = true;
-
-                lv_anim_t a_fill;
-                lv_anim_init(&a_fill);
-                lv_anim_set_var(&a_fill, p->arc_exposure);
-                lv_anim_set_values(&a_fill, current_val, ARC_RANGE);
-                lv_anim_set_time(&a_fill, ARC_TRANSITION_MS / 2);
-                lv_anim_set_exec_cb(&a_fill, (lv_anim_exec_xcb_t)lv_arc_set_value);
-                lv_anim_set_path_cb(&a_fill, lv_anim_path_ease_out);
-                lv_anim_start(&a_fill);
-
-                lv_anim_t a_shrink;
-                lv_anim_init(&a_shrink);
-                lv_anim_set_var(&a_shrink, p->arc_exposure);
-                lv_anim_set_values(&a_shrink, ARC_RANGE, new_progress);
-                lv_anim_set_time(&a_shrink, ARC_TRANSITION_MS / 2);
-                lv_anim_set_delay(&a_shrink, ARC_TRANSITION_MS / 2);
-                lv_anim_set_exec_cb(&a_shrink, (lv_anim_exec_xcb_t)lv_arc_set_value);
-                lv_anim_set_path_cb(&a_shrink, lv_anim_path_ease_in);
-                a_shrink.user_data = p;
-                lv_anim_set_ready_cb(&a_shrink, arc_transition_complete_cb);
-                lv_anim_start(&a_shrink);
-            } else {
-                // Arc is in lower half — animate directly to new progress
-                p->arc_completing = true;
-
-                lv_anim_t a;
-                lv_anim_init(&a);
-                lv_anim_set_var(&a, p->arc_exposure);
-                lv_anim_set_values(&a, current_val, new_progress);
-                lv_anim_set_time(&a, ARC_TRANSITION_MS);
-                lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t)lv_arc_set_value);
-                lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
-                a.user_data = p;
-                lv_anim_set_ready_cb(&a, arc_transition_complete_cb);
-                lv_anim_start(&a);
-            }
+        if (new_exposure) {
+            lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
+            p->arc_completing = false;
+            lv_arc_set_value(p->arc_exposure, 0);
+            arc_start_exposure_anim(p);
         }
         // Normal progress updates are handled by the 200ms timer (arc_interp_timer_cb)
 


### PR DESCRIPTION
### Summary
Simplifies the exposure arc animation to prevent visual glitches when new exposures start. This makes the UI appear smoother and more consistent during camera operation.

### Changes
*   The exposure arc animation logic is simplified.
*   This change reduces visual glitches that appeared during new exposures.
*   The UI now displays a smoother animation during exposure transitions.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-05-29T08:15:22.425Z | Generated by GitHub Actions</sub>