### PR TITLE
feat: add loading overlay for image display

### DIFF
--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -568,7 +568,7 @@
     <div class="brand"><img class="logo" src="/favicon.ico" alt=""> <span id="brandName">NINA Display</span></div>
     <div class="tabs" id="topTabs">
       <button class="tab-btn active" data-tab="display">Display</button>
-      <button class="tab-btn" data-tab="nodes">Nodes &amp; Data</button>
+      <button class="tab-btn" data-tab="nodes">N.I.N.A.</button>
       <button class="tab-btn" data-tab="behavior">Behavior</button>
       <button class="tab-btn" data-tab="system">System</button>
       <button class="tab-btn" data-tab="allsky">AllSky</button>
@@ -592,7 +592,7 @@
       </button>
       <button class="nav-btn" data-tab="nodes">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
-        Nodes
+        N.I.N.A.
       </button>
       <button class="nav-btn" data-tab="behavior">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83 0 2 2 0 010-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
@@ -764,17 +764,17 @@
     <div id="tab-nodes" class="tab-panel">
 
       <div class="card" id="instance-overview">
-        <div class="card-title">Active Instances</div>
+        <div class="card-title">Active N.I.N.A. Instances</div>
         <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label" id="inst_lbl_0">Node 1</span>
+          <span class="toggle-label" id="inst_lbl_0">N.I.N.A. 1</span>
           <label class="toggle"><input type="checkbox" id="instance_enabled_0" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
         </div>
         <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label" id="inst_lbl_1">Node 2</span>
+          <span class="toggle-label" id="inst_lbl_1">N.I.N.A. 2</span>
           <label class="toggle"><input type="checkbox" id="instance_enabled_1" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
         </div>
         <div class="toggle-row">
-          <span class="toggle-label" id="inst_lbl_2">Node 3</span>
+          <span class="toggle-label" id="inst_lbl_2">N.I.N.A. 3</span>
           <label class="toggle"><input type="checkbox" id="instance_enabled_2" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
         </div>
       </div>
@@ -1601,7 +1601,7 @@
         const urlId='url'+(i+1);
         container.insertAdjacentHTML('beforeend',
           '<div class="card node-config-card" id="node_card_'+i+'" data-node="'+i+'">'+
-            '<div class="card-title">Node '+(i+1)+' <span id="node_card_hostname_'+i+'" style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted);font-size:0.7rem"></span></div>'+
+            '<div class="card-title">N.I.N.A. '+(i+1)+' <span id="node_card_hostname_'+i+'" style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted);font-size:0.7rem"></span></div>'+
             '<div class="field"><label class="field-label">Hostname / IP</label>'+
             '<input type="text" class="input" id="'+urlId+'" placeholder="'+placeholders[i]+'" oninput="updateNodeLabels()"></div>'+
             '<div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">'+
@@ -1950,7 +1950,7 @@
     function updateNodeLabels(){
       var urls=[$('url1').value.trim(),$('url2').value.trim(),$('url3').value.trim()];
       for(var i=0;i<3;i++){
-        var label=urls[i]||('Node '+(i+1));
+        var label=urls[i]||('N.I.N.A. '+(i+1));
         var hostnameSpan=$('node_card_hostname_'+i);
         if(hostnameSpan) hostnameSpan.textContent=urls[i]?urls[i]:'';
         var instLbl=$('inst_lbl_'+i);

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -186,7 +186,9 @@
       background: rgba(0, 0, 0, 0.4);
     }
     .input::placeholder { color: var(--text-hint); opacity: 0.6; }
-    select.input { cursor: pointer; appearance: none; -webkit-appearance: none; }
+    select.input { cursor: pointer; appearance: none; -webkit-appearance: none; color-scheme: dark; }
+    select.input option, select.input optgroup { background: #14171f; color: #f4f4f5; }
+    select.input option:checked { background: rgba(var(--accent-rgb), 0.35); }
 
     .toggle { position: relative; display: inline-block; width: 48px; height: 26px; flex-shrink: 0; }
     .toggle input { opacity: 0; width: 0; height: 0; position: absolute; }
@@ -1399,11 +1401,12 @@
             <label class="toggle"><input type="checkbox" id="image_display_show_overlay" onchange="applyImageDisplay();checkDirty()" checked><span class="toggle-track"></span></label>
           </div>
           <div class="field-hint">Region/phase name and update time overlay on the display</div>
+          <div id="discOptions">
           <div class="toggle-row">
             <span class="toggle-label">Fill (crop borders)</span>
             <label class="toggle"><input type="checkbox" id="image_display_crop" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
           </div>
-          <div class="field-hint">Zoom the disc to fill the screen and hide the image's timestamp/label. Not applied to the Moon.</div>
+          <div class="field-hint">Zoom the disc to fill the screen and hide the image's timestamp/label.</div>
           <div class="field" style="margin-top:16px">
             <label class="field-label">Update Interval</label>
             <select class="input" id="goesInterval" onchange="applyImageDisplay();checkDirty()">
@@ -1414,7 +1417,8 @@
               <option value="3600">1 hour</option>
               <option value="7200">2 hours</option>
             </select>
-            <div class="field-hint">How often GOES and Solar images refresh. The Moon updates continuously.</div>
+            <div class="field-hint">How often the image refreshes.</div>
+          </div>
           </div>
           <div id="goesGroup">
           <div class="field" style="margin-top:16px">
@@ -3334,6 +3338,7 @@
 
     function updateImageSourceUI(){
       var s=getImageSource();
+      if($('discOptions')) $('discOptions').style.display=(s===1)?'none':'';
       if($('goesGroup'))  $('goesGroup').style.display =(s===0)?'':'none';
       if($('moonGroup'))  $('moonGroup').style.display =(s===1)?'':'none';
       if($('solarGroup')) $('solarGroup').style.display=(s===2)?'':'none';

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1303,7 +1303,11 @@
             <li>Go to <a href="https://developer.spotify.com" target="_blank" rel="noopener" style="color:rgba(var(--accent-rgb),1);text-decoration:underline">developer.spotify.com</a> and create a free app</li>
             <li>Set the redirect URI in your Spotify app to: <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;font-size:0.78rem">http://127.0.0.1:8000/callback</code></li>
             <li>Copy the <strong>Client ID</strong> from your Spotify app and paste it below</li>
-            <li>Click <strong>Save</strong> at the bottom of this page, then use the Login button in the Account section</li>
+            <li>Click <strong>Save</strong> at the bottom of this page</li>
+            <li>In the <strong>Account</strong> section below, click <strong>Login with Spotify</strong> and approve access in the popup</li>
+            <li>After approving, Spotify redirects to <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;font-size:0.78rem">http://127.0.0.1:8000/callback?code=...</code> and your browser shows a "can't connect" / "site can't be reached" page. This is expected.</li>
+            <li>Copy the <strong>full URL</strong> from that page's address bar (it must include the <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;font-size:0.78rem">?code=</code> part)</li>
+            <li>Paste it into the <strong>Redirect URL</strong> field in the Account section and click <strong>Submit</strong></li>
           </ol>
         </div>
         <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">

--- a/main/moon_render.c
+++ b/main/moon_render.c
@@ -9,6 +9,14 @@
 
 static const char *TAG = "moon_render";
 
+/* 4x4 Bayer ordered-dither threshold matrix (0..15). */
+static const uint8_t s_bayer4[4][4] = {
+    { 0,  8,  2, 10},
+    {12,  4, 14,  6},
+    { 3, 11,  1,  9},
+    {15,  7, 13,  5}
+};
+
 /* Embedded PNG (see CMakeLists EMBED_FILES). */
 extern const uint8_t moon_png_start[] asm("_binary_moon_texture_png_start");
 extern const uint8_t moon_png_end[]   asm("_binary_moon_texture_png_end");
@@ -168,7 +176,11 @@ uint16_t *moon_render(int w, int h, const moon_state_t *st, uint8_t bg_style)
                 int r = ((c>>11)&0x1F)*255/31 + add;
                 int g = ((c>>5)&0x3F)*255/63 + add*9/10;
                 int b = (c&0x1F)*255/31 + add*7/10;
-                row[px] = rgb565(r,g,b);
+                /* Ordered dither fills rgb565 truncation slack (kills rings). */
+                int dr = s_bayer4[py & 3][px & 3] >> 1;  /* 0..7, red step 8 */
+                int dg = s_bayer4[py & 3][px & 3] >> 2;  /* 0..3, green step 4 */
+                int db = dr;                             /* 0..7, blue step 8 */
+                row[px] = rgb565(r + dr, g + dg, b + db);
             }
         }
     }

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -689,26 +689,31 @@ void goes_poll_task(void *arg)
         /* GOES needs network — wait for WiFi before attempting any HTTP requests. */
         xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
 
-        /* Show the full-screen wait overlay only for a user-initiated source/
-         * band change (manual flag), and only while the Image Display page is
-         * actually visible — a takeover on an unrelated page would be jarring.
-         * Periodic refreshes and page-entry refreshes leave the flag clear, so
-         * they never trigger the overlay. The overlay is hidden again when the
-         * new image is committed in nina_image_display_update(), or below on a
-         * fetch error. */
+        /* Show the full-screen wait overlay while the Image Display page is
+         * visible and either (a) the user changed the source/band (manual flag)
+         * or (b) nothing is on screen yet — which is the case on page (re)entry
+         * because the buffers are freed on leave, so has_image() is false on the
+         * first refresh after entry. Periodic background refreshes keep the
+         * current image on screen (has_image() true) and skip the overlay so it
+         * never flickers over a good frame. A takeover on an unrelated page
+         * would be jarring, so it stays gated on image_display_page_active. The
+         * overlay is hidden again when the new image is committed in
+         * nina_image_display_update(), or below on a fetch error. */
         bool manual_fetch = atomic_exchange(&image_display_manual_fetch, false);
         bool show_wait = false;
-        if (manual_fetch && image_display_page_active) {
+        if (image_display_page_active) {
             const char *band_name = (cfg->image_display_source == 2)
                                         ? solar_band_label(cfg->solar_band) : NULL;
             /* Only treat the overlay as shown if the lock was acquired and the
              * show actually ran — otherwise the error-hide below would be a
              * spurious no-op against an overlay that never appeared. */
             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                nina_wait_overlay_show("Loading image...", band_name);
-                nina_wait_overlay_set_progress(-1);   /* indeterminate */
+                if (manual_fetch || !nina_image_display_has_image()) {
+                    nina_wait_overlay_show("Loading image...", band_name);
+                    nina_wait_overlay_set_progress(-1);   /* indeterminate */
+                    show_wait = true;
+                }
                 bsp_display_unlock();
-                show_wait = true;
             }
         }
 

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -450,6 +450,14 @@ void nina_image_display_force_redraw(void)
     force_redraw = true;
 }
 
+bool nina_image_display_has_image(void)
+{
+    /* True once a frame has been committed to the page; reset to 0 by
+     * nina_image_display_cleanup() on page leave and at create. Read under the
+     * display lock held by the caller, matching this module's convention. */
+    return displayed_poll_ms != 0;
+}
+
 void nina_image_display_cleanup(void)
 {
     if (!page_container) return;

--- a/main/ui/nina_image_display.h
+++ b/main/ui/nina_image_display.h
@@ -11,6 +11,9 @@ void      nina_image_display_update(goes_data_t *data);
  * it immediately before nina_image_display_update(&goes_data), both under the
  * display lock. No-op if no image is cached. */
 void      nina_image_display_force_redraw(void);
+/* True if a frame is currently displayed on the image page (false right after
+ * page leave / cleanup, which frees the buffers). Call under the display lock. */
+bool      nina_image_display_has_image(void);
 void      nina_image_display_cleanup(void);
 void      nina_image_display_set_overlay_visible(bool visible);
 void      nina_image_display_apply_theme(void);

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -80,6 +80,7 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     uint8_t prev_source = cfg->image_display_source;
     uint8_t prev_band   = cfg->solar_band;
     bool    prev_crop   = cfg->image_display_crop;
+    uint8_t prev_bg     = cfg->moon_bg_style;
     char    prev_region[sizeof(cfg->goes_region)];
     strlcpy(prev_region, cfg->goes_region, sizeof(prev_region));
 
@@ -131,6 +132,28 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
              * the re-download path re-applies the new crop, so no separate local
              * re-render is needed. */
             atomic_store(&image_display_manual_fetch, true);
+            goes_ensure_task_running();
+            if (goes_task_handle) {
+                xTaskNotifyGive(goes_task_handle);
+            }
+        } else if (cfg->image_display_source == 1 && cfg->moon_bg_style != prev_bg) {
+            /* Moon background style changed only (source unchanged, so the
+             * source_band_region_changed branch above did not fire): wake the
+             * image-display task so its Moon branch re-renders moon_render() with
+             * the new cfg->moon_bg_style and commits it via goes_set_image() /
+             * nina_image_display_update(). The Moon branch (image_display_source
+             * == 1 in goes_poll_task) is purely local — it renders, commits, and
+             * `continue`s before ever reaching the manual-fetch / wait-overlay
+             * block, so it never shows the "Loading image..." overlay and never
+             * consumes image_display_manual_fetch. A bare task notify is therefore
+             * sufficient: do NOT set image_display_manual_fetch here, since the
+             * Moon branch would not clear it and it could leak a spurious overlay
+             * onto a later GOES/Solar fetch. A background-only change leaves moon
+             * illumination/orientation unchanged, so moon_anim_request stays clear
+             * and only a single still re-render occurs. This branch is mutually
+             * exclusive with the source-change branch above (that one runs only
+             * when source/band/region changed), so the task is woken at most once
+             * per request. */
             goes_ensure_task_running();
             if (goes_task_handle) {
                 xTaskNotifyGive(goes_task_handle);


### PR DESCRIPTION
### Summary
This PR improves the user experience by adding a loading overlay for image displays and manual source changes, while also refining the moon rendering with ordered dithering. It also updates UI labels for clarity and consistency.

### Changes
*   Displays a loading overlay when an image page loads or its source changes manually.
*   Skips the loading overlay during background image refreshes if an image is already visible.
*   Applies ordered dithering to the moon rendering for improved visual quality.
*   Triggers a re-render of the moon when the background style changes.
*   Renames "Nodes" tab and instance labels to "N.I.N.A." throughout the configuration UI.
*   Improves the styling of dropdown menus in the configuration UI.
*   Simplifies labels for disc and image refresh actions in the UI.

---
<sub>Analyzed **5** commit(s) | Updated: 2026-06-01T07:54:37.654Z | Generated by GitHub Actions</sub>