### PR TITLE
feat: add SDO solar image support

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -12,6 +12,7 @@ idf_component_register(
          ui/nina_info_overlay.c ui/nina_info_camera.c ui/nina_info_mount.c
          ui/nina_info_imagestats.c ui/nina_info_sequence.c ui/nina_info_filter.c ui/nina_info_autofocus.c ui/nina_info_session_stats.c
          ui/nina_ota_prompt.c
+         ui/nina_wait_overlay.c
          ${LV_DEMOS_SOURCES}
     INCLUDE_DIRS . ui ${LV_DEMO_DIR}
     EMBED_TXTFILES config_ui.html login.html setup_ui.html

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -782,6 +782,8 @@ static void set_defaults(app_config_t *cfg) {
     cfg->moon_bg_style = 0;          // 0=black, 1=stars, 2=glow
     cfg->moon_lat = 0.0f;            // unset until configured / prefilled from weather
     cfg->moon_lon = 0.0f;
+    cfg->solar_band = 0;             // SDO/AIA band index 0..9
+    cfg->image_display_crop = false; // crop/zoom image to fill & hide baked-in labels
 
     // Auth is on by default — protects device from open-LAN access
     cfg->auth_enabled = true;
@@ -1750,6 +1752,32 @@ static void migrate_from_v23(const app_config_v23_t *old, app_config_t *cfg) {
 
 /* --- v32 → v33 migration (added Image Display fields; IDLE_TARGET_SYSINFO 3→4) --- */
 /* --- v33 → v34 migration (added Moon phase fields) --- */
+static void migrate_from_v35(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v35_t) ? raw_size : sizeof(app_config_v35_t);
+    memcpy(cfg, raw, copy);
+
+    /* image_display_crop field: new in v36 — defaults already set by set_defaults() */
+    cfg->image_display_crop = false;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v35 to v%d", APP_CONFIG_VERSION);
+}
+
+static void migrate_from_v34(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v34_t) ? raw_size : sizeof(app_config_v34_t);
+    memcpy(cfg, raw, copy);
+
+    /* Solar band field: new in v35 — defaults already set by set_defaults() */
+    cfg->solar_band = 0;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v34 to v%d", APP_CONFIG_VERSION);
+}
+
 static void migrate_from_v33(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -2300,12 +2328,16 @@ static bool validate_config(app_config_t *cfg) {
         strcpy(cfg->goes_region, "umv");
         fixed = true;
     }
-    if (cfg->image_display_source > 1) {
+    if (cfg->image_display_source > 2) {
         cfg->image_display_source = 0;
         fixed = true;
     }
     if (cfg->moon_bg_style > 3) {
         cfg->moon_bg_style = 0;
+        fixed = true;
+    }
+    if (cfg->solar_band > 17) {
+        cfg->solar_band = 0;
         fixed = true;
     }
     if (cfg->allsky_thresholds[0] == '\0' ||
@@ -2375,6 +2407,18 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 35) {
+        /* v35 → v36: added image_display_crop */
+        migrate_from_v35(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
+    } else if (version_check == 34) {
+        /* v34 → v35: added solar_band */
+        migrate_from_v34(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 33) {
         /* v33 → v34: added Moon phase fields (prefill moon lat/lon from weather) */
         migrate_from_v33(raw, stored_size, &s_config);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,7 +13,7 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 34
+#define APP_CONFIG_VERSION 36
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -144,6 +144,12 @@ typedef struct {
     uint8_t  moon_bg_style;          // 0=black, 1=stars, 2=glow, 3=stars+glow
     float    moon_lat;               // observer latitude (deg), 0=unset
     float    moon_lon;               // observer longitude (deg), 0=unset
+
+    // Added after v34 — must stay at end to preserve NVS binary compatibility
+    uint8_t  solar_band;             // SDO/AIA band index 0..9 (default 0)
+
+    // Added after v35 — must stay at end to preserve NVS binary compatibility
+    bool     image_display_crop;     // crop/zoom image to fill & hide baked-in labels (default false)
 } app_config_t;
 
 // v17 snapshot — AllSky fields without allsky_enabled
@@ -1048,6 +1054,181 @@ typedef struct {
     char     goes_region[16];
     uint16_t goes_update_interval_s;
 } app_config_v33_t;
+
+// v34 snapshot — layout before solar_band was added
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+} app_config_v34_t;
+
+// v35 snapshot — layout before image_display_crop was added
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+} app_config_v35_t;
 
 // WiFi credentials are stored in app_config_t.wifi_networks[3] (up to 3
 // priority-ordered networks). The AP provides headless access for initial

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1495,7 +1495,7 @@
               <option value="16">SDO/HMI Continuum</option>
               <option value="17">SDO/HMI Magnetogram</option>
             </select>
-            <div class="field-hint">NASA SDO/AIA and SOHO realtime (LASCO, EIT, HMI), 1024px, updated every few minutes</div>
+            <div class="field-hint">NASA SDO/AIA and SOHO realtime (LASCO, EIT, HMI)</div>
           </div>
           </div>
         </div>

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1388,6 +1388,10 @@
                 <input type="radio" name="imageSourceSel" id="imageSource1" value="1" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
                 <span class="pn-pill-visual">Moon Phase</span>
               </label>
+              <label class="pn-pill rotate-pill">
+                <input type="radio" name="imageSourceSel" id="imageSource2" value="2" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
+                <span class="pn-pill-visual">Solar (SDO)</span>
+              </label>
             </div>
           </div>
           <div class="toggle-row">
@@ -1395,6 +1399,23 @@
             <label class="toggle"><input type="checkbox" id="image_display_show_overlay" onchange="applyImageDisplay();checkDirty()" checked><span class="toggle-track"></span></label>
           </div>
           <div class="field-hint">Region/phase name and update time overlay on the display</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Fill (crop borders)</span>
+            <label class="toggle"><input type="checkbox" id="image_display_crop" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Zoom the disc to fill the screen and hide the image's timestamp/label. Not applied to the Moon.</div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Update Interval</label>
+            <select class="input" id="goesInterval" onchange="applyImageDisplay();checkDirty()">
+              <option value="300">5 minutes</option>
+              <option value="600" selected>10 minutes</option>
+              <option value="900">15 minutes</option>
+              <option value="1800">30 minutes</option>
+              <option value="3600">1 hour</option>
+              <option value="7200">2 hours</option>
+            </select>
+            <div class="field-hint">How often GOES and Solar images refresh. The Moon updates continuously.</div>
+          </div>
           <div id="goesGroup">
           <div class="field" style="margin-top:16px">
             <label class="field-label">Region</label>
@@ -1424,17 +1445,6 @@
             </select>
             <div class="field-hint">GOES-19 GEOCOLOR sector for satellite imagery</div>
           </div>
-          <div class="field">
-            <label class="field-label">Update Interval</label>
-            <select class="input" id="goesInterval" onchange="applyImageDisplay();checkDirty()">
-              <option value="300">5 minutes</option>
-              <option value="600" selected>10 minutes</option>
-              <option value="900">15 minutes</option>
-              <option value="1800">30 minutes</option>
-              <option value="3600">1 hour</option>
-              <option value="7200">2 hours</option>
-            </select>
-          </div>
           <div class="field" style="margin-top:16px">
             <button onclick="fetchGoesPreview()" class="btn btn-primary" id="goesPreviewBtn" style="width:100%">Fetch Preview</button>
           </div>
@@ -1460,6 +1470,32 @@
             <label class="field-label">Longitude</label>
             <input class="input" id="moonLon" type="number" step="0.0001" placeholder="e.g. -74.0060" onchange="applyImageDisplay();checkDirty()">
             <div class="field-hint" id="moonLocHint">Set your location for accurate moon orientation. Prefilled from Weather when available.</div>
+          </div>
+          </div>
+          <div id="solarGroup" style="display:none">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Band</label>
+            <select class="input" id="solarBand" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">AIA 94 (Fe XVIII)</option>
+              <option value="1">AIA 131 (Fe XX)</option>
+              <option value="2">AIA 171 (Fe IX/X)</option>
+              <option value="3">AIA 193 (Fe XII)</option>
+              <option value="4">AIA 211 (Fe XIV)</option>
+              <option value="5">AIA 304 (He II)</option>
+              <option value="6">AIA 335 (Fe XVI)</option>
+              <option value="7">AIA 1600 (C IV+cont)</option>
+              <option value="8">AIA 1700 (continuum)</option>
+              <option value="9">AIA 4500 (continuum)</option>
+              <option value="10">LASCO C2 (coronagraph)</option>
+              <option value="11">LASCO C3 (coronagraph)</option>
+              <option value="12">SOHO EIT 171</option>
+              <option value="13">SOHO EIT 195</option>
+              <option value="14">SOHO EIT 284</option>
+              <option value="15">SOHO EIT 304</option>
+              <option value="16">SDO/HMI Continuum</option>
+              <option value="17">SDO/HMI Magnetogram</option>
+            </select>
+            <div class="field-hint">NASA SDO/AIA and SOHO realtime (LASCO, EIT, HMI), 1024px, updated every few minutes</div>
           </div>
           </div>
         </div>
@@ -2118,10 +2154,12 @@
         spotify_overlay_timeout_s:parseInt($('spotifyOverlayTimeout').value)||0,
         image_display_enabled:!!$('image_display_enabled').checked,
         image_display_show_overlay:!!$('image_display_show_overlay').checked,
+        image_display_crop:!!$('image_display_crop').checked,
         goes_region:$('goesRegion').value,
         goes_update_interval_s:parseInt($('goesInterval').value)||600,
         image_display_source:getImageSource(),
         moon_bg_style:parseInt($('moonBg').value,10)||0,
+        solar_band:parseInt($('solarBand').value,10)||0,
         moon_lat:parseFloat($('moonLat').value)||0,
         moon_lon:parseFloat($('moonLon').value)||0,
         weather_provider:parseInt($('weather_provider').value)||0,
@@ -2281,12 +2319,15 @@
       // Image Display fields
       if($('image_display_enabled')) $('image_display_enabled').checked=!!data.image_display_enabled;
       if($('image_display_show_overlay')) $('image_display_show_overlay').checked=data.image_display_show_overlay!=null?!!data.image_display_show_overlay:true;
+      if($('image_display_crop')) $('image_display_crop').checked=!!data.image_display_crop;
       if($('goesRegion')) $('goesRegion').value=data.goes_region||'umv';
       if($('goesInterval')) $('goesInterval').value=data.goes_update_interval_s||600;
       var imgSrc=parseInt(data.image_display_source||0,10)||0;
       if($('imageSource0')) $('imageSource0').checked=(imgSrc===0);
       if($('imageSource1')) $('imageSource1').checked=(imgSrc===1);
+      if($('imageSource2')) $('imageSource2').checked=(imgSrc===2);
       if($('moonBg')) $('moonBg').value=String(data.moon_bg_style||0);
+      if($('solarBand')) $('solarBand').value=String(data.solar_band||0);
       var mlat=data.moon_lat, mlon=data.moon_lon;
       // Prefill from weather location when moon coords are unset
       if((!mlat && !mlon) && (data.weather_lat || data.weather_lon)){ mlat=data.weather_lat; mlon=data.weather_lon; }
@@ -3293,20 +3334,23 @@
 
     function updateImageSourceUI(){
       var s=getImageSource();
-      if($('goesGroup')) $('goesGroup').style.display=(s===1)?'none':'';
-      if($('moonGroup')) $('moonGroup').style.display=(s===1)?'':'none';
+      if($('goesGroup'))  $('goesGroup').style.display =(s===0)?'':'none';
+      if($('moonGroup'))  $('moonGroup').style.display =(s===1)?'':'none';
+      if($('solarGroup')) $('solarGroup').style.display=(s===2)?'':'none';
     }
 
     function applyImageDisplay(){
       postJson('/api/image-display-config', {
         image_display_enabled: !!$('image_display_enabled').checked,
         image_display_show_overlay: !!$('image_display_show_overlay').checked,
+        image_display_crop: !!$('image_display_crop').checked,
         goes_region: $('goesRegion').value,
         goes_update_interval_s: parseInt($('goesInterval').value,10)||600,
         image_display_source: getImageSource(),
         moon_bg_style: parseInt($('moonBg').value,10)||0,
         moon_lat: parseFloat($('moonLat').value)||0,
-        moon_lon: parseFloat($('moonLon').value)||0
+        moon_lon: parseFloat($('moonLon').value)||0,
+        solar_band: parseInt($('solarBand').value,10)||0
       });
     }
 

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -8,27 +8,30 @@
   <style>
     /* === FOUNDATION === */
     :root {
-      --bg: #0a0a0b;
-      --surface: rgba(255, 255, 255, 0.035);
-      --surface-hover: rgba(255, 255, 255, 0.06);
-      --border: rgba(255, 255, 255, 0.08);
+      --bg: #080a10;
+      --surface: rgba(30, 35, 48, 0.96);
+      --surface-hover: rgba(40, 46, 62, 0.96);
+      --border: rgba(255, 255, 255, 0.12);
       --border-focus: rgba(var(--accent-rgb), 0.5);
-      --accent: #14b8a6;
-      --accent-rgb: 20, 184, 166;
-      --accent-hover: #0d9488;
+      --accent: #7aa2f7;
+      --accent-rgb: 122, 162, 247;
+      --accent-hover: #9dbcff;
       --accent-glow: rgba(var(--accent-rgb), 0.15);
-      --text: #f4f4f5;
-      --text-muted: #c4c4cc;
-      --text-hint: #9a9aa6;
-      --danger: #ef4444;
-      --danger-hover: #dc2626;
-      --warning: #f59e0b;
-      --success: #10b981;
+      --text: #e2e8f0;
+      --text-muted: #94a3b8;
+      --text-hint: #7a8ba4;
+      --danger: #f87171;
+      --danger-hover: #ef4444;
+      --warning: #fbbf24;
+      --success: #4ade80;
       --radius: 16px;
       --radius-sm: 10px;
       --glass-blur: 20px;
-      --glass-bg: rgba(255, 255, 255, 0.035);
-      --glass-border: rgba(255, 255, 255, 0.08);
+      --glass-bg: rgba(30, 35, 48, 0.96);
+      --glass-border: rgba(255, 255, 255, 0.14);
+      --elevated: rgba(48, 54, 72, 0.96);
+      --border-em: rgba(255, 255, 255, 0.20);
+      --input-bg: rgba(12, 14, 20, 0.92);
       --nav-height: 60px;
       --bottom-nav-height: 68px;
       --save-bar-height: 64px;
@@ -40,9 +43,9 @@
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
       background-image:
-        radial-gradient(ellipse at 20% 0%, rgba(20, 184, 166, 0.06) 0%, transparent 50%),
-        radial-gradient(ellipse at 80% 100%, rgba(139, 92, 246, 0.04) 0%, transparent 50%),
-        linear-gradient(180deg, #0d0d12 0%, #0a0a0b 100%);
+        radial-gradient(ellipse at 20% 0%, rgba(122, 162, 247, 0.05) 0%, transparent 50%),
+        radial-gradient(ellipse at 80% 100%, rgba(124, 141, 240, 0.04) 0%, transparent 50%),
+        linear-gradient(135deg, #0a0c14 0%, #0f1320 100%);
       color: var(--text);
       line-height: 1.5;
       overflow-x: hidden;
@@ -58,12 +61,12 @@
       border-radius: var(--radius);
       padding: 28px;
       margin-bottom: 20px;
-      box-shadow: 0 4px 24px rgba(0, 0, 0, 0.2), inset 0 1px 0 rgba(255, 255, 255, 0.04);
+      box-shadow: 0 10px 36px rgba(0, 0, 0, 0.6), 0 2px 8px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.06);
       transition: border-color 0.3s ease, box-shadow 0.3s ease;
     }
     .card:hover {
-      border-color: rgba(255, 255, 255, 0.12);
-      box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), inset 0 1px 0 rgba(255, 255, 255, 0.06);
+      border-color: var(--border-em);
+      box-shadow: 0 14px 44px rgba(0, 0, 0, 0.65), 0 2px 8px rgba(0, 0, 0, 0.45), inset 0 1px 0 rgba(255, 255, 255, 0.08);
     }
     .card-title {
       font-size: 0.7rem; font-weight: 700; color: var(--accent);
@@ -170,7 +173,7 @@
 
     /* === COMPONENTS === */
     .input {
-      background: rgba(0, 0, 0, 0.3); border: 1px solid rgba(255, 255, 255, 0.06);
+      background: var(--input-bg); border: 1px solid rgba(255, 255, 255, 0.06);
       color: #f4f4f5; padding: 11px 16px; border-radius: 10px;
       width: 100%; font-size: 0.875rem; min-height: 46px;
       transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
@@ -269,10 +272,10 @@
     .filter-chip {
       display: flex; flex-direction: column; align-items: center; gap: 8px;
       padding: 12px 6px; border-radius: 10px;
-      background: rgba(255, 255, 255, 0.02); border: 1px solid rgba(255, 255, 255, 0.04);
+      background: var(--elevated); border: 1px solid var(--border);
       transition: background 0.2s ease, border-color 0.2s ease;
     }
-    .filter-chip:hover { background: rgba(255, 255, 255, 0.04); border-color: rgba(255, 255, 255, 0.08); }
+    .filter-chip:hover { background: var(--surface-hover); border-color: var(--border-em); }
     .filter-chip label {
       font-size: 0.65rem; color: var(--text-muted);
       white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
@@ -407,11 +410,11 @@
     /* === FIRMWARE & OTA === */
     .fw-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); gap: 10px; margin-bottom: 24px; }
     .fw-item {
-      background: rgba(255, 255, 255, 0.02); padding: 12px 14px;
-      border-radius: 10px; border: 1px solid rgba(255, 255, 255, 0.05);
+      background: var(--elevated); padding: 12px 14px;
+      border-radius: 10px; border: 1px solid var(--border);
       transition: border-color 0.2s;
     }
-    .fw-item:hover { border-color: rgba(255, 255, 255, 0.1); }
+    .fw-item:hover { border-color: var(--border-em); }
     .fw-label { font-size: 0.65rem; color: var(--text-hint); text-transform: uppercase; letter-spacing: 0.04em; margin-bottom: 4px; }
     .fw-value { font-size: 0.85rem; font-weight: 600; word-break: break-all; }
     .ota-label {
@@ -470,9 +473,9 @@
     .save-bar .changes-hint { font-size: 0.8rem; color: var(--accent); margin-right: auto; opacity: 0.8; }
     .toast {
       position: fixed; top: 76px; right: 24px; z-index: 200;
-      background: rgba(20, 20, 24, 0.9);
+      background: var(--elevated);
       backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
-      border: 1px solid rgba(255, 255, 255, 0.08);
+      border: 1px solid var(--border);
       padding: 14px 22px; border-radius: 16px; font-size: 0.85rem;
       box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
       transform: translateX(120%); transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
@@ -1743,14 +1746,14 @@
 
     /* === Tab Accent Colors === */
     const tabAccents={
-      display: {color:'#14b8a6', rgb:'20, 184, 166'},
-      nodes:   {color:'#34d399', rgb:'52, 211, 153'},
-      behavior:{color:'#a78bfa', rgb:'167, 139, 250'},
-      system:  {color:'#fb7185', rgb:'251, 113, 133'},
-      allsky:  {color:'#60a5fa', rgb:'96, 165, 250'},
-      clock:   {color:'#e8e2d4', rgb:'232, 226, 212'},
-      spotify: {color:'#4ade80', rgb:'74, 222, 128'},
-      backup:  {color:'#fbbf24', rgb:'251, 191, 36'}
+      display: {color:'#7aa2f7', rgb:'122, 162, 247'},
+      nodes:   {color:'#7aa2f7', rgb:'122, 162, 247'},
+      behavior:{color:'#7aa2f7', rgb:'122, 162, 247'},
+      system:  {color:'#7aa2f7', rgb:'122, 162, 247'},
+      allsky:  {color:'#7aa2f7', rgb:'122, 162, 247'},
+      clock:   {color:'#7aa2f7', rgb:'122, 162, 247'},
+      spotify: {color:'#7aa2f7', rgb:'122, 162, 247'},
+      backup:  {color:'#7aa2f7', rgb:'122, 162, 247'}
     };
 
     function setAccent(name){

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -9,7 +9,7 @@
 
 static const char *TAG = "goes_client";
 
-#define GOES_JPEG_MAX_SIZE   (512 * 1024)
+#define GOES_JPEG_MAX_SIZE   (1024 * 1024)   /* 1MB: fits SOHO LASCO C3 1024 (~815KB) */
 #define GOES_HTTP_BUF_SIZE   4096
 #define GOES_HTTP_TIMEOUT_MS 30000
 
@@ -71,6 +71,48 @@ static const char *goes_region_size(const char *region)
     return "600x600";
 }
 
+/* Solar imagery: SDO/AIA 1024px JPEGs (NASA SDO) plus SOHO realtime 1024px JPEGs
+ * (SOHO/EIT, LASCO coronagraphs, SDO/HMI). All 1024px; LASCO C3 is ~815KB, so
+ * GOES_JPEG_MAX_SIZE is 1MB to fit them. Index 0..17. */
+#define SOLAR_BAND_COUNT 18
+static const char *SOLAR_URLS[SOLAR_BAND_COUNT] = {
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0094.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0131.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0171.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0193.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0211.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0304.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_0335.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_1600.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_1700.jpg",
+    "https://sdo.gsfc.nasa.gov/assets/img/latest/latest_1024_4500.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/c2/1024/latest.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/c3/1024/latest.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/eit_171/1024/latest.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/eit_195/1024/latest.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/eit_284/1024/latest.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/eit_304/1024/latest.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/hmi_igr/1024/latest.jpg",
+    "https://soho.nascom.nasa.gov/data/realtime/hmi_mag/1024/latest.jpg",
+};
+static const char *SOLAR_LABELS[SOLAR_BAND_COUNT] = {
+    "AIA 94","AIA 131","AIA 171","AIA 193","AIA 211","AIA 304","AIA 335","AIA 1600","AIA 1700","AIA 4500",
+    "LASCO C2","LASCO C3","SOHO EIT 171","SOHO EIT 195","SOHO EIT 284","SOHO EIT 304",
+    "HMI Continuum","HMI Magnetogram"
+};
+
+const char *solar_band_url(uint8_t idx)   { return idx < SOLAR_BAND_COUNT ? SOLAR_URLS[idx]   : SOLAR_URLS[0]; }
+const char *solar_band_label(uint8_t idx) { return idx < SOLAR_BAND_COUNT ? SOLAR_LABELS[idx] : SOLAR_LABELS[0]; }
+
+/* All solar imagery (SDO/AIA and SOHO) needs a vertical flip to display upright
+ * on this panel, same as the GOES path. */
+bool solar_band_vflip(uint8_t idx) { (void)idx; return true; }
+
+/* Bands whose disc/field fills the frame edge-to-edge must NOT be center-cropped
+ * or the disc gets clipped: LASCO C2/C3 (10,11) and SDO/HMI continuum/magnetogram
+ * (16,17). AIA (0..9) and SOHO EIT (12..15) have margin and crop cleanly. */
+bool solar_band_croppable(uint8_t idx) { return !(idx == 10 || idx == 11 || idx == 16 || idx == 17); }
+
 esp_err_t goes_client_poll(const char *region, goes_data_t *data)
 {
     if (!region || !data) return ESP_ERR_INVALID_ARG;
@@ -80,6 +122,14 @@ esp_err_t goes_client_poll(const char *region, goes_data_t *data)
     snprintf(url, sizeof(url),
              "https://cdn.star.nesdis.noaa.gov/GOES19/ABI/SECTOR/%s/GEOCOLOR/%s.jpg",
              region, size);
+
+    /* NESDIS GOES JPEGs decode upside-down on this panel; flip them. */
+    return goes_client_poll_url(url, data, true);
+}
+
+esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip)
+{
+    if (!url || !data) return ESP_ERR_INVALID_ARG;
 
     ESP_LOGI(TAG, "Fetching %s", url);
 
@@ -190,7 +240,7 @@ esp_err_t goes_client_poll(const char *region, goes_data_t *data)
         data->image_buf = rgb565;
         data->image_w = (uint16_t)out_w;
         data->image_h = (uint16_t)out_h;
-        data->vflip = true;
+        data->vflip = vflip;
         data->connected = true;
         data->last_poll_ms = esp_timer_get_time() / 1000;
         goes_data_unlock(data);

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -108,10 +108,39 @@ const char *solar_band_label(uint8_t idx) { return idx < SOLAR_BAND_COUNT ? SOLA
  * on this panel, same as the GOES path. */
 bool solar_band_vflip(uint8_t idx) { (void)idx; return true; }
 
-/* Bands whose disc/field fills the frame edge-to-edge must NOT be center-cropped
- * or the disc gets clipped: LASCO C2/C3 (10,11) and SDO/HMI continuum/magnetogram
- * (16,17). AIA (0..9) and SOHO EIT (12..15) have margin and crop cleanly. */
-bool solar_band_croppable(uint8_t idx) { return !(idx == 10 || idx == 11 || idx == 16 || idx == 17); }
+/* Per-band center-crop percentage (100 = no crop). AIA (0..9) and SOHO EIT
+ * (12..15) have a wide source border, so 88% zooms past the timestamp/label.
+ * HMI continuum/magnetogram (16,17) have only a ~4.2% black margin around a
+ * ~91.5%-diameter disc, so 92% trims the caption border while leaving a thin
+ * black ring (disc NOT clipped). LASCO C2/C3 (10,11) fill the frame edge-to-edge
+ * with a burned-in timestamp at the very bottom (~3.5% up); 90% (~5%/side) crops
+ * it off, sacrificing some outer corona (acceptable) and avoiding a blend patch. */
+uint8_t solar_band_crop_pct(uint8_t idx)
+{
+    if (idx == 10 || idx == 11) return 90;   /* LASCO: crop off the burned-in timestamp */
+    if (idx == 16 || idx == 17) return 92;   /* HMI: trim to disc edge */
+    return 88;                               /* AIA / SOHO EIT */
+}
+
+/* Upright-full-image fractional rect (0..1, origin top-left, y down) covering a
+ * caption that the crop alone does not remove. Returns false when no mask is
+ * needed. The HMI rect is below the disc bottom (~row 0.97) and normally cropped
+ * away (belt-and-suspenders for a taller-than-expected future caption). LASCO is
+ * cropped instead of masked, so it returns false here. */
+bool solar_band_text_mask(uint8_t idx, float *x0, float *y0, float *x1, float *y1)
+{
+    float a, b, c, d;
+    switch (idx) {
+        case 16:
+        case 17: a = 0.0f; b = 0.97f; c = 0.50f; d = 1.0f; break;  /* HMI */
+        default: return false;  /* LASCO (10,11) now cropped, not masked */
+    }
+    if (x0) *x0 = a;
+    if (y0) *y0 = b;
+    if (x1) *x1 = c;
+    if (y1) *y1 = d;
+    return true;
+}
 
 esp_err_t goes_client_poll(const char *region, goes_data_t *data)
 {

--- a/main/goes_client.h
+++ b/main/goes_client.h
@@ -20,4 +20,10 @@ void      goes_data_init(goes_data_t *data);
 bool      goes_data_lock(goes_data_t *data, int timeout_ms);
 void      goes_data_unlock(goes_data_t *data);
 esp_err_t goes_client_poll(const char *region, goes_data_t *data);
+esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip);
 void      goes_client_cleanup(goes_data_t *data);
+
+const char *solar_band_url(uint8_t idx);
+const char *solar_band_label(uint8_t idx);
+bool        solar_band_vflip(uint8_t idx);
+bool        solar_band_croppable(uint8_t idx);

--- a/main/goes_client.h
+++ b/main/goes_client.h
@@ -26,4 +26,11 @@ void      goes_client_cleanup(goes_data_t *data);
 const char *solar_band_url(uint8_t idx);
 const char *solar_band_label(uint8_t idx);
 bool        solar_band_vflip(uint8_t idx);
-bool        solar_band_croppable(uint8_t idx);
+
+/* Per-band center-crop percentage (100 = no crop). */
+uint8_t     solar_band_crop_pct(uint8_t idx);
+
+/* Fills an upright-full-image fractional rect [x0,y0,x1,y1] (0..1, origin
+ * top-left, y down) for a band whose caption needs masking; returns false
+ * when no mask is needed. Any of the out pointers may be NULL. */
+bool        solar_band_text_mask(uint8_t idx, float *x0, float *y0, float *x1, float *y1);

--- a/main/login.html
+++ b/main/login.html
@@ -5,18 +5,34 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Sign in - NINA Display</title>
 <style>
-  html,body{margin:0;padding:0;height:100%;background:#0b0f17;color:#e5e7eb;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
-  body{display:flex;align-items:center;justify-content:center;min-height:100vh}
-  .card{background:#111827;border:1px solid #1f2937;border-radius:10px;padding:28px 28px 24px;width:320px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+  :root{
+    --bg:#0a0c14;
+    --surface:#14171f;
+    --elevated:#181b26;
+    --input-bg:#0c0e14;
+    --border:rgba(255,255,255,0.08);
+    --border-em:rgba(255,255,255,0.15);
+    --text:#e2e8f0;
+    --text-muted:#94a3b8;
+    --text-hint:#7a8ba4;
+    --accent:#7aa2f7;
+    --accent-hover:#9dbcff;
+    --accent-strong:#5a86e8;
+    --accent-strong-hover:#4a72d8;
+    --danger:#f87171;
+  }
+  html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  body{display:flex;align-items:center;justify-content:center;min-height:100vh;background-image:linear-gradient(135deg,#0a0c14 0%,#0f1320 100%)}
+  .card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:28px 28px 24px;width:320px;box-shadow:0 8px 32px rgba(0,0,0,0.4)}
   h1{font-size:18px;margin:0 0 4px;font-weight:600;letter-spacing:.2px}
-  .sub{font-size:12px;color:#9ca3af;margin:0 0 20px}
-  label{display:block;font-size:12px;color:#9ca3af;margin:0 0 6px}
-  input[type=password]{width:100%;box-sizing:border-box;background:#0b0f17;color:#e5e7eb;border:1px solid #273142;border-radius:6px;padding:10px 12px;font-size:14px;outline:none}
-  input[type=password]:focus{border-color:#3b82f6}
-  button{margin-top:14px;width:100%;background:#2563eb;color:#fff;border:0;border-radius:6px;padding:10px 12px;font-size:14px;font-weight:600;cursor:pointer}
-  button:hover{background:#1d4ed8}
+  .sub{font-size:12px;color:var(--text-muted);margin:0 0 20px}
+  label{display:block;font-size:12px;color:var(--text-muted);margin:0 0 6px}
+  input[type=password]{width:100%;box-sizing:border-box;background:var(--input-bg);color:var(--text);border:1px solid var(--border-em);border-radius:6px;padding:10px 12px;font-size:14px;outline:none}
+  input[type=password]:focus{border-color:var(--accent)}
+  button{margin-top:14px;width:100%;background:var(--accent-strong);color:#fff;border:0;border-radius:6px;padding:10px 12px;font-size:14px;font-weight:600;cursor:pointer}
+  button:hover{background:var(--accent-strong-hover)}
   button:disabled{background:#374151;cursor:not-allowed}
-  .err{color:#f87171;font-size:12px;margin-top:10px;min-height:16px}
+  .err{color:var(--danger);font-size:12px;margin-top:10px;min-height:16px}
 </style>
 </head>
 <body>
@@ -27,7 +43,7 @@
     <input id="p" type="password" autocomplete="current-password" autofocus required>
     <button id="b" type="submit">Sign in</button>
     <div class="err" id="e"></div>
-    <div id="hint" style="display:none;font-size:12px;color:#9ca3af;margin-top:10px">Default password: <code style="color:#d1d5db;background:#1f2937;padding:2px 6px;border-radius:3px;font-size:12px">changeme123!</code></div>
+    <div id="hint" style="display:none;font-size:12px;color:var(--text-muted);margin-top:10px">Default password: <code style="color:var(--text-muted);background:var(--elevated);padding:2px 6px;border-radius:3px;font-size:12px">changeme123!</code></div>
   </form>
 <script>
 (function(){

--- a/main/setup_ui.html
+++ b/main/setup_ui.html
@@ -5,76 +5,94 @@
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>WiFi Setup - NINA Display</title>
 <style>
-  html,body{margin:0;padding:0;height:100%;background:#0b0f17;color:#e5e7eb;font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
-  body{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:16px;box-sizing:border-box}
-  .card{background:#111827;border:1px solid #1f2937;border-radius:10px;padding:28px;width:100%;max-width:420px;box-shadow:0 10px 30px rgba(0,0,0,.5)}
+  :root{
+    --bg:#0a0c14;
+    --surface:#14171f;
+    --elevated:#181b26;
+    --input-bg:#0c0e14;
+    --border:rgba(255,255,255,0.08);
+    --border-em:rgba(255,255,255,0.15);
+    --text:#e2e8f0;
+    --text-muted:#94a3b8;
+    --text-hint:#7a8ba4;
+    --accent:#7aa2f7;
+    --accent-hover:#9dbcff;
+    --accent-strong:#5a86e8;
+    --accent-strong-hover:#4a72d8;
+    --danger:#f87171;
+    --success:#4ade80;
+    --warning:#fbbf24;
+  }
+  html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  body{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:16px;box-sizing:border-box;background-image:linear-gradient(135deg,#0a0c14 0%,#0f1320 100%)}
+  .card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:28px;width:100%;max-width:420px;box-shadow:0 8px 32px rgba(0,0,0,0.4)}
   h1{font-size:18px;margin:0 0 4px;font-weight:600;letter-spacing:.2px}
-  .sub{font-size:14px;color:#9ca3af;margin:0 0 20px}
+  .sub{font-size:14px;color:var(--text-muted);margin:0 0 20px}
 
   /* Scan panel */
-  .scan-panel{background:#0b0f17;border:1px solid #1f2937;border-radius:8px;margin-bottom:20px;overflow:hidden}
-  .scan-header{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid #1f2937}
-  .scan-label{font-size:13px;font-weight:600;color:#e5e7eb}
-  .btn-rescan{background:transparent;color:#3b82f6;border:1px solid #3b82f6;border-radius:5px;padding:4px 10px;font-size:11px;font-weight:600;cursor:pointer;font-family:inherit;text-transform:uppercase;letter-spacing:.3px}
-  .btn-rescan:hover{background:rgba(59,130,246,.1)}
+  .scan-panel{background:var(--elevated);border:1px solid var(--border);border-radius:8px;margin-bottom:20px;overflow:hidden}
+  .scan-header{display:flex;align-items:center;justify-content:space-between;padding:12px 14px;border-bottom:1px solid var(--border)}
+  .scan-label{font-size:13px;font-weight:600;color:var(--text)}
+  .btn-rescan{background:transparent;color:var(--accent);border:1px solid var(--accent);border-radius:5px;padding:4px 10px;font-size:11px;font-weight:600;cursor:pointer;font-family:inherit;text-transform:uppercase;letter-spacing:.3px}
+  .btn-rescan:hover{background:rgba(122,162,247,.1)}
   .btn-rescan:disabled{opacity:.5;cursor:not-allowed}
-  .scan-list{max-height:260px;overflow-y:auto;scrollbar-width:thin;scrollbar-color:#273142 transparent}
+  .scan-list{max-height:260px;overflow-y:auto;scrollbar-width:thin;scrollbar-color:rgba(255,255,255,0.10) transparent}
   .scan-list::-webkit-scrollbar{width:6px}
   .scan-list::-webkit-scrollbar-track{background:transparent}
-  .scan-list::-webkit-scrollbar-thumb{background:#273142;border-radius:3px}
-  .scan-empty{padding:20px;text-align:center;color:#9ca3af;font-size:13px}
-  .scan-footer{padding:8px 14px;border-top:1px solid #1f2937;font-size:11px;color:#6b7280;text-align:center}
+  .scan-list::-webkit-scrollbar-thumb{background:rgba(255,255,255,0.10);border-radius:3px}
+  .scan-empty{padding:20px;text-align:center;color:var(--text-muted);font-size:13px}
+  .scan-footer{padding:8px 14px;border-top:1px solid var(--border);font-size:11px;color:var(--text-hint);text-align:center}
 
   /* Spinner */
-  .spinner-wrap{display:flex;align-items:center;justify-content:center;padding:24px;gap:10px;color:#9ca3af;font-size:13px}
-  .spinner{width:18px;height:18px;border:2px solid #273142;border-top-color:#3b82f6;border-radius:50%;animation:spin .8s linear infinite;flex-shrink:0}
+  .spinner-wrap{display:flex;align-items:center;justify-content:center;padding:24px;gap:10px;color:var(--text-muted);font-size:13px}
+  .spinner{width:18px;height:18px;border:2px solid rgba(255,255,255,0.10);border-top-color:var(--accent);border-radius:50%;animation:spin .8s linear infinite;flex-shrink:0}
   @keyframes spin{to{transform:rotate(360deg)}}
 
   /* Network row */
-  .net-row{display:flex;align-items:center;padding:10px 14px;border-bottom:1px solid #1a1f2e;gap:10px;transition:background .15s}
+  .net-row{display:flex;align-items:center;padding:10px 14px;border-bottom:1px solid var(--border);gap:10px;transition:background .15s}
   .net-row:last-child{border-bottom:none}
-  .net-row:hover{background:rgba(59,130,246,.04)}
+  .net-row:hover{background:rgba(122,162,247,.04)}
   .net-row.incompatible{opacity:.45}
   .net-row.incompatible:hover{background:transparent}
   .net-info{flex:1;min-width:0}
   .net-ssid{font-size:13px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
   .net-ssid.struck{text-decoration:line-through}
-  .net-meta{font-size:11px;color:#6b7280;margin-top:2px}
-  .badge-incompat{display:inline-block;background:rgba(244,67,54,.15);color:#f44336;font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;text-transform:uppercase;letter-spacing:.3px;margin-left:6px;vertical-align:middle}
-  .btn-select{background:#3b82f6;color:#0b0f17;border:none;border-radius:5px;padding:5px 12px;font-size:11px;font-weight:700;cursor:pointer;font-family:inherit;text-transform:uppercase;letter-spacing:.3px;flex-shrink:0;white-space:nowrap}
-  .btn-select:hover{background:#60a5fa}
+  .net-meta{font-size:11px;color:var(--text-hint);margin-top:2px}
+  .badge-incompat{display:inline-block;background:rgba(248,113,113,.15);color:var(--danger);font-size:9px;font-weight:700;padding:1px 5px;border-radius:3px;text-transform:uppercase;letter-spacing:.3px;margin-left:6px;vertical-align:middle}
+  .btn-select{background:var(--accent);color:#0a0c14;border:none;border-radius:5px;padding:5px 12px;font-size:11px;font-weight:700;cursor:pointer;font-family:inherit;text-transform:uppercase;letter-spacing:.3px;flex-shrink:0;white-space:nowrap}
+  .btn-select:hover{background:var(--accent-hover)}
 
   /* Signal bars */
   .signal-bars{display:flex;align-items:flex-end;gap:2px;flex-shrink:0;width:18px;height:16px}
-  .signal-bars .bar{width:3px;border-radius:1px;background:#273142}
+  .signal-bars .bar{width:3px;border-radius:1px;background:rgba(255,255,255,0.10)}
   .signal-bars .bar:nth-child(1){height:4px}
   .signal-bars .bar:nth-child(2){height:7px}
   .signal-bars .bar:nth-child(3){height:11px}
   .signal-bars .bar:nth-child(4){height:16px}
-  .signal-bars.bars-4 .bar{background:#4caf50}
-  .signal-bars.bars-3 .bar:nth-child(1),.signal-bars.bars-3 .bar:nth-child(2),.signal-bars.bars-3 .bar:nth-child(3){background:#ff9800}
-  .signal-bars.bars-2 .bar:nth-child(1),.signal-bars.bars-2 .bar:nth-child(2){background:#f44336}
+  .signal-bars.bars-4 .bar{background:var(--success)}
+  .signal-bars.bars-3 .bar:nth-child(1),.signal-bars.bars-3 .bar:nth-child(2),.signal-bars.bars-3 .bar:nth-child(3){background:var(--warning)}
+  .signal-bars.bars-2 .bar:nth-child(1),.signal-bars.bars-2 .bar:nth-child(2){background:var(--danger)}
 
   /* Form */
   .form-group{margin-bottom:14px}
-  .form-group label{display:block;font-size:12px;color:#9ca3af;margin-bottom:6px}
-  .form-group input{width:100%;box-sizing:border-box;background:#0b0f17;color:#e5e7eb;border:1px solid #273142;border-radius:6px;padding:10px 12px;font-size:14px;outline:none;font-family:inherit}
-  .form-group input:focus{border-color:#3b82f6}
-  .btn-connect{margin-top:6px;width:100%;background:#2563eb;color:#fff;border:0;border-radius:6px;padding:10px 12px;font-size:14px;font-weight:600;cursor:pointer;font-family:inherit}
-  .btn-connect:hover{background:#1d4ed8}
+  .form-group label{display:block;font-size:12px;color:var(--text-muted);margin-bottom:6px}
+  .form-group input{width:100%;box-sizing:border-box;background:var(--input-bg);color:var(--text);border:1px solid var(--border-em);border-radius:6px;padding:10px 12px;font-size:14px;outline:none;font-family:inherit}
+  .form-group input:focus{border-color:var(--accent)}
+  .btn-connect{margin-top:6px;width:100%;background:var(--accent-strong);color:#fff;border:0;border-radius:6px;padding:10px 12px;font-size:14px;font-weight:600;cursor:pointer;font-family:inherit}
+  .btn-connect:hover{background:var(--accent-strong-hover)}
   .btn-connect:disabled{background:#374151;cursor:not-allowed}
 
   /* Status area */
   .status-area{margin-top:16px;text-align:center;display:none}
-  .status-connecting{display:flex;align-items:center;justify-content:center;gap:10px;color:#9ca3af;font-size:13px;padding:8px 0}
-  .status-success{color:#4caf50;font-size:14px;font-weight:500}
-  .status-success .ip{display:block;font-size:12px;color:#9ca3af;margin-top:4px;font-weight:400}
-  .status-success a{display:inline-block;margin-top:12px;color:#3b82f6;font-size:13px;font-weight:600;text-decoration:none}
+  .status-connecting{display:flex;align-items:center;justify-content:center;gap:10px;color:var(--text-muted);font-size:13px;padding:8px 0}
+  .status-success{color:var(--success);font-size:14px;font-weight:500}
+  .status-success .ip{display:block;font-size:12px;color:var(--text-muted);margin-top:4px;font-weight:400}
+  .status-success a{display:inline-block;margin-top:12px;color:var(--accent);font-size:13px;font-weight:600;text-decoration:none}
   .status-success a:hover{text-decoration:underline}
-  .status-fail{color:#f87171;font-size:13px}
-  .btn-retry{margin-top:10px;background:transparent;color:#3b82f6;border:1px solid #3b82f6;border-radius:6px;padding:8px 16px;font-size:13px;font-weight:600;cursor:pointer;font-family:inherit}
-  .btn-retry:hover{background:rgba(59,130,246,.1)}
-  .err{color:#f87171;font-size:12px;margin-top:8px;min-height:16px;text-align:center}
+  .status-fail{color:var(--danger);font-size:13px}
+  .btn-retry{margin-top:10px;background:transparent;color:var(--accent);border:1px solid var(--accent);border-radius:6px;padding:8px 16px;font-size:13px;font-weight:600;cursor:pointer;font-family:inherit}
+  .btn-retry:hover{background:rgba(122,162,247,.1)}
+  .err{color:var(--danger);font-size:12px;margin-top:8px;min-height:16px;text-align:center}
 </style>
 </head>
 <body>

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -32,6 +32,8 @@
 #include "ui/nina_ota_prompt.h"
 #include "ui/nina_idle_indicator.h"
 #include "ui/nina_image_display.h"
+#include "ui/nina_wait_overlay.h"
+#include "ui/nina_toast.h"
 #include "ota_github.h"
 #include "esp_ota_ops.h"
 #include "bsp/esp-bsp.h"
@@ -554,6 +556,11 @@ static moon_state_t s_moon_state;
  * consumed once by goes_poll_task via atomic_exchange. Declared extern in tasks.h. */
 _Atomic bool moon_anim_request = false;
 
+/* Set by the Image Display config POST handler on a user source/band change,
+ * consumed once by goes_poll_task to gate the wait overlay. Declared extern in
+ * tasks.h. */
+_Atomic bool image_display_manual_fetch = false;
+
 /* Provide the caption text for the Image Display page when the Moon source is
  * active. Declared (extern) in nina_image_display.c. */
 void moon_caption(char *name_out, size_t name_sz, char *pct_out, size_t pct_sz)
@@ -682,12 +689,56 @@ void goes_poll_task(void *arg)
         /* GOES needs network — wait for WiFi before attempting any HTTP requests. */
         xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
 
+        /* Show the full-screen wait overlay only for a user-initiated source/
+         * band change (manual flag), and only while the Image Display page is
+         * actually visible — a takeover on an unrelated page would be jarring.
+         * Periodic refreshes and page-entry refreshes leave the flag clear, so
+         * they never trigger the overlay. The overlay is hidden again when the
+         * new image is committed in nina_image_display_update(), or below on a
+         * fetch error. */
+        bool manual_fetch = atomic_exchange(&image_display_manual_fetch, false);
+        bool show_wait = false;
+        if (manual_fetch && image_display_page_active) {
+            const char *band_name = (cfg->image_display_source == 2)
+                                        ? solar_band_label(cfg->solar_band) : NULL;
+            /* Only treat the overlay as shown if the lock was acquired and the
+             * show actually ran — otherwise the error-hide below would be a
+             * spurious no-op against an overlay that never appeared. */
+            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                nina_wait_overlay_show("Loading image...", band_name);
+                nina_wait_overlay_set_progress(-1);   /* indeterminate */
+                bsp_display_unlock();
+                show_wait = true;
+            }
+        }
+
+        esp_err_t fetch_err = ESP_OK;
         if (cfg->image_display_source == 2) {                       /* Solar (SDO/AIA) */
             const char *url = solar_band_url(cfg->solar_band);
             /* All solar bands need a vertical flip to display upright (see solar_band_vflip). */
-            if (url && url[0]) goes_client_poll_url(url, &goes_data, solar_band_vflip(cfg->solar_band));
+            if (url && url[0]) {
+                fetch_err = goes_client_poll_url(url, &goes_data, solar_band_vflip(cfg->solar_band));
+            } else {
+                fetch_err = ESP_ERR_INVALID_ARG;
+            }
         } else if (cfg->goes_region[0] != '\0') {                   /* GOES */
-            goes_client_poll(cfg->goes_region, &goes_data);
+            fetch_err = goes_client_poll(cfg->goes_region, &goes_data);
+        } else {
+            /* No region configured: nothing is fetched, so the new image never
+             * arrives. Mark as failed so the error-hide below clears any
+             * manual-fetch overlay instead of leaving it stuck. */
+            fetch_err = ESP_FAIL;
+        }
+
+        /* On a failed manual fetch the new image never arrives, so
+         * nina_image_display_update() will not hide the overlay — clear it here
+         * so it never gets stuck. */
+        if (show_wait && fetch_err != ESP_OK) {
+            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                nina_wait_overlay_hide();
+                bsp_display_unlock();
+            }
+            nina_toast_show(TOAST_WARNING, "Failed to load image");
         }
 
         /* Sleep for the configured interval (clamped 5min-2h to respect the
@@ -1689,6 +1740,9 @@ main_loop:
             if (!on_image_display && prev_on_image_display) {
                 if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                     nina_image_display_cleanup();
+                    /* If a manual fetch was still in flight when the user left,
+                     * clear its loading overlay so it can't linger off-page. */
+                    nina_wait_overlay_hide();
                     bsp_display_unlock();
                 }
                 goes_client_cleanup(&goes_data);

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -682,8 +682,11 @@ void goes_poll_task(void *arg)
         /* GOES needs network — wait for WiFi before attempting any HTTP requests. */
         xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
 
-        /* Only poll when a region is configured */
-        if (cfg->goes_region[0] != '\0') {
+        if (cfg->image_display_source == 2) {                       /* Solar (SDO/AIA) */
+            const char *url = solar_band_url(cfg->solar_band);
+            /* All solar bands need a vertical flip to display upright (see solar_band_vflip). */
+            if (url && url[0]) goes_client_poll_url(url, &goes_data, solar_band_vflip(cfg->solar_band));
+        } else if (cfg->goes_region[0] != '\0') {                   /* GOES */
             goes_client_poll(cfg->goes_region, &goes_data);
         }
 

--- a/main/tasks.h
+++ b/main/tasks.h
@@ -77,6 +77,12 @@ extern goes_data_t goes_data;
  *  Consumed (cleared) once by goes_poll_task via atomic_exchange. */
 extern _Atomic bool moon_anim_request;
 
+/** Set by the Image Display config POST handler when the user changes the
+ *  source/band, so goes_poll_task can show the wait overlay only for a
+ *  user-initiated fetch (not routine periodic polling or page-entry refresh).
+ *  Consumed (cleared) once by goes_poll_task via atomic_exchange. */
+extern _Atomic bool image_display_manual_fetch;
+
 /** Weather poll task — spawned by weather_client_start() when location is configured. */
 /* (Task handle is internal to weather_client.c; no extern needed here.) */
 

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -24,6 +24,7 @@
 #include "nina_safety.h"
 #include "nina_idle_indicator.h"
 #include "nina_ota_prompt.h"
+#include "nina_wait_overlay.h"
 #include "ui_styles.h"
 #include "app_config.h"
 #include "themes.h"
@@ -304,6 +305,7 @@ void nina_dashboard_apply_theme(int theme_index) {
     nina_alerts_apply_theme();
     nina_safety_apply_theme();
     nina_ota_prompt_apply_theme();
+    nina_wait_overlay_apply_theme();
 
     update_indicators();
 
@@ -908,6 +910,9 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
 
     // OTA update prompt overlay (on top of everything)
     nina_ota_prompt_create(scr_dashboard);
+
+    // Generic wait/loading overlay (created last so it sits on top)
+    nina_wait_overlay_create(scr_dashboard);
 
     // Make header box clickable on all pages to open thumbnail
     for (int i = 0; i < page_count; i++) {

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -12,6 +12,7 @@
  */
 
 #include "nina_image_display.h"
+#include "nina_wait_overlay.h"
 #include "nina_dashboard_internal.h"
 #include "app_config.h"
 #include "display_defs.h"
@@ -51,6 +52,12 @@ static lv_image_dsc_t img_dsc_b;
 static bool front_is_a = true;
 static int64_t displayed_poll_ms;
 static bool crossfade_active = false;
+/* Set by nina_image_display_force_redraw() to make the NEXT update() re-render
+ * the already-cached frame even though last_poll_ms hasn't advanced. Consumed
+ * (cleared) on the next update() once the new-image gate has been bypassed.
+ * Used for a crop/full-mode toggle so the page re-crops the cached image
+ * locally instead of forcing an HTTP re-download. */
+static bool force_redraw = false;
 
 /* NESDIS sector code -> human-readable region name. */
 static const struct { const char *code; const char *name; } region_labels[] = {
@@ -209,7 +216,14 @@ void nina_image_display_update(goes_data_t *data)
     if (crossfade_active) return;
     if (!goes_data_lock(data, 100)) return;
 
-    if (!data->image_buf || data->last_poll_ms <= displayed_poll_ms) {
+    /* Consume the force-redraw request: a crop/full toggle re-renders the cached
+     * frame, so bypass the "new image" half of the gate this once. Still bail if
+     * nothing is cached (!image_buf). The flag is read-and-cleared here under the
+     * goes lock; the actual swap below is forced instant (no crossfade) since a
+     * crossfade between two crops of the same frame is pointless. */
+    bool forced = force_redraw;
+    force_redraw = false;
+    if (!data->image_buf || (!forced && data->last_poll_ms <= displayed_poll_ms)) {
         goes_data_unlock(data);
         return;
     }
@@ -220,22 +234,28 @@ void nina_image_display_update(goes_data_t *data)
     uint16_t sw = data->image_w, sh = data->image_h;
     if (sw == 0 || sh == 0) {
         goes_data_unlock(data);
+        /* New-image gate passed but the image is unusable — release any
+         * manual-fetch wait overlay so it can't get stuck. */
+        nina_wait_overlay_hide();
         return;
     }
 
-    /* Optional center-crop: keep the central ~88% so the solar/satellite disc
+    /* Optional center-crop: keep the central portion so the solar/satellite disc
      * zooms to fill the panel and the timestamp/label baked into the source
      * border is cropped off. Skipped for the Moon (source 1): it has no text
-     * and is already framed to fill. */
+     * and is already framed to fill. The crop percentage is per-band for Solar
+     * (source 2): 88% for AIA/EIT, 92% for HMI (trims to the disc edge), 100%
+     * (no crop) for LASCO. Non-solar sources keep the historic 88% (e.g. GOES). */
+    extern uint8_t solar_band_crop_pct(uint8_t idx);
+    extern bool    solar_band_text_mask(uint8_t idx, float *x0, float *y0, float *x1, float *y1);
     const app_config_t *cfg = app_config_get();
     uint16_t w = sw, h = sh, ox = 0, oy = 0;
-    /* Crop only when enabled, not the Moon, and (for Solar) not a frame-filling
-     * band (LASCO/HMI) whose disc would be clipped. */
-    extern bool solar_band_croppable(uint8_t idx);
-    bool croppable = (cfg->image_display_source != 2) || solar_band_croppable(cfg->solar_band);
-    if (cfg->image_display_crop && cfg->image_display_source != 1 && croppable) {
-        w  = (uint16_t)((uint32_t)sw * 88 / 100);
-        h  = (uint16_t)((uint32_t)sh * 88 / 100);
+    uint8_t crop_pct = (cfg->image_display_source == 2)
+                           ? solar_band_crop_pct(cfg->solar_band)
+                           : 88;
+    if (cfg->image_display_crop && cfg->image_display_source != 1 && crop_pct < 100) {
+        w  = (uint16_t)((uint32_t)sw * crop_pct / 100);
+        h  = (uint16_t)((uint32_t)sh * crop_pct / 100);
         ox = (uint16_t)((sw - w) / 2);
         oy = (uint16_t)((sh - h) / 2);
     }
@@ -246,6 +266,9 @@ void nina_image_display_update(goes_data_t *data)
         ESP_LOGE(TAG, "PSRAM alloc failed for crossfade buffer (%u bytes)",
                  (unsigned)buf_size);
         goes_data_unlock(data);
+        /* New-image gate passed but the display copy failed — release any
+         * manual-fetch wait overlay so it can't get stuck. */
+        nina_wait_overlay_hide();
         return;
     }
     /* Copy the (optionally cropped) source row-by-row. The software JPEG decoder
@@ -254,11 +277,60 @@ void nina_image_display_update(goes_data_t *data)
      * buffer is upright. ox/oy apply the center-crop. */
     size_t src_stride = (size_t)sw * 2;
     size_t dst_stride = (size_t)w * 2;
+
+    /* Optional caption mask (Solar bands only). The mask rect is in upright-full
+     * image fractional coords; convert to a pixel rect [mx0..mx1, my0..my1]. For
+     * masked pixels we composite a color-sampled blend: per row, sample one
+     * source pixel just to the RIGHT of the mask (col mx1+PAD) at the same
+     * upright row and stretch it across the masked span. This extends the
+     * neighbouring background (black margin for HMI -> seamless; corona for
+     * LASCO -> blends) horizontally over the burned-in timestamp. */
+    bool  mask_on = false;
+    int   mx0 = 0, mx1 = 0, my0 = 0, my1 = 0, sample_col = 0;
+    /* Gate the caption mask on the same crop/clean toggle as the crop, so turning
+     * the toggle off shows the raw frame (incl. burned-in timestamp). */
+    if (cfg->image_display_crop && cfg->image_display_source == 2) {
+        float fx0, fy0, fx1, fy1;
+        if (solar_band_text_mask(cfg->solar_band, &fx0, &fy0, &fx1, &fy1)) {
+            mask_on = true;
+            mx0 = (int)(fx0 * sw);
+            mx1 = (int)(fx1 * sw);
+            my0 = (int)(fy0 * sh);
+            my1 = (int)(fy1 * sh);
+            const int PAD = 8;
+            sample_col = mx1 + PAD;
+            if (sample_col > sw - 1) sample_col = sw - 1;  /* clamp into bounds */
+        }
+    }
+
     for (uint32_t y = 0; y < h; y++) {
         uint32_t src_y = data->vflip ? (uint32_t)(sh - 1 - (oy + y)) : (uint32_t)(oy + y);
         memcpy((uint8_t *)copy + (size_t)y * dst_stride,
                data->image_buf + (size_t)src_y * src_stride + (size_t)ox * 2,
                dst_stride);
+
+        if (!mask_on) continue;
+
+        /* Upright-full row for this dst row. Mask rect is in upright coords. */
+        int uY = (int)oy + (int)y;
+        if (uY < my0 || uY >= my1) continue;  /* row outside the mask band */
+
+        /* Sample the per-row replacement color ONCE (right of the mask, same
+         * upright row, same vflip mapping the copy uses). */
+        const uint8_t *src_px = data->image_buf
+                                + (size_t)src_y * src_stride
+                                + (size_t)sample_col * 2;
+        uint8_t lo = src_px[0], hi = src_px[1];
+
+        /* Overwrite the masked columns in this dst row. dst col x maps to
+         * upright col (ox + x); paint where ox+x is within [mx0, mx1). */
+        for (uint32_t x = 0; x < w; x++) {
+            int uX = (int)ox + (int)x;
+            if (uX < mx0 || uX >= mx1) continue;
+            uint8_t *dst_px = (uint8_t *)copy + (size_t)y * dst_stride + (size_t)x * 2;
+            dst_px[0] = lo;
+            dst_px[1] = hi;
+        }
     }
     int64_t poll_ms = data->last_poll_ms;
     goes_data_unlock(data);
@@ -287,8 +359,14 @@ void nina_image_display_update(goes_data_t *data)
     bool first_image = (displayed_poll_ms == 0);
     /* The Moon source re-posts a near-identical frame every ~60s; a crossfade
      * dips brightness at its midpoint (two ~50% copies over black) and reads as
-     * a once-a-minute flicker. Swap instantly for the moon (and the first image). */
-    bool instant = first_image || (app_config_get()->image_display_source == 1);
+     * a once-a-minute flicker. Swap instantly for the moon (and the first image).
+     * A forced re-crop also swaps instantly: crossfading two crops of the same
+     * frame is pointless and, since displayed_poll_ms == poll_ms here, would not
+     * key as first_image. */
+    bool instant = first_image || forced || (app_config_get()->image_display_source == 1);
+    /* poll_ms == displayed_poll_ms on a forced re-crop (same cached frame), so
+     * this assignment leaves displayed_poll_ms unchanged and a later real
+     * download (higher last_poll_ms) still passes the new-image gate. */
     displayed_poll_ms = poll_ms;
 
     if (instant) {
@@ -354,6 +432,22 @@ void nina_image_display_update(goes_data_t *data)
         char ts[32]; strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
         lv_label_set_text(lbl_timestamp, ts);
     }
+
+    /* The new image is now committed (swap done, overlay labels updated). Hide
+     * the wait overlay if it was shown for a manual source/band change. This is
+     * a no-op when the overlay is already hidden. We hold the display lock (the
+     * caller does), so call directly — matching this module's convention. */
+    nina_wait_overlay_hide();
+}
+
+void nina_image_display_force_redraw(void)
+{
+    /* Request that the next nina_image_display_update() re-render the cached
+     * frame even though last_poll_ms has not advanced. The flag is a plain bool
+     * touched only here (httpd task, display lock held by caller) and in
+     * update() under the goes lock; the caller wraps both this and the following
+     * update() in bsp_display_lock, so no extra synchronization is needed. */
+    force_redraw = true;
 }
 
 void nina_image_display_cleanup(void)

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -217,11 +217,29 @@ void nina_image_display_update(goes_data_t *data)
     /* Copy the RGB565 source into a freshly allocated PSRAM buffer so we can
      * release the goes mutex before running the (asynchronous) crossfade and
      * so this page owns its display buffers independently of the poller. */
-    uint16_t w = data->image_w, h = data->image_h;
-    if (w == 0 || h == 0) {
+    uint16_t sw = data->image_w, sh = data->image_h;
+    if (sw == 0 || sh == 0) {
         goes_data_unlock(data);
         return;
     }
+
+    /* Optional center-crop: keep the central ~88% so the solar/satellite disc
+     * zooms to fill the panel and the timestamp/label baked into the source
+     * border is cropped off. Skipped for the Moon (source 1): it has no text
+     * and is already framed to fill. */
+    const app_config_t *cfg = app_config_get();
+    uint16_t w = sw, h = sh, ox = 0, oy = 0;
+    /* Crop only when enabled, not the Moon, and (for Solar) not a frame-filling
+     * band (LASCO/HMI) whose disc would be clipped. */
+    extern bool solar_band_croppable(uint8_t idx);
+    bool croppable = (cfg->image_display_source != 2) || solar_band_croppable(cfg->solar_band);
+    if (cfg->image_display_crop && cfg->image_display_source != 1 && croppable) {
+        w  = (uint16_t)((uint32_t)sw * 88 / 100);
+        h  = (uint16_t)((uint32_t)sh * 88 / 100);
+        ox = (uint16_t)((sw - w) / 2);
+        oy = (uint16_t)((sh - h) / 2);
+    }
+
     size_t   buf_size = (size_t)w * h * 2;
     uint8_t *copy = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
     if (!copy) {
@@ -230,22 +248,17 @@ void nina_image_display_update(goes_data_t *data)
         goes_data_unlock(data);
         return;
     }
-    /* The software JPEG decoder feeding this page produces a vertically flipped
-     * buffer (top<->bottom) relative to the hardware decode path used by
-     * Spotify art / NINA thumbnails, which render correctly. Confirmed via the
-     * device /api/screenshot (logical, rotation-independent): without this the
-     * caption/logo render at the top. Copy row-reversed so the logical buffer
-     * is upright and matches the hardware convention; the panel rotation then
-     * handles physical orientation uniformly, as it does for the other pages. */
-    if (data->vflip) {
-        size_t row_bytes = (size_t)w * 2;
-        for (uint32_t y = 0; y < h; y++) {
-            memcpy((uint8_t *)copy + (size_t)y * row_bytes,
-                   data->image_buf + (size_t)(h - 1 - y) * row_bytes,
-                   row_bytes);
-        }
-    } else {
-        memcpy(copy, data->image_buf, buf_size);
+    /* Copy the (optionally cropped) source row-by-row. The software JPEG decoder
+     * path sets vflip=true (its buffer is top<->bottom relative to the hardware
+     * decode path); reverse the source row index in that case so the logical
+     * buffer is upright. ox/oy apply the center-crop. */
+    size_t src_stride = (size_t)sw * 2;
+    size_t dst_stride = (size_t)w * 2;
+    for (uint32_t y = 0; y < h; y++) {
+        uint32_t src_y = data->vflip ? (uint32_t)(sh - 1 - (oy + y)) : (uint32_t)(oy + y);
+        memcpy((uint8_t *)copy + (size_t)y * dst_stride,
+               data->image_buf + (size_t)src_y * src_stride + (size_t)ox * 2,
+               dst_stride);
     }
     int64_t poll_ms = data->last_poll_ms;
     goes_data_unlock(data);
@@ -321,7 +334,7 @@ void nina_image_display_update(goes_data_t *data)
         lv_anim_start(&a_out);
     }
 
-    const app_config_t *cfg = app_config_get();
+    /* cfg is already fetched above (crop check). */
     if (cfg->image_display_source == 1) {           /* Moon */
         extern void moon_caption(char *name_out, size_t name_sz,
                                  char *pct_out, size_t pct_sz);
@@ -329,6 +342,12 @@ void nina_image_display_update(goes_data_t *data)
         moon_caption(name, sizeof(name), pct, sizeof(pct));
         lv_label_set_text(lbl_region, name);
         lv_label_set_text(lbl_timestamp, pct);
+    } else if (cfg->image_display_source == 2) {     /* Solar (SDO/AIA) */
+        extern const char *solar_band_label(uint8_t idx);
+        lv_label_set_text(lbl_region, solar_band_label(cfg->solar_band));
+        time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);
+        char ts[32]; strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
+        lv_label_set_text(lbl_timestamp, ts);
     } else {                                         /* GOES */
         lv_label_set_text(lbl_region, region_code_to_name(cfg->goes_region));
         time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);

--- a/main/ui/nina_image_display.h
+++ b/main/ui/nina_image_display.h
@@ -6,6 +6,11 @@
 
 lv_obj_t *nina_image_display_create(lv_obj_t *parent);
 void      nina_image_display_update(goes_data_t *data);
+/* Force the next nina_image_display_update() to re-render the already-cached
+ * frame (e.g. re-apply a crop change locally) without an HTTP re-download. Call
+ * it immediately before nina_image_display_update(&goes_data), both under the
+ * display lock. No-op if no image is cached. */
+void      nina_image_display_force_redraw(void);
 void      nina_image_display_cleanup(void);
 void      nina_image_display_set_overlay_visible(bool visible);
 void      nina_image_display_apply_theme(void);

--- a/main/ui/nina_wait_overlay.c
+++ b/main/ui/nina_wait_overlay.c
@@ -1,0 +1,256 @@
+/**
+ * @file nina_wait_overlay.c
+ * @brief Generic full-screen wait/loading overlay.
+ *
+ * Visually mirrors the OTA progress screen (nina_ota_prompt): a full-screen
+ * theme-colored cover with a centered title/subtitle and an OTA-style progress
+ * bar (dim glow behind a brighter main bar) plus an optional large percentage
+ * label.
+ *
+ * It supports two modes:
+ *   - Determinate:   nina_wait_overlay_set_progress(0..100) — fills the bar and
+ *                    shows "NN%".
+ *   - Indeterminate: nina_wait_overlay_set_progress(-1) — pulses the bar outward
+ *                    from the center in both directions and hides the
+ *                    percentage. This is the default after _show() because the
+ *                    solar download/decode time is not known in advance.
+ *
+ * Threading: every function here runs under the display lock held by the
+ * CALLER (dashboard init, theme apply, goes_poll_task with an explicit
+ * bsp_display_lock, or data_update_task). Do NOT take the display lock here —
+ * matches the nina_ota_prompt convention.
+ */
+
+#include "nina_wait_overlay.h"
+#include "nina_dashboard_internal.h"
+#include "app_config.h"
+#include "display_defs.h"
+#include <string.h>
+#include <stdio.h>
+
+/* ── Widget pointers ────────────────────────────────────────────────── */
+static lv_obj_t *wait_overlay = NULL;
+static lv_obj_t *lbl_title    = NULL;
+static lv_obj_t *lbl_subtitle = NULL;
+static lv_obj_t *lbl_percent  = NULL;
+static lv_obj_t *bar_progress = NULL;
+static lv_obj_t *bar_glow     = NULL;
+
+static bool indeterminate = false;
+
+/* ── Helpers ────────────────────────────────────────────────────────── */
+
+/* Dim a color to ~30% brightness for bar track / glow (matches OTA prompt). */
+static uint32_t dim_color(uint32_t c) {
+    uint8_t r = ((c >> 16) & 0xFF) * 30 / 100;
+    uint8_t g = ((c >> 8)  & 0xFF) * 30 / 100;
+    uint8_t b = ((c)       & 0xFF) * 30 / 100;
+    return ((uint32_t)r << 16) | ((uint32_t)g << 8) | b;
+}
+
+/* Indeterminate pulse: drive both bars together so the glow tracks the main
+ * bar. The animation value `v` is the total span (0..100) and we expand it
+ * symmetrically around the center (50), so the indicator grows outward in both
+ * directions from the middle. lv_anim's playback (yoyo) then collapses it back
+ * to the center and repeats. Both bars are in LV_BAR_MODE_RANGE. */
+static void pulse_anim_cb(void *obj, int32_t v) {
+    LV_UNUSED(obj);
+    int32_t half  = v / 2;
+    int32_t start = 50 - half;
+    int32_t end   = 50 + half;
+    if (bar_progress) {
+        lv_bar_set_start_value(bar_progress, start, LV_ANIM_OFF);
+        lv_bar_set_value(bar_progress, end, LV_ANIM_OFF);
+    }
+    if (bar_glow) {
+        lv_bar_set_start_value(bar_glow, start, LV_ANIM_OFF);
+        lv_bar_set_value(bar_glow, end, LV_ANIM_OFF);
+    }
+}
+
+static void start_pulse(void) {
+    if (!bar_progress) return;
+    indeterminate = true;
+    if (lbl_percent) lv_obj_add_flag(lbl_percent, LV_OBJ_FLAG_HIDDEN);
+
+    lv_anim_t a;
+    lv_anim_init(&a);
+    lv_anim_set_var(&a, bar_progress);          /* var is only an animation key */
+    lv_anim_set_values(&a, 0, 100);             /* span: collapsed -> full width */
+    lv_anim_set_duration(&a, 900);
+    lv_anim_set_playback_duration(&a, 900);     /* sweep back */
+    lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
+    lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
+    lv_anim_set_exec_cb(&a, pulse_anim_cb);
+    lv_anim_start(&a);
+}
+
+static void stop_pulse(void) {
+    indeterminate = false;
+    /* Delete by the var+exec_cb pair used in start_pulse. */
+    if (bar_progress) lv_anim_delete(bar_progress, pulse_anim_cb);
+}
+
+/* ── Create ─────────────────────────────────────────────────────────── */
+
+void nina_wait_overlay_create(lv_obj_t *parent) {
+    wait_overlay = lv_obj_create(parent);
+    lv_obj_remove_style_all(wait_overlay);
+    lv_obj_set_size(wait_overlay, SCREEN_SIZE, SCREEN_SIZE);
+    lv_obj_set_style_bg_color(wait_overlay, lv_color_hex(0x000000), 0);
+    lv_obj_set_style_bg_opa(wait_overlay, LV_OPA_COVER, 0);
+    lv_obj_add_flag(wait_overlay, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(wait_overlay, LV_OBJ_FLAG_CLICKABLE);          /* eat taps   */
+    lv_obj_clear_flag(wait_overlay, LV_OBJ_FLAG_GESTURE_BUBBLE);   /* eat swipes */
+
+    lv_obj_set_flex_flow(wait_overlay, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(wait_overlay, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(wait_overlay, 16, 0);
+    lv_obj_clear_flag(wait_overlay, LV_OBJ_FLAG_SCROLLABLE);
+
+    lbl_title = lv_label_create(wait_overlay);
+    lv_label_set_text(lbl_title, "");
+    lv_obj_set_style_text_font(lbl_title, &lv_font_montserrat_36, 0);
+    lv_obj_set_style_text_color(lbl_title, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_align(lbl_title, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_width(lbl_title, LV_PCT(90));
+
+    lbl_subtitle = lv_label_create(wait_overlay);
+    lv_label_set_text(lbl_subtitle, "");
+    lv_obj_set_style_text_font(lbl_subtitle, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(lbl_subtitle, lv_color_hex(0x999999), 0);
+    lv_obj_set_style_text_align(lbl_subtitle, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_width(lbl_subtitle, LV_PCT(90));
+
+    lbl_percent = lv_label_create(wait_overlay);
+    lv_label_set_text(lbl_percent, "0%");
+    lv_obj_set_style_text_font(lbl_percent, &lv_font_montserrat_48, 0);
+    lv_obj_set_style_text_color(lbl_percent, lv_color_hex(0x3b82f6), 0);
+    lv_obj_set_style_text_align(lbl_percent, LV_TEXT_ALIGN_CENTER, 0);
+
+    /* Bar container — holds glow + main bar overlapping (mirrors OTA prompt). */
+    lv_obj_t *bar_wrap = lv_obj_create(wait_overlay);
+    lv_obj_remove_style_all(bar_wrap);
+    lv_obj_set_size(bar_wrap, 580, 28);
+    lv_obj_clear_flag(bar_wrap, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_style_pad_top(bar_wrap, 16, 0);
+
+    bar_glow = lv_bar_create(bar_wrap);
+    lv_obj_remove_style_all(bar_glow);
+    lv_obj_set_size(bar_glow, 580, 24);
+    lv_bar_set_range(bar_glow, 0, 100);
+    lv_bar_set_mode(bar_glow, LV_BAR_MODE_RANGE);   /* span between start..value */
+    lv_bar_set_start_value(bar_glow, 50, LV_ANIM_OFF);
+    lv_bar_set_value(bar_glow, 50, LV_ANIM_OFF);
+    lv_obj_set_style_bg_opa(bar_glow, LV_OPA_TRANSP, LV_PART_MAIN);
+    lv_obj_set_style_radius(bar_glow, 12, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(bar_glow, lv_color_hex(0x3b82f6), LV_PART_INDICATOR);
+    lv_obj_set_style_bg_opa(bar_glow, LV_OPA_40, LV_PART_INDICATOR);
+    lv_obj_set_style_radius(bar_glow, 12, LV_PART_INDICATOR);
+    lv_obj_center(bar_glow);
+
+    bar_progress = lv_bar_create(bar_wrap);
+    lv_obj_remove_style_all(bar_progress);
+    lv_obj_set_size(bar_progress, 560, 12);
+    lv_bar_set_range(bar_progress, 0, 100);
+    lv_bar_set_mode(bar_progress, LV_BAR_MODE_RANGE);   /* span between start..value */
+    lv_bar_set_start_value(bar_progress, 50, LV_ANIM_OFF);
+    lv_bar_set_value(bar_progress, 50, LV_ANIM_OFF);
+    lv_obj_set_style_bg_color(bar_progress, lv_color_hex(0x1a1a2e), LV_PART_MAIN);
+    lv_obj_set_style_bg_opa(bar_progress, LV_OPA_30, LV_PART_MAIN);
+    lv_obj_set_style_radius(bar_progress, 6, LV_PART_MAIN);
+    lv_obj_set_style_bg_color(bar_progress, lv_color_hex(0x3b82f6), LV_PART_INDICATOR);
+    lv_obj_set_style_bg_opa(bar_progress, LV_OPA_COVER, LV_PART_INDICATOR);
+    lv_obj_set_style_radius(bar_progress, 6, LV_PART_INDICATOR);
+    lv_obj_center(bar_progress);
+}
+
+/* ── Public API ─────────────────────────────────────────────────────── */
+
+void nina_wait_overlay_show(const char *title, const char *subtitle) {
+    if (!wait_overlay) return;
+
+    nina_wait_overlay_apply_theme();
+
+    lv_label_set_text(lbl_title, title ? title : "");
+    if (subtitle && subtitle[0]) {
+        lv_label_set_text(lbl_subtitle, subtitle);
+        lv_obj_clear_flag(lbl_subtitle, LV_OBJ_FLAG_HIDDEN);
+    } else {
+        lv_label_set_text(lbl_subtitle, "");
+        lv_obj_add_flag(lbl_subtitle, LV_OBJ_FLAG_HIDDEN);
+    }
+
+    lv_obj_clear_flag(wait_overlay, LV_OBJ_FLAG_HIDDEN);
+
+    /* Default to the indeterminate pulse — the download/decode time is unknown. */
+    nina_wait_overlay_set_progress(-1);
+}
+
+void nina_wait_overlay_set_progress(int percent) {
+    if (!wait_overlay) return;
+
+    if (percent < 0) {
+        /* Indeterminate — start (or keep) the pulse, hide the percentage. */
+        if (!indeterminate) start_pulse();
+        return;
+    }
+
+    if (indeterminate) stop_pulse();
+    if (percent > 100) percent = 100;
+
+    if (lbl_percent) {
+        char buf[8];
+        snprintf(buf, sizeof(buf), "%d%%", percent);
+        lv_label_set_text(lbl_percent, buf);
+        lv_obj_clear_flag(lbl_percent, LV_OBJ_FLAG_HIDDEN);
+    }
+    /* Determinate: fill from the left edge, so reset the range start to 0
+     * (the indeterminate pulse leaves it centered). */
+    if (bar_progress) {
+        lv_bar_set_start_value(bar_progress, 0, LV_ANIM_OFF);
+        lv_bar_set_value(bar_progress, percent, LV_ANIM_ON);
+    }
+    if (bar_glow) {
+        lv_bar_set_start_value(bar_glow, 0, LV_ANIM_OFF);
+        lv_bar_set_value(bar_glow, percent, LV_ANIM_ON);
+    }
+}
+
+void nina_wait_overlay_hide(void) {
+    if (!wait_overlay) return;
+    stop_pulse();
+    lv_obj_add_flag(wait_overlay, LV_OBJ_FLAG_HIDDEN);
+}
+
+bool nina_wait_overlay_visible(void) {
+    if (!wait_overlay) return false;
+    return !lv_obj_has_flag(wait_overlay, LV_OBJ_FLAG_HIDDEN);
+}
+
+void nina_wait_overlay_apply_theme(void) {
+    if (!wait_overlay || !current_theme) return;
+    int gb = app_config_get()->color_brightness;
+
+    uint32_t accent = app_config_apply_brightness(current_theme->progress_color, gb);
+    uint32_t text   = app_config_apply_brightness(current_theme->text_color, gb);
+    uint32_t label  = app_config_apply_brightness(current_theme->label_color, gb);
+    uint32_t bg     = current_theme->bg_main;
+
+    lv_obj_set_style_bg_color(wait_overlay, lv_color_hex(bg), 0);
+
+    if (lbl_title)
+        lv_obj_set_style_text_color(lbl_title, lv_color_hex(text), 0);
+    if (lbl_subtitle)
+        lv_obj_set_style_text_color(lbl_subtitle, lv_color_hex(label), 0);
+    if (lbl_percent)
+        lv_obj_set_style_text_color(lbl_percent, lv_color_hex(accent), 0);
+    if (bar_glow)
+        lv_obj_set_style_bg_color(bar_glow, lv_color_hex(accent), LV_PART_INDICATOR);
+    if (bar_progress) {
+        lv_obj_set_style_bg_color(bar_progress, lv_color_hex(dim_color(accent)), LV_PART_MAIN);
+        lv_obj_set_style_bg_color(bar_progress, lv_color_hex(accent), LV_PART_INDICATOR);
+    }
+
+    lv_obj_invalidate(wait_overlay);
+}

--- a/main/ui/nina_wait_overlay.h
+++ b/main/ui/nina_wait_overlay.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "lvgl.h"
+#include <stdbool.h>
+
+/**
+ * Generic full-screen "wait/loading" overlay, styled to mirror the OTA
+ * progress screen (glow + main progress bar, large percentage label).
+ *
+ * All functions must be called from a display-locked context (the caller
+ * holds bsp_display_lock); this module does NOT acquire the lock itself,
+ * matching the nina_ota_prompt convention.
+ */
+
+/* Create the overlay once (hidden) under @p parent at dashboard init. */
+void nina_wait_overlay_create(lv_obj_t *parent);
+
+/* Show the overlay with the given title and optional subtitle (may be NULL
+ * or empty). Starts an indeterminate pulse animation. */
+void nina_wait_overlay_show(const char *title, const char *subtitle);
+
+/* Set progress. percent >= 0 -> determinate bar + "NN%" label.
+ * percent < 0 -> indeterminate pulse animation (percentage label hidden). */
+void nina_wait_overlay_set_progress(int percent);
+
+/* Hide the overlay and stop any running animation. */
+void nina_wait_overlay_hide(void);
+
+/* True when the overlay is currently visible. */
+bool nina_wait_overlay_visible(void);
+
+/* Recolor the overlay from the active theme (mirrors nina_ota_prompt_apply_theme). */
+void nina_wait_overlay_apply_theme(void);

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -127,12 +127,14 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     cJSON_AddBoolToObject(obj, "spotify_overlay_visible", cfg->spotify_overlay_visible);
     cJSON_AddBoolToObject(obj, "image_display_enabled", cfg->image_display_enabled);
     cJSON_AddBoolToObject(obj, "image_display_show_overlay", cfg->image_display_show_overlay);
+    cJSON_AddBoolToObject(obj, "image_display_crop", cfg->image_display_crop);
     cJSON_AddStringToObject(obj, "goes_region", cfg->goes_region);
     cJSON_AddNumberToObject(obj, "goes_update_interval_s", cfg->goes_update_interval_s);
     cJSON_AddNumberToObject(obj, "image_display_source", cfg->image_display_source);
     cJSON_AddNumberToObject(obj, "moon_bg_style", cfg->moon_bg_style);
     cJSON_AddNumberToObject(obj, "moon_lat", (double)cfg->moon_lat);
     cJSON_AddNumberToObject(obj, "moon_lon", (double)cfg->moon_lon);
+    cJSON_AddNumberToObject(obj, "solar_band", cfg->solar_band);
     cJSON_AddNumberToObject(obj, "toast_aggregation_window_s", cfg->toast_aggregation_window_s);
     cJSON_AddNumberToObject(obj, "toast_notify_mask", cfg->toast_notify_mask);
     cJSON_AddBoolToObject(obj, "toast_instance_muted_1", cfg->toast_instance_muted[0]);
@@ -307,12 +309,14 @@ static const backup_field_t s_backup_fields[] = {
     /* Image Display */
     {"image_display_enabled",      "Image Display Enabled","Image Display", false, false},
     {"image_display_show_overlay", "Show Overlay",         "Image Display", false, false},
+    {"image_display_crop",         "Image Crop/Fill",      "Image Display", false, false},
     {"goes_region",                "GOES Region",          "Image Display", false, false},
     {"goes_update_interval_s",     "GOES Update Interval", "Image Display", false, false},
     {"image_display_source",       "Image Source",         "Image Display", false, false},
     {"moon_bg_style",              "Moon Background Style", "Image Display", false, false},
     {"moon_lat",                   "Moon Latitude",        "Image Display", false, false},
     {"moon_lon",                   "Moon Longitude",       "Image Display", false, false},
+    {"solar_band",                 "Solar Band",           "Image Display", false, false},
 
     /* MQTT (non-sensitive) */
     {"mqtt_enabled",       "MQTT Enabled",       "MQTT", false, false},
@@ -852,6 +856,7 @@ static app_config_t *parse_config_from_json(cJSON *root)
 
     JSON_TO_BOOL  (root, "image_display_enabled",       cfg->image_display_enabled);
     JSON_TO_BOOL  (root, "image_display_show_overlay",   cfg->image_display_show_overlay);
+    JSON_TO_BOOL  (root, "image_display_crop",           cfg->image_display_crop);
     JSON_TO_STRING(root, "goes_region",                  cfg->goes_region);
 
     cJSON *goes_interval = cJSON_GetObjectItem(root, "goes_update_interval_s");
@@ -869,6 +874,8 @@ static app_config_t *parse_config_from_json(cJSON *root)
     if (jmoonlat && cJSON_IsNumber(jmoonlat)) cfg->moon_lat = (float)jmoonlat->valuedouble;
     cJSON *jmoonlon = cJSON_GetObjectItem(root, "moon_lon");
     if (jmoonlon && cJSON_IsNumber(jmoonlon)) cfg->moon_lon = (float)jmoonlon->valuedouble;
+
+    JSON_TO_INT(root, "solar_band", cfg->solar_band);
 
     cJSON *taw_item = cJSON_GetObjectItem(root, "toast_aggregation_window_s");
     if (cJSON_IsNumber(taw_item)) {

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -73,6 +73,16 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
 
     app_config_t *cfg = app_config_get();
 
+    /* Capture the current source/band/region/crop so we can tell, after saving,
+     * whether the change needs a new image (source/band/region -> re-download +
+     * wait overlay) or only a crop/full toggle (-> local re-render of the cached
+     * frame, no download). */
+    uint8_t prev_source = cfg->image_display_source;
+    uint8_t prev_band   = cfg->solar_band;
+    bool    prev_crop   = cfg->image_display_crop;
+    char    prev_region[sizeof(cfg->goes_region)];
+    strlcpy(prev_region, cfg->goes_region, sizeof(prev_region));
+
     JSON_TO_BOOL(root, "image_display_enabled", cfg->image_display_enabled);
     JSON_TO_BOOL(root, "image_display_show_overlay", cfg->image_display_show_overlay);
     JSON_TO_BOOL(root, "image_display_crop", cfg->image_display_crop);
@@ -108,9 +118,35 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     }
 
     if (cfg->image_display_enabled) {
-        goes_ensure_task_running();
-        if (goes_task_handle) {
-            xTaskNotifyGive(goes_task_handle);
+        bool source_band_region_changed =
+            cfg->image_display_source != prev_source ||
+            cfg->solar_band != prev_band ||
+            strcmp(cfg->goes_region, prev_region) != 0;
+        bool crop_changed = cfg->image_display_crop != prev_crop;
+
+        if (source_band_region_changed) {
+            /* Source/band/region needs a genuinely new image: flag the next
+             * fetch as manual so goes_poll_task shows the wait overlay during
+             * the re-download/decode, then wake the task. If crop also changed,
+             * the re-download path re-applies the new crop, so no separate local
+             * re-render is needed. */
+            atomic_store(&image_display_manual_fetch, true);
+            goes_ensure_task_running();
+            if (goes_task_handle) {
+                xTaskNotifyGive(goes_task_handle);
+            }
+        } else if (crop_changed) {
+            /* Crop/full toggle only: re-render the already-decoded frame locally
+             * instead of re-downloading. nina_image_display_update() locks
+             * goes_data internally but REQUIRES the display lock held by the
+             * caller (see tasks.c), so wrap both calls in bsp_display_lock. The
+             * force-redraw gate is a safe no-op if no image is cached or the page
+             * is not on the image path. */
+            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                nina_image_display_force_redraw();
+                nina_image_display_update(&goes_data);
+                bsp_display_unlock();
+            }
         }
     }
 

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -24,12 +24,14 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
 
     cJSON_AddBoolToObject(root, "image_display_enabled", cfg->image_display_enabled);
     cJSON_AddBoolToObject(root, "image_display_show_overlay", cfg->image_display_show_overlay);
+    cJSON_AddBoolToObject(root, "image_display_crop", cfg->image_display_crop);
     cJSON_AddStringToObject(root, "goes_region", cfg->goes_region);
     cJSON_AddNumberToObject(root, "goes_update_interval_s", cfg->goes_update_interval_s);
     cJSON_AddNumberToObject(root, "image_display_source", cfg->image_display_source);
     cJSON_AddNumberToObject(root, "moon_bg_style", cfg->moon_bg_style);
     cJSON_AddNumberToObject(root, "moon_lat", cfg->moon_lat);
     cJSON_AddNumberToObject(root, "moon_lon", cfg->moon_lon);
+    cJSON_AddNumberToObject(root, "solar_band", cfg->solar_band);
 
     const char *json_str = cJSON_PrintUnformatted(root);
     if (json_str == NULL) {
@@ -73,6 +75,7 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
 
     JSON_TO_BOOL(root, "image_display_enabled", cfg->image_display_enabled);
     JSON_TO_BOOL(root, "image_display_show_overlay", cfg->image_display_show_overlay);
+    JSON_TO_BOOL(root, "image_display_crop", cfg->image_display_crop);
     JSON_TO_STRING(root, "goes_region", cfg->goes_region);
 
     cJSON *interval = cJSON_GetObjectItem(root, "goes_update_interval_s");
@@ -84,13 +87,15 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     }
 
     cJSON *src = cJSON_GetObjectItem(root, "image_display_source");
-    if (cJSON_IsNumber(src)) cfg->image_display_source = (src->valueint == 1) ? 1 : 0;
+    if (cJSON_IsNumber(src)) { int v = src->valueint; cfg->image_display_source = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
     cJSON *bg = cJSON_GetObjectItem(root, "moon_bg_style");
     if (cJSON_IsNumber(bg)) { int v = bg->valueint; cfg->moon_bg_style = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *mlat = cJSON_GetObjectItem(root, "moon_lat");
     if (cJSON_IsNumber(mlat)) cfg->moon_lat = (float)mlat->valuedouble;
     cJSON *mlon = cJSON_GetObjectItem(root, "moon_lon");
     if (cJSON_IsNumber(mlon)) cfg->moon_lon = (float)mlon->valuedouble;
+    cJSON *sb = cJSON_GetObjectItem(root, "solar_band");
+    if (cJSON_IsNumber(sb)) { int v = sb->valueint; cfg->solar_band = (v >= 0 && v <= 17) ? (uint8_t)v : 0; }
 
     cJSON_Delete(root);
 


### PR DESCRIPTION
### Summary
The device now supports fetching and displaying SDO solar images, expanding the available solar data sources. This update also improves the visual presentation of solar images with smarter cropping and a loading indicator, and standardizes the web UI's color scheme.

### Changes
*   Adds support for fetching and displaying SDO solar images.
*   Improves solar image display with smarter cropping.
*   Shows a loading overlay while solar images are being processed or loaded.
*   Unifies the web UI's color palette to a blue-grey theme across all configuration and login pages.
*   Updates configuration and client logic to manage SDO image data.

---
<sub>Analyzed **4** commit(s) | Updated: 2026-05-30T16:48:50.294Z | Generated by GitHub Actions</sub>