### PR TITLE
feat: add GOES satellite image display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,7 @@ docs/
 plans/
 
 # Generated tool output
-repomix-output.xml
+repomix-output.*
 
 # Python cache (if using Python scripts)
 __pycache__/

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -4,9 +4,9 @@ file(GLOB_RECURSE LV_DEMOS_SOURCES ${LV_DEMO_DIR}/*.c)
 idf_component_register(
     SRCS main.c tasks.c power_mgmt.c jpeg_utils.c stb_image.c perf_monitor.c ota_github.c
          nina_connection.c nina_client.c nina_api_fetchers.c nina_sequence.c nina_websocket.c
-         allsky_client.c weather_client.c spotify_auth.c spotify_client.c demo_data.c
-         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_auth.c web_handlers_wifi.c mqtt_ha.c
-         ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
+         allsky_client.c goes_client.c weather_client.c spotify_auth.c spotify_client.c demo_data.c
+         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_image_display.c web_handlers_auth.c web_handlers_wifi.c mqtt_ha.c
+         ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_image_display.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
          ui/nina_toast.c ui/nina_event_log.c ui/nina_alerts.c ui/nina_safety.c ui/nina_session_stats.c ui/lv_font_material_safety.c ui/lv_font_superscript_24.c ui/lv_font_playfair_228.c ui/lv_font_playfair_90.c ui/lv_font_overpass_27.c ui/lv_font_overpass_16.c
          ui/nina_setup_screen.c ui/nina_idle_indicator.c
          ui/nina_info_overlay.c ui/nina_info_camera.c ui/nina_info_mount.c

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -771,6 +771,12 @@ static void set_defaults(app_config_t *cfg) {
     // Admin password default — change via web UI on first boot
     strcpy(cfg->admin_password, "changeme123!");
 
+    // Image Display defaults
+    cfg->image_display_enabled = false;
+    cfg->image_display_show_overlay = true;
+    strcpy(cfg->goes_region, "umv");
+    cfg->goes_update_interval_s = 600;
+
     // Auth is on by default — protects device from open-LAN access
     cfg->auth_enabled = true;
 }
@@ -1736,7 +1742,25 @@ static void migrate_from_v23(const app_config_v23_t *old, app_config_t *cfg) {
     ESP_LOGI(TAG, "Migrated config from v23 to v%d", APP_CONFIG_VERSION);
 }
 
-/* --- v31 → v32 migration (added auth_enabled) --- */
+/* --- v32 → v33 migration (added Image Display fields; IDLE_TARGET_SYSINFO 3→4) --- */
+static void migrate_from_v32(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v32_t) ? raw_size : sizeof(app_config_v32_t);
+    memcpy(cfg, raw, copy);
+
+    /* Image Display fields: new in v33 — defaults already set by set_defaults() */
+
+    /* v32→v33: IDLE_TARGET_SYSINFO shifted from 3 to 4 */
+    if (cfg->idle_page_override_target == 3) {
+        cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
+    }
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v32 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v31 → v33 migration (added auth_enabled) --- */
 static void migrate_from_v31(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -1746,11 +1770,16 @@ static void migrate_from_v31(const void *raw, size_t raw_size, app_config_t *cfg
     /* auth_enabled: existing devices default to ON so upgrade stays locked down */
     cfg->auth_enabled = true;
 
+    /* v32→v33: IDLE_TARGET_SYSINFO shifted from 3 to 4 */
+    if (cfg->idle_page_override_target == 3) {
+        cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
+    }
+
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v31 to v%d", APP_CONFIG_VERSION);
 }
 
-/* --- v30 → v32 migration (added admin_password, auth_enabled) --- */
+/* --- v30 → v33 migration (added admin_password, auth_enabled) --- */
 static void migrate_from_v30(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -1762,11 +1791,16 @@ static void migrate_from_v30(const void *raw, size_t raw_size, app_config_t *cfg
     /* auth_enabled defaults to true from set_defaults() */
     cfg->auth_enabled = true;
 
+    /* v32→v33: IDLE_TARGET_SYSINFO shifted from 3 to 4 */
+    if (cfg->idle_page_override_target == 3) {
+        cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
+    }
+
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v30 to v%d", APP_CONFIG_VERSION);
 }
 
-/* --- v29 → v32 migration (added idle_indicator_enabled, admin_password, auth_enabled) --- */
+/* --- v29 → v33 migration (added idle_indicator_enabled, admin_password, auth_enabled) --- */
 static void migrate_from_v29(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -1777,6 +1811,11 @@ static void migrate_from_v29(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->idle_indicator_enabled = true;
     strcpy(cfg->admin_password, "changeme123!");
     cfg->auth_enabled = true;
+
+    /* v32→v33: IDLE_TARGET_SYSINFO shifted from 3 to 4 */
+    if (cfg->idle_page_override_target == 3) {
+        cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
+    }
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v29 to v%d", APP_CONFIG_VERSION);
@@ -1876,7 +1915,7 @@ static void migrate_from_v28(const void *raw, size_t raw_size, app_config_t *cfg
 static void migrate_from_v27(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
-    size_t copy = raw_size < sizeof(app_config_t) ? raw_size : sizeof(app_config_t);
+    size_t copy = raw_size < sizeof(app_config_v27_t) ? raw_size : sizeof(app_config_v27_t);
     memcpy(cfg, raw, copy);
     cfg->toast_aggregation_window_s = 5;
     cfg->toast_notify_mask = 0xFFFFFFFF;
@@ -1892,8 +1931,11 @@ static void migrate_from_v26(const void *raw, size_t raw_size, app_config_t *cfg
 {
     set_defaults(cfg);
     /* v26 blob is identical layout minus trailing auto_rotate_order[7].
-     * Copy old data — new trailing field stays at default from set_defaults(). */
-    size_t copy = raw_size < sizeof(app_config_t) ? raw_size : sizeof(app_config_t);
+     * Copy old data — new trailing field stays at default from set_defaults().
+     * No app_config_v26_t snapshot exists, so bound the copy by the largest
+     * pre-v33 layout (app_config_v32_t) to ensure the v33 image_display fields
+     * always come from set_defaults(), never from copied blob bytes. */
+    size_t copy = raw_size < sizeof(app_config_v32_t) ? raw_size : sizeof(app_config_v32_t);
     memcpy(cfg, raw, copy);
     for (int i = 0; i < 8; i++) cfg->auto_rotate_order[i] = (uint8_t)i;
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2226,6 +2268,15 @@ static bool validate_config(app_config_t *cfg) {
         cfg->allsky_dew_offset = 5.0f;
         fixed = true;
     }
+    if (cfg->goes_update_interval_s < 300 || cfg->goes_update_interval_s > 7200) {
+        cfg->goes_update_interval_s = 600;
+        fixed = true;
+    }
+    cfg->goes_region[sizeof(cfg->goes_region) - 1] = '\0';
+    if (cfg->goes_region[0] == '\0') {
+        strcpy(cfg->goes_region, "umv");
+        fixed = true;
+    }
     if (cfg->allsky_thresholds[0] == '\0' ||
         strstr(cfg->allsky_thresholds, "thermal_main") == NULL) {
         /* Empty or contains old-format keys (cpu_temp, sqm, etc.) — reset to new positional format */
@@ -2293,6 +2344,12 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 32) {
+        /* v32 → v33: added Image Display fields; IDLE_TARGET_SYSINFO 3→4 */
+        migrate_from_v32(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 31) {
         /* v31 → v32: added auth_enabled */
         migrate_from_v31(raw, stored_size, &s_config);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,16 +13,17 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 32
+#define APP_CONFIG_VERSION 33
 
 #define WIDGET_STYLE_COUNT 13
 
 typedef enum {
-    IDLE_TARGET_SUMMARY  = -1,
-    IDLE_TARGET_CLOCK    =  0,
-    IDLE_TARGET_ALLSKY   =  1,
-    IDLE_TARGET_SPOTIFY  =  2,
-    IDLE_TARGET_SYSINFO  =  3,
+    IDLE_TARGET_SUMMARY        = -1,
+    IDLE_TARGET_CLOCK          =  0,
+    IDLE_TARGET_ALLSKY         =  1,
+    IDLE_TARGET_SPOTIFY        =  2,
+    IDLE_TARGET_IMAGE_DISPLAY  =  3,
+    IDLE_TARGET_SYSINFO        =  4,
 } idle_target_t;
 
 typedef struct {
@@ -130,6 +131,13 @@ typedef struct {
 
     // Added after v31 — must stay at end to preserve NVS binary compatibility
     bool     auth_enabled;              // When false, all endpoints are open; secrets still redacted (default true)
+
+    // Added after v32 — must stay at end to preserve NVS binary compatibility
+    // Image Display page
+    bool     image_display_enabled;          // Enable Image Display page + poll task (default false)
+    bool     image_display_show_overlay;     // Show region/timestamp overlay bar (default true)
+    char     goes_region[16];                // NESDIS sector code, e.g. "umv" (default "umv")
+    uint16_t goes_update_interval_s;         // Poll interval in seconds, 300-7200 (default 600)
 } app_config_t;
 
 // v17 snapshot — AllSky fields without allsky_enabled
@@ -872,6 +880,85 @@ typedef struct {
     bool     idle_indicator_enabled;
     char     admin_password[33];
 } app_config_v31_t;
+
+// v32 snapshot — layout before Image Display fields were added
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+} app_config_v32_t;
 
 // WiFi credentials are stored in app_config_t.wifi_networks[3] (up to 3
 // priority-ordered networks). The AP provides headless access for initial

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -571,6 +571,7 @@
       <button class="tab-btn" data-tab="allsky">AllSky</button>
       <button class="tab-btn" data-tab="clock">Clock</button>
       <button class="tab-btn" data-tab="spotify">Spotify</button>
+      <button class="tab-btn" data-tab="image-display">Image Display</button>
       <button class="tab-btn" data-tab="backup">Backup</button>
     </div>
     <a class="github-link" href="https://github.com/chvvkumar/ESP32-P4-NINA-Display" target="_blank" rel="noopener">
@@ -609,6 +610,10 @@
       <button class="nav-btn" data-tab="spotify">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z"/></svg>
         Spotify
+      </button>
+      <button class="nav-btn" data-tab="image-display">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
+        Image
       </button>
       <button class="nav-btn" data-tab="backup">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -731,7 +736,8 @@
             <option value="0">Clock</option>
             <option value="1">AllSky</option>
             <option value="2">Spotify</option>
-            <option value="3">System Info</option>
+            <option value="3">Image Display</option>
+            <option value="4">System Info</option>
           </select>
           <div class="toggle-row" style="margin-top:12px">
             <div>
@@ -1358,6 +1364,71 @@
 
     </div>
 
+    <!-- ==================== TAB: IMAGE DISPLAY ==================== -->
+    <div id="tab-image-display" class="tab-panel">
+
+      <div class="card">
+        <div class="card-title">GOES Satellite Imagery</div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable Image Display</span>
+          <label class="toggle"><input type="checkbox" id="image_display_enabled" onchange="updateImageDisplayEnabledUI()"><span class="toggle-track"></span></label>
+        </div>
+        <div id="imageDisplayFields">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Region</label>
+            <select class="input" id="goesRegion">
+              <option value="umv">Upper Mississippi Valley</option>
+              <option value="cgl">Great Lakes</option>
+              <option value="ne">Northeast</option>
+              <option value="se">Southeast</option>
+              <option value="smv">Southern Mississippi Valley</option>
+              <option value="sp">Southern Plains</option>
+              <option value="nr">Northern Rockies</option>
+              <option value="sr">Southern Rockies</option>
+              <option value="pnw">Pacific Northwest</option>
+              <option value="psw">Pacific Southwest</option>
+              <option value="eus">U.S. Atlantic Coast</option>
+              <option value="pr">Puerto Rico</option>
+              <option value="mex">Mexico</option>
+              <option value="cam">Central America</option>
+              <option value="car">Caribbean</option>
+              <option value="ga">Gulf of America</option>
+              <option value="can">Canada</option>
+              <option value="na">Northern Atlantic</option>
+              <option value="taw">Tropical Atlantic</option>
+              <option value="eep">Eastern Pacific</option>
+              <option value="nsa">South America (North)</option>
+              <option value="ssa">South America (South)</option>
+            </select>
+            <div class="field-hint">GOES-19 GEOCOLOR sector for satellite imagery</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Update Interval</label>
+            <select class="input" id="goesInterval">
+              <option value="300">5 minutes</option>
+              <option value="600" selected>10 minutes</option>
+              <option value="900">15 minutes</option>
+              <option value="1800">30 minutes</option>
+              <option value="3600">1 hour</option>
+              <option value="7200">2 hours</option>
+            </select>
+          </div>
+          <div class="toggle-row">
+            <span class="toggle-label">Show Overlay</span>
+            <label class="toggle"><input type="checkbox" id="image_display_show_overlay" checked><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Region name and update time overlay on the display</div>
+          <div class="field" style="margin-top:16px">
+            <button onclick="fetchGoesPreview()" class="btn btn-primary" id="goesPreviewBtn" style="width:100%">Fetch Preview</button>
+          </div>
+          <div id="goesPreviewContainer" style="display:none;margin-top:12px;text-align:center">
+            <img id="goesPreviewImg" style="max-width:100%;border-radius:10px;border:1px solid rgba(255,255,255,0.1)" />
+          </div>
+        </div>
+      </div>
+
+    </div>
+
     <!-- ==================== TAB 7: BACKUP ==================== -->
     <div id="tab-backup" class="tab-panel">
       <!-- Export Card -->
@@ -1709,13 +1780,15 @@
       var enabled=[$('instance_enabled_0').checked,$('instance_enabled_1').checked,$('instance_enabled_2').checked];
       var allskyOn=$('allsky_enabled')?$('allsky_enabled').checked:false;
       var spotifyOn=$('spotify_enabled')?$('spotify_enabled').checked:false;
+      var imageDisplayOn=$('image_display_enabled')?$('image_display_enabled').checked:false;
 
       var pages=[];
-      pages.push({value:'3', label:'Summary'});
+      pages.push({value:'4', label:'Summary'});
       if(allskyOn) pages.push({value:'0', label:'AllSky'});
       if(spotifyOn) pages.push({value:'1', label:'Spotify'});
       pages.push({value:'2', label:'Clock'});
-      var pageIdx=4;
+      if(imageDisplayOn) pages.push({value:'3', label:'Image Display'});
+      var pageIdx=5;
       for(var i=0;i<3;i++){
         if(urls[i].length>0&&enabled[i]){
           pages.push({value:''+pageIdx, label:urls[i]||('NINA '+(i+1))});
@@ -2005,6 +2078,10 @@
         spotify_overlay_visible:!!$('spotify_overlay_visible').checked,
         spotify_scroll_text:!!$('spotify_scroll_text').checked,
         spotify_overlay_timeout_s:parseInt($('spotifyOverlayTimeout').value)||0,
+        image_display_enabled:!!$('image_display_enabled').checked,
+        image_display_show_overlay:!!$('image_display_show_overlay').checked,
+        goes_region:$('goesRegion').value,
+        goes_update_interval_s:parseInt($('goesInterval').value)||600,
         weather_provider:parseInt($('weather_provider').value)||0,
         weather_api_key:$('weather_api_key').value.trim(),
         weather_lat:parseFloat($('weather_lat').value)||0,
@@ -2158,6 +2235,13 @@
       if($('spotify_scroll_text')) $('spotify_scroll_text').checked=data.spotify_scroll_text!=null?!!data.spotify_scroll_text:true;
       if($('spotifyOverlayTimeout')) $('spotifyOverlayTimeout').value=data.spotify_overlay_timeout_s!=null?data.spotify_overlay_timeout_s:5;
       updateSpotifyEnabledUI();
+
+      // Image Display fields
+      if($('image_display_enabled')) $('image_display_enabled').checked=!!data.image_display_enabled;
+      if($('image_display_show_overlay')) $('image_display_show_overlay').checked=data.image_display_show_overlay!=null?!!data.image_display_show_overlay:true;
+      if($('goesRegion')) $('goesRegion').value=data.goes_region||'umv';
+      if($('goesInterval')) $('goesInterval').value=data.goes_update_interval_s||600;
+      updateImageDisplayEnabledUI();
 
       // Clock & Weather fields
       if($('weather_provider')) $('weather_provider').value=data.weather_provider||0;
@@ -3142,6 +3226,38 @@
         if(Object.keys(qData).length>0) config[quadDef.quad]=qData;
       });
       return config;
+    }
+
+    function updateImageDisplayEnabledUI(){
+      var on=$('image_display_enabled').checked;
+      $('imageDisplayFields').style.display=on?'':'none';
+      updatePageSelectOptions();
+    }
+
+    function fetchGoesPreview(){
+      var btn=$('goesPreviewBtn');
+      var region=$('goesRegion').value;
+      var previewSizes={
+        umv:'300x300',cgl:'300x300',ne:'300x300',se:'300x300',smv:'300x300',
+        sp:'300x300',nr:'300x300',sr:'300x300',pnw:'300x300',psw:'300x300',pr:'300x300',
+        eus:'250x250',cam:'250x250',car:'250x250',mex:'250x250',ga:'250x250',
+        na:'450x270',ssa:'450x270',eep:'450x270',taw:'450x270',nsa:'450x270',
+        can:'280x140'
+      };
+      var psize=previewSizes[region]||'300x300';
+      btn.disabled=true;btn.textContent='Loading...';
+      var img=$('goesPreviewImg');
+      var container=$('goesPreviewContainer');
+      img.onload=function(){
+        container.style.display='block';
+        btn.disabled=false;btn.textContent='Fetch Preview';
+      };
+      img.onerror=function(){
+        container.style.display='none';
+        btn.disabled=false;btn.textContent='Fetch Preview';
+        showToast('Failed to load preview image','error');
+      };
+      img.src='https://cdn.star.nesdis.noaa.gov/GOES19/ABI/SECTOR/'+region+'/GEOCOLOR/'+psize+'.jpg?t='+Date.now();
     }
 
     function updateAllSkyEnabledUI(){

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -1,0 +1,203 @@
+#include "goes_client.h"
+#include "jpeg_utils.h"
+#include "esp_http_client.h"
+#include "esp_crt_bundle.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "esp_timer.h"
+#include <string.h>
+
+static const char *TAG = "goes_client";
+
+#define GOES_JPEG_MAX_SIZE   (512 * 1024)
+#define GOES_HTTP_BUF_SIZE   4096
+#define GOES_HTTP_TIMEOUT_MS 30000
+
+void goes_data_init(goes_data_t *data)
+{
+    memset(data, 0, sizeof(*data));
+    data->mutex = xSemaphoreCreateMutex();
+}
+
+bool goes_data_lock(goes_data_t *data, int timeout_ms)
+{
+    if (!data || !data->mutex) return false;
+    return xSemaphoreTake(data->mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
+}
+
+void goes_data_unlock(goes_data_t *data)
+{
+    if (data && data->mutex) xSemaphoreGive(data->mutex);
+}
+
+void goes_client_cleanup(goes_data_t *data)
+{
+    if (!data) return;
+    if (goes_data_lock(data, 1000)) {
+        if (data->image_buf) {
+            heap_caps_free(data->image_buf);
+            data->image_buf = NULL;
+        }
+        data->image_w = 0;
+        data->image_h = 0;
+        data->connected = false;
+        goes_data_unlock(data);
+    }
+}
+
+/* NESDIS sectors publish different size ladders. Return the GEOCOLOR image
+ * size string (WxH, no extension) the device should fetch for a given sector.
+ * Square regional sectors use 600x600 or 500x500; wide oceanic/continental
+ * sectors are non-square. Unknown regions default to 600x600. */
+static const char *goes_region_size(const char *region)
+{
+    static const struct { const char *code; const char *size; } sizes[] = {
+        /* 600x600 square */
+        {"umv","600x600"}, {"cgl","600x600"}, {"ne","600x600"}, {"se","600x600"},
+        {"smv","600x600"}, {"sp","600x600"},  {"nr","600x600"}, {"sr","600x600"},
+        {"pnw","600x600"}, {"psw","600x600"}, {"pr","600x600"},
+        /* 500x500 square */
+        {"eus","500x500"}, {"cam","500x500"}, {"car","500x500"},
+        {"mex","500x500"}, {"ga","500x500"},
+        /* 900x540 wide (5:3) */
+        {"na","900x540"},  {"ssa","900x540"}, {"eep","900x540"},
+        {"taw","900x540"}, {"nsa","900x540"},
+        /* 560x280 wide (2:1) */
+        {"can","560x280"},
+    };
+    for (size_t i = 0; i < sizeof(sizes)/sizeof(sizes[0]); i++) {
+        if (strcmp(sizes[i].code, region) == 0) return sizes[i].size;
+    }
+    return "600x600";
+}
+
+esp_err_t goes_client_poll(const char *region, goes_data_t *data)
+{
+    if (!region || !data) return ESP_ERR_INVALID_ARG;
+
+    const char *size = goes_region_size(region);
+    char url[192];
+    snprintf(url, sizeof(url),
+             "https://cdn.star.nesdis.noaa.gov/GOES19/ABI/SECTOR/%s/GEOCOLOR/%s.jpg",
+             region, size);
+
+    ESP_LOGI(TAG, "Fetching %s", url);
+
+    esp_http_client_config_t http_cfg = {
+        .url = url,
+        .timeout_ms = GOES_HTTP_TIMEOUT_MS,
+        .buffer_size = GOES_HTTP_BUF_SIZE,
+        .buffer_size_tx = 1024,
+        .crt_bundle_attach = esp_crt_bundle_attach,
+    };
+
+    esp_http_client_handle_t client = esp_http_client_init(&http_cfg);
+    if (!client) {
+        ESP_LOGE(TAG, "Failed to create HTTP client");
+        if (goes_data_lock(data, 1000)) {
+            data->connected = false;
+            goes_data_unlock(data);
+        }
+        return ESP_FAIL;
+    }
+
+    esp_err_t err = esp_http_client_open(client, 0);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "HTTP open failed: %s", esp_err_to_name(err));
+        esp_http_client_cleanup(client);
+        if (goes_data_lock(data, 1000)) {
+            data->connected = false;
+            goes_data_unlock(data);
+        }
+        return err;
+    }
+
+    int content_length = esp_http_client_fetch_headers(client);
+    int status = esp_http_client_get_status_code(client);
+
+    if (status != 200) {
+        ESP_LOGW(TAG, "HTTP status %d", status);
+        esp_http_client_cleanup(client);
+        if (goes_data_lock(data, 1000)) {
+            data->connected = false;
+            goes_data_unlock(data);
+        }
+        return ESP_FAIL;
+    }
+
+    if (content_length <= 0) {
+        content_length = GOES_JPEG_MAX_SIZE;
+    }
+    if (content_length > GOES_JPEG_MAX_SIZE) {
+        content_length = GOES_JPEG_MAX_SIZE;
+    }
+
+    uint8_t *jpeg_buf = heap_caps_malloc(content_length, MALLOC_CAP_SPIRAM);
+    if (!jpeg_buf) {
+        ESP_LOGE(TAG, "PSRAM alloc failed for JPEG (%d bytes)", content_length);
+        esp_http_client_cleanup(client);
+        if (goes_data_lock(data, 1000)) {
+            data->connected = false;
+            goes_data_unlock(data);
+        }
+        return ESP_ERR_NO_MEM;
+    }
+
+    int total_read = 0;
+    while (total_read < content_length) {
+        int read_len = esp_http_client_read(client, (char *)(jpeg_buf + total_read),
+                                            content_length - total_read);
+        if (read_len <= 0) break;
+        total_read += read_len;
+    }
+
+    esp_http_client_cleanup(client);
+
+    if (total_read < 1000) {
+        ESP_LOGW(TAG, "JPEG too small (%d bytes), likely error page", total_read);
+        heap_caps_free(jpeg_buf);
+        if (goes_data_lock(data, 1000)) {
+            data->connected = false;
+            goes_data_unlock(data);
+        }
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Downloaded %d bytes JPEG, decoding...", total_read);
+
+    uint8_t *rgb565 = NULL;
+    uint32_t out_w = 0, out_h = 0;
+    size_t out_size = 0;
+
+    bool decoded = jpeg_sw_decode_rgb565(jpeg_buf, total_read,
+                                          &rgb565, &out_w, &out_h, &out_size);
+    heap_caps_free(jpeg_buf);
+
+    if (!decoded || !rgb565) {
+        ESP_LOGE(TAG, "JPEG decode failed");
+        if (rgb565) heap_caps_free(rgb565);
+        if (goes_data_lock(data, 1000)) {
+            data->connected = false;
+            goes_data_unlock(data);
+        }
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "Decoded %lux%lu (%u bytes)", out_w, out_h, (unsigned)out_size);
+
+    if (goes_data_lock(data, 2000)) {
+        uint8_t *old = data->image_buf;
+        data->image_buf = rgb565;
+        data->image_w = (uint16_t)out_w;
+        data->image_h = (uint16_t)out_h;
+        data->connected = true;
+        data->last_poll_ms = esp_timer_get_time() / 1000;
+        goes_data_unlock(data);
+        if (old) heap_caps_free(old);
+    } else {
+        heap_caps_free(rgb565);
+        return ESP_ERR_TIMEOUT;
+    }
+
+    return ESP_OK;
+}

--- a/main/goes_client.h
+++ b/main/goes_client.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef struct {
+    bool              connected;
+    int64_t           last_poll_ms;
+    uint8_t          *image_buf;
+    uint16_t          image_w;
+    uint16_t          image_h;
+    SemaphoreHandle_t mutex;
+} goes_data_t;
+
+void      goes_data_init(goes_data_t *data);
+bool      goes_data_lock(goes_data_t *data, int timeout_ms);
+void      goes_data_unlock(goes_data_t *data);
+esp_err_t goes_client_poll(const char *region, goes_data_t *data);
+void      goes_client_cleanup(goes_data_t *data);

--- a/main/jpeg_utils.c
+++ b/main/jpeg_utils.c
@@ -173,7 +173,8 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
         return false;
     }
 
-    /* Convert RGB888 to RGB565 (BGR byte order to match HW decoder output) */
+    /* Convert RGB888 to standard RGB565 (R high, B low) — same in-memory layout
+     * the HW decoder produces, which the panel/LVGL pipeline renders correctly. */
     uint16_t *dst = (uint16_t *)rgb565;
 
     for (int y = 0; y < h; y++) {
@@ -183,8 +184,11 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
             uint8_t r = src_row[x * 3 + 0];
             uint8_t g = src_row[x * 3 + 1];
             uint8_t b = src_row[x * 3 + 2];
-            /* BGR565 to match JPEG_DEC_RGB_ELEMENT_ORDER_BGR */
-            dst_row[x] = ((b >> 3) << 11) | ((g >> 2) << 5) | (r >> 3);
+            /* Standard RGB565 (R high, B low). This matches the in-memory layout
+             * the panel/LVGL pipeline expects — the same result the HW decoder
+             * produces with JPEG_DEC_RGB_ELEMENT_ORDER_BGR. Packing B into the
+             * high bits here swaps red and blue (sodium lights render blue). */
+            dst_row[x] = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
         }
     }
 

--- a/main/main.c
+++ b/main/main.c
@@ -681,7 +681,8 @@ void app_main(void)
 
         {
             /* Apply persisted page override immediately on boot.
-             * Override stores absolute page index: 0=allsky, 1=spotify, 2=summary, 3..N+2=NINA, N+3=settings, N+4=sysinfo */
+             * Override stores absolute page index: 0=allsky, 1=spotify, 2=clock,
+             * 3=image_display, 4=summary, 5..N+4=NINA, then settings, then sysinfo */
             app_config_t *cfg = app_config_get();
             int total = nina_dashboard_get_total_page_count();
             if (cfg->active_page_override >= 0 && cfg->active_page_override < total) {

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -10,6 +10,7 @@
 #include "nina_websocket.h"
 #include "nina_connection.h"
 #include "allsky_client.h"
+#include "goes_client.h"
 #include "spotify_auth.h"
 #include "spotify_client.h"
 #include "app_config.h"
@@ -27,6 +28,7 @@
 #include "ui/nina_session_stats.h"
 #include "ui/nina_ota_prompt.h"
 #include "ui/nina_idle_indicator.h"
+#include "ui/nina_image_display.h"
 #include "ota_github.h"
 #include "esp_ota_ops.h"
 #include "bsp/esp-bsp.h"
@@ -153,6 +155,13 @@ _Atomic bool nina_pages_active   = false;
 /* AllSky polling state */
 static allsky_data_t allsky_data;
 static TaskHandle_t allsky_task_handle = NULL;
+
+/* GOES / Image Display polling state.
+ * Non-static: tasks.h externs these and web handlers use goes_task_handle /
+ * goes_ensure_task_running to spawn/wake the task on runtime enable. */
+TaskHandle_t goes_task_handle = NULL;
+_Atomic bool image_display_page_active = false;
+goes_data_t goes_data;
 static demo_task_params_t demo_params;
 
 /* ── Idle page override state ── */
@@ -173,6 +182,7 @@ static int idle_target_to_page_index(int8_t target)
         case IDLE_TARGET_CLOCK:    return PAGE_IDX_CLOCK;
         case IDLE_TARGET_ALLSKY:   return PAGE_IDX_ALLSKY;
         case IDLE_TARGET_SPOTIFY:  return PAGE_IDX_SPOTIFY;
+        case IDLE_TARGET_IMAGE_DISPLAY:  return PAGE_IDX_IMAGE_DISPLAY;
         case IDLE_TARGET_SYSINFO:  return SYSINFO_PAGE_IDX(page_count);
         default:                   return PAGE_IDX_SUMMARY;
     }
@@ -298,7 +308,8 @@ void input_task(void *arg) {
             /* Short press — cycle page */
             int total = nina_dashboard_get_total_page_count();
             int current = nina_dashboard_get_active_page();
-            /* Skip settings, disabled allsky, and disabled spotify in button cycling */
+            /* Skip settings, disabled allsky, disabled spotify, and disabled
+             * image display in button cycling */
             int new_page = current;
             for (int step = 1; step < total; step++) {
                 int candidate = (current + step) % total;
@@ -307,6 +318,8 @@ void input_task(void *arg) {
                     && !app_config_get()->allsky_enabled) continue;
                 if (candidate == PAGE_IDX_SPOTIFY && !nina_dashboard_is_spotify_page()
                     && !app_config_get()->spotify_enabled) continue;
+                if (candidate == PAGE_IDX_IMAGE_DISPLAY && !nina_dashboard_is_image_display_page()
+                    && !app_config_get()->image_display_enabled) continue;
                 new_page = candidate;
                 break;
             }
@@ -522,6 +535,72 @@ void allsky_poll_task(void *arg) {
         uint32_t interval_ms = (uint32_t)cfg->allsky_update_interval_s * 1000;
         if (interval_ms < 1000) interval_ms = 1000;
         ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(interval_ms));
+    }
+}
+
+// =============================================================================
+// GOES Image Display Poll Task — independent poller pinned to Core 0
+// =============================================================================
+
+void goes_poll_task(void *arg)
+{
+    ESP_LOGI(TAG, "GOES poll task started");
+
+    // Wait for WiFi before attempting any HTTP requests
+    xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
+
+    while (1) {
+        /* Suspend during OTA or when the Image Display page is not visible */
+        while (ota_in_progress || !image_display_page_active) {
+            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000));
+        }
+
+        /* Read fields directly from config pointer — avoids copying the full
+         * app_config_t onto this task's small stack. */
+        const app_config_t *cfg = app_config_get();
+
+        /* Only poll when a region is configured */
+        if (cfg->goes_region[0] != '\0') {
+            goes_client_poll(cfg->goes_region, &goes_data);
+        }
+
+        /* Sleep for the configured interval (clamped 5min-2h to respect the
+         * satellite image cadence and avoid hammering the source). */
+        uint32_t interval_ms = (uint32_t)cfg->goes_update_interval_s * 1000;
+        if (interval_ms < 300000) interval_ms = 300000;
+        if (interval_ms > 7200000) interval_ms = 7200000;
+        ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(interval_ms));
+    }
+}
+
+// =============================================================================
+// GOES task lifecycle
+// =============================================================================
+
+void goes_ensure_task_running(void)
+{
+    /* Guard check-and-assign against a double-spawn race: this may be called
+     * concurrently from the boot task and an httpd task (runtime enable). */
+    static portMUX_TYPE goes_spawn_mux = portMUX_INITIALIZER_UNLOCKED;
+    portENTER_CRITICAL(&goes_spawn_mux);
+    bool already = (goes_task_handle != NULL);
+    portEXIT_CRITICAL(&goes_spawn_mux);
+    if (already) return;
+
+    /* 12288 words: TLS handshake + software JPEG decode headroom (matches/
+     * exceeds the spotify TLS task). */
+    StackType_t  *stack = heap_caps_malloc(12288 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
+    StaticTask_t *tcb   = heap_caps_calloc(1, sizeof(StaticTask_t), MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    if (stack && tcb) {
+        portENTER_CRITICAL(&goes_spawn_mux);
+        goes_task_handle = xTaskCreateStaticPinnedToCore(
+            goes_poll_task, "goes", 12288, NULL, 3, stack, tcb, 0);
+        portEXIT_CRITICAL(&goes_spawn_mux);
+        ESP_LOGI(TAG, "GOES poll task spawned");
+    } else {
+        ESP_LOGE(TAG, "Failed to allocate GOES poll task stack");
+        if (stack) heap_caps_free(stack);
+        if (tcb) heap_caps_free(tcb);
     }
 }
 
@@ -1104,6 +1183,9 @@ void data_update_task(void *arg) {
 
         /* Initialize AllSky data struct (needed even in demo mode) */
         allsky_data_init(&allsky_data);
+        /* Initialize GOES data struct so its mutex exists even in demo mode
+         * (a later web-handler enable + page entry would otherwise NULL-deref). */
+        goes_data_init(&goes_data);
 
         instance_count = app_config_get_instance_count();
         instance_count = 3;  /* demo mode always shows all 3 instance profiles */
@@ -1257,6 +1339,14 @@ void data_update_task(void *arg) {
         }
     }
 
+    /* GOES / Image Display poll task.
+     * goes_data_init must run UNCONDITIONALLY so the mutex exists before any
+     * later web-handler-triggered enable + page entry. */
+    goes_data_init(&goes_data);
+    if (app_config_get()->image_display_enabled) {
+        goes_ensure_task_running();
+    }
+
     /* Spawn async fetch worker (pinned to Core 0, networking) */
     if (s_fetch_queue && s_fetch_result_queue) {
         StackType_t *fw_stack = heap_caps_malloc(8192 * sizeof(StackType_t), MALLOC_CAP_SPIRAM);
@@ -1385,13 +1475,15 @@ main_loop:
         bool on_settings = nina_dashboard_is_settings_page();
         bool on_summary = nina_dashboard_is_summary_page();
         bool on_clock = nina_dashboard_is_clock_page();
+        bool on_image_display = nina_dashboard_is_image_display_page();
 
         /*
          * Page index convention (see PAGE_IDX_* / NINA_PAGE_OFFSET / EXTRA_PAGES):
-         *   PAGE_IDX_ALLSKY  (0)                        = AllSky page
-         *   PAGE_IDX_SPOTIFY (1)                        = Spotify page
-         *   PAGE_IDX_CLOCK   (2)                        = Clock page (always present)
-         *   PAGE_IDX_SUMMARY (3)                        = summary page
+         *   PAGE_IDX_ALLSKY        (0)                  = AllSky page
+         *   PAGE_IDX_SPOTIFY       (1)                  = Spotify page
+         *   PAGE_IDX_CLOCK         (2)                  = Clock page (always present)
+         *   PAGE_IDX_IMAGE_DISPLAY (3)                  = Image Display page
+         *   PAGE_IDX_SUMMARY       (4)                  = summary page
          *   NINA_PAGE_OFFSET .. NINA_PAGE_OFFSET+pc-1   = NINA instance pages
          *   SETTINGS_PAGE_IDX(pc)                       = settings page
          *   SYSINFO_PAGE_IDX(pc)                        = sysinfo page
@@ -1461,6 +1553,22 @@ main_loop:
             }
             prev_on_clock = on_clock;
             clock_page_active = on_clock;
+
+            /* Image Display lifecycle — wake on entry, free buffers on leave */
+            static bool prev_on_image_display = false;
+            if (on_image_display && !prev_on_image_display && goes_task_handle) {
+                xTaskNotifyGive(goes_task_handle);
+            }
+            image_display_page_active = on_image_display;   /* gate poll task BEFORE cleanup */
+            if (!on_image_display && prev_on_image_display) {
+                if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                    nina_image_display_cleanup();
+                    bsp_display_unlock();
+                }
+                goes_client_cleanup(&goes_data);
+                ESP_LOGI(TAG, "Left Image Display: freed buffers");
+            }
+            prev_on_image_display = on_image_display;
         }
 
         // Re-read instance count from config so API URL changes take effect live
@@ -1748,6 +1856,14 @@ main_loop:
                     bsp_display_unlock();
                 }
                 allsky_data_unlock(&allsky_data);
+            }
+        } else if (on_image_display) {
+            /* Image Display page — repaint when a new GOES image has arrived.
+             * nina_image_display_update locks goes_data internally; it must be
+             * called with the display lock held. */
+            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                nina_image_display_update(&goes_data);
+                bsp_display_unlock();
             }
         } else if (on_summary) {
             /* Summary page — pre-lock all instances with short timeout, then single LVGL lock */

--- a/main/tasks.h
+++ b/main/tasks.h
@@ -5,6 +5,7 @@
 #include "freertos/event_groups.h"
 #include "nina_client.h"
 #include "app_config.h"
+#include "goes_client.h"
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdatomic.h>
@@ -67,6 +68,11 @@ extern _Atomic bool allsky_page_active;
 extern _Atomic bool clock_page_active;
 extern _Atomic bool nina_pages_active;
 
+/** GOES / Image Display poll task handle, page-active flag, and shared data. */
+extern TaskHandle_t goes_task_handle;
+extern _Atomic bool image_display_page_active;
+extern goes_data_t goes_data;
+
 /** Weather poll task — spawned by weather_client_start() when location is configured. */
 /* (Task handle is internal to weather_client.c; no extern needed here.) */
 
@@ -75,6 +81,12 @@ void spotify_poll_task(void *arg);
 
 /** Create the Spotify poll task if it isn't already running. Safe to call multiple times. */
 void spotify_ensure_task_running(void);
+
+/** FreeRTOS task: GOES Image Display poller — fetches satellite imagery at goes_update_interval_s rate. */
+void goes_poll_task(void *arg);
+
+/** Create the GOES poll task if it isn't already running. Safe to call multiple times. */
+void goes_ensure_task_running(void);
 
 /** FreeRTOS task: UI coordinator — reads cached data, updates LVGL, handles auto-rotate. */
 void data_update_task(void *arg);

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -16,6 +16,7 @@
 #include "nina_allsky.h"
 #include "nina_spotify.h"
 #include "nina_clock.h"
+#include "nina_image_display.h"
 #include "nina_settings_tabview.h"
 #include "nina_toast.h"
 #include "nina_event_log.h"
@@ -49,7 +50,11 @@ static lv_obj_t *spotify_page_created = NULL;  /* Always holds the created page 
 /* Clock page — always at PAGE_IDX_CLOCK (2), always present */
 lv_obj_t *clock_obj = NULL;
 
-/* Summary page — at PAGE_IDX_SUMMARY (3), excluded from indicators */
+/* Image Display page — always at PAGE_IDX_IMAGE_DISPLAY (3), excluded from indicators */
+lv_obj_t *image_display_obj = NULL;
+static lv_obj_t *image_display_page_created = NULL;
+
+/* Summary page — at PAGE_IDX_SUMMARY (4), excluded from indicators */
 static lv_obj_t *summary_obj = NULL;
 
 /* Settings page — at SETTINGS_PAGE_IDX(page_count), excluded from indicators */
@@ -134,10 +139,11 @@ lv_obj_t *create_value_label(lv_obj_t *parent) {
 
 /*
  * Page index convention (see PAGE_IDX_* / NINA_PAGE_OFFSET / EXTRA_PAGES in nina_dashboard_internal.h):
- *   PAGE_IDX_ALLSKY  (0)                        = AllSky page
- *   PAGE_IDX_SPOTIFY (1)                        = Spotify page
- *   PAGE_IDX_CLOCK   (2)                        = Clock page (always present)
- *   PAGE_IDX_SUMMARY (3)                        = summary page
+ *   PAGE_IDX_ALLSKY        (0)                  = AllSky page
+ *   PAGE_IDX_SPOTIFY       (1)                  = Spotify page
+ *   PAGE_IDX_CLOCK         (2)                  = Clock page (always present)
+ *   PAGE_IDX_IMAGE_DISPLAY (3)                  = Image Display page
+ *   PAGE_IDX_SUMMARY       (4)                  = summary page
  *   NINA_PAGE_OFFSET .. NINA_PAGE_OFFSET+pc-1   = NINA instance pages  (pages[idx - NINA_PAGE_OFFSET])
  *   SETTINGS_PAGE_IDX(pc)                       = settings page
  *   SYSINFO_PAGE_IDX(pc)                        = sysinfo page
@@ -156,6 +162,8 @@ static void hide_page_at(int idx) {
         lv_obj_add_flag(clock_obj, LV_OBJ_FLAG_HIDDEN);
         clock_page_on_hide();
     }
+    else if (idx == PAGE_IDX_IMAGE_DISPLAY && image_display_obj)
+        lv_obj_add_flag(image_display_obj, LV_OBJ_FLAG_HIDDEN);
     else if (idx == PAGE_IDX_SUMMARY && summary_obj)
         lv_obj_add_flag(summary_obj, LV_OBJ_FLAG_HIDDEN);
     else if (idx >= NINA_PAGE_OFFSET && idx < NINA_PAGE_OFFSET + page_count)
@@ -179,6 +187,8 @@ static void show_page_at(int idx) {
         lv_obj_clear_flag(clock_obj, LV_OBJ_FLAG_HIDDEN);
         clock_page_on_show();
     }
+    else if (idx == PAGE_IDX_IMAGE_DISPLAY && image_display_obj)
+        lv_obj_clear_flag(image_display_obj, LV_OBJ_FLAG_HIDDEN);
     else if (idx == PAGE_IDX_SUMMARY && summary_obj)
         lv_obj_clear_flag(summary_obj, LV_OBJ_FLAG_HIDDEN);
     else if (idx >= NINA_PAGE_OFFSET && idx < NINA_PAGE_OFFSET + page_count)
@@ -200,6 +210,7 @@ static lv_obj_t *get_page_obj(int idx) {
     if (idx == PAGE_IDX_ALLSKY && allsky_obj) return allsky_obj;
     if (idx == PAGE_IDX_SPOTIFY && spotify_obj) return spotify_obj;
     if (idx == PAGE_IDX_CLOCK && clock_obj) return clock_obj;
+    if (idx == PAGE_IDX_IMAGE_DISPLAY && image_display_obj) return image_display_obj;
     if (idx == PAGE_IDX_SUMMARY && summary_obj) return summary_obj;
     if (idx >= NINA_PAGE_OFFSET && idx < NINA_PAGE_OFFSET + page_count)
         return pages[idx - NINA_PAGE_OFFSET].page;
@@ -281,6 +292,7 @@ void nina_dashboard_apply_theme(int theme_index) {
     if (allsky_obj) allsky_page_apply_theme();
     if (spotify_obj) spotify_page_apply_theme();
     clock_page_apply_theme();
+    if (image_display_obj) nina_image_display_apply_theme();
     summary_page_apply_theme();
     if (settings_obj) settings_tabview_apply_theme();
     sysinfo_page_apply_theme();
@@ -672,7 +684,7 @@ static void create_page_indicator(lv_obj_t *parent, int count) {
     lv_obj_set_flex_align(indicator_cont, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_pad_column(indicator_cont, 8, 0);
 
-    /* Start hidden — summary page (index 1) is the default boot page */
+    /* Start hidden — summary page (PAGE_IDX_SUMMARY) is the default boot page */
     lv_obj_add_flag(indicator_cont, LV_OBJ_FLAG_HIDDEN);
 
     int gb = app_config_get()->color_brightness;
@@ -720,6 +732,7 @@ static void gesture_event_cb(lv_event_t *e) {
             if (candidate == SETTINGS_PAGE_IDX(page_count)) continue;
             if (candidate == PAGE_IDX_ALLSKY && allsky_obj == NULL) continue;
             if (candidate == PAGE_IDX_SPOTIFY && spotify_obj == NULL) continue;
+            if (candidate == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) continue;
             new_page = candidate;
             break;
         }
@@ -729,6 +742,7 @@ static void gesture_event_cb(lv_event_t *e) {
             if (candidate == SETTINGS_PAGE_IDX(page_count)) continue;
             if (candidate == PAGE_IDX_ALLSKY && allsky_obj == NULL) continue;
             if (candidate == PAGE_IDX_SPOTIFY && spotify_obj == NULL) continue;
+            if (candidate == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) continue;
             new_page = candidate;
             break;
         }
@@ -845,6 +859,12 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
     clock_obj = clock_page_create(main_cont);
     lv_obj_add_flag(clock_obj, LV_OBJ_FLAG_HIDDEN);
 
+    /* Image Display page — PAGE_IDX_IMAGE_DISPLAY, always created but hidden initially.
+     * image_display_obj is set to NULL when disabled to remove from navigation. */
+    image_display_page_created = nina_image_display_create(main_cont);
+    lv_obj_add_flag(image_display_page_created, LV_OBJ_FLAG_HIDDEN);
+    image_display_obj = app_config_get()->image_display_enabled ? image_display_page_created : NULL;
+
     /* Summary page — PAGE_IDX_SUMMARY, visible by default */
     summary_obj = summary_page_create(main_cont, page_count);
 
@@ -904,6 +924,7 @@ void nina_dashboard_show_page(int page_index, int instance_count) {
     if (page_index < 0 || page_index >= total_page_count) return;
     if (page_index == PAGE_IDX_ALLSKY && allsky_obj == NULL) return;  /* allsky disabled */
     if (page_index == PAGE_IDX_SPOTIFY && spotify_obj == NULL) return;  /* spotify disabled */
+    if (page_index == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) return;  /* image display disabled */
     if (page_index == active_page) return;
 
     hide_page_at(active_page);
@@ -956,6 +977,25 @@ void nina_dashboard_set_spotify_enabled(bool enabled) {
             lv_obj_add_flag(spotify_page_created, LV_OBJ_FLAG_HIDDEN);
         }
         spotify_obj = NULL;
+    }
+}
+
+bool nina_dashboard_is_image_display_page(void) {
+    return image_display_obj != NULL && active_page == PAGE_IDX_IMAGE_DISPLAY;
+}
+
+void nina_dashboard_set_image_display_enabled(bool enabled) {
+    if (enabled) {
+        image_display_obj = image_display_page_created;
+    } else {
+        /* If currently viewing the Image Display page, switch to summary first */
+        if (active_page == PAGE_IDX_IMAGE_DISPLAY && image_display_obj != NULL) {
+            nina_dashboard_show_page(PAGE_IDX_SUMMARY, total_page_count);
+        }
+        if (image_display_page_created) {
+            lv_obj_add_flag(image_display_page_created, LV_OBJ_FLAG_HIDDEN);
+        }
+        image_display_obj = NULL;
     }
 }
 
@@ -1083,6 +1123,7 @@ void nina_dashboard_show_page_animated(int page_index, int instance_count, int e
     if (page_index < 0 || page_index >= total_page_count) return;
     if (page_index == PAGE_IDX_ALLSKY && allsky_obj == NULL) return;  /* allsky disabled */
     if (page_index == PAGE_IDX_SPOTIFY && spotify_obj == NULL) return;  /* spotify disabled */
+    if (page_index == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) return;  /* image display disabled */
     if (page_index == active_page) return;
 
     lv_obj_t *old_obj = get_page_obj(active_page);

--- a/main/ui/nina_dashboard.h
+++ b/main/ui/nina_dashboard.h
@@ -106,6 +106,19 @@ bool nina_dashboard_is_spotify_page(void);
 void nina_dashboard_set_spotify_enabled(bool enabled);
 
 /**
+ * @brief Check if the active page is the Image Display page
+ * @return true if the Image Display page is currently shown
+ */
+bool nina_dashboard_is_image_display_page(void);
+
+/**
+ * @brief Enable or disable the Image Display page at runtime.
+ * When disabled, switches away if currently viewing and removes from navigation.
+ * Must be called with LVGL display lock held.
+ */
+void nina_dashboard_set_image_display_enabled(bool enabled);
+
+/**
  * @brief Check if the active page is the clock page
  * @return true if the clock page is currently shown
  */

--- a/main/ui/nina_dashboard_internal.h
+++ b/main/ui/nina_dashboard_internal.h
@@ -17,21 +17,23 @@
 /* ── Page index constants ──
  *
  * Page index convention:
- *   PAGE_IDX_ALLSKY   (0)  = AllSky page
- *   PAGE_IDX_SPOTIFY  (1)  = Spotify page
- *   PAGE_IDX_CLOCK    (2)  = Clock page (always present)
- *   PAGE_IDX_SUMMARY  (3)  = Summary page
- *   NINA_PAGE_OFFSET  (4)  .. NINA_PAGE_OFFSET + page_count - 1 = NINA instance pages
+ *   PAGE_IDX_ALLSKY         (0)  = AllSky page
+ *   PAGE_IDX_SPOTIFY        (1)  = Spotify page
+ *   PAGE_IDX_CLOCK          (2)  = Clock page (always present)
+ *   PAGE_IDX_IMAGE_DISPLAY  (3)  = Image Display page
+ *   PAGE_IDX_SUMMARY        (4)  = Summary page
+ *   NINA_PAGE_OFFSET        (5)  .. NINA_PAGE_OFFSET + page_count - 1 = NINA instance pages
  *   page_count + NINA_PAGE_OFFSET     = settings page
  *   page_count + NINA_PAGE_OFFSET + 1 = sysinfo page
  *   total_page_count = page_count + EXTRA_PAGES
  */
-#define PAGE_IDX_ALLSKY   0
-#define PAGE_IDX_SPOTIFY  1
-#define PAGE_IDX_CLOCK    2
-#define PAGE_IDX_SUMMARY  3
-#define NINA_PAGE_OFFSET  4   /* First NINA page index */
-#define EXTRA_PAGES       6   /* allsky + spotify + clock + summary + settings + sysinfo */
+#define PAGE_IDX_ALLSKY          0
+#define PAGE_IDX_SPOTIFY         1
+#define PAGE_IDX_CLOCK           2
+#define PAGE_IDX_IMAGE_DISPLAY   3
+#define PAGE_IDX_SUMMARY         4
+#define NINA_PAGE_OFFSET         5   /* First NINA page index */
+#define EXTRA_PAGES              7   /* allsky + spotify + clock + image_display + summary + settings + sysinfo */
 
 /* Derived page index helpers (use these instead of hardcoded arithmetic) */
 #define SETTINGS_PAGE_IDX(pc)  ((pc) + NINA_PAGE_OFFSET)
@@ -126,6 +128,9 @@ extern lv_obj_t *spotify_obj;
 
 /* Clock page — defined in nina_dashboard.c */
 extern lv_obj_t *clock_obj;
+
+/* Image Display page — defined in nina_dashboard.c */
+extern lv_obj_t *image_display_obj;
 
 /* Shared state — defined in nina_dashboard.c, used by update and thumbnail modules */
 extern dashboard_page_t pages[MAX_NINA_INSTANCES];

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -1,0 +1,333 @@
+/**
+ * @file nina_image_display.c
+ * @brief Full-screen satellite image page with crossfade transitions.
+ *
+ * Displays a GOES/NESDIS sector image scaled to fill the 720x720 panel.
+ * New images crossfade over the previous one (500 ms ease-in-out). A
+ * toggle-able bottom overlay bar shows the region name and last-update time.
+ *
+ * Threading: all LVGL calls below run under the display lock held by the
+ * CALLER (data_update_task / web handler), matching allsky_page_update and
+ * nina_spotify_update. Do NOT take lvgl_port_lock / bsp_display_lock here.
+ */
+
+#include "nina_image_display.h"
+#include "nina_dashboard_internal.h"
+#include "app_config.h"
+#include "display_defs.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include <string.h>
+#include <time.h>
+
+static const char *TAG = "image_display";
+
+/* Overlay label font — overpass_27 is unconditionally compiled into the
+ * firmware (see main/CMakeLists.txt), so it avoids any dependency on the
+ * LV_FONT_MONTSERRAT_* Kconfig toggles. */
+extern const lv_font_t lv_font_overpass_27;
+
+static lv_obj_t *page_container;
+static lv_obj_t *img_front;
+static lv_obj_t *img_back;
+static lv_obj_t *overlay_bar;
+static lv_obj_t *lbl_region;
+static lv_obj_t *lbl_timestamp;
+
+/* One persistent RGB565 descriptor per image slot. The slot whose image is
+ * currently "front" owns the displayed buffer; the "back" slot owns the
+ * incoming/copy buffer during a crossfade. */
+static lv_image_dsc_t img_dsc_a;
+static lv_image_dsc_t img_dsc_b;
+static bool front_is_a = true;
+static int64_t displayed_poll_ms;
+static bool crossfade_active = false;
+
+/* NESDIS sector code -> human-readable region name. */
+static const struct { const char *code; const char *name; } region_labels[] = {
+    {"umv","Upper Mississippi Valley"}, {"cgl","Great Lakes"},
+    {"ne","Northeast"},                 {"se","Southeast"},
+    {"smv","Southern Mississippi Valley"},{"sp","Southern Plains"},
+    {"nr","Northern Rockies"},          {"sr","Southern Rockies"},
+    {"pnw","Pacific Northwest"},        {"psw","Pacific Southwest"},
+    {"pr","Puerto Rico"},               {"eus","U.S. Atlantic Coast"},
+    {"cam","Central America"},          {"car","Caribbean"},
+    {"mex","Mexico"},                   {"ga","Gulf of America"},
+    {"na","Northern Atlantic"},         {"ssa","South America (South)"},
+    {"eep","Eastern Pacific"},          {"taw","Tropical Atlantic"},
+    {"nsa","South America (North)"},    {"can","Canada"},
+    {NULL,NULL}
+};
+
+static const char *region_code_to_name(const char *code)
+{
+    for (int i = 0; region_labels[i].code; i++) {
+        if (!strcmp(region_labels[i].code, code)) return region_labels[i].name;
+    }
+    return code;
+}
+
+static void init_image_dsc(lv_image_dsc_t *dsc)
+{
+    memset(dsc, 0, sizeof(*dsc));
+    dsc->header.magic = LV_IMAGE_HEADER_MAGIC;
+    dsc->header.cf    = LV_COLOR_FORMAT_RGB565;
+}
+
+static void anim_opa_cb(void *obj, int32_t v)
+{
+    lv_obj_set_style_opa((lv_obj_t *)obj, (lv_opa_t)v, 0);
+}
+
+/* Runs when the fade-IN of the new image completes. Hides/clears the OLD
+ * image (the one that just faded OUT, which is always img_front at callback
+ * time), frees its buffer, flips the front/back designation, and recomputes
+ * the img_front/img_back pointers from the container children. */
+static void crossfade_done_cb(lv_anim_t *a)
+{
+    (void)a;
+    /* img_front is the OLD image that just faded OUT. Its buffer is img_dsc_a
+     * when front_is_a, else img_dsc_b. */
+    lv_image_dsc_t *old_dsc = front_is_a ? &img_dsc_a : &img_dsc_b;
+
+    /* Detach the source BEFORE freeing the buffer so LVGL never dereferences a
+     * freed descriptor. */
+    lv_obj_add_flag(img_front, LV_OBJ_FLAG_HIDDEN);
+    lv_image_set_src(img_front, NULL);
+    if (old_dsc->data) {
+        heap_caps_free((void *)old_dsc->data);
+        old_dsc->data       = NULL;
+        old_dsc->data_size  = 0;
+        old_dsc->header.w   = 0;
+        old_dsc->header.h   = 0;
+    }
+
+    front_is_a = !front_is_a;
+    img_front  = front_is_a ? lv_obj_get_child(page_container, 0)
+                            : lv_obj_get_child(page_container, 1);
+    img_back   = front_is_a ? lv_obj_get_child(page_container, 1)
+                            : lv_obj_get_child(page_container, 0);
+    crossfade_active = false;
+}
+
+lv_obj_t *nina_image_display_create(lv_obj_t *parent)
+{
+    page_container = lv_obj_create(parent);
+    lv_obj_remove_style_all(page_container);
+    lv_obj_set_size(page_container, SCREEN_SIZE, SCREEN_SIZE);
+    /* Negate the parent main_cont's OUTER_PADDING so the image fills edge-to-edge
+     * (matches nina_spotify spotify_page_create). Without this the page renders
+     * inset by OUTER_PADDING, leaving a black band on the top and left. */
+    lv_obj_set_pos(page_container, -OUTER_PADDING, -OUTER_PADDING);
+    lv_obj_set_style_bg_color(page_container, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(page_container, LV_OPA_COVER, 0);
+    lv_obj_clear_flag(page_container, LV_OBJ_FLAG_SCROLLABLE);
+
+    init_image_dsc(&img_dsc_a);
+    init_image_dsc(&img_dsc_b);
+
+    /* Child 0 = image A, child 1 = image B (the two stacked crossfade images);
+     * overlay_bar (child 2) MUST be created after both images so the child-index
+     * math in crossfade_done_cb / cleanup (children 0 and 1) stays valid.
+     *
+     * Each image uses pos + pivot (0,0) and no explicit object size, so the
+     * source auto-sizes and lv_image_set_scale() (in _update) expands it from
+     * the top-left to fill the panel — matching nina_spotify's album art. Do
+     * NOT add LV_IMAGE_ALIGN_CENTER or a fixed 720x720 size: combined with the
+     * scale transform they offset the image and leave a black border. */
+    lv_obj_t *img_a = lv_image_create(page_container);
+    lv_obj_set_pos(img_a, 0, 0);
+    lv_image_set_pivot(img_a, 0, 0);
+    lv_obj_add_flag(img_a, LV_OBJ_FLAG_HIDDEN);
+
+    lv_obj_t *img_b = lv_image_create(page_container);
+    lv_obj_set_pos(img_b, 0, 0);
+    lv_image_set_pivot(img_b, 0, 0);
+    lv_obj_add_flag(img_b, LV_OBJ_FLAG_HIDDEN);
+
+    img_front = img_a;
+    img_back  = img_b;
+    front_is_a = true;
+    displayed_poll_ms = 0;
+    crossfade_active  = false;
+
+    overlay_bar = lv_obj_create(page_container);
+    lv_obj_remove_style_all(overlay_bar);
+    lv_obj_set_size(overlay_bar, SCREEN_SIZE, 68);
+    lv_obj_align(overlay_bar, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_set_style_bg_color(overlay_bar, lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(overlay_bar, 210, 0);
+    lv_obj_set_style_pad_left(overlay_bar, 18, 0);
+    lv_obj_set_style_pad_right(overlay_bar, 18, 0);
+    lv_obj_clear_flag(overlay_bar, LV_OBJ_FLAG_SCROLLABLE);
+
+    lbl_region = lv_label_create(overlay_bar);
+    lv_obj_set_style_text_color(lbl_region, lv_color_white(), 0);
+    lv_obj_set_style_text_font(lbl_region, &lv_font_overpass_27, 0);
+    lv_obj_align(lbl_region, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_label_set_text(lbl_region, "");
+
+    lbl_timestamp = lv_label_create(overlay_bar);
+    lv_obj_set_style_text_color(lbl_timestamp, lv_color_hex(0xE8E8E8), 0);
+    lv_obj_set_style_text_font(lbl_timestamp, &lv_font_overpass_27, 0);
+    lv_obj_align(lbl_timestamp, LV_ALIGN_RIGHT_MID, 0, 0);
+    lv_label_set_text(lbl_timestamp, "");
+
+    if (!app_config_get()->image_display_show_overlay) {
+        lv_obj_add_flag(overlay_bar, LV_OBJ_FLAG_HIDDEN);
+    }
+    return page_container;
+}
+
+void nina_image_display_update(goes_data_t *data)
+{
+    if (!data || !page_container) return;
+    if (crossfade_active) return;
+    if (!goes_data_lock(data, 100)) return;
+
+    if (!data->image_buf || data->last_poll_ms <= displayed_poll_ms) {
+        goes_data_unlock(data);
+        return;
+    }
+
+    /* Copy the RGB565 source into a freshly allocated PSRAM buffer so we can
+     * release the goes mutex before running the (asynchronous) crossfade and
+     * so this page owns its display buffers independently of the poller. */
+    uint16_t w = data->image_w, h = data->image_h;
+    if (w == 0 || h == 0) {
+        goes_data_unlock(data);
+        return;
+    }
+    size_t   buf_size = (size_t)w * h * 2;
+    uint8_t *copy = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
+    if (!copy) {
+        ESP_LOGE(TAG, "PSRAM alloc failed for crossfade buffer (%u bytes)",
+                 (unsigned)buf_size);
+        goes_data_unlock(data);
+        return;
+    }
+    /* The software JPEG decoder feeding this page produces a vertically
+     * flipped buffer relative to the hardware decode path (Spotify art / NINA
+     * thumbnails), which render correctly. Copy it row-reversed (mirror
+     * top<->bottom, columns unchanged) so it renders upright. A full end-to-end
+     * reversal would also mirror left<->right, so flip rows only. */
+    {
+        size_t row_bytes = (size_t)w * 2;
+        for (uint32_t y = 0; y < h; y++) {
+            memcpy((uint8_t *)copy + (size_t)y * row_bytes,
+                   data->image_buf + (size_t)(h - 1 - y) * row_bytes,
+                   row_bytes);
+        }
+    }
+    int64_t poll_ms = data->last_poll_ms;
+    goes_data_unlock(data);
+
+    /* Point the BACK slot's descriptor at the new copy. */
+    lv_image_dsc_t *back_dsc = front_is_a ? &img_dsc_b : &img_dsc_a;
+    if (back_dsc->data) heap_caps_free((void *)back_dsc->data);
+    back_dsc->data          = copy;
+    back_dsc->data_size     = buf_size;
+    back_dsc->header.magic  = LV_IMAGE_HEADER_MAGIC;
+    back_dsc->header.cf     = LV_COLOR_FORMAT_RGB565;
+    back_dsc->header.w      = w;
+    back_dsc->header.h      = h;
+    back_dsc->header.stride = w * 2;
+
+    /* Scale the source to fill the panel width. 256 = 1.0x. Do NOT call
+     * lv_obj_set_pos() on the image here: re-anchoring a scaled image every
+     * update flips it upside down under 90/270 display rotation. The image
+     * stays at its create-time (0,0); wide sectors are top-aligned. */
+    uint16_t scale = (w > 0) ? (uint16_t)(((uint32_t)SCREEN_SIZE * 256 + w / 2) / w) : 256;
+    lv_image_set_src(img_back, back_dsc);
+    lv_image_set_scale(img_back, scale);
+    lv_obj_set_style_opa(img_back, LV_OPA_TRANSP, 0);
+    lv_obj_clear_flag(img_back, LV_OBJ_FLAG_HIDDEN);
+
+    bool first_image = (displayed_poll_ms == 0);
+    displayed_poll_ms = poll_ms;
+
+    if (first_image) {
+        /* No previous image to fade from: just show it and swap slots. */
+        lv_obj_set_style_opa(img_back, LV_OPA_COVER, 0);
+        front_is_a = !front_is_a;
+        lv_obj_t *tmp = img_front;
+        img_front = img_back;
+        img_back  = tmp;
+    } else {
+        crossfade_active = true;
+
+        lv_anim_t a_in;
+        lv_anim_init(&a_in);
+        lv_anim_set_var(&a_in, img_back);
+        lv_anim_set_values(&a_in, 0, 255);
+        lv_anim_set_duration(&a_in, 500);
+        lv_anim_set_path_cb(&a_in, lv_anim_path_ease_in_out);
+        lv_anim_set_exec_cb(&a_in, anim_opa_cb);
+        lv_anim_set_completed_cb(&a_in, crossfade_done_cb);
+        lv_anim_start(&a_in);
+
+        lv_anim_t a_out;
+        lv_anim_init(&a_out);
+        lv_anim_set_var(&a_out, img_front);
+        lv_anim_set_values(&a_out, 255, 0);
+        lv_anim_set_duration(&a_out, 500);
+        lv_anim_set_path_cb(&a_out, lv_anim_path_ease_in_out);
+        lv_anim_set_exec_cb(&a_out, anim_opa_cb);
+        lv_anim_start(&a_out);
+    }
+
+    const app_config_t *cfg = app_config_get();
+    lv_label_set_text(lbl_region, region_code_to_name(cfg->goes_region));
+
+    time_t now;
+    struct tm ti;
+    time(&now);
+    localtime_r(&now, &ti);
+    char ts[32];
+    strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
+    lv_label_set_text(lbl_timestamp, ts);
+}
+
+void nina_image_display_cleanup(void)
+{
+    if (!page_container) return;
+
+    crossfade_active = false;
+    lv_anim_delete(img_front, anim_opa_cb);
+    lv_anim_delete(img_back, anim_opa_cb);
+
+    lv_obj_t *child0 = lv_obj_get_child(page_container, 0);
+    lv_obj_t *child1 = lv_obj_get_child(page_container, 1);
+    lv_image_set_src(child0, NULL);
+    lv_image_set_src(child1, NULL);
+    lv_obj_add_flag(child0, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(child1, LV_OBJ_FLAG_HIDDEN);
+
+    if (img_dsc_a.data) { heap_caps_free((void *)img_dsc_a.data); img_dsc_a.data = NULL; }
+    if (img_dsc_b.data) { heap_caps_free((void *)img_dsc_b.data); img_dsc_b.data = NULL; }
+    img_dsc_a.data_size = 0;
+    img_dsc_b.data_size = 0;
+    img_dsc_a.header.w = img_dsc_a.header.h = 0;
+    img_dsc_b.header.w = img_dsc_b.header.h = 0;
+
+    displayed_poll_ms = 0;
+    front_is_a = true;
+    img_front  = child0;
+    img_back   = child1;
+}
+
+void nina_image_display_set_overlay_visible(bool visible)
+{
+    if (!overlay_bar) return;
+    if (visible) lv_obj_clear_flag(overlay_bar, LV_OBJ_FLAG_HIDDEN);
+    else         lv_obj_add_flag(overlay_bar, LV_OBJ_FLAG_HIDDEN);
+}
+
+void nina_image_display_apply_theme(void)
+{
+    if (!overlay_bar || !current_theme) return;
+    int gb = app_config_get()->color_brightness;
+    lv_obj_set_style_text_color(
+        lbl_region,
+        lv_color_hex(app_config_apply_brightness(current_theme->text_color, gb)), 0);
+}

--- a/main/ui/nina_image_display.h
+++ b/main/ui/nina_image_display.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "lvgl.h"
+#include "goes_client.h"
+#include <stdbool.h>
+
+lv_obj_t *nina_image_display_create(lv_obj_t *parent);
+void      nina_image_display_update(goes_data_t *data);
+void      nina_image_display_cleanup(void);
+void      nina_image_display_set_overlay_visible(bool visible);
+void      nina_image_display_apply_theme(void);

--- a/main/ui/settings_tab_behavior.c
+++ b/main/ui/settings_tab_behavior.c
@@ -681,10 +681,11 @@ void settings_tab_behavior_create(lv_obj_t *parent) {
                                     "Clock\n"
                                     "AllSky\n"
                                     "Spotify\n"
+                                    "Image Display\n"
                                     "System Info");
 
             /* Map idle_target_t enum to dropdown index:
-             * IDLE_TARGET_SUMMARY(-1)=0, CLOCK(0)=1, ALLSKY(1)=2, SPOTIFY(2)=3, SYSINFO(3)=4 */
+             * IDLE_TARGET_SUMMARY(-1)=0, CLOCK(0)=1, ALLSKY(1)=2, SPOTIFY(2)=3, IMAGE_DISPLAY(3)=4, SYSINFO(4)=5 */
             lv_dropdown_set_selected(dd_idle_target, (uint32_t)(cfg->idle_page_override_target + 1));
 
             if (current_theme) {

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -125,6 +125,10 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     cJSON_AddBoolToObject(obj, "spotify_scroll_text", cfg->spotify_scroll_text);
     cJSON_AddNumberToObject(obj, "spotify_overlay_timeout_s", cfg->spotify_overlay_timeout_s);
     cJSON_AddBoolToObject(obj, "spotify_overlay_visible", cfg->spotify_overlay_visible);
+    cJSON_AddBoolToObject(obj, "image_display_enabled", cfg->image_display_enabled);
+    cJSON_AddBoolToObject(obj, "image_display_show_overlay", cfg->image_display_show_overlay);
+    cJSON_AddStringToObject(obj, "goes_region", cfg->goes_region);
+    cJSON_AddNumberToObject(obj, "goes_update_interval_s", cfg->goes_update_interval_s);
     cJSON_AddNumberToObject(obj, "toast_aggregation_window_s", cfg->toast_aggregation_window_s);
     cJSON_AddNumberToObject(obj, "toast_notify_mask", cfg->toast_notify_mask);
     cJSON_AddBoolToObject(obj, "toast_instance_muted_1", cfg->toast_instance_muted[0]);
@@ -295,6 +299,12 @@ static const backup_field_t s_backup_fields[] = {
     {"spotify_minimal_mode",      "Minimal Mode",         "Spotify", false, false},
     {"spotify_scroll_text",       "Scroll Text",          "Spotify", false, false},
     {"spotify_overlay_visible",   "Show Overlay",         "Spotify", false, false},
+
+    /* Image Display */
+    {"image_display_enabled",      "Image Display Enabled","Image Display", false, false},
+    {"image_display_show_overlay", "Show Overlay",         "Image Display", false, false},
+    {"goes_region",                "GOES Region",          "Image Display", false, false},
+    {"goes_update_interval_s",     "GOES Update Interval", "Image Display", false, false},
 
     /* MQTT (non-sensitive) */
     {"mqtt_enabled",       "MQTT Enabled",       "MQTT", false, false},
@@ -566,7 +576,8 @@ static bool validate_config_fields(cJSON *root, httpd_req_t *req)
         !validate_string_len(root, "hfr_thresholds_3", 256) ||
         !validate_string_len(root, "allsky_hostname", 128) ||
         !validate_string_len(root, "allsky_field_config", 1536) ||
-        !validate_string_len(root, "allsky_thresholds", 1024)) {
+        !validate_string_len(root, "allsky_thresholds", 1024) ||
+        !validate_string_len(root, "goes_region", sizeof(((app_config_t *)0)->goes_region))) {
         send_400(req, "String field exceeds maximum length");
         return false;
     }
@@ -830,6 +841,18 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_BOOL  (root, "spotify_scroll_text",        cfg->spotify_scroll_text);
     JSON_TO_INT   (root, "spotify_overlay_timeout_s",  cfg->spotify_overlay_timeout_s);
     JSON_TO_BOOL  (root, "spotify_overlay_visible",   cfg->spotify_overlay_visible);
+
+    JSON_TO_BOOL  (root, "image_display_enabled",       cfg->image_display_enabled);
+    JSON_TO_BOOL  (root, "image_display_show_overlay",   cfg->image_display_show_overlay);
+    JSON_TO_STRING(root, "goes_region",                  cfg->goes_region);
+
+    cJSON *goes_interval = cJSON_GetObjectItem(root, "goes_update_interval_s");
+    if (cJSON_IsNumber(goes_interval)) {
+        int v = goes_interval->valueint;
+        if (v < 300) v = 300;
+        if (v > 7200) v = 7200;
+        cfg->goes_update_interval_s = (uint16_t)v;
+    }
 
     cJSON *taw_item = cJSON_GetObjectItem(root, "toast_aggregation_window_s");
     if (cJSON_IsNumber(taw_item)) {

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -6,6 +6,7 @@
 #include "bsp/display.h"
 #include "display_defs.h"
 #include "ui/nina_dashboard.h"
+#include "ui/nina_image_display.h"
 #include "ui/nina_spotify.h"
 #include "ui/themes.h"
 #include "lvgl.h"
@@ -71,6 +72,20 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
             allsky_page_refresh_config();
             nina_dashboard_set_allsky_enabled(new_cfg->allsky_enabled);
             bsp_display_unlock();
+        }
+    }
+    /* Image Display (GOES) enable/overlay/region/interval change */
+    if (new_cfg->image_display_enabled != old_cfg->image_display_enabled ||
+        new_cfg->image_display_show_overlay != old_cfg->image_display_show_overlay ||
+        strcmp(new_cfg->goes_region, old_cfg->goes_region) != 0 ||
+        new_cfg->goes_update_interval_s != old_cfg->goes_update_interval_s) {
+        if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+            nina_dashboard_set_image_display_enabled(new_cfg->image_display_enabled);
+            nina_image_display_set_overlay_visible(new_cfg->image_display_show_overlay);
+            bsp_display_unlock();
+        }
+        if (new_cfg->image_display_enabled) {
+            goes_ensure_task_running();
         }
     }
     /* Weather config change — invalidate stale data and force refresh */

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -1,0 +1,102 @@
+#include "web_server_internal.h"
+#include "nina_image_display.h"
+#include "ui/nina_dashboard.h"
+#include "tasks.h"
+#include "bsp/esp-bsp.h"
+#include "bsp/display.h"
+#include "display_defs.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <string.h>
+
+/**
+ * @brief GET /api/image-display-config -- return Image Display config fields.
+ */
+esp_err_t image_display_config_get_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+    app_config_t *cfg = app_config_get();
+    cJSON *root = cJSON_CreateObject();
+    if (root == NULL) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    cJSON_AddBoolToObject(root, "image_display_enabled", cfg->image_display_enabled);
+    cJSON_AddBoolToObject(root, "image_display_show_overlay", cfg->image_display_show_overlay);
+    cJSON_AddStringToObject(root, "goes_region", cfg->goes_region);
+    cJSON_AddNumberToObject(root, "goes_update_interval_s", cfg->goes_update_interval_s);
+
+    const char *json_str = cJSON_PrintUnformatted(root);
+    if (json_str == NULL) {
+        cJSON_Delete(root);
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, json_str, HTTPD_RESP_USE_STRLEN);
+
+    free((void *)json_str);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+/**
+ * @brief POST /api/image-display-config -- update Image Display config fields and save to NVS.
+ */
+esp_err_t image_display_config_post_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+    char buf[CONFIG_MAX_PAYLOAD];
+    int received = httpd_req_recv(req, buf, sizeof(buf) - 1);
+    if (received <= 0) {
+        return send_400(req, "Empty request body");
+    }
+    buf[received] = '\0';
+
+    cJSON *root = cJSON_Parse(buf);
+    if (root == NULL) {
+        return send_400(req, "Invalid JSON");
+    }
+
+    /* Validate string lengths */
+    if (!validate_string_len(root, "goes_region", sizeof(((app_config_t *)0)->goes_region))) {
+        cJSON_Delete(root);
+        return send_400(req, "goes_region too long");
+    }
+
+    app_config_t *cfg = app_config_get();
+
+    JSON_TO_BOOL(root, "image_display_enabled", cfg->image_display_enabled);
+    JSON_TO_BOOL(root, "image_display_show_overlay", cfg->image_display_show_overlay);
+    JSON_TO_STRING(root, "goes_region", cfg->goes_region);
+
+    cJSON *interval = cJSON_GetObjectItem(root, "goes_update_interval_s");
+    if (cJSON_IsNumber(interval)) {
+        int v = interval->valueint;
+        if (v < 300) v = 300;
+        if (v > 7200) v = 7200;
+        cfg->goes_update_interval_s = (uint16_t)v;
+    }
+
+    cJSON_Delete(root);
+
+    app_config_save(cfg);
+
+    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+        nina_dashboard_set_image_display_enabled(cfg->image_display_enabled);
+        nina_image_display_set_overlay_visible(cfg->image_display_show_overlay);
+        bsp_display_unlock();
+    }
+
+    if (cfg->image_display_enabled) {
+        goes_ensure_task_running();
+        if (goes_task_handle) {
+            xTaskNotifyGive(goes_task_handle);
+        }
+    }
+
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -244,6 +244,8 @@ void start_web_server(void)
         { "/api/spotify/logout",         HTTP_POST, spotify_logout_post_handler, NULL },
         { "/api/spotify/status",         HTTP_GET,  spotify_status_get_handler, NULL },
         { "/api/spotify/control",        HTTP_POST, spotify_control_post_handler, NULL },
+        { "/api/image-display-config",   HTTP_GET,  image_display_config_get_handler, NULL },
+        { "/api/image-display-config",   HTTP_POST, image_display_config_post_handler, NULL },
         { "/api/config/backup",          HTTP_GET,  backup_get_handler,   NULL },
         { "/api/config/restore",         HTTP_POST, restore_post_handler, NULL },
         { "/api/status",                 HTTP_GET,  status_get_handler, NULL },

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -95,6 +95,8 @@ esp_err_t spotify_token_exchange_post_handler(httpd_req_t *req);
 esp_err_t spotify_logout_post_handler(httpd_req_t *req);
 esp_err_t spotify_status_get_handler(httpd_req_t *req);
 esp_err_t spotify_control_post_handler(httpd_req_t *req);
+esp_err_t image_display_config_get_handler(httpd_req_t *req);
+esp_err_t image_display_config_post_handler(httpd_req_t *req);
 esp_err_t backup_get_handler(httpd_req_t *req);
 esp_err_t restore_post_handler(httpd_req_t *req);
 esp_err_t status_get_handler(httpd_req_t *req);


### PR DESCRIPTION
### Summary
This PR introduces a new feature that allows the device to fetch and display GOES satellite images. Users can now view current satellite imagery directly on the device's display. This provides real-time visual weather information.

### Changes
*   Adds a new client module to fetch GOES satellite images from a remote server.
*   Introduces a dedicated display component to render and show satellite images on the device screen.
*   Adds new configuration options for GOES image display, including settings for image source and refresh rates.
*   Updates the web configuration interface with new controls for managing GOES image settings.
*   Integrates the GOES image display into the existing dashboard user interface.
*   Adds background tasks to periodically fetch and update GOES satellite images.
*   Adds new web server handlers to manage GOES image data and configuration requests.
*   Updates build configurations, utility functions, and main application logic to support the new image display feature.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-05-29T11:39:36.320Z | Generated by GitHub Actions</sub>