### PR TITLE
feat: idle page override supports any page with auto-rotate

### DIFF
--- a/main/app_config.h
+++ b/main/app_config.h
@@ -24,6 +24,9 @@ typedef enum {
     IDLE_TARGET_SPOTIFY        =  2,
     IDLE_TARGET_IMAGE_DISPLAY  =  3,
     IDLE_TARGET_SYSINFO        =  4,
+    IDLE_TARGET_NINA1          =  5,
+    IDLE_TARGET_NINA2          =  6,
+    IDLE_TARGET_NINA3          =  7,
 } idle_target_t;
 
 typedef struct {

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1194,7 +1194,7 @@
         <div class="toggle-row">
           <div>
             <span class="toggle-label">Switch page when no connections</span>
-            <div class="field-hint" style="margin-top:2px">Automatically switches to the selected page when all NINA instances are disconnected. Disabled while auto-rotate is active.</div>
+            <div class="field-hint" style="margin-top:2px">Automatically switches to the selected page when all NINA instances are disconnected, then resumes auto-rotate (if enabled) on reconnect.</div>
           </div>
           <label class="toggle"><input type="checkbox" id="idle_page_override_enabled" onchange="toggleIdleOverride();checkDirty()"><span class="toggle-track"></span></label>
         </div>
@@ -1207,6 +1207,9 @@
             <option value="2">Spotify</option>
             <option value="3">Image Display</option>
             <option value="4">System Info</option>
+            <option value="5">NINA Instance 1</option>
+            <option value="6">NINA Instance 2</option>
+            <option value="7">NINA Instance 3</option>
           </select>
           <div class="toggle-row" style="margin-top:12px">
             <div>

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -182,15 +182,26 @@ static int64_t idle_all_disconnected_since_us = 0;
  */
 static int idle_target_to_page_index(int8_t target)
 {
+    int idx;
     switch (target) {
-        case IDLE_TARGET_SUMMARY:  return PAGE_IDX_SUMMARY;
-        case IDLE_TARGET_CLOCK:    return PAGE_IDX_CLOCK;
-        case IDLE_TARGET_ALLSKY:   return PAGE_IDX_ALLSKY;
-        case IDLE_TARGET_SPOTIFY:  return PAGE_IDX_SPOTIFY;
-        case IDLE_TARGET_IMAGE_DISPLAY:  return PAGE_IDX_IMAGE_DISPLAY;
-        case IDLE_TARGET_SYSINFO:  return SYSINFO_PAGE_IDX(page_count);
-        default:                   return PAGE_IDX_SUMMARY;
+        case IDLE_TARGET_SUMMARY:  idx = PAGE_IDX_SUMMARY; break;
+        case IDLE_TARGET_CLOCK:    idx = PAGE_IDX_CLOCK; break;
+        case IDLE_TARGET_ALLSKY:   idx = PAGE_IDX_ALLSKY; break;
+        case IDLE_TARGET_SPOTIFY:  idx = PAGE_IDX_SPOTIFY; break;
+        case IDLE_TARGET_IMAGE_DISPLAY:  idx = PAGE_IDX_IMAGE_DISPLAY; break;
+        case IDLE_TARGET_SYSINFO:  idx = SYSINFO_PAGE_IDX(page_count); break;
+        /* NINA instance pages — mirror auto-rotate's bitmask mapping. */
+        case IDLE_TARGET_NINA1:    idx = (page_count >= 1) ? NINA_PAGE_OFFSET + 0 : PAGE_IDX_SUMMARY; break;
+        case IDLE_TARGET_NINA2:    idx = (page_count >= 2) ? NINA_PAGE_OFFSET + 1 : PAGE_IDX_SUMMARY; break;
+        case IDLE_TARGET_NINA3:    idx = (page_count >= 3) ? NINA_PAGE_OFFSET + 2 : PAGE_IDX_SUMMARY; break;
+        default:                   idx = PAGE_IDX_SUMMARY; break;
     }
+    /* Availability guard: optional pages (AllSky/Spotify/Image Display) may be
+     * disabled. Falling back to Summary (always present) prevents a blank screen. */
+    if (!nina_dashboard_page_is_available(idx)) {
+        idx = PAGE_IDX_SUMMARY;
+    }
+    return idx;
 }
 
 /**
@@ -1914,7 +1925,8 @@ main_loop:
 
         /* If auto-rotate is active and we're on a NINA instance page but no instances
          * are connected, fall back to the summary page automatically. */
-        if (app_config_get()->auto_rotate_enabled && !on_summary && !on_sysinfo && !on_settings && !on_allsky && !on_spotify && !on_clock) {
+        if (app_config_get()->auto_rotate_enabled && !app_config_get()->idle_page_override_enabled
+            && !on_summary && !on_sysinfo && !on_settings && !on_allsky && !on_spotify && !on_clock) {
             bool any_connected = false;
             for (int i = 0; i < instance_count; i++) {
                 if (nina_connection_is_connected(i)) { any_connected = true; break; }
@@ -1943,7 +1955,9 @@ main_loop:
          */
         {
             app_config_t *r_cfg = app_config_get();
-            if (r_cfg->auto_rotate_enabled && r_cfg->auto_rotate_interval_s > 0) {
+            /* Pause rotation while the idle override has parked the device on its
+             * target page — rotation resumes after reconnect clears the override. */
+            if (r_cfg->auto_rotate_enabled && r_cfg->auto_rotate_interval_s > 0 && !idle_override_active) {
                 if (last_rotate_ms == 0) last_rotate_ms = now_ms;
                 if (now_ms - last_rotate_ms >= (int64_t)r_cfg->auto_rotate_interval_s * 1000) {
                     uint8_t page_mask = r_cfg->auto_rotate_pages;
@@ -2332,11 +2346,12 @@ main_loop:
         }
 
         /* ── Idle page override: switch to target page when all NINA instances disconnected ──
-         * Only active when auto-rotate is disabled (auto-rotate takes priority per spec).
+         * Coexists with auto-rotate: while parked on the idle target, rotation is
+         * paused; on reconnect the override clears and auto-rotate resumes.
          * Uses 5-second debounce to avoid flashing on transient disconnects. */
         {
             app_config_t *idle_cfg = app_config_get();
-            if (idle_cfg->idle_page_override_enabled && !idle_cfg->auto_rotate_enabled) {
+            if (idle_cfg->idle_page_override_enabled) {
                 /* Check if ALL enabled NINA instances are disconnected */
                 bool all_disc = true;
                 bool any_enabled = false;
@@ -2405,6 +2420,9 @@ main_loop:
                         }
                         idle_override_active = false;
                         nina_idle_indicator_set_active(false);
+                        /* Resume auto-rotate cleanly: wait a full interval before the
+                         * next advance instead of jumping immediately on un-pause. */
+                        last_rotate_ms = now_ms;
                         page_changed = true;
                         ESP_LOGI(TAG, "Idle override: restoring page %d", restore);
                     }

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -220,6 +220,13 @@ static lv_obj_t *get_page_obj(int idx) {
     return NULL;
 }
 
+bool nina_dashboard_page_is_available(int page_idx) {
+    /* A page is available iff its backing object exists. Optional pages
+     * (AllSky/Spotify/Image Display) have NULL objects when disabled, and NINA
+     * indices beyond page_count resolve to NULL as well. */
+    return get_page_obj(page_idx) != NULL;
+}
+
 /* Set theme colors on all widgets in a page */
 static void apply_theme_to_page(dashboard_page_t *p) {
     if (!p->page || !current_theme) return;

--- a/main/ui/nina_dashboard.h
+++ b/main/ui/nina_dashboard.h
@@ -149,6 +149,18 @@ bool nina_dashboard_is_sysinfo_page(void);
 int nina_dashboard_get_total_page_count(void);
 
 /**
+ * @brief Check whether a page index currently maps to an existing, navigable page.
+ *
+ * Returns false for optional pages that are disabled (AllSky, Spotify, Image
+ * Display) and for NINA instance indices beyond the enabled instance count.
+ * Used to validate idle/park targets so the screen never goes blank.
+ *
+ * @param page_idx Absolute page index (e.g. PAGE_IDX_SUMMARY, NINA_PAGE_OFFSET+n)
+ * @return true if the page object exists and can be shown
+ */
+bool nina_dashboard_page_is_available(int page_idx);
+
+/**
  * @brief Check if a thumbnail image has been requested (target name was clicked)
  * @return true if thumbnail fetch is needed
  */

--- a/main/ui/settings_tab_behavior.c
+++ b/main/ui/settings_tab_behavior.c
@@ -682,10 +682,14 @@ void settings_tab_behavior_create(lv_obj_t *parent) {
                                     "AllSky\n"
                                     "Spotify\n"
                                     "Image Display\n"
-                                    "System Info");
+                                    "System Info\n"
+                                    "NINA Instance 1\n"
+                                    "NINA Instance 2\n"
+                                    "NINA Instance 3");
 
-            /* Map idle_target_t enum to dropdown index:
-             * IDLE_TARGET_SUMMARY(-1)=0, CLOCK(0)=1, ALLSKY(1)=2, SPOTIFY(2)=3, IMAGE_DISPLAY(3)=4, SYSINFO(4)=5 */
+            /* Map idle_target_t enum to dropdown index (index = enum + 1):
+             * SUMMARY(-1)=0, CLOCK(0)=1, ALLSKY(1)=2, SPOTIFY(2)=3, IMAGE_DISPLAY(3)=4,
+             * SYSINFO(4)=5, NINA1(5)=6, NINA2(6)=7, NINA3(7)=8 */
             lv_dropdown_set_selected(dd_idle_target, (uint32_t)(cfg->idle_page_override_target + 1));
 
             if (current_theme) {


### PR DESCRIPTION
### Summary
Users can now set any available page as the idle screen, which appears after a period of inactivity. This idle page override feature now works correctly alongside the auto-rotate function.

### Changes
*   Add configuration options to specify any available page as the idle screen.
*   Update the web interface to let users select the desired idle page.
*   Modify core display logic to activate the chosen idle page after inactivity.
*   Ensure the idle page override functions correctly when auto-rotate is enabled.
*   Update dashboard UI to handle transitions to and from the selected idle page.
*   Adjust settings tab behavior to manage the new idle page configuration.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-06-02T00:01:41.436Z | Generated by GitHub Actions</sub>