### PR TITLE
feat: add Spotify live status panel

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -363,6 +363,9 @@ static void event_handler(void *arg, esp_event_base_t event_base,
         if (is_setup_mode()) {
             set_setup_mode(false);
             ESP_LOGI(TAG, "WiFi connected during setup — transitioning to dashboard");
+            /* Create Spotify auth mutex before dashboard build so the Spotify page's
+             * spotify_status_refresh() (spotify_auth_get_state) is safe. No display lock needed. */
+            spotify_auth_init();
             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                 nina_setup_screen_destroy();
                 lv_obj_t *scr = lv_scr_act();
@@ -377,7 +380,7 @@ static void event_handler(void *arg, esp_event_base_t event_base,
             nina_client_init();
             nina_client_init_image_buffers();
             nina_thumbnail_init();
-            spotify_auth_init();
+            /* spotify_auth_init() already ran before dashboard creation above. */
             spotify_client_init();
 
             xTaskCreatePinnedToCore(input_task, "input_task", 6144, NULL, 5, NULL, 0);
@@ -694,6 +697,13 @@ void app_main(void)
     /* Weather client init — creates mutex before dashboard (clock page timer fires immediately) */
     weather_client_init();
 
+    /* Spotify auth init — creates its mutex before dashboard so the Spotify page's
+     * spotify_status_refresh() (calls spotify_auth_get_state) is safe during page build.
+     * Only creates a mutex and loads NVS tokens; needs no display lock. */
+    if (!setup_mode) {
+        spotify_auth_init();
+    }
+
     /* ── Build UI: dashboard behind splash, everything starts immediately ── */
     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
         lv_obj_t *scr = lv_scr_act();
@@ -767,8 +777,8 @@ void app_main(void)
         nina_client_init_image_buffers();  // Pre-allocate PSRAM image fetch buffer
         nina_thumbnail_init();  // Pre-allocate PSRAM zoom buffer
 
-        /* Spotify init — always called so web handlers (config, login) work even when disabled */
-        spotify_auth_init();
+        /* Spotify init — always called so web handlers (config, login) work even when disabled.
+         * spotify_auth_init() already ran before dashboard creation above. */
         spotify_client_init();
 
         /* weather_client_init() already called above, before dashboard creation */

--- a/main/nina_api_fetchers.c
+++ b/main/nina_api_fetchers.c
@@ -25,13 +25,33 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
 
     cJSON *json = http_get_json(url);
     if (!json) {
+        // Transport failure / non-2xx / empty body — API unreachable.
+        data->connected = false;
+        strcpy(data->status, "OFFLINE");
+        return;
+    }
+
+    // Honor the application-level Success flag: connectivity requires Success==true,
+    // not merely a non-NULL body. Recomputed every poll so a stuck `true` can't latch.
+    if (!nina_api_envelope_ok(json)) {
+        cJSON_Delete(json);
+        data->connected = false;
+        strcpy(data->status, "OFFLINE");
+        return;
+    }
+
+    cJSON *response = nina_api_response(json);
+    if (!response) {
+        // Envelope OK but no Response object — treat as offline this poll
+        // (symmetric with fetch_equipment_info_bundled).
+        cJSON_Delete(json);
+        data->connected = false;
         strcpy(data->status, "OFFLINE");
         return;
     }
 
     data->connected = true;
-    cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (response) {
+    {
         // Camera name
         cJSON *cam_name = cJSON_GetObjectItem(response, "Name");
         if (cam_name && cam_name->valuestring && cam_name->valuestring[0] != '\0')
@@ -509,23 +529,36 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
 
     cJSON *json = http_get_json(url);
     if (!json) {
+        // Transport failure / non-2xx / empty body — API unreachable.
+        data->connected = false;
         strcpy(data->status, "OFFLINE");
         return -1;
     }
 
-    cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (!response) {
-        // No Response object — may be a 404 or unsupported endpoint
+    // Honor the application-level Success flag: a 2xx body with Success!=true
+    // means the API is up but reported a failure — treat as offline this poll.
+    if (!nina_api_envelope_ok(json)) {
         cJSON_Delete(json);
+        data->connected = false;
+        strcpy(data->status, "OFFLINE");
+        return -1;
+    }
+
+    cJSON *response = nina_api_response(json);
+    if (!response) {
+        // Envelope OK but no Response object — may be a 404 or unsupported endpoint
+        cJSON_Delete(json);
+        data->connected = false;
         strcpy(data->status, "OFFLINE");
         return -2;
     }
 
+    // Envelope is OK with a Response object — the API is reachable this poll.
+    data->connected = true;
+
     // ── Camera ──
     cJSON *camera = cJSON_GetObjectItem(response, "Camera");
     if (camera) {
-        data->connected = true;
-
         cJSON *cam_name = cJSON_GetObjectItem(camera, "Name");
         if (cam_name && cam_name->valuestring && cam_name->valuestring[0] != '\0')
             strncpy(data->camera_name, cam_name->valuestring, sizeof(data->camera_name) - 1);

--- a/main/nina_client.c
+++ b/main/nina_client.c
@@ -333,6 +333,25 @@ cJSON *http_get_json(const char *url) {
     return NULL;  // All attempts exhausted
 }
 
+/* ── NINA API envelope helpers ──
+ * The Advanced API wraps every response in an envelope:
+ *   { "Response": ..., "Error": "", "StatusCode": 200, "Success": true, "Type": "API" }
+ * http_get_json() already returns NULL on transport failure / non-2xx / empty /
+ * partial bodies, so NULL is a reliable "unreachable" signal. These helpers add the
+ * application-level Success check so connectivity reflects the CURRENT poll's
+ * envelope rather than a latched side-effect. Neither helper deletes the
+ * envelope — the caller owns it. */
+
+bool nina_api_envelope_ok(cJSON *envelope) {
+    if (!envelope) return false;
+    return cJSON_IsTrue(cJSON_GetObjectItem(envelope, "Success"));
+}
+
+cJSON *nina_api_response(cJSON *envelope) {
+    if (!nina_api_envelope_ok(envelope)) return NULL;
+    return cJSON_GetObjectItem(envelope, "Response");
+}
+
 // =============================================================================
 // Exposure Timing Fixup
 // =============================================================================
@@ -420,9 +439,13 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
 
     int64_t now_ms = esp_timer_get_time() / 1000;
 
-    // Don't reset data->connected here — the fetcher sets it based on HTTP result,
-    // and the connection state machine below provides hysteresis. Pre-clearing it
-    // would race with WebSocket handlers that also write to the struct.
+    // No need to pre-clear data->connected here: the fetchers now explicitly set
+    // data->connected = false on every failure path (unreachable, Success!=true,
+    // missing Response) and = true only on an OK envelope, so connectivity is
+    // recomputed fresh each poll. The WebSocket handlers do NOT write data->connected
+    // (they only write websocket_connected / rotator_connected / safety_connected),
+    // so there is no struct race to worry about. The connection state machine below
+    // adds hysteresis on top of this per-poll value.
 
     ESP_LOGI(TAG, "=== Polling NINA data (%s: %s) ===",
              state->bundle_not_available ? "tiered" : "bundled",
@@ -444,7 +467,8 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
             state->bundle_not_available = true;
             // Fall through to legacy path below
         }
-        // bundle_result == -1: HTTP failure, data->connected stays false (set at line 332)
+        // bundle_result == -1: API unreachable or Success!=true — the fetcher already
+        // set data->connected = false, so the connection check below sees a failed poll.
     }
 
     if (state->bundle_not_available) {

--- a/main/nina_client_internal.h
+++ b/main/nina_client_internal.h
@@ -46,5 +46,17 @@ http_poll_ctx_t *http_poll_ctx_get(void);
  * Uses per-task poll context for client reuse when available. */
 cJSON *http_get_json(const char *url);
 
+/* NINA Advanced API envelope helpers. The API wraps every response in
+ * { "Response": ..., "Success": bool, ... }. These honor the application-level
+ * Success flag so callers can treat Success!=true as "API unavailable" even when
+ * the HTTP transport succeeded. Neither helper deletes the envelope — caller owns it. */
+
+/* True iff envelope != NULL and its "Success" field is true. */
+bool nina_api_envelope_ok(cJSON *envelope);
+
+/* Returns the inner "Response" item ONLY if the envelope is OK (Success true);
+ * else NULL. */
+cJSON *nina_api_response(cJSON *envelope);
+
 /* Parse ISO-8601 datetime string to time_t (UTC). Returns 0 on failure. */
 time_t parse_iso8601(const char *str);

--- a/main/spotify_auth.c
+++ b/main/spotify_auth.c
@@ -304,6 +304,7 @@ void spotify_auth_init(void) {
 }
 
 spotify_auth_state_t spotify_auth_get_state(void) {
+    if (!s_mutex) return SPOTIFY_AUTH_NONE;
     spotify_auth_state_t state;
     xSemaphoreTake(s_mutex, portMAX_DELAY);
     state = s_state;
@@ -313,6 +314,7 @@ spotify_auth_state_t spotify_auth_get_state(void) {
 
 esp_err_t spotify_auth_exchange_code(const char *code, const char *code_verifier,
                                       const char *redirect_uri) {
+    if (!s_mutex) return ESP_ERR_INVALID_STATE;
     if (!code || !code_verifier || !redirect_uri) {
         ESP_LOGE(TAG, "exchange_code: NULL parameter");
         return ESP_ERR_INVALID_ARG;
@@ -365,6 +367,7 @@ esp_err_t spotify_auth_exchange_code(const char *code, const char *code_verifier
 }
 
 esp_err_t spotify_auth_get_access_token(char *buf, size_t buf_size) {
+    if (!s_mutex) return ESP_ERR_INVALID_STATE;
     if (!buf || buf_size == 0) return ESP_ERR_INVALID_ARG;
 
     buf[0] = '\0';
@@ -436,6 +439,7 @@ esp_err_t spotify_auth_get_access_token(char *buf, size_t buf_size) {
 }
 
 void spotify_auth_invalidate_token(void) {
+    if (!s_mutex) return;
     xSemaphoreTake(s_mutex, portMAX_DELAY);
     s_access_token[0] = '\0';
     s_token_expiry_ms = 0;
@@ -444,6 +448,7 @@ void spotify_auth_invalidate_token(void) {
 }
 
 void spotify_auth_logout(void) {
+    if (!s_mutex) return;
     xSemaphoreTake(s_mutex, portMAX_DELAY);
 
     s_access_token[0] = '\0';
@@ -459,6 +464,7 @@ void spotify_auth_logout(void) {
 }
 
 bool spotify_auth_has_tokens(void) {
+    if (!s_mutex) return false;
     bool has;
     xSemaphoreTake(s_mutex, portMAX_DELAY);
     has = (s_refresh_token[0] != '\0');

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -828,6 +828,13 @@ void spotify_poll_task(void *arg)
 
         app_config_t *cfg = app_config_get();
         if (!cfg->spotify_enabled || spotify_auth_get_state() != SPOTIFY_AUTH_AUTHORIZED) {
+            /* Push the current setup/connection status to the UI so it updates
+             * live (e.g. when the user links the account or a token error
+             * occurs). Cheap — just sets label text. */
+            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                nina_spotify_refresh_status();
+                bsp_display_unlock();
+            }
             vTaskDelay(pdMS_TO_TICKS(5000));
             continue;
         }

--- a/main/ui/nina_spotify.c
+++ b/main/ui/nina_spotify.c
@@ -19,6 +19,7 @@
 #include "display_defs.h"
 #include "themes.h"
 #include "app_config.h"
+#include "spotify_auth.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
@@ -29,10 +30,6 @@
 #include <string.h>
 #include <stdlib.h>
 #include "nina_idle_indicator.h"
-
-/* Embedded Spotify logo PNG (linked via EMBED_FILES) */
-extern const uint8_t spotify_logo_png_start[] asm("_binary_spotify_logo_png_start");
-extern const uint8_t spotify_logo_png_end[]   asm("_binary_spotify_logo_png_end");
 
 static const char *TAG = "spotify_ui";
 
@@ -74,8 +71,11 @@ static lv_obj_t *minimal_artist_name = NULL;
 static lv_obj_t *minimal_album_name = NULL;
 static lv_obj_t *minimal_progress = NULL;      /* Optional thin progress bar */
 
-static lv_obj_t *loading_logo = NULL;      /* Spotify logo shown while loading */
-static lv_image_dsc_t logo_dsc;            /* Persistent descriptor for logo PNG */
+/* Status panel — text-based setup/connecting indicator (replaces logo).
+ * Page-owned so it persists as the empty/connecting state; drawn on top. */
+static lv_obj_t *status_panel = NULL;
+static lv_obj_t *status_title = NULL;
+static lv_obj_t *status_subtitle = NULL;
 
 static lv_timer_t *idle_timer = NULL;
 static bool is_idle = true;
@@ -90,6 +90,10 @@ static lv_image_dsc_t art_dsc;             /* Persistent image descriptor */
 static void create_track_info_container(void);
 static void create_controls(void);
 static void create_minimal_widgets(void);
+static void create_status_panel(void);
+static void spotify_status_set(const char *title, const char *subtitle);
+static void spotify_status_hide(void);
+static void spotify_status_refresh(void);
 static void set_idle_state(bool idle);
 static void dim_anim_cb(void *var, int32_t value);
 static void idle_timer_cb(lv_timer_t *timer);
@@ -109,30 +113,72 @@ static void set_refr_period(uint32_t period_ms)
     }
 }
 
-/* Pulse animation: breathe opacity between 80 and 255 */
-static void pulse_opa_cb(void *var, int32_t value)
+/* ── Status panel (setup / connecting state) ─────────────────────────── */
+
+/** Show the status panel with the given title and (optional) subtitle.
+ *  A NULL/empty subtitle hides the subtitle label. Panel is brought to the
+ *  foreground so it draws above album art and the dim overlay. */
+static void spotify_status_set(const char *title, const char *subtitle)
 {
-    lv_obj_set_style_image_opa((lv_obj_t *)var, (lv_opa_t)value, 0);
+    if (!status_panel) return;
+    if (status_title) lv_label_set_text(status_title, title ? title : "");
+    if (status_subtitle) {
+        if (subtitle && subtitle[0]) {
+            lv_label_set_text(status_subtitle, subtitle);
+            lv_obj_remove_flag(status_subtitle, LV_OBJ_FLAG_HIDDEN);
+        } else {
+            lv_label_set_text(status_subtitle, "");
+            lv_obj_add_flag(status_subtitle, LV_OBJ_FLAG_HIDDEN);
+        }
+    }
+    lv_obj_remove_flag(status_panel, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(status_panel);
 }
 
-static void start_logo_pulse(void)
+static void spotify_status_hide(void)
 {
-    if (!loading_logo) return;
-    lv_anim_t a;
-    lv_anim_init(&a);
-    lv_anim_set_var(&a, loading_logo);
-    lv_anim_set_values(&a, 80, 255);
-    lv_anim_set_time(&a, 1500);
-    lv_anim_set_playback_time(&a, 1500);
-    lv_anim_set_repeat_count(&a, LV_ANIM_REPEAT_INFINITE);
-    lv_anim_set_exec_cb(&a, pulse_opa_cb);
-    lv_anim_start(&a);
+    if (status_panel) lv_obj_add_flag(status_panel, LV_OBJ_FLAG_HIDDEN);
 }
 
-static void stop_logo_pulse(void)
+/** Compute the current setup/connection state from auth + config and either
+ *  show the matching status text or hide the panel (when art is showing or
+ *  authorized playback data has arrived). */
+static void spotify_status_refresh(void)
 {
-    if (!loading_logo) return;
-    lv_anim_delete(loading_logo, pulse_opa_cb);
+    if (!status_panel) return;
+
+    /* Art present, or data received while playing -> nothing to announce. */
+    if (has_art) {
+        spotify_status_hide();
+        return;
+    }
+
+    const app_config_t *cfg = app_config_get();
+    spotify_auth_state_t state = spotify_auth_get_state();
+
+    if (cfg->spotify_client_id[0] == '\0') {
+        spotify_status_set("Spotify Not Set Up", "Add your Client ID in the web UI");
+        return;
+    }
+
+    switch (state) {
+        case SPOTIFY_AUTH_NONE:
+            spotify_status_set("Spotify Not Connected", "Link your account in the web UI");
+            return;
+        case SPOTIFY_AUTH_ERROR:
+            spotify_status_set("Spotify Sign-In Needed", "Re-link your account in the web UI");
+            return;
+        case SPOTIFY_AUTH_AUTHORIZED:
+        default:
+            if (!has_received_data) {
+                spotify_status_set("Connecting to Spotify\xE2\x80\xA6", "");
+                return;
+            }
+            /* Authorized and data has arrived (nothing-playing handled by the
+             * existing track_info_cont path) — keep the panel hidden. */
+            spotify_status_hide();
+            return;
+    }
 }
 
 /** Update label text only if it changed — avoids restarting scroll animation. */
@@ -333,24 +379,7 @@ lv_obj_t *spotify_page_create(lv_obj_t *parent)
     lv_image_set_pivot(img_album_art, 0, 0);
     lv_obj_add_flag(img_album_art, LV_OBJ_FLAG_HIDDEN); /* Hidden until art arrives */
 
-    /* 1b. Loading indicator — Spotify logo PNG, centered, pulsing.
-     * lodepng decoder (CONFIG_LV_USE_LODEPNG) handles decoding from
-     * the embedded binary.  We pass the raw PNG data as an lv_image_dsc_t. */
-    {
-        size_t png_size = (size_t)(spotify_logo_png_end - spotify_logo_png_start);
-        memset(&logo_dsc, 0, sizeof(logo_dsc));
-        logo_dsc.header.magic = LV_IMAGE_HEADER_MAGIC;
-        logo_dsc.header.cf = LV_COLOR_FORMAT_RAW;
-        logo_dsc.data = spotify_logo_png_start;
-        logo_dsc.data_size = (uint32_t)png_size;
-
-        loading_logo = lv_image_create(spotify_page);
-        lv_image_set_src(loading_logo, &logo_dsc);
-        lv_obj_align(loading_logo, LV_ALIGN_CENTER, 0, 0);
-        lv_obj_remove_flag(loading_logo, LV_OBJ_FLAG_CLICKABLE);
-        has_art = false;
-        start_logo_pulse();
-    }
+    has_art = false;
 
     /* 2. Dim overlay (semi-transparent black, animated) */
     dim_overlay = lv_obj_create(spotify_page);
@@ -371,6 +400,10 @@ lv_obj_t *spotify_page_create(lv_obj_t *parent)
     /* 5. Minimal mode widgets (hidden by default) */
     create_minimal_widgets();
 
+    /* 6. Status panel — text-based setup/connecting indicator, created last so
+     * it draws above album art and the dim overlay. Hidden until needed. */
+    create_status_panel();
+
     /* Touch handler on entire page */
     lv_obj_add_event_cb(spotify_page, page_touch_cb, LV_EVENT_CLICKED, NULL);
 
@@ -385,6 +418,9 @@ lv_obj_t *spotify_page_create(lv_obj_t *parent)
     set_idle_state(true);
 
     nina_idle_indicator_create(spotify_page, LV_ALIGN_BOTTOM_MID, false);
+
+    /* Show the correct setup/connecting status immediately. */
+    spotify_status_refresh();
 
     return spotify_page;
 }
@@ -606,6 +642,46 @@ static void create_minimal_widgets(void)
     /* Start minimal widgets hidden — shown by set_idle_state when tapped */
     lv_obj_add_flag(minimal_info_cont, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(minimal_progress, LV_OBJ_FLAG_HIDDEN);
+}
+
+/* ── Status panel (setup / connecting) creation ──────────────────────── */
+
+static void create_status_panel(void)
+{
+    /* Full-screen centered container, themed background so it isn't a blank
+     * black screen. Mirrors the wait-overlay layout (centered title/subtitle). */
+    status_panel = lv_obj_create(spotify_page);
+    lv_obj_remove_style_all(status_panel);
+    lv_obj_set_size(status_panel, SCREEN_SIZE, SCREEN_SIZE);
+    lv_obj_set_pos(status_panel, 0, 0);
+    lv_obj_set_style_bg_color(status_panel,
+        lv_color_hex(current_theme ? current_theme->bg_main : 0x000000), 0);
+    lv_obj_set_style_bg_opa(status_panel, LV_OPA_COVER, 0);
+    lv_obj_set_flex_flow(status_panel, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(status_panel, LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(status_panel, 16, 0);
+    lv_obj_remove_flag(status_panel, LV_OBJ_FLAG_SCROLLABLE);
+    /* Let taps/swipes pass through to the page so navigation still works. */
+    lv_obj_remove_flag(status_panel, LV_OBJ_FLAG_CLICKABLE);
+
+    status_title = lv_label_create(status_panel);
+    lv_label_set_text(status_title, "");
+    lv_obj_set_style_text_font(status_title, &lv_font_montserrat_48, 0);
+    lv_obj_set_style_text_color(status_title,
+        lv_color_hex(current_theme ? current_theme->text_color : 0xFFFFFF), 0);
+    lv_obj_set_style_text_align(status_title, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_width(status_title, LV_PCT(85));
+
+    status_subtitle = lv_label_create(status_panel);
+    lv_label_set_text(status_subtitle, "");
+    lv_obj_set_style_text_font(status_subtitle, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(status_subtitle,
+        lv_color_hex(current_theme ? current_theme->label_color : 0x999999), 0);
+    lv_obj_set_style_text_align(status_subtitle, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_width(status_subtitle, LV_PCT(85));
+
+    lv_obj_add_flag(status_panel, LV_OBJ_FLAG_HIDDEN);
 }
 
 /* ── Idle / active state management ──────────────────────────────────── */
@@ -903,12 +979,11 @@ void nina_spotify_set_album_art(const uint8_t *rgb565_data, uint32_t w, uint32_t
 
     lv_image_set_src(img_album_art, &art_dsc);
 
-    /* Hide loading logo now that we have album art */
-    if (loading_logo && !has_art) {
-        stop_logo_pulse();
-        lv_obj_add_flag(loading_logo, LV_OBJ_FLAG_HIDDEN);
+    /* Hide status panel now that we have album art */
+    if (!has_art) {
+        spotify_status_hide();
         has_art = true;
-        /* Now safe to throttle refresh if idle (logo animation no longer needed) */
+        /* Now safe to throttle refresh if idle */
         if (is_idle) {
             set_refr_period(REFR_PERIOD_IDLE_MS);
         }
@@ -973,13 +1048,11 @@ void nina_spotify_set_idle(void)
     has_art = false;
     lv_obj_add_flag(img_album_art, LV_OBJ_FLAG_HIDDEN);
 
-    /* Hide the loading logo — we've heard from the API, nothing is playing.
-     * The pulsing logo is only for the initial loading state before first data. */
+    /* Hide the status panel — we've heard from the API, nothing is playing.
+     * The "Nothing Playing" text (track_info_cont / minimal_info_cont) is shown
+     * by set_idle_state instead. */
     has_received_data = true;
-    if (loading_logo) {
-        stop_logo_pulse();
-        lv_obj_add_flag(loading_logo, LV_OBJ_FLAG_HIDDEN);
-    }
+    spotify_status_hide();
 }
 
 /* ── Public API: theme ───────────────────────────────────────────────── */
@@ -998,6 +1071,20 @@ void spotify_page_apply_theme(void)
     if (minimal_progress) {
         lv_obj_set_style_bg_color(minimal_progress,
             lv_color_hex(current_theme->progress_color), LV_PART_INDICATOR);
+    }
+
+    /* Status panel inherits theme colors (themed background + title/subtitle). */
+    if (status_panel) {
+        lv_obj_set_style_bg_color(status_panel,
+            lv_color_hex(current_theme->bg_main), 0);
+    }
+    if (status_title) {
+        lv_obj_set_style_text_color(status_title,
+            lv_color_hex(current_theme->text_color), 0);
+    }
+    if (status_subtitle) {
+        lv_obj_set_style_text_color(status_subtitle,
+            lv_color_hex(current_theme->label_color), 0);
     }
 
     lv_obj_invalidate(spotify_page);
@@ -1030,12 +1117,9 @@ void nina_spotify_on_show(void)
         set_idle_state(true);
     }
 
-    /* Show loading logo pulse only if we haven't received any API data yet.
-     * Once we know "nothing playing", the logo stays hidden. */
-    if (!has_art && !has_received_data && loading_logo) {
-        lv_obj_remove_flag(loading_logo, LV_OBJ_FLAG_HIDDEN);
-        start_logo_pulse();
-    }
+    /* Show the correct setup/connecting status (or hide it if art/data present)
+     * so the right state appears immediately when landing on the page. */
+    spotify_status_refresh();
 }
 
 void nina_spotify_on_hide(void)
@@ -1086,10 +1170,15 @@ void nina_spotify_free_art(void)
         ESP_LOGI(TAG, "Album art buffer freed");
     }
 
-    /* Show loading logo only if we haven't received API data yet.
-     * If data was received (nothing playing), keep logo hidden. */
-    if (loading_logo && !has_received_data) {
-        lv_obj_remove_flag(loading_logo, LV_OBJ_FLAG_HIDDEN);
-        start_logo_pulse();
-    }
+    /* Re-evaluate the status panel: if no API data yet, show the
+     * setup/connecting state; otherwise it stays hidden. */
+    spotify_status_refresh();
+}
+
+/* ── Public API: status panel refresh ────────────────────────────────── */
+
+void nina_spotify_refresh_status(void)
+{
+    if (!spotify_page) return;
+    spotify_status_refresh();
 }

--- a/main/ui/nina_spotify.h
+++ b/main/ui/nina_spotify.h
@@ -78,6 +78,14 @@ void nina_spotify_refresh_layout(void);
  */
 void nina_spotify_free_art(void);
 
+/**
+ * Recompute and display the connection/setup status panel from the current
+ * Spotify auth state and config (Client ID). Hidden when album art is showing
+ * or playback data has arrived. No-op if the page has not been created.
+ * Must be called under LVGL display lock.
+ */
+void nina_spotify_refresh_status(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tmpnd2_logs.txt
+++ b/tmpnd2_logs.txt
@@ -1,0 +1,7696 @@
+SI: cur=-60  avg=-59  min=-61  max=-54 dBm  [n=30]
+I (339364) perf:   Disconnects:    0 (interval) / 0 (total)
+I (339370) perf: ── Memory ──
+I (339373) perf:   Internal heap:  free=76583  min_ever=65351  largest_block=31744  frag_ratio=0.415
+I (339382) perf:   PSRAM:          free=20901376  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+W (339385) nina_client: desktop-bdt978m.lan unreachable
+I (339391) perf: ── Task Stacks ──
+I (339400) perf:   data_task HWM:  8080 bytes free
+I (339405) perf:   input_task HWM: 5484 bytes free
+I (339409) perf:   spotify_task HWM: 7164 bytes free
+I (339413) nina_client: === Poll Summary ===
+I (339418) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (339424) nina_client: Target: , Filter: 
+I (339427) nina_client: Exposure: 0.0s (0.0/0.0)
+I (339432) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (339437) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (340444) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (340473) nina_client: === Poll Summary ===
+I (340473) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (340473) nina_client: Target: , Filter: 
+I (340475) nina_client: Exposure: 0.0s (0.0/0.0)
+I (340479) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (340485) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (341492) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (341577) nina_client: === Poll Summary ===
+I (341577) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (341577) nina_client: Target: , Filter: 
+I (341579) nina_client: Exposure: 0.0s (0.0/0.0)
+I (341583) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (341589) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+W (341776) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+I (342596) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (343010) nina_client: === Poll Summary ===
+I (343010) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (343010) nina_client: Target: , Filter: 
+I (343012) nina_client: Exposure: 0.0s (0.0/0.0)
+I (343016) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (343022) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (344046) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (344239) nina_client: === Poll Summary ===
+I (344239) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (344239) nina_client: Target: , Filter: 
+I (344242) nina_client: Exposure: 0.0s (0.0/0.0)
+I (344246) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (344251) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (345258) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (345285) nina_client: === Poll Summary ===
+I (345285) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (345286) nina_client: Target: , Filter: 
+I (345288) nina_client: Exposure: 0.0s (0.0/0.0)
+I (345292) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (345297) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (346304) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (346513) nina_client: === Poll Summary ===
+I (346513) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (346513) nina_client: Target: , Filter: 
+I (346515) nina_client: Exposure: 0.0s (0.0/0.0)
+I (346519) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (346525) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (347532) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (348356) nina_client: === Poll Summary ===
+I (348356) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (348356) nina_client: Target: , Filter: 
+I (348358) nina_client: Exposure: 0.0s (0.0/0.0)
+I (348363) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (348368) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (349375) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (350303) nina_client: === Poll Summary ===
+I (350303) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (350303) nina_client: Target: , Filter: 
+I (350305) nina_client: Exposure: 0.0s (0.0/0.0)
+I (350310) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (350315) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (351322) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (351382) nina_client: === Poll Summary ===
+I (351383) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (351383) nina_client: Target: , Filter: 
+I (351385) nina_client: Exposure: 0.0s (0.0/0.0)
+I (351389) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (351394) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (352401) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (352519) nina_client: === Poll Summary ===
+I (352520) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (352520) nina_client: Target: , Filter: 
+I (352522) nina_client: Exposure: 0.0s (0.0/0.0)
+I (352526) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (352531) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (353524) tasks: Auto-rotate: switched to page 4
+I (353538) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (354099) nina_client: === Poll Summary ===
+I (354099) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (354099) nina_client: Target: , Filter: 
+I (354101) nina_client: Exposure: 0.0s (0.0/0.0)
+I (354106) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (354111) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (354558) tasks: Page switched to 4 (summary)
+I (354558) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (354603) nina_client: === Poll Summary ===
+I (354603) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (354603) nina_client: Target: , Filter: 
+I (354605) nina_client: Exposure: 0.0s (0.0/0.0)
+I (354609) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (354615) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (355118) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (355537) nina_client: === Poll Summary ===
+I (355537) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (355537) nina_client: Target: , Filter: 
+I (355540) nina_client: Exposure: 0.0s (0.0/0.0)
+I (355544) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (355549) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (355622) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (356032) nina_client: === Poll Summary ===
+I (356032) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (356032) nina_client: Target: , Filter: 
+I (356034) nina_client: Exposure: 0.0s (0.0/0.0)
+I (356038) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (356044) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (356556) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (356703) nina_client: === Poll Summary ===
+I (356703) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (356703) nina_client: Target: , Filter: 
+I (356706) nina_client: Exposure: 0.0s (0.0/0.0)
+I (356710) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (356715) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+W (356868) nina_client: desktop-bdt978m.lan unreachable
+I (356868) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (357051) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (357176) nina_client: === Poll Summary ===
+I (357176) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (357176) nina_client: Target: , Filter: 
+I (357178) nina_client: Exposure: 0.0s (0.0/0.0)
+I (357183) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (357188) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (357722) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (357777) nina_client: === Poll Summary ===
+I (357777) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (357777) nina_client: Target: , Filter: 
+I (357779) nina_client: Exposure: 0.0s (0.0/0.0)
+I (357783) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (357789) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (358195) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (358463) nina_client: === Poll Summary ===
+I (358463) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (358463) nina_client: Target: , Filter: 
+I (358465) nina_client: Exposure: 0.0s (0.0/0.0)
+I (358469) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (358475) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (358796) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (359272) nina_client: === Poll Summary ===
+I (359272) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (359272) nina_client: Target: , Filter: 
+I (359274) nina_client: Exposure: 0.0s (0.0/0.0)
+I (359279) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (359284) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (359482) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (359516) nina_client: === Poll Summary ===
+I (359516) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (359516) nina_client: Target: , Filter: 
+I (359518) nina_client: Exposure: 0.0s (0.0/0.0)
+I (359522) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (359527) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (360291) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (360501) nina_client: === Poll Summary ===
+I (360501) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (360501) nina_client: Target: , Filter: 
+I (360504) nina_client: Exposure: 0.0s (0.0/0.0)
+I (360508) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (360513) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (360534) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (360640) nina_client: === Poll Summary ===
+I (360640) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (360640) nina_client: Target: , Filter: 
+I (360642) nina_client: Exposure: 0.0s (0.0/0.0)
+I (360647) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (360652) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (361520) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (361659) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (361995) nina_client: === Poll Summary ===
+I (361995) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (361995) nina_client: Target: , Filter: 
+I (361997) nina_client: Exposure: 0.0s (0.0/0.0)
+I (362002) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (362007) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (362056) nina_client: === Poll Summary ===
+I (362056) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (362056) nina_client: Target: , Filter: 
+I (362058) nina_client: Exposure: 0.0s (0.0/0.0)
+I (362063) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (362068) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (363014) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (363075) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (363097) nina_client: === Poll Summary ===
+I (363097) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (363097) nina_client: Target: , Filter: 
+I (363100) nina_client: Exposure: 0.0s (0.0/0.0)
+I (363104) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (363109) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (363164) nina_client: === Poll Summary ===
+I (363164) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (363164) nina_client: Target: , Filter: 
+I (363166) nina_client: Exposure: 0.0s (0.0/0.0)
+I (363171) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (363176) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (363495) nina_client: desktop-bdt978m.lan unreachable
+I (363495) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (364116) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (364183) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (364217) nina_client: === Poll Summary ===
+I (364218) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (364218) nina_client: Target: , Filter: 
+I (364220) nina_client: Exposure: 0.0s (0.0/0.0)
+I (364224) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (364229) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (364243) nina_client: === Poll Summary ===
+I (364243) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (364246) nina_client: Target: , Filter: 
+I (364250) nina_client: Exposure: 0.0s (0.0/0.0)
+I (364254) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (364259) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (364496) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (365236) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (365266) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (365335) nina_client: === Poll Summary ===
+I (365335) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (365335) nina_client: Target: , Filter: 
+I (365337) nina_client: Exposure: 0.0s (0.0/0.0)
+I (365342) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (365347) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (365442) nina_client: === Poll Summary ===
+I (365442) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (365442) nina_client: Target: , Filter: 
+I (365444) nina_client: Exposure: 0.0s (0.0/0.0)
+I (365449) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (365454) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (366354) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (366419) nina_client: === Poll Summary ===
+I (366419) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (366420) nina_client: Target: , Filter: 
+I (366422) nina_client: Exposure: 0.0s (0.0/0.0)
+I (366426) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (366431) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (366461) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (366583) nina_client: === Poll Summary ===
+I (366583) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (366583) nina_client: Target: , Filter: 
+I (366585) nina_client: Exposure: 0.0s (0.0/0.0)
+I (366589) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (366595) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (367438) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (367596) nina_client: === Poll Summary ===
+I (367596) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (367596) nina_client: Target: , Filter: 
+I (367598) nina_client: Exposure: 0.0s (0.0/0.0)
+I (367603) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (367603) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (367608) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (367776) nina_client: === Poll Summary ===
+I (367776) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (367776) nina_client: Target: , Filter: 
+I (367779) nina_client: Exposure: 0.0s (0.0/0.0)
+I (367783) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (367788) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (368615) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (368748) nina_client: === Poll Summary ===
+I (368748) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (368748) nina_client: Target: , Filter: 
+I (368751) nina_client: Exposure: 0.0s (0.0/0.0)
+I (368755) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (368760) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (368795) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (369011) nina_client: === Poll Summary ===
+I (369011) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (369011) nina_client: Target: , Filter: 
+I (369013) nina_client: Exposure: 0.0s (0.0/0.0)
+I (369017) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (369023) tasks: Poll[1] (active682) tasks: Auto-rotate: switched to page 5
+W (369714) perf: uxTaskGetSystemState returned 0 tasks
+I (369714) perf: ╔══════════════════════════════════════════════════════════════╗
+I (369726) perf: ║              PERFORMANCE REPORT                             ║
+I (369734) perf: ╚══════════════════════════════════════════════════════════════╝
+I (369752) perf: ── Poll Cycle ──
+I (369756) perf:   poll_cycle_total         avg=   16.9  min=    5.9  max= 3057.2  last=   36.2 ms  [n=354]
+I (369765) perf:   effective_interval       avg= 1021.3  min=    8.6  max= 4058.0  last= 1008.0 ms  [n=353]
+I (369767) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (369775) perf: ── Endpoint Fetchers ──
+I (369786) perf:   equipment_bundle         avg=  260.2  min=   16.1  max= 6568.5  last=  216.0 ms  [n=117]
+I (369795) perf:   camera                   (no samples)
+I (369800) perf:   guider                   (no samples)
+I (369805) perf:   mount                    (no samples)
+I (369810) perf:   focuser                  (no samples)
+I (369815) perf:   sequence                 avg=   89.1  min=   23.5  max=  256.3  last=   38.3 ms  [n=11]
+I (369825) perf:   switch                   (no samples)
+I (369830) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (369839) perf:   filter                   (no samples)
+I (369844) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (369853) perf: ── Network ──
+I (369857) perf:   http_request             avg=  528.8  min=    0.4  max= 7045.4  last=  215.0 ms  [n=151]
+I (369866) perf:   HTTP requests:  45 (interval) / 198 (total)
+I (369872) perf:   HTTP retries:   3 (interval) / 39 (total)
+I (369877) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (369882) perf:   HTTP unreachable:2 (interval) / 37 (total)
+I (369888) perf:   WS events:      0 (interval) / 0 (total)
+I (369893) perf: ── JSON Parsing ──
+I (369897) perf:   json_parse               avg=    2.9  min=    0.1  max=    7.4  last=    3.2 ms  [n=159]
+I (369906) nina_client: === Poll Summary ===
+I (369907) perf:   json_sequence            (no samples)
+I (369911) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (369916) perf:   json_config_color        (no samples)
+I (369921) nina_client: Target: , Filter: 
+I (369926) perf:   Parse calls:    42 (interval) / 160 (total)
+I (369930) nina_client: Exposure: 0.0s (0.0/0.0)
+I (369936) perf: ── UI Updates ──
+I (369940) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (369944) perf:   ui_update_total          avg=    1.7  min=    0.0  max=   25.9  last=   23.4 ms  [n=127]
+I (369949) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (369958) perf:   ui_lock_wait             avg=    1.6  min=    0.0  max=   25.8  last=   23.4 ms  [n=127]
+I (369975) perf:   ui_dashboard             avg=    0.1  min=    0.1  max=    1.8  last=    0.1 ms  [n=64]
+I (369984) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.1 ms  [n=63]
+I (369994) perf: ── Latency ──
+I (369997) perf:   ws_to_ui                 (no samples)
+I (370002) perf: ── JPEG ──
+I (370005) perf:   jpeg_decode              (no samples)
+I (370010) perf:   jpeg_fetch               (no samples)
+I (370015) perf: ── Spotify ──
+I (370019) perf:   spotify_poll_cycle       (no samples)
+I (370024) perf:   spotify_api_fetch        (no samples)
+I (370029) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (370029) perf:   spotify_art_fetch        (no samples)
+I (370041) perf:   spotify_art_decode       (no samples)
+I (370046) perf:   spotify_ui_update        (no samples)
+I (370051) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (370056) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (370062) perf:   Spotify art:      0 (interval) / 0 (total)
+I (370067) perf: ── WiFi ──
+I (370070) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (370077) perf:   RSSI: cur=-58  avg=-59  min=-63  max=-57 dBm  [n=30]
+I (370084) perf:   Disconnects:    0 (interval) / 0 (total)
+I (370089) perf: ── Memory ──
+I (370092) perf:   Internal heap:  free=73467  min_ever=62651  largest_block=31744  frag_ratio=0.432
+I (370101) perf:   PSRAM:          free=20901460  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (370111) perf: ── Task Stacks ──
+I (370115) perf:   data_task HWM:  8080 bytes free
+I (370119) perf:   input_task HWM: 5484 bytes free
+I (370119) nina_client: === Poll Summary ===
+I (370124) perf:   spotify_task HWM: 7164 bytes free
+I (370128) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (370138) nina_client: Target: , Filter: 
+I (370142) nina_client: Exposure: 0.0s (0.0/0.0)
+I (370146) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (370151) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (370965) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (371009) nina_client: desktop-bdt978m.lan unreachable
+I (371009) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (371132) tasks: Page switched to 5
+I (371158) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (371207) nina_client: === Poll Summary ===
+I (371208) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (371208) nina_client: Target: , Filter: 
+I (371210) nina_client: Exposure: 0.0s (0.0/0.0)
+I (371214) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (371219) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+I (371281) nina_client: === Poll Summary ===
+I (371281) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (371281) nina_client: Target: , Filter: 
+I (371283) nina_client: Exposure: 0.0s (0.0/0.0)
+I (371287) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (371292) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (372299) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (372408) nina_client: === Poll Summary ===
+I (372408) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (372408) nina_client: Target: , Filter: 
+I (372410) nina_client: Exposure: 0.0s (0.0/0.0)
+I (372414) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (372420) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (373427) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (373504) nina_client: === Poll Summary ===
+I (373504) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (373504) nina_client: Target: , Filter: 
+I (373506) nina_client: Exposure: 0.0s (0.0/0.0)
+I (373511) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (373516) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (374523) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (374625) nina_client: === Poll Summary ===
+I (374625) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (374625) nina_client: Target: , Filter: 
+I (374627) nina_client: Exposure: 0.0s (0.0/0.0)
+I (374631) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (374637) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (375644) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (375683) nina_client: === Poll Summary ===
+I (375683) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (375684) nina_client: Target: , Filter: 
+I (375686) nina_client: Exposure: 0.0s (0.0/0.0)
+I (375690) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (375695) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (376702) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (376784) nina_client: === Poll Summary ===
+I (376784) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (376784) nina_client: Target: , Filter: 
+I (376786) nina_client: Exposure: 0.0s (0.0/0.0)
+I (376790) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (376796) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (377803) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (377845) nina_client: === Poll Summary ===
+I (377845) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (377845) nina_client: Target: , Filter: 
+I (377847) nina_client: Exposure: 0.0s (0.0/0.0)
+I (377851) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (377857) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (378584) nina_client: desktop-bdt978m.lan unreachable
+I (378864) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (378949) nina_client: === Poll Summary ===
+I (378949) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (378949) nina_client: Target: , Filter: 
+I (378951) nina_client: Exposure: 0.0s (0.0/0.0)
+I (378956) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (378961) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (379240) nina_ws: WS[1]: Camera disconnected
+I (379968) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (380058) nina_client: === Poll Summary ===
+I (380058) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (380058) nina_client: Target: , Filter: 
+I (380060) nina_client: Exposure: 0.0s (0.0/0.0)
+I (380064) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (380070) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (380890) nina_ws: WS[1]: Camera connected
+I (381077) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (381274) nina_client: === Poll Summary ===
+I (381274) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (381274) nina_client: Target: , Filter: 
+I (381276) nina_client: Exposure: 0.0s (0.0/0.0)
+I (381280) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (381285) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (382089) toast: Toast shown [slot 0, pos 0]: [1] astromele2.lan: Connected Camera
+I (382292) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (382400) nina_client: === Poll Summary ===
+I (382400) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (382400) nina_client: Target: , Filter: 
+I (382402) nina_client: Exposure: 0.0s (0.0/0.0)
+I (382406) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (382412) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (383419) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (383466) nina_client: === Poll Summary ===
+I (383466) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (383466) nina_client: Target: , Filter: 
+I (383468) nina_client: Exposure: 0.0s (0.0/0.0)
+I (383472) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (383478) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (384485) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (384565) nina_client: === Poll Summary ===
+I (384565) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (384565) nina_client: Target: , Filter: 
+I (384568) nina_client: Exposure: 0.0s (0.0/0.0)
+I (384572) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (384577) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (384756) nina_ws: WS[0]: Camera disconnected
+I (384756) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (384807) nina_client: === Poll Summary ===
+I (384807) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (384807) nina_client: Target: , Filter: 
+I (384809) nina_client: Exposure: 0.0s (0.0/0.0)
+I (384813) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (384819) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (385481) nina_ws: WS[0]: Camera connected
+I (385481) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (385521) nina_client: === Poll Summary ===
+I (385521) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (385521) nina_client: Target: , Filter: 
+I (385523) nina_client: Exposure: 0.0s (0.0/0.0)
+I (385527) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (385534) tasks: Poll[1] (active): connected=1, status=Idle, target=, ws=1
+I (385933) toast: Toast shown [slot 1, pos 1]: [1] astromele1.lan: Connected Camera
+I (386495) tasks: Auto-rotate: switched to page 6
+I (386539) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (386644) nina_client: === Poll Summary ===
+I (386644) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (386644) nina_client: Target: , Filter: 
+I (386646) nina_client: Exposure: 0.0s (0.0/0.0)
+I (386651) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (386656) tasks: Poll[1] (active): connected=1, status=Idle, target=, ws=1
+I (387528) tasks: Page switched to 6
+I (387528) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (387652) nina_client: === Poll Summary ===
+I (387652) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (387653) nina_client: Target: , Filter: 
+I (387655) nina_client: Exposure: 0.0s (0.0/0.0)
+I (387659) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (387664) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (388671) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (388715) nina_client: === Poll Summary ===
+I (388715) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (388715) nina_client: Target: , Filter: 
+I (388717) nina_client: Exposure: 0.0s (0.0/0.0)
+I (388722) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (388727) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+W (388884) nina_ws: WS[0]: Camera disconnected
+I (389734) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (389918) nina_client: === Poll Summary ===
+I (389918) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (389918) nina_client: Target: , Filter: 
+I (389920) nina_client: Exposure: 0.0s (0.0/0.0)
+I (389925) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (389930) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (389974) toast: Toast shown [slot 0, pos 1]: [2] astromele1.lan: Camera disconnected
+I (390937) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (391053) nina_client: === Poll Summary ===
+I (391053) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (391053) nina_client: Target: , Filter: 
+I (391055) nina_client: Exposure: 0.0s (0.0/0.0)
+I (391060) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (391065) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (392072) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (392159) nina_client: === Poll Summary ===
+I (392159) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (392159) nina_client: Target: , Filter: 
+I (392161) nina_client: Exposure: 0.0s (0.0/0.0)
+I (392166) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (392171) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (393178) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (393257) nina_client: === Poll Summary ===
+I (393257) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (393257) nina_client: Target: , Filter: 
+I (393259) nina_client: Exposure: 0.0s (0.0/0.0)
+I (393263) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (393269) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (394275) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (394400) nina_client: === Poll Summary ===
+I (394400) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (394400) nina_client: Target: , Filter: 
+I (394402) nina_client: Exposure: 0.0s (0.0/0.0)
+I (394407) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (394412) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+W (395093) nina_client: desktop-bdt978m.lan unreachable
+I (395419) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (395459) nina_client: === Poll Summary ===
+I (395459) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (395459) nina_client: Target: , Filter: 
+I (395462) nina_client: Exposure: 0.0s (0.0/0.0)
+I (395466) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (395471) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (396478) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (396668) nina_client: === Poll Summary ===
+I (396668) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (396668) nina_client: Target: , Filter: 
+I (396670) nina_client: Exposure: 0.0s (0.0/0.0)
+I (396675) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (396680) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (397687) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (397759) nina_client: === Poll Summary ===
+I (397759) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (397759) nina_client: Target: , Filter: 
+I (397761) nina_client: Exposure: 0.0s (0.0/0.0)
+I (397765) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (397771) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (398777) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (398823) nina_client: === Poll Summary ===
+I (398823) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (398823) nina_client: Target: , Filter: 
+I (398826) nina_client: Exposure: 0.0s (0.0/0.0)
+I (398830) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (398835) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (399842) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (399900) nina_client: === Poll Summary ===
+I (399900) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (399900) nina_client: Target: , Filter: 
+I (399902) nina_client: Exposure: 0.0s (0.0/0.0)
+I (399907) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (399912) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (400919) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (400987) perf: uxTaskGetSystemState returned 0 tasks
+I (400987) perf: ╔══════════════════════════════════════════════════════════════╗
+I (400989) nina_client: === Poll Summary ===
+I (400999) perf: ║              PERFORMANCE REPORT                             ║
+I (401003) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (401010) perf: ╚══════════════════════════════════════════════════════════════╝
+I (401016) nina_client: Target: , Filter: 
+I (401034) perf: ── Poll Cycle ──
+I (401038) nina_client: Exposure: 0.0s (0.0/0.0)
+I (401042) perf:   poll_cycle_total         avg=   16.2  min=    5.9  max= 3057.2  last=    7.3 ms  [n=387]
+I (401046) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (401056) perf:   effective_interval       avg= 1015.0  min=    8.6  max= 4058.0  last= 1007.6 ms  [n=386]
+I (401061) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (401070) perf: ── Endpoint Fetchers ──
+I (401081) perf:   equipment_bundle         avg=  221.5  min=   16.1  max= 6568.5  last=   70.0 ms  [n=149]
+I (401091) perf:   camera                   (no samples)
+I (401096) perf:   guider                   (no samples)
+I (401101) perf:   mount                    (no samples)
+I (401106) perf:   focuser                  (no samples)
+I (401111) perf:   sequence                 avg=   93.4  min=   23.5  max=  256.3  last=   80.7 ms  [n=13]
+I (401120) perf:   switch                   (no samples)
+I (401125) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (401135) perf:   filter                   (no samples)
+I (401140) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (401149) perf: ── Network ──
+I (401153) perf:   http_request             avg=  439.1  min=    0.4  max= 7045.4  last=   68.8 ms  [n=189]
+I (401162) perf:   HTTP requests:  38 (interval) / 237 (total)
+I (401168) perf:   HTTP retries:   2 (interval) / 41 (total)
+I (401173) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (401178) perf:   HTTP unreachable:3 (interval) / 40 (total)
+I (401184) perf:   WS events:      5 (interval) / 5 (total)
+I (401189) perf: ── JSON Parsing ──
+I (401193) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    4.4 ms  [n=197]
+I (401202) perf:   json_sequence            (no samples)
+I (401207) perf:   json_config_color        (no samples)
+I (401212) perf:   Parse calls:    36 (interval) / 197 (total)
+I (401218) perf: ── UI Updates ──
+I (401222) perf:   ui_update_total          avg=    1.7  min=    0.0  max=   25.9  last=    0.2 ms  [n=160]
+I (401231) perf:   ui_lock_wait             avg=    1.6  min=    0.0  max=   25.8  last=    0.0 ms  [n=160]
+I (401241) perf:   ui_dashboard             avg=    0.1  min=    0.1  max=    1.8  last=    0.1 ms  [n=97]
+I (401250) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.1 ms  [n=63]
+I (401259) perf: ── Latency ──
+I (401263) perf:   ws_to_ui                 avg=    7.0  min=    6.3  max=    7.6  last=    6.9 ms  [n=5]
+I (401272) perf: ── JPEG ──
+I (401275) perf:   jpeg_decode              (no samples)
+I (401280) perf:   jpeg_fetch               (no samples)
+I (401285) perf: ── Spotify ──
+I (401289) perf:   spotify_poll_cycle       (no samples)
+I (401294) perf:   spotify_api_fetch        (no samples)
+I (401299) perf:   spotify_art_fetch        (no samples)
+I (401304) perf:   spotify_art_decode       (no samples)
+I (401309) perf:   spotify_ui_update        (no samples)
+I (401314) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (401320) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (401325) perf:   Spotify art:      0 (interval) / 0 (total)
+I (401330) perf: ── WiFi ──
+I (401334) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (401341) perf:   RSSI: cur=-60  avg=-58  min=-61  max=-56 dBm  [n=33]
+I (401347) perf:   Disconnects:    0 (interval) / 0 (total)
+I (401352) perf: ── Memory ──
+I (401356) perf:   Internal heap:  free=74555  min_ever=56907  largest_block=31744  frag_ratio=0.426
+I (401364) perf:   PSRAM:          free=20886032  min_ever=15259512  largest_block=20447232  frag_ratio=0.979
+I (401374) perf: ── Task Stacks ──
+I (401378) perf:   data_task HWM:  8080 bytes free
+I (401382) perf:   input_task HWM: 5484 bytes free
+I (401387) perf:   spotify_task HWM: 7164 bytes free
+I (402077) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (402112) nina_client: === Poll Summary ===
+I (402112) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (402112) nina_client: Target: , Filter: 
+I (402115) nina_client: Exposure: 0.0s (0.0/0.0)
+I (402119) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (402124) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (403131) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (403233) nina_client: === Poll Summary ===
+I (403233) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (403233) nina_client: Target: , Filter: 
+I (403236) nina_client: Exposure: 0.0s (0.0/0.0)
+I (403240) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (403245) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (403406) tasks: Auto-rotate: switched to page 4
+I (404254) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (404348) nina_client: === Poll Summary ===
+I (404348) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (404348) nina_client: Target: , Filter: 
+I (404351) nina_client: Exposure: 0.0s (0.0/0.0)
+I (404355) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (404360) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (404439) tasks: Page switched to 4 (summary)
+I (404440) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (404441) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (404641) nina_client: === Poll Summary ===
+I (404641) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (404641) nina_client: Target: , Filter: 
+I (404643) nina_client: Exposure: 0.0s (0.0/0.0)
+I (404647) nI (404653) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (405367) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (405413) nina_client: === Poll Summary ===
+I (405413) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (405413) nina_client: Target: , Filter: 
+I (405415) nina_client: Exposure: 0.0s (0.0/0.0)
+I (405419) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (405425) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (405659) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (405694) nina_client: === Poll Summary ===
+I (405694) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (405694) nina_client: Target: , Filter: 
+I (405696) nina_client: Exposure: 0.0s (0.0/0.0)
+I (405700) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (405706) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (406431) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (406506) nina_client: === Poll Summary ===
+I (406506) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (406506) nina_client: Target: , Filter: 
+I (406508) nina_client: Exposure: 0.0s (0.0/0.0)
+I (406513) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (406518) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (406713) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (406813) nina_client: === Poll Summary ===
+I (406813) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (406813) nina_client: Target: , Filter: 
+I (406815) nina_client: Exposure: 0.0s (0.0/0.0)
+I (406820) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (406825) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (407525) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (407832) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (408363) nina_client: === Poll Summary ===
+I (408363) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (408363) nina_client: Target: , Filter: 
+I (408365) nina_client: Exposure: 0.0s (0.0/0.0)
+I (408369) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (408375) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (409279) nina_client: === Poll Summary ===
+I (409279) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (409279) nina_client: Target: , Filter: 
+I (409281) nina_client: Exposure: 0.0s (0.0/0.0)
+I (409286) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (409291) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (409381) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (410094) nina_client: === Poll Summary ===
+I (410094) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (410094) nina_client: Target: , Filter: 
+I (410097) nina_client: Exposure: 0.0s (0.0/0.0)
+I (410101) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (410106) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (410300) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (410404) nina_client: === Poll Summary ===
+I (410404) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (410404) nina_client: Target: , Filter: 
+I (410406) nina_client: Exposure: 0.0s (0.0/0.0)
+I (410410) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (410416) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (411113) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (411199) nina_client: === Poll Summary ===
+I (411199) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (411199) nina_client: Target: , Filter: 
+I (411201) nina_client: Exposure: 0.0s (0.0/0.0)
+I (411206) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (411211) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+W (411255) nina_client: desktop-bdt978m.lan unreachable
+I (411255) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (411423) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (411533) nina_client: === Poll Summary ===
+I (411533) nina_client: Connected: 136) nina_client: Exposure: 0.0s (0.0/0.0)
+I (411540) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (411545) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (412218) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (412261) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (412321) nina_client: === Poll Summary ===
+I (412321) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (412321) nina_client: Target: , Filter: 
+I (412323) nina_client: Exposure: 0.0s (0.0/0.0)
+I (412327) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (412333) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (412552) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (412644) nina_client: === Poll Summary ===
+I (412644) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (412644) nina_client: Target: , Filter: 
+I (412646) nina_client: Exposure: 0.0s (0.0/0.0)
+I (412650) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (412655) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (413339) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (413376) nina_client: === Poll Summary ===
+I (413376) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (413377) nina_client: Target: , Filter: 
+I (413379) nina_client: Exposure: 0.0s (0.0/0.0)
+I (413383) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (413388) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (413662) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (413744) nina_client: === Poll Summary ===
+I (413744) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (413744) nina_client: Target: , Filter: 
+I (413746) nina_client: Exposure: 0.0s (0.0/0.0)
+I (413750) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (413756) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (414395) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (414488) nina_client: === Poll Summary ===
+I (414488) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (414488) nina_client: Target: , Filter: 
+I (414490) nina_client: Exposure: 0.0s (0.0/0.0)
+I (414495) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (414500) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (414763) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (414829) nina_client: === Poll Summary ===
+I (414829) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (414829) nina_client: Target: , Filter: 
+I (414831) nina_client: Exposure: 0.0s (0.0/0.0)
+I (414835) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (414840) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (415506) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (415542) nina_client: === Poll Summary ===
+I (415543) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (415543) nina_client: Target: , Filter: 
+I (415545) nina_client: Exposure: 0.0s (0.0/0.0)
+I (415549) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (415554) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (415847) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (415917) nina_client: === Poll Summary ===
+I (415917) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (415917) nina_client: Target: , Filter: 
+I (415919) nina_client: Exposure: 0.0s (0.0/0.0)
+I (415923) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (415928) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (416561) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (416653) nina_client: === Poll Summary ===
+I (416653) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (416654) nina_client: Target: , Filter: 
+I (416656) nina_client: Exposure: 0.0s (0.0/0.0)
+I (416660) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (416665) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (416935) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (417025) nina_client: === Poll Summary ===
+I (417025) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (417025) nina_client: Target: , Filter: 
+I (417027) nina_client: Exposure: 0.0s (0.0/0.0)
+I (417031) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (417036) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (417672) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (417797) nina_client: === Poll Summary ===
+I (417797) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (417797) nina_client: Target: , Filter: 
+I (417799) nina_client: Exposure: 0.0s (0.0/0.0)
+I (417803) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (417809) tasks: Poll[2] (active): connected=1, status=Idle, target=, ws=1
+I (418043) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (418080) nina_client: === Poll Summary ===
+I (418080) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (418080) nina_client: Target: , Filter: 
+I (418083) nina_client: Exposure: 0.0s (0.0/0.0)
+I (418087) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (418092) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (418479) nina_ws: WS[1]: Camera disconnected
+I (418479) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (418738) nina_client: === Poll Summary ===
+I (418738) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (418738) nina_client: Target: , Filter: 
+I (418740) nina_client: Exposure: 0.0s (0.0/0.0)
+I (418745) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (418750) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+W (418824) nina_client: desktop-bdt978m.lan unreachable
+I (418824) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (419099) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (419173) nina_client: === Poll Summary ===
+I (419174) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (419174) nina_client: Target: , Filter: 
+I (419176) nina_client: Exposure: 0.0s (0.0/0.0)
+I (419180) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (419185) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (419492) tasks: Auto-rotate: switched to page 5
+I (419564) toast: Toast shown [slot 0, pos 0]: [2] astromele2.lan: Camera disconnected
+I (419757) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (419789) tasks: Page switched to 5
+I (419833) nina_client: === Poll Summary ===
+I (419833) nina_client: Connected: 1, Profile: SQA55_2600MM_AM5
+I (419833) nina_client: Target: , Filter: 
+I (419835) nina_client: Exposure: 0.0s (0.0/0.0)
+I (419839) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (419845) tasks: Poll[2] (active): connected=1, status=NoState, target=, ws=1
+W (419985) nina_ws: WS[1]: Camera disconnected
+I (420192) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (420240) nina_client: === Poll Summary ===
+I (420240) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (420240) nina_client: Target: , Filter: 
+I (420242) nina_client: Exposure: 0.0s (0.0/0.0)
+I (420247) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (420252) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+E (420710) transport_ws: Error read data(-1)
+E (420710) websocket_client: esp_transport_read() failed with -1, transport_error=ESP_ERR_ESP_TLS_TCP_CLOSED_FIN, tls_error_code=0, tls_flags=0, errno=128
+W (420716) nina_ws: WS[1]: Error
+E (420719) websocket_client: Error receive data
+I (420724) websocket_client: Reconnect after 86400000 ms
+W (420729) nina_ws: WS[1]: Disconnected from NINA
+I (421259) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (421378) nina_client: === Poll Summary ===
+I (421378) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (421378) nina_client: Target: , Filter: 
+I (421380) nina_client: Exposure: 0.0s (0.0/0.0)
+I (421385) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (421390) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (422398) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (422591) nina_client: === Poll Summary ===
+I (422591) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (422591) nina_client: Target: , Filter: 
+I (422593) nina_client: Exposure: 0.0s (0.0/0.0)
+I (422598) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (422604) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (422844) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (422888) nina_client: === Poll Summary ===
+I (422888) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (422888) nina_client: Target: , Filter: 
+I (422890) nina_client: Exposure: 0.0s (0.0/0.0)
+I (422895) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (422900) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (422954) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (422956) nina_ws: WS[0]: Camera disconnected
+I (423003) nina_client: === Poll Summary ===
+I (423003) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (423003) nina_client: Target: , Filter: 
+I (423005) nina_client: Exposure: 0.0s (0.0/0.0)
+I (423011) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (423015) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (423022) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (423036) transport_ws: Error read data(-1)
+E (423036) websocket_client: esp_transport_read() failed with -1, transport_error=ESP_ERR_ESP_TLS_TCP_CLOSED_FIN, tls_error_code=0, tls_flags=0, errno=128
+W (423046) nina_ws: WS[0]: Error
+E (423049) websocket_client: Error receive data
+I (423054) websocket_client: Reconnect after 86400000 ms
+W (423059) nina_ws: WS[0]: Disconnected from NINA
+I (424003) toast: Toast shown [slot 1, pos 1]: [2] astromele1.lan: Camera disconnected
+W (426363) nina_client: desktop-bdt978m.lan unreachable
+W (428287) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (429571) nina_client: astromele1.lan unreachable
+W (432093) perf: uxTaskGetSystemState returned 0 tasks
+I (432093) perf: ╔══════════════════════════════════════════════════════════════╗
+I (432105) perf: ║              PERFORMANCE REPORT                             ║
+I (432113) perf: ╚══════════════════════════════════════════════════════════════╝
+I (432131) perf: ── Poll Cycle ──
+I (432135) perf:   poll_cycle_total         avg=   15.8  min=    5.9  max= 3057.2  last=    7.2 ms  [n=424]
+I (432144) perf:   effective_interval       avg=  999.8  min=    7.6  max= 4058.0  last= 1008.0 ms  [n=423]
+I (432154) perf: ── Endpoint Fetchers ──
+I (432158) perf:   equipment_bundle         avg=  237.2  min=   16.1  max= 6568.5  last= 6542.3 ms  [n=183]
+I (432167) perf:   camera                   (no samples)
+I (432172) perf:   guider                   (no samples)
+I (432177) perf:   mount                    (no samples)
+I (432183) perf:   focuser                  (no samples)
+I (432188) perf:   sequence                 avg=   83.1  min=   23.5  max=  256.3  last=   57.6 ms  [n=16]
+I (432197) perf:   switch                   (no samples)
+I (432202) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (432211) perf:   filter                   (no samples)
+I (432216) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (432226) perf: ── Network ──
+I (432229) perf:   http_request             avg=  397.6  min=    0.4  max= 7045.4  last= 3334.3 ms  [n=227]
+I (432238) perf:   HTTP requests:  44 (interval) / 281 (total)
+I (432244) perf:   HTTP retries:   4 (interval) / 45 (total)
+I (432249) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (432255) perf:   HTTP unreachable:4 (interval) / 44 (total)
+I (432260) perf:   WS events:      23 (interval) / 28 (total)
+I (432266) perf: ── JSON Parsing ──
+I (432270) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    4.0 ms  [n=235]
+I (432279) perf:   json_sequence            (no samples)
+I (432284) perf:   json_config_color        (no samples)
+I (432289) perf:   Parse calls:    38 (interval) / 235 (total)
+I (432295) perf: ── UI Updates ──
+I (432298) perf:   ui_update_total          avg=    2.0  min=    0.0  max=   28.3  last=    0.1 ms  [n=197]
+I (432308) perf:   ui_lock_wait             avg=    1.9  min=    0.0  max=   28.2  last=    0.0 ms  [n=197]
+I (432317) perf:   ui_dashboard             avg=    0.1  min=    0.1  max=    1.8  last=    0.1 ms  [n=118]
+I (432327) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.1 ms  [n=79]
+I (432336) perf: ── Latency ──
+I (432340) perf:   ws_to_ui                 avg=   10.6  min=    0.2  max=   32.4  last=    9.7 ms  [n=11]
+I (432349) perf: ── JPEG ──
+I (432352) perf:   jpeg_decode              (no samples)
+I (432357) perf:   jpeg_fetch               (no samples)
+I (432362) perf: ── Spotify ──
+I (432366) perf:   spotify_poll_cycle       (no samples)
+I (432371) perf:   spotify_api_fetch        (no samples)
+I (432376) perf:   spotify_art_fetch        (no samples)
+I (432381) perf:   spotify_art_decode       (no samples)
+I (432386) perf:   spotify_ui_update        (no samples)
+I (432391) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (432396) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (432402) perf:   Spotify art:      0 (interval) / 0 (total)
+I (432407) perf: ── WiFi ──
+I (432411) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (432417) perf:   RSSI: cur=-60  avg=-58  min=-61  max=-55 dBm  [n=37]
+I (432424) perf:   Disconnects:    0 (interval) / 0 (total)
+I (432429) perf: ── Memory ──
+I (432432) perf:   Internal heap:  free=74655  min_ever=56907  largest_block=31744  frag_ratio=0.425
+I (432441) perf:   PSRAM:          free=20901876  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (432451) perf: ── Task Stacks ──
+I (432455) perf:   data_task HWM:  8080 bytes free
+I (432459) perf:   input_task HWM: 5484 bytes free
+I (432464) perf:   spotify_task HWM: 7164 bytes free
+I (432790) nina_client: === Poll Summary ===
+I (432790) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (432790) nina_client: Target: , Filter: 
+I (432792) nina_client: Exposure: 0.0s (0.0/0.0)
+I (432797) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (432802) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=0
+I (432809) nina_ws: WS[0]: Connecting to ws://astromele1.lan:1888/v2/socket
+I (432816) websocket_client: Started
+I (432847) nina_ws: WS[0]: Connected to NINA
+I (433819) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (435390) nina_client: === Poll Summary ===
+I (435390) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (435390) nina_client: Target: , Filter: 
+I (435392) nina_client: Exposure: 0.0s (0.0/0.0)
+I (435397) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (435402) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (435503) tasks: Auto-rotate: switched to page 6
+I (436409) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (436519) nina_client: astromele2.lan unreachable
+I (436519) nina_conn: Instance 1: CONNECTED -> DISCONNECTED (failures=1, successes=0)
+I (436520) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (436527) tasks: Page switched to 6
+I (436527) websocket_client: Started
+I (436533) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (437840) nina_client: === Poll Summary ===
+I (437840) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (437840) nina_client: Target: , Filter: 
+I (437842) nina_client: Exposure: 0.0s (0.0/0.0)
+I (437847) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (437852) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (442887) nina_client: desktop-bdt978m.lan unreachable
+W (443102) nina_client: astromele2.lan unreachable
+I (443102) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (444102) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (446534) transport_ws: Error connecting to host astromele2.lan:1888
+E (446534) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (446546) nina_ws: WS[1]: Error
+I (446549) websocket_client: Reconnect after 86400000 ms
+W (446554) nina_ws: WS[1]: Disconnected from NINA
+W (450633) nina_client: astromele2.lan unreachable
+I (450633) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (451633) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (451654) tasks: Auto-rotate: switched to page 4
+I (452683) tasks: Page switched to 4 (summary)
+I (452737) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (452737) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (453070) nina_client: === Poll Summary ===
+I (453070) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (453070) nina_client: Target: , Filter: 
+I (453072) nina_client: Exposure: 0.0s (0.0/0.0)
+I (453077) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (453082) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (454089) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (454153) nina_client: === Poll Summary ===
+I (454153) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (454153) nina_client: Target: , Filter: 
+I (454155) nina_client: Exposure: 0.0s (0.0/0.0)
+I (454159) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (454165) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (455172) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (455311) nina_client: === Poll Summary ===
+I (455311) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (455311) nina_client: Target: , Filter: 
+I (455313) nina_client: Exposure: 0.0s (0.0/0.0)
+I (455318) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (455323) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (456330) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (456375) nina_client: === Poll Summary ===
+I (456375) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (456376) nina_client: Target: , Filter: 
+I (456377) nina_client: Exposure: 0.0s (0.0/0.0)
+I (456382) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (456387) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (457394) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (457497) nina_client: === Poll Summary ===
+I (457497) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (457497) nina_client: Target: , Filter: 
+I (457499) nina_client: Exposure: 0.0s (0.0/0.0)
+I (457504) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (457509) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (458150) nina_client: astromele2.lan unreachable
+I (458150) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (458150) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (458158) websocket_client: Started
+I (458516) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (458625) nina_client: === Poll Summary ===
+I (458625) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (458626) nina_client: Target: , Filter: 
+I (458628) nina_client: Exposure: 0.0s (0.0/0.0)
+I (458632) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (458637) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (459160) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (459266) nina_client: desktop-bdt978m.lan unreachable
+I (459266) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (459644) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (459881) nina_client: === Poll Summary ===
+I (459881) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (459881) nina_client: Target: , Filter: 
+I (459883) nina_ofile: 140APO_533_AM5n
+I (460979) nina_client: Target: , Filter: 
+I (460981) nina_client: Exposure: 0.0s (0.0/0.0)
+I (460985) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (460990) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (461997) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (462031) nina_client: === Poll Summary ===
+I (462031) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (462031) nina_client: Target: , Filter: 
+I (462033) nina_client: Exposure: 0.0s (0.0/0.0)
+I (462037) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (462043) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (462855) perf: uxTaskGetSystemState returned 0 tasks
+I (462855) perf: ╔══════════════════════════════════════════════════════════════╗
+I (462867) perf: ║              PERFORMANCE REPORT                             ║
+I (462874) perf: ╚══════════════════════════════════════════════════════════════╝
+I (462893) perf: ── Poll Cycle ──
+I (462896) perf:   poll_cycle_total         avg=   15.5  min=    5.9  max= 3057.2  last=    7.0 ms  [n=454]
+I (462906) perf:   effective_interval       avg= 1001.5  min=    7.6  max= 4058.0  last= 1008.0 ms  [n=453]
+I (462915) perf: ── Endpoint Fetchers ──
+I (462920) perf:   equipment_bundle         avg=  270.1  min=   16.1  max= 6568.5  last=   34.1 ms  [n=196]
+I (462929) perf:   camera                   (no samples)
+I (462934) perf:   guider                   (no samples)
+I (462939) perf:   mount                    (no samples)
+I (462944) perf:   focuser                  (no samples)
+I (462949) perf:   sequence                 avg=  135.8  min=   23.5  max=  902.9  last=  212.7 ms  [n=18]
+I (462959) perf:   switch                   (no samples)
+I (462964) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (462973) perf:   filter                   (no samples)
+I (462978) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (462987) perf: ── Network ──
+I (462991) perf:   http_request             avg=  398.9  min=    0.4  max= 7045.4  last=   33.1 ms  [n=244]
+I (463000) perf:   HTTP requests:  21 (interval) / 302 (total)
+I (463006) perf:   HTTP retries:   7 (interval) / 52 (total)
+I (463011) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (463016) perf:   HTTP unreachable:6 (interval) / 50 (total)
+I (463022) perf:   WS events:      0 (interval) / 28 (total)
+I (463027) perf: ── JSON Parsing ──
+I (463031) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.3 ms  [n=250]
+I (463041) perf:   json_sequence            (no samples)
+I (463046) perf:   json_config_color        (no samples)
+I (463050) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (463051) perf:   Parse calls:    15 (interval) / 250 (total)
+I (463063) perf: ── UI Updates ──
+I (463067) perf:   ui_update_total          avg=    2.1  min=    0.0  max=   29.8  last=    0.0 ms  [n=227]
+I (463076) perf:   ui_lock_wait             avg=    2.0  min=    0.0  max=   29.8  last=    0.0 ms  [n=227]
+I (463086) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=137]
+I (463095) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=90]
+I (463104) perf: ── Latency ──
+I (463108) perf:   ws_to_ui                 avg=   10.6  min=    0.2  max=   32.4  last=    9.7 ms  [n=11]
+I (463117) perf: ── JPEG ──
+I (463121) perf:   jpeg_decode              (no samples)
+I (463126) perf:   jpeg_fetch               (no samples)
+I (463131) perf: ── Spotify ──
+I (463134) perf:   spotify_poll_cycle       (no samples)
+I (463139) perf:   spotify_api_fetch        (no samples)
+I (463144) perf:   spotify_art_fetch        (no samples)
+I (463149) perf:   spotify_art_decode       (no samples)
+I (463154) perf:   spotify_ui_update        (no samples)
+I (463157) nina_client: === Poll Summary ===
+I (463159) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (463163) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (463169) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (463174) nina_client: Target: , Filter: 
+I (463180) perf:   Spotify art:      0 (interval) / 0 (total)
+I (463184) nina_client: Exposure: 0.0s (0.0/0.0)
+I (463189) perf: ── WiFi ──
+I (463193) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (463197) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (463202) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (463209) perf:   RSSI: cur=-60  avg=-59  min=-65  max=-58 dBm  [n=30]
+I (463222) perf:   Disconnects:    0 (interval) / 0 (total)
+I (463227) perf: ── Memory ──
+I (463231) perf:   Internal heap:  free=71971  min_ever=56907  largest_block=31744  frag_ratio=0.441
+I (463240) perf:   PSRAM:          free=20901276  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (463249) perf: ── Task Stacks ──
+I (463253) perf:   data_task HWM:  8080 bytes free
+I (463257) perf:   input_task HWM: 5484 bytes free
+I (463262) perf:   spotify_task HWM: 7164 bytes free
+I (464216) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (464241) nina_client: === Poll Summary ===
+I (464241) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (464242) nina_client: Target: , Filter: 
+I (464244) nina_client: Exposure: 0.0s (0.0/0.0)
+I (464248) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (464253) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (465260) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (465292) nina_client: === Poll Summary ===
+I (465292) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (465292) nina_client: Target: , Filter: 
+I (465294) nina_client: Exposure: 0.0s (0.0/0.0)
+I (465298) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (465304) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (465851) nina_client: astromele2.lan unreachable
+I (465851) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (466311) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (466409) nina_client: === Poll Summary ===
+I (466409) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (466410) nina_client: Target: , Filter: 
+I (466412) nina_client: Exposure: 0.0s (0.0/0.0)
+I (466416) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (466421) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (466804) nina_client: desktop-bdt978m.lan unreachable
+I (466804) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (466885) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (467428) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (467805) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (468176) transport_ws: Error connecting to host astromele2.lan:1888
+E (468176) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (468188) nina_ws: WS[1]: Error
+I (468191) websocket_client: Reconnect after 86400000 ms
+W (468196) nina_ws: WS[1]: Disconnected from NINA
+I (468304) tasks: Auto-rotate: switched to page 5
+I (468485) nina_client: === Poll Summary ===
+I (468485) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (468485) nina_client: Target: , Filter: 
+I (468487) nina_client: Exposure: 0.0s (0.0/0.0)
+I (468492) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (468497) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (469336) tasks: Page switched to 5
+I (469504) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (470088) nina_client: === Poll Summary ===
+I (470088) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (470088) nina_client: Target: , Filter: 
+I (470090) nina_client: Exposure: 0.0s (0.0/0.0)
+I (470094) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (470099) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (471113) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (471186) nina_client: === Poll Summary ===
+I (471186) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (471186) nina_client: Target: , Filter: 
+I (471188) nina_client: Exposure: 0.0s (0.0/0.0)
+I (471192) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (471198) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (472205) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (472337) nina_client: === Poll Summary ===
+I (472337) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (472337) nina_client: Target: , Filter: 
+I (472339) nina_client: Exposure: 0.0s (0.0/0.0)
+I (472343) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (472348) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (473355) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (473400) nina_client: astromele2.lan unreachable
+I (473400) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (473400) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (473408) websocket_client: Started
+I (473685) nina_client: === Poll Summary ===
+I (473685) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (473686) nina_client: Target: , Filter: 
+I (473688) nina_client: Exposure: 0.0s (0.0/0.0)
+I (473692) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (473697) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+W (474500) nina_client: desktop-bdt978m.lan unreachable
+I (474500) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (474572) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (474601) nina_client: === Poll Summary ===
+I (474601) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (474601) nina_client: Target: , Filter: 
+I (474603) nina_client: Exposure: 0.0s (0.0/0.0)
+I (474607) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (474612) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (474703) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (474705) nina_ws: WS[0]: Camera disconnected
+I (474885) nina_client: === Poll Summary ===
+I (474885) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (474885) nina_client: Target: , Filter: 
+I (474887) nina_client: Exposure: 0.0s (0.0/0.0)
+I (474892) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (474897) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (474904) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (475077) nina_client: === Poll Summary ===
+I (475077) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (475077) nina_client: Target: , Filter: 
+I (475079) nina_client: Exposure: 0.0s (0.0/0.0)
+I (475084) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (475089) tasks: Poll[1] (active): connected=1, status=NoState, target=, ws=1
+I (475577) toast: Toast shown [slot 0, pos 0]: [2] astromele1.lan: Camera disconnected
+I (476096) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (482608) nina_client: astromele1.lan unreachable
+I (482608) nina_client: === Poll Summary ===
+I (482608) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (482611) nina_client: Target: , Filter: 
+I (482615) nina_client: Exposure: 0.0s (0.0/0.0)
+I (482619) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (482624) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+E (483483) transport_ws: Error connecting to host astromele2.lan:1888
+E (483483) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (483495) nina_ws: WS[1]: Error
+I (483498) websocket_client: Reconnect after 86400000 ms
+W (483503) nina_ws: WS[1]: Disconnected from NINA
+I (483631) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (484836) tasks: Auto-rotate: switched to page 4
+I (485862) tasks: Page switched to 4 (summary)
+W (489977) nina_client: astromele2.lan unreachable
+I (489977) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (489978) websocket_client: Started
+I (489980) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (490205) nina_client: astromele1.lan unreachable
+I (490205) nina_client: === Poll Summary ===
+I (490205) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (490208) nina_client: Target: , Filter: 
+I (490212) nina_client: Exposure: 0.0s (0.0/0.0)
+I (490216) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (490221) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (491015) nina_client: desktop-bdt978m.lan unreachable
+I (491015) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (491228) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (493969) perf: uxTaskGetSystemState returned 0 tasks
+I (493969) perf: ╔══════════════════════════════════════════════════════════════╗
+I (493981) perf: ║              PERFORMANCE REPORT                             ║
+I (493988) perf: ╚══════════════════════════════════════════════════════════════╝
+I (494007) perf: ── Poll Cycle ──
+I (494010) perf:   poll_cycle_total         avg=   15.2  min=    5.9  max= 3057.2  last=    6.9 ms  [n=488]
+I (494020) perf:   effective_interval       avg=  995.5  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=487]
+I (494029) perf: ── Endpoint Fetchers ──
+I (494034) perf:   equipment_bundle         avg=  293.9  min=   16.1  max= 6568.5  last=  217.9 ms  [n=210]
+I (494043) perf:   camera                   (no samples)
+I (494048) perf:   guider                   (no samples)
+I (494053) perf:   mount                    (no samples)
+I (494058) perf:   focuser                  (no samples)
+I (494063) perf:   sequence                 avg=  133.7  min=   23.5  max=  902.9  last=   95.6 ms  [n=19]
+I (494073) perf:   switch                   (no samples)
+I (494078) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (494087) perf:   filter                   (no samples)
+I (494092) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (494101) perf: ── Network ──
+I (494105) perf:   http_request             avg=  429.5  min=    0.4  max= 7045.4  last=  217.9 ms  [n=260]
+I (494114) perf:   HTTP requests:  21 (interval) / 324 (total)
+I (494120) perf:   HTTP retries:   9 (interval) / 61 (total)
+I (494125) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (494130) perf:   HTTP unreachable:8 (interval) / 58 (total)
+I (494136) perf:   WS events:      11 (interval) / 39 (total)
+I (494141) perf: ── JSON Parsing ──
+I (494145) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (494155) perf:   json_sequence            (no samples)
+I (494160) perf:   json_config_color        (no samples)
+I (494165) perf:   Parse calls:    12 (interval) / 263 (total)
+I (494170) perf: ── UI Updates ──
+I (494174) perf:   ui_update_total          avg=    2.1  min=    0.0  max=   29.8  last=    0.0 ms  [n=261]
+I (494183) perf:   ui_lock_wait             avg=    2.0  min=    0.0  max=   29.8  last=    0.0 ms  [n=261]
+I (494193) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=157]
+I (494202) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=104]
+I (494212) perf: ── Latency ──
+I (494215) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (494225) perf: ── JPEG ──
+I (494228) perf:   jpeg_decode              (no samples)
+I (494233) perf:   jpeg_fetch               (no samples)
+I (494238) perf: ── Spotify ──
+I (494241) perf:   spotify_poll_cycle       (no samples)
+I (494246) perf:   spotify_api_fetch        (no samples)
+I (494252) perf:   spotify_art_fetch        (no samples)
+I (494257) perf:   spotify_art_decode       (no samples)
+I (494262) perf:   spotify_ui_update        (no samples)
+I (494267) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (494272) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (494278) perf:   Spotify art:      0 (interval) / 0 (total)
+I (494283) perf: ── WiFi ──
+I (494286) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (494293) perf:   RSSI: cur=-57  avg=-59  min=-62  max=-57 dBm  [n=34]
+I (494299) perf:   Disconnects:    0 (interval) / 0 (total)
+I (494305) perf: ── Memory ──
+I (494308) perf:   Internal heap:  free=76543  min_ever=56907  largest_block=31744  frag_ratio=0.415
+I (494317) perf:   PSRAM:          free=20903080  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (494327) perf: ── Task Stacks ──
+I (494330) perf:   data_task HWM:  8080 bytes free
+I (494335) perf:   input_task HWM: 5484 bytes free
+I (494339) perf:   spotify_task HWM: 7164 bytes free
+W (496555) nina_client: astromele2.lan unreachable
+I (496555) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (497555) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (497565) nina_client: desktop-bdt978m.lan unreachable
+I (497565) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (497778) nina_client: astromele1.lan unreachable
+I (498566) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (499986) transport_ws: Error connecting to host astromele2.lan:1888
+E (499986) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (499998) nina_ws: WS[1]: Error
+I (500001) websocket_client: Reconnect after 86400000 ms
+W (500006) nina_ws: WS[1]: Disconnected from NINA
+I (501397) tasks: Auto-rotate: switched to page 5
+I (502419) tasks: Page switched to 5
+W (504121) nina_client: astromele2.lan unreachable
+I (504121) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (504313) nina_client: astromele1.lan unreachable
+W (504313) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (504314) nina_client: === Poll Summary ===
+I (504318) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (504323) nina_client: Target: , Filter: 
+I (504327) nina_client: Exposure: 0.0s (0.0/0.0)
+I (504331) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (504337) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (505095) nina_client: desktop-bdt978m.lan unreachable
+I (505095) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (505343) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (511886) nina_client: astromele1.lan unreachable
+I (511886) nina_client: === Poll Summary ===
+I (511886) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (511889) nina_client: Target: , Filter: 
+I (511893) nina_client: Exposure: 0.0s (0.0/0.0)
+I (511897) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (511902) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (512909) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (517545) tasks: Auto-rotate: switched to page 4
+I (518576) tasks: Page switched to 4 (summary)
+W (519440) nina_client: astromele1.lan unreachable
+W (520713) nina_client: astromele2.lan unreachable
+I (520713) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (520714) websocket_client: Started
+I (520716) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (521608) nina_client: desktop-bdt978m.lan unreachable
+I (521608) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (524631) perf: uxTaskGetSystemState returned 0 tasks
+I (524631) perf: ╔══════════════════════════════════════════════════════════════╗
+I (524643) perf: ║              PERFORMANCE REPORT                             ║
+I (524650) perf: ╚══════════════════════════════════════════════════════════════╝
+I (524669) perf: ── Poll Cycle ──
+I (524672) perf:   poll_cycle_total         avg=   14.8  min=    5.9  max= 3057.2  last=    7.0 ms  [n=518]
+I (524682) perf:   effective_interval       avg=  997.0  min=    7.5  max= 4058.0  last= 1007.0 ms  [n=517]
+I (524691) perf: ── Endpoint Fetchers ──
+I (524696) perf:   equipment_bundle         avg=  398.6  min=   10.3  max= 6568.5  last= 6531.3 ms  [n=215]
+I (524705) perf:   camera                   (no samples)
+I (524710) perf:   guider                   (no samples)
+I (524715) perf:   mount                    (no samples)
+I (524720) perf:   focuser                  (no samples)
+I (524725) perf:   sequence                 avg=  453.8  min=   23.5  max= 6535.6  last= 6535.6 ms  [n=20]
+I (524735) perf:   switch                   (no samples)
+I (524740) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (524749) perf:   filter                   (no samples)
+I (524754) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (524763) perf: ── Network ──
+I (524767) perf:   http_request             avg=  507.9  min=    0.4  max= 7045.4  last=  885.0 ms  [n=267]
+I (524776) perf:   HTTP requests:  10 (interval) / 334 (total)
+I (524782) perf:   HTTP retries:   10 (interval) / 72 (total)
+I (524787) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (524792) perf:   HTTP unreachable:10 (interval) / 68 (total)
+I (524798) perf:   WS events:      0 (interval) / 39 (total)
+I (524803) perf: ── JSON Parsing ──
+I (524807) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (524817) perf:   json_sequence            (no samples)
+I (524822) perf:   json_config_color        (no samples)
+I (524827) perf:   Parse calls:    0 (interval) / 263 (total)
+I (524832) perf: ── UI Updates ──
+I (524836) perf:   ui_update_total          avg=    2.0  min=    0.0  max=   29.8  last=    0.0 ms  [n=291]
+I (524845) perf:   ui_lock_wait             avg=    1.9  min=    0.0  max=   29.8  last=    0.0 ms  [n=291]
+I (524855) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=173]
+I (524864) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=118]
+I (524874) perf: ── Latency ──
+I (524877) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (524887) perf: ── JPEG ──
+I (524890) perf:   jpeg_decode              (no samples)
+I (524895) perf:   jpeg_fetch               (no samples)
+I (524900) perf: ── Spotify ──
+I (524903) perf:   spotify_poll_cycle       (no samples)
+I (524908) perf:   spotify_api_fetch        (no samples)
+I (524914) perf:   spotify_art_fetch        (no samples)
+I (524919) perf:   spotify_art_decode       (no samples)
+I (524924) perf:   spotify_ui_update        (no samples)
+I (524929) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (524934) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (524940) perf:   Spotify art:      0 (interval) / 0 (total)
+I (524945) perf: ── WiFi ──
+I (524948) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (524955) perf:   RSSI: cur=-56  avg=-59  min=-61  max=-56 dBm  [n=30]
+I (524961) perf:   Disconnects:    0 (interval) / 0 (total)
+I (524967) perf: ── Memory ──
+I (524970) perf:   Internal heap:  free=79079  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (524979) perf:   PSRAM:          free=20904060  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (524989) perf: ── Task Stacks ──
+I (524992) perf:   data_task HWM:  8080 bytes free
+I (524997) perf:   input_task HWM: 5484 bytes free
+I (525001) perf:   spotify_task HWM: 7164 bytes free
+W (525999) nina_client: astromele1.lan unreachable
+W (525999) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (526000) nina_client: === Poll Summary ===
+I (526004) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (526009) nina_client: Target: , Filter: 
+I (526013) nina_client: Exposure: 0.0s (0.0/0.0)
+I (526017) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (526023) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (527029) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (527263) nina_client: astromele2.lan unreachable
+I (527263) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (528134) nina_client: desktop-bdt978m.lan unreachable
+I (528134) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (528467) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (529135) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (530755) transport_ws: Error connecting to host astromele2.lan:1888
+E (530755) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (530767) nina_ws: WS[1]: Error
+I (530770) websocket_client: Reconnect after 86400000 ms
+W (530775) nina_ws: WS[1]: Disconnected from NINA
+W (533573) nina_client: astromele1.lan unreachable
+I (533573) nina_client: === Poll Summary ===
+I (533573) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (533576) nina_client: Target: , Filter: 
+I (533580) nina_client: Exposure: 0.0s (0.0/0.0)
+I (533584) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (533589) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (534079) tasks: Auto-rotate: switched to page 5
+I (534600) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (535002) nina_client: astromele2.lan unreachable
+I (535002) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (535101) tasks: Page switched to 5
+W (535738) nina_client: desktop-bdt978m.lan unreachable
+I (535738) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (541113) nina_client: astromele1.lan unreachable
+W (542517) nina_client: astromele2.lan unreachable
+I (542517) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (542518) websocket_client: Started
+W (547624) nina_client: astromele1.lan unreachable
+W (547624) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (547625) nina_client: === Poll Summary ===
+I (547629) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (547634) nina_client: Target: , Filter: 
+I (547638) nina_client: Exposure: 0.0s (0.0/0.0)
+I (547642) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (547648) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (548654) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (550226) tasks: Auto-rotate: switched to page 4
+I (551257) tasks: Page switched to 4 (summary)
+I (551257) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (552309) nina_client: desktop-bdt978m.lan unreachable
+I (552309) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (552574) transport_ws: Error connecting to host astromele2.lan:1888
+E (552574) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (552586) nina_ws: WS[1]: Error
+I (552589) websocket_client: Reconnect after 86400000 ms
+W (552594) nina_ws: WS[1]: Disconnected from NINA
+W (555214) nina_client: astromele1.lan unreachable
+I (555214) nina_client: === Poll Summary ===
+I (555214) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (555217) nina_client: Target: , Filter: 
+I (555221) nina_client: Exposure: 0.0s (0.0/0.0)
+I (555225) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (555230) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (555297) perf: uxTaskGetSystemState returned 0 tasks
+I (555297) perf: ╔══════════════════════════════════════════════════════════════╗
+I (555309) perf: ║              PERFORMANCE REPORT                             ║
+I (555316) perf: ╚══════════════════════════════════════════════════════════════╝
+I (555334) perf: ── Poll Cycle ──
+I (555338) perf:   poll_cycle_total         avg=   14.5  min=    5.9  max= 3057.2  last=    6.8 ms  [n=548]
+I (555348) perf:   effective_interval       avg=  998.4  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=547]
+I (555357) perf: ── Endpoint Fetchers ──
+I (555361) perf:   equipment_bundle         avg=  427.7  min=   10.3  max= 6568.5  last= 2904.5 ms  [n=219]
+I (555371) perf:   camera                   (no samples)
+I (555376) perf:   guider                   (no samples)
+I (555381) perf:   mount                    (no samples)
+I (555386) perf:   focuser                  (no samples)
+I (555391) perf:   sequence                 avg= 1006.7  min=   23.5  max= 6559.6  last= 6511.6 ms  [n=22]
+I (555400) perf:   switch                   (no samples)
+I (555405) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (555415) perf:   filter                   (no samples)
+I (555420) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (555429) perf: ── Network ──
+I (555433) perf:   http_request             avg=  570.3  min=    0.4  max= 7045.4  last= 2904.5 ms  [n=276]
+I (555442) perf:   HTTP requests:  10 (interval) / 344 (total)
+I (555448) perf:   HTTP retries:   10 (interval) / 82 (total)
+I (555453) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (555458) perf:   HTTP unreachable:11 (interval) / 79 (total)
+I (555464) perf:   WS events:      0 (interval) / 39 (total)
+I (555469) perf: ── JSON Parsing ──
+I (555473) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (555483) perf:   json_sequence            (no samples)
+I (555488) perf:   json_config_color        (no samples)
+I (555493) perf:   Parse calls:    0 (interval) / 263 (total)
+I (555498) perf: ── UI Updates ──
+I (555502) perf:   ui_update_total          avg=    2.0  min=    0.0  max=   29.8  last=    0.0 ms  [n=321]
+I (555511) perf:   ui_lock_wait             avg=    1.9  min=    0.0  max=   29.8  last=    0.0 ms  [n=321]
+I (555521) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=189]
+I (555530) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=132]
+I (555540) perf: ── Latency ──
+I (555543) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (555553) perf: ── JPEG ──
+I (555556) perf:   jpeg_decode              (no samples)
+I (555561) perf:   jpeg_fetch               (no samples)
+I (555566) perf: ── Spotify ──
+I (555569) perf:   spotify_poll_cycle       (no samples)
+I (555574) perf:   spotify_api_fetch        (no samples)
+I (555579) perf:   spotify_art_fetch        (no samples)
+I (555584) perf:   spotify_art_decode       (no samples)
+I (555589) perf:   spotify_ui_update        (no samples)
+I (555595) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (555600) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (555605) perf:   Spotify art:      0 (interval) / 0 (total)
+I (555611) perf: ── WiFi ──
+I (555614) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (555621) perf:   RSSI: cur=-60  avg=-60  min=-66  max=-58 dBm  [n=30]
+I (555627) perf:   Disconnects:    0 (interval) / 0 (total)
+I (555633) perf: ── Memory ──
+I (555636) perf:   Internal heap:  free=79163  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (555645) perf:   PSRAM:          free=20904636  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (555654) perf: ── Task Stacks ──
+I (555658) perf:   data_task HWM:  8080 bytes free
+I (555663) perf:   input_task HWM: 5484 bytes free
+I (555667) perf:   spotify_task HWM: 7164 bytes free
+I (556237) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (557786) nina_client: astromele2.lan unreachable
+I (557786) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (557786) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (557794) websocket_client: Started
+I (558796) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (558884) nina_client: desktop-bdt978m.lan unreachable
+I (558884) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (559885) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (562781) nina_client: astromele1.lan unreachable
+W (565346) nina_client: astromele2.lan unreachable
+I (565346) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (566346) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (566457) nina_client: desktop-bdt978m.lan unreachable
+I (566457) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (566757) tasks: Auto-rotate: switched to page 5
+I (567458) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (567782) tasks: Page switched to 5
+E (567833) transport_ws: Error connecting to host astromele2.lan:1888
+E (567833) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (567845) nina_ws: WS[1]: Error
+I (567848) websocket_client: Reconnect after 86400000 ms
+W (567853) nina_ws: WS[1]: Disconnected from NINA
+W (569413) nina_client: astromele1.lan unreachable
+W (569413) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (569414) nina_client: === Poll Summary ===
+I (569418) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (569423) nina_client: Target: , Filter: 
+I (569427) nina_client: Exposure: 0.0s (0.0/0.0)
+I (569431) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (569437) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (570443) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (572922) nina_client: astromele2.lan unreachable
+I (572922) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (572922) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (572929) websocket_client: Started
+W (573976) nina_client: desktop-bdt978m.lan unreachable
+I (573976) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (577001) nina_client: astromele1.lan unreachable
+I (577001) nina_client: === Poll Summary ===
+I (577001) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (577004) nina_client: Target: , Filter: 
+I (577008) nina_client: Exposure: 0.0s (0.0/0.0)
+I (577012) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (577017) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (578024) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (582908) tasks: Auto-rotate: switched to page 4
+E (582968) transport_ws: Error connecting to host astromele2.lan:1888
+E (582968) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (582980) nina_ws: WS[1]: Error
+I (582983) websocket_client: Reconnect after 86400000 ms
+W (582988) nina_ws: WS[1]: Disconnected from NINA
+I (583939) tasks: Page switched to 4 (summary)
+I (583939) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (584555) nina_client: astromele1.lan unreachable
+W (585963) perf: uxTaskGetSystemState returned 0 tasks
+I (585963) perf: ╔══════════════════════════════════════════════════════════════╗
+I (585975) perf: ║              PERFORMANCE REPORT                             ║
+I (585982) perf: ╚══════════════════════════════════════════════════════════════╝
+I (586000) perf: ── Poll Cycle ──
+I (586004) perf:   poll_cycle_total         avg=   14.2  min=    5.9  max= 3057.2  last=    6.9 ms  [n=578]
+I (586014) perf:   effective_interval       avg=  999.6  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=577]
+I (586023) perf: ── Endpoint Fetchers ──
+I (586027) perf:   equipment_bundle         avg=  450.7  min=   10.3  max= 6568.5  last=  615.6 ms  [n=225]
+I (586037) perf:   camera                   (no samples)
+I (586042) perf:   guider                   (no samples)
+I (586047) perf:   mount                    (no samples)
+I (586052) perf:   focuser                  (no samples)
+I (586057) perf:   sequence                 avg= 1251.3  min=   23.5  max= 6632.8  last= 6632.8 ms  [n=23]
+I (586066) perf:   switch                   (no samples)
+I (586071) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (586081) perf:   filter                   (no samples)
+I (586086) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (586095) perf: ── Network ──
+I (586099) perf:   http_request             avg=  597.4  min=    0.4  max= 7045.4  last=  615.6 ms  [n=284]
+I (586108) perf:   HTTP requests:  11 (interval) / 355 (total)
+I (586114) perf:   HTTP retries:   9 (interval) / 91 (total)
+I (586119) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (586124) perf:   HTTP unreachable:10 (interval) / 89 (total)
+I (586130) perf:   WS events:      0 (interval) / 39 (total)
+I (586135) perf: ── JSON Parsing ──
+I (586139) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (586149) perf:   json_sequence            (no samples)
+I (586154) perf:   json_config_color        (no samples)
+I (586159) perf:   Parse calls:    0 (interval) / 263 (total)
+I (586164) perf: ── UI Updates ──
+I (586168) perf:   ui_update_total          avg=    1.9  min=    0.0  max=   29.8  last=    0.0 ms  [n=351]
+I (586177) perf:   ui_lock_wait             avg=    1.8  min=    0.0  max=   29.8  last=    0.0 ms  [n=351]
+I (586187) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=205]
+I (586196) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=146]
+I (586206) perf: ── Latency ──
+I (586209) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (586219) perf: ── JPEG ──
+I (586222) perf:   jpeg_decode              (no samples)
+I (586227) perf:   jpeg_fetch               (no samples)
+I (586232) perf: ── Spotify ──
+I (586235) perf:   spotify_poll_cycle       (no samples)
+I (586240) perf:   spotify_api_fetch        (no samples)
+I (586245) perf:   spotify_art_fetch        (no samples)
+I (586250) perf:   spotify_art_decode       (no samples)
+I (586255) perf:   spotify_ui_update        (no samples)
+I (586260) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (586266) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (586271) perf:   Spotify art:      0 (interval) / 0 (total)
+I (586277) perf: ── WiFi ──
+I (586280) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (586287) perf:   RSSI: cur=-60  avg=-59  min=-61  max=-55 dBm  [n=30]
+I (586293) perf:   Disconnects:    0 (interval) / 0 (total)
+I (586299) perf: ── Memory ──
+I (586302) perf:   Internal heap:  free=79143  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (586311) perf:   PSRAM:          free=20904636  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (586320) perf: ── Task Stacks ──
+I (586324) perf:   data_task HWM:  8080 bytes free
+I (586329) perf:   input_task HWM: 5484 bytes free
+I (586333) perf:   spotify_task HWM: 7164 bytes free
+W (589476) nina_client: astromele2.lan unreachable
+I (589476) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (589477) websocket_client: Started
+I (589498) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (590842) nina_client: desktop-bdt978m.lan unreachable
+I (590842) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (591454) nina_client: astromele1.lan unreachable
+W (591454) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (591455) nina_client: === Poll Summary ===
+I (591459) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (591464) nina_client: Target: , Filter: 
+I (591468) nina_client: Exposure: 0.0s (0.0/0.0)
+I (591472) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (591478) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (591843) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (592484) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (596101) nina_client: astromele2.lan unreachable
+I (596101) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (597101) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (598440) nina_client: desktop-bdt978m.lan unreachable
+I (598440) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (599111) nina_client: astromele1.lan unreachable
+I (599111) nina_client: === Poll Summary ===
+I (599111) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (599114) nina_client: Target: , Filter: 
+I (599118) nina_client: Exposure: 0.0s (0.0/0.0)
+I (599122) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (599127) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (599439) tasks: Auto-rotate: switched to page 5
+I (599441) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (599499) transport_ws: Error connecting to host astromele2.lan:1888
+E (599499) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (599511) nina_ws: WS[1]: Error
+I (599514) websocket_client: Reconnect after 86400000 ms
+W (599519) nina_ws: WS[1]: Disconnected from NINA
+I (600138) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (600464) tasks: Page switched to 5
+W (603638) nina_client: astromele2.lan unreachable
+I (603638) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (605993) nina_client: desktop-bdt978m.lan unreachable
+I (605993) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (606690) nina_client: astromele1.lan unreachable
+W (613233) nina_client: astromele1.lan unreachable
+W (613233) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (613234) nina_client: === Poll Summary ===
+I (613238) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (613243) nina_client: Target: , Filter: 
+I (613247) nina_client: Exposure: 0.0s (0.0/0.0)
+I (613251) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (613257) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (614263) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (615590) tasks: Auto-rotate: switched to page 4
+I (616620) tasks: Page switched to 4 (summary)
+W (616628) perf: uxTaskGetSystemState returned 0 tasks
+I (616628) perf: ╔══════════════════════════════════════════════════════════════╗
+I (616640) perf: ║              PERFORMANCE REPORT                             ║
+I (616648) perf: ╚══════════════════════════════════════════════════════════════╝
+I (616666) perf: ── Poll Cycle ──
+I (616670) perf:   poll_cycle_total         avg=   13.9  min=    5.9  max= 3057.2  last=    7.2 ms  [n=608]
+I (616679) perf:   effective_interval       avg= 1000.7  min=    7.5  max= 4058.0  last= 1036.0 ms  [n=607]
+I (616689) perf: ── Endpoint Fetchers ──
+I (616693) perf:   equipment_bundle         avg=  485.6  min=   10.3  max= 6568.5  last= 3500.0 ms  [n=229]
+I (616702) perf:   camera                   (no samples)
+I (616707) perf:   guider                   (no samples)
+I (616712) perf:   mount                    (no samples)
+I (616717) perf:   focuser                  (no samples)
+I (616722) perf:   sequence                 avg= 1688.9  min=   23.5  max= 6899.6  last= 6543.6 ms  [n=25]
+I (616732) perf:   switch                   (no samples)
+I (616737) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (616746) perf:   filter                   (no samples)
+I (616751) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (616760) perf: ── Network ──
+I (616764) perf:   http_request             avg=  658.3  min=    0.4  max= 7045.4  last= 6543.0 ms  [n=290]
+I (616773) perf:   HTTP requests:  10 (interval) / 365 (total)
+I (616779) perf:   HTTP retries:   10 (interval) / 101 (total)
+I (616785) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (616790) perf:   HTTP unreachable:10 (interval) / 99 (total)
+I (616795) perf:   WS events:      0 (interval) / 39 (total)
+I (616801) perf: ── JSON Parsing ──
+I (616805) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (616814) perf:   json_sequence            (no samples)
+I (616819) perf:   json_config_color        (no samples)
+I (616824) perf:   Parse calls:    0 (interval) / 263 (total)
+I (616830) perf: ── UI Updates ──
+I (616833) perf:   ui_update_total          avg=    1.9  min=    0.0  max=   29.8  last=    0.0 ms  [n=381]
+I (616843) perf:   ui_lock_wait             avg=    1.8  min=    0.0  max=   29.8  last=    0.0 ms  [n=381]
+I (616852) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=221]
+I (616862) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=160]
+I (616871) perf: ── Latency ──
+I (616875) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (616884) perf: ── JPEG ──
+I (616887) perf:   jpeg_decode              (no samples)
+I (616892) perf:   jpeg_fetch               (no samples)
+I (616897) perf: ── Spotify ──
+I (616901) perf:   spotify_poll_cycle       (no samples)
+I (616906) perf:   spotify_api_fetch        (no samples)
+I (616911) perf:   spotify_art_fetch        (no samples)
+I (616916) perf:   spotify_art_decode       (no samples)
+I (616921) perf:   spotify_ui_update        (no samples)
+I (616926) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (616931) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (616937) perf:   Spotify art:      0 (interval) / 0 (total)
+I (616942) perf: ── WiFi ──
+I (616946) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (616952) perf:   RSSI: cur=-61  avg=-60  min=-66  max=-58 dBm  [n=30]
+I (616959) perf:   Disconnects:    0 (interval) / 0 (total)
+I (616964) perf: ── Memory ──
+I (616967) perf:   Internal heap:  free=76663  min_ever=56907  largest_block=31744  frag_ratio=0.414
+I (616976) perf:   PSRAM:          free=20904064  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (616986) perf: ── Task Stacks ──
+I (616990) perf:   data_task HWM:  8080 bytes free
+I (616994) perf:   input_task HWM: 5484 bytes free
+I (616999) perf:   spotify_task HWM: 7164 bytes free
+W (620162) nina_client: astromele2.lan unreachable
+I (620162) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (620163) websocket_client: Started
+I (620165) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (620779) nina_client: astromele1.lan unreachable
+I (620779) nina_client: === Poll Summary ===
+I (620779) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (620782) nina_client: Target: , Filter: 
+I (620786) nina_client: Exposure: 0.0s (0.0/0.0)
+I (620790) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (620795) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (621802) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (622518) nina_client: desktop-bdt978m.lan unreachable
+I (622518) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (626693) nina_client: astromele2.lan unreachable
+I (626693) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (627693) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (628319) nina_client: astromele1.lan unreachable
+W (629050) nina_client: desktop-bdt978m.lan unreachable
+I (629050) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (630051) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (630173) transport_ws: Error connecting to host astromele2.lan:1888
+E (630173) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (630185) nina_ws: WS[1]: Error
+I (630188) websocket_client: Reconnect after 86400000 ms
+W (630193) nina_ws: WS[1]: Disconnected from NINA
+I (632120) tasks: Auto-rotate: switched to page 5
+I (633146) tasks: Page switched to 5
+W (634270) nina_client: astromele2.lan unreachable
+I (634270) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (634838) nina_client: astromele1.lan unreachable
+W (634838) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (634839) nina_client: === Poll Summary ===
+I (634843) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (634848) nina_client: Target: , Filter: 
+I (634852) nina_client: Exposure: 0.0s (0.0/0.0)
+I (634856) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (634862) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (635868) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (636648) nina_client: desktop-bdt978m.lan unreachable
+I (636648) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (642453) nina_client: astromele1.lan unreachable
+I (642453) nina_client: === Poll Summary ===
+I (642453) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (642456) nina_client: Target: , Filter: 
+I (642460) nina_client: Exposure: 0.0s (0.0/0.0)
+I (642464) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (642469) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (643476) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (647268) perf: uxTaskGetSystemState returned 0 tasks
+I (647268) perf: ╔══════════════════════════════════════════════════════════════╗
+I (647280) perf: ║              PERFORMANCE REPORT                             ║
+I (647287) perf: ╚══════════════════════════════════════════════════════════════╝
+I (647306) perf: ── Poll Cycle ──
+I (647309) perf:   poll_cycle_total         avg=   13.6  min=    5.9  max= 3057.2  last=    7.0 ms  [n=638]
+I (647319) perf:   effective_interval       avg= 1001.7  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=637]
+I (647328) perf: ── Endpoint Fetchers ──
+I (647333) perf:   equipment_bundle         avg=  519.7  min=   10.3  max= 6568.5  last=  780.3 ms  [n=234]
+I (647342) perf:   camera                   (no samples)
+I (647347) perf:   guider                   (no samples)
+I (647352) perf:   mount                    (no samples)
+I (647357) perf:   focuser                  (no samples)
+I (647362) perf:   sequence                 avg= 1874.7  min=   23.5  max= 6899.6  last= 6519.6 ms  [n=26]
+I (647372) perf:   switch                   (no samples)
+I (647377) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (647386) perf:   filter                   (no samples)
+I (647391) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (647400) perf: ── Network ──
+I (647404) perf:   http_request             avg=  694.4  min=    0.4  max= 7045.4  last=  780.3 ms  [n=298]
+I (647413) perf:   HTTP requests:  10 (interval) / 375 (total)
+I (647419) perf:   HTTP retries:   11 (interval) / 112 (total)
+I (647424) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (647430) perf:   HTTP unreachable:10 (interval) / 109 (total)
+I (647435) perf:   WS events:      0 (interval) / 39 (total)
+I (647441) perf: ── JSON Parsing ──
+I (647444) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (647454) perf:   json_sequence            (no samples)
+I (647459) perf:   json_config_color        (no samples)
+I (647464) perf:   Parse calls:    0 (interval) / 263 (total)
+I (647469) perf: ── UI Updates ──
+I (647473) perf:   ui_update_total          avg=    1.8  min=    0.0  max=   29.8  last=    0.1 ms  [n=411]
+I (647483) perf:   ui_lock_wait             avg=    1.7  min=    0.0  max=   29.8  last=    0.0 ms  [n=411]
+I (647492) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=236]
+I (647502) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=175]
+I (647511) perf: ── Latency ──
+I (647515) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (647524) perf: ── JPEG ──
+I (647527) perf:   jpeg_decode              (no samples)
+I (647532) perf:   jpeg_fetch               (no samples)
+I (647537) perf: ── Spotify ──
+I (647541) perf:   spotify_poll_cycle       (no samples)
+I (647546) perf:   spotify_api_fetch        (no samples)
+I (647551) perf:   spotify_art_fetch        (no samples)
+I (647556) perf:   spotify_art_decode       (no samples)
+I (647561) perf:   spotify_ui_update        (no samples)
+I (647566) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (647571) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (647577) perf:   Spotify art:      0 (interval) / 0 (total)
+I (647582) perf: ── WiFi ──
+I (647585) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (647592) perf:   RSSI: cur=-58  avg=-59  min=-63  max=-53 dBm  [n=30]
+I (647599) perf:   Disconnects:    0 (interval) / 0 (total)
+I (647604) perf: ── Memory ──
+I (647607) perf:   Internal heap:  free=76675  min_ever=56907  largest_block=31744  frag_ratio=0.414
+I (647616) perf:   PSRAM:          free=20904064  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (647626) perf: ── Task Stacks ──
+I (647630) perf:   data_task HWM:  8080 bytes free
+I (647634) perf:   input_task HWM: 5484 bytes free
+I (647639) perf:   spotify_task HWM: 7164 bytes free
+I (648649) tasks: Auto-rotate: switched to page 4
+I (649671) tasks: Page switched to 4 (summary)
+W (650013) nina_client: astromele1.lan unreachable
+W (651396) nina_client: astromele2.lan unreachable
+I (651396) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (651397) websocket_client: Started
+I (651402) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (653382) nina_client: desktop-bdt978m.lan unreachable
+I (653382) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (656614) nina_client: astromele1.lan unreachable
+W (656614) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (656615) nina_client: === Poll Summary ===
+I (656619) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (656624) nina_client: Target: , Filter: 
+I (656628) nina_client: Exposure: 0.0s (0.0/0.0)
+I (656632) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (656638) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (657644) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (657920) nina_client: astromele2.lan unreachable
+I (657920) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (658920) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (659942) nina_client: desktop-bdt978m.lan unreachable
+I (659942) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (660943) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (661403) transport_ws: Error connecting to host astromele2.lan:1888
+E (661403) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (661415) nina_ws: WS[1]: Error
+I (661418) websocket_client: Reconnect after 86400000 ms
+W (661423) nina_ws: WS[1]: Disconnected from NINA
+W (664181) nina_client: astromele1.lan unreachable
+I (664181) nina_client: === Poll Summary ===
+I (664181) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (664184) nina_client: Target: , Filter: 
+I (664188) nina_client: Exposure: 0.0s (0.0/0.0)
+I (664192) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (664197) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (664795) tasks: Auto-rotate: switched to page 5
+I (665228) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (665509) nina_client: astromele2.lan unreachable
+I (665509) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (665827) tasks: Page switched to 5
+W (667518) nina_client: desktop-bdt978m.lan unreachable
+I (667518) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (671744) nina_client: astromele1.lan unreachable
+W (673293) nina_client: astromele2.lan unreachable
+I (673293) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (673294) websocket_client: Started
+W (677931) perf: uxTaskGetSystemState returned 0 tasks
+I (677931) perf: ╔══════════════════════════════════════════════════════════════╗
+I (677943) perf: ║              PERFORMANCE REPORT                             ║
+I (677950) perf: ╚══════════════════════════════════════════════════════════════╝
+I (677969) perf: ── Poll Cycle ──
+I (677972) perf:   poll_cycle_total         avg=   13.4  min=    5.9  max= 3057.2  last=    7.0 ms  [n=668]
+I (677982) perf:   effective_interval       avg= 1002.6  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=667]
+I (677991) perf: ── Endpoint Fetchers ──
+I (677996) perf:   equipment_bundle         avg=  556.4  min=   10.3  max= 6568.5  last=  281.2 ms  [n=239]
+I (678005) perf:   camera                   (no samples)
+I (678010) perf:   guider                   (no samples)
+I (678015) perf:   mount                    (no samples)
+I (678020) perf:   focuser                  (no samples)
+I (678025) perf:   sequence                 avg= 2049.8  min=   23.5  max= 6899.6  last= 6601.6 ms  [n=27]
+I (678035) perf:   switch                   (no samples)
+I (678040) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (678049) perf:   filter                   (no samples)
+I (678054) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (678063) perf: ── Network ──
+I (678067) perf:   http_request             avg=  728.1  min=    0.4  max= 7045.4  last= 1549.0 ms  [n=308]
+I (678076) perf:   HTTP requests:  10 (interval) / 385 (total)
+I (678082) perf:   HTTP retries:   10 (interval) / 122 (total)
+I (678087) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (678093) perf:   HTTP unreachable:11 (interval) / 120 (total)
+I (678098) perf:   WS events:      0 (interval) / 39 (total)
+I (678104) perf: ── JSON Parsing ──
+I (678107) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (678117) perf:   json_sequence            (no samples)
+I (678122) perf:   json_config_color        (no samples)
+I (678127) perf:   Parse calls:    0 (interval) / 263 (total)
+I (678132) perf: ── UI Updates ──
+I (678136) perf:   ui_update_total          avg=    1.7  min=    0.0  max=   29.8  last=    0.1 ms  [n=441]
+I (678146) perf:   ui_lock_wait             avg=    1.7  min=    0.0  max=   29.8  last=    0.0 ms  [n=441]
+I (678155) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=250]
+I (678165) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=191]
+I (678174) perf: ── Latency ──
+I (678178) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (678187) perf: ── JPEG ──
+I (678190) perf:   jpeg_decode              (no samples)
+I (678195) perf:   jpeg_fetch               (no samples)
+I (678200) perf: ── Spotify ──
+I (678204) perf:   spotify_poll_cycle       (no samples)
+I (678209) perf:   spotify_api_fetch        (no samples)
+I (678214) perf:   spotify_art_fetch        (no samples)
+I (678219) perf:   spotify_art_decode       (no samples)
+I (678224) perf:   spotify_ui_update        (no samples)
+I (678229) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (678234) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (678240) perf:   Spotify art:      0 (interval) / 0 (total)
+I (678245) perf: ── WiFi ──
+I (678248) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (678255) perf:   RSSI: cur=-60  avg=-59  min=-62  max=-58 dBm  [n=30]
+I (678262) perf:   Disconnects:    0 (interval) / 0 (total)
+I (678267) perf: ── Memory ──
+I (678270) perf:   Internal heap:  free=78967  min_ever=56907  largest_block=31744  frag_ratio=0.402
+I (678279) perf:   PSRAM:          free=20904052  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (678289) perf: ── Task Stacks ──
+I (678293) perf:   data_task HWM:  8080 bytes free
+I (678297) perf:   input_task HWM: 5484 bytes free
+W (678301) nina_client: astromele1.lan unreachable
+I (678302) perf:   spotify_task HWM: 7164 bytes free
+W (678306) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (678318) nina_client: === Poll Summary ===
+I (678322) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (678328) nina_client: Target: , Filter: 
+I (678331) nina_client: Exposure: 0.0s (0.0/0.0)
+I (678336) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (678341) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (679348) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (681333) tasks: Auto-rotate: switched to page 4
+I (682353) tasks: Page switched to 4 (summary)
+I (682353) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (683341) transport_ws: Error connecting to host astromele2.lan:1888
+E (683341) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (683353) nina_ws: WS[1]: Error
+I (683356) websocket_client: Reconnect after 86400000 ms
+W (683361) nina_ws: WS[1]: Disconnected from NINA
+W (684043) nina_client: desktop-bdt978m.lan unreachable
+I (684043) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (685876) nina_client: astromele1.lan unreachable
+I (685876) nina_client: === Poll Summary ===
+I (685876) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (685879) nina_client: Target: , Filter: 
+I (685883) nina_client: Exposure: 0.0s (0.0/0.0)
+I (685887) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (685892) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (686899) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (688911) nina_client: astromele2.lan unreachable
+I (688911) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (688911) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (688918) websocket_client: Started
+I (689921) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (690563) nina_client: desktop-bdt978m.lan unreachable
+I (690563) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (691564) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (693551) nina_client: astromele1.lan unreachable
+W (696484) nina_client: astromele2.lan unreachable
+I (696484) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (697478) tasks: Auto-rotate: switched to page 5
+I (697484) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (698087) nina_client: desktop-bdt978m.lan unreachable
+I (698087) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (698509) tasks: Page switched to 5
+E (698923) transport_ws: Error connecting to host astromele2.lan:1888
+E (698923) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (698935) nina_ws: WS[1]: Error
+I (698938) websocket_client: Reconnect after 86400000 ms
+W (698943) nina_ws: WS[1]: Disconnected from NINA
+W (700082) nina_client: astromele1.lan unreachable
+W (700082) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (700083) nina_client: === Poll Summary ===
+I (700087) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (700092) nina_client: Target: , Filter: 
+I (700096) nina_client: Exposure: 0.0s (0.0/0.0)
+I (700100) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (700106) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (701112) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (704009) nina_client: astromele2.lan unreachable
+I (704009) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (704009) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (704017) websocket_client: Started
+W (705631) nina_client: desktop-bdt978m.lan unreachable
+W (707661) nina_client: astromele1.lan unreachable
+I (707661) nina_client: === Poll Summary ===
+I (707661) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (707664) nina_client: Target: , Filter: 
+I (707668) nina_client: Exposure: 0.0s (0.0/0.0)
+I (707672) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (707677) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (708596) perf: uxTaskGetSystemState returned 0 tasks
+I (708596) perf: ╔══════════════════════════════════════════════════════════════╗
+I (708608) perf: ║              PERFORMANCE REPORT                             ║
+I (708615) perf: ╚══════════════════════════════════════════════════════════════╝
+I (708634) perf: ── Poll Cycle ──
+I (708637) perf:   poll_cycle_total         avg=   13.2  min=    5.9  max= 3057.2  last=    6.9 ms  [n=698]
+I (708647) perf:   effective_interval       avg= 1003.5  min=    7.5  max= 4058.0  last= 1007.0 ms  [n=697]
+I (708656) perf: ── Endpoint Fetchers ──
+I (708661) perf:   equipment_bundle         avg=  583.5  min=   10.3  max= 6568.5  last= 2897.3 ms  [n=245]
+I (708670) perf:   camera                   (no samples)
+I (708675) perf:   guider                   (no samples)
+I (708680) perf:   mount                    (no samples)
+I (708684) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (708685) perf:   focuser                  (no samples)
+I (708697) perf:   sequence                 avg= 2360.3  min=   23.5  max= 6899.6  last= 6531.7 ms  [n=29]
+I (708706) perf:   switch                   (no samples)
+I (708711) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (708721) perf:   filter                   (no samples)
+I (708726) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (708735) perf: ── Network ──
+I (708738) perf:   http_request             avg=  756.7  min=    0.4  max= 7045.4  last= 2897.3 ms  [n=318]
+I (708748) perf:   HTTP requests:  11 (interval) / 396 (total)
+I (708753) perf:   HTTP retries:   11 (interval) / 133 (total)
+I (708759) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (708764) perf:   HTTP unreachable:11 (interval) / 132 (total)
+I (708770) perf:   WS events:      0 (interval) / 39 (total)
+I (708775) perf: ── JSON Parsing ──
+I (708779) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (708789) perf:   json_sequence            (no samples)
+I (708794) perf:   json_config_color        (no samples)
+I (708799) perf:   Parse calls:    0 (interval) / 263 (total)
+I (708804) perf: ── UI Updates ──
+I (708808) perf:   ui_update_total          avg=    1.7  min=    0.0  max=   29.8  last=    0.1 ms  [n=471]
+I (708817) perf:   ui_lock_wait             avg=    1.6  min=    0.0  max=   29.8  last=    0.0 ms  [n=471]
+I (708827) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=264]
+I (708836) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=207]
+I (708846) perf: ── Latency ──
+I (708849) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (708859) perf: ── JPEG ──
+I (708862) perf:   jpeg_decode              (no samples)
+I (708867) perf:   jpeg_fetch               (no samples)
+I (708872) perf: ── Spotify ──
+I (708875) perf:   spotify_poll_cycle       (no samples)
+I (708880) perf:   spotify_api_fetch        (no samples)
+I (708885) perf:   spotify_art_fetch        (no samples)
+I (708890) perf:   spotify_art_decode       (no samples)
+I (708895) perf:   spotify_ui_update        (no samples)
+I (708900) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (708906) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (708911) perf:   Spotify art:      0 (interval) / 0 (total)
+I (708917) perf: ── WiFi ──
+I (708920) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (708927) perf:   RSSI: cur=-59  avg=-59  min=-62  max=-57 dBm  [n=30]
+I (708933) perf:   Disconnects:    0 (interval) / 0 (total)
+I (708939) perf: ── Memory ──
+I (708942) perf:   Internal heap:  free=83919  min_ever=56907  largest_block=31744  frag_ratio=0.378
+I (708951) perf:   PSRAM:          free=20905256  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (708960) perf: ── Task Stacks ──
+I (708964) perf:   data_task HWM:  8080 bytes free
+I (708969) perf:   input_task HWM: 5484 bytes free
+I (708973) perf:   spotify_task HWM: 7164 bytes free
+I (714016) tasks: Auto-rotate: switched to page 4
+E (714035) transport_ws: Error connecting to host astromele2.lan:1888
+E (714035) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (714047) nina_ws: WS[1]: Error
+I (714050) websocket_client: Reconnect after 86400000 ms
+W (714055) nina_ws: WS[1]: Disconnected from NINA
+I (715034) tasks: Page switched to 4 (summary)
+I (715034) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (715394) nina_client: astromele1.lan unreachable
+W (720581) nina_client: astromele2.lan unreachable
+I (720581) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (720582) websocket_client: Started
+I (720584) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (721590) nina_client: desktop-bdt978m.lan unreachable
+I (721590) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (721909) nina_client: astromele1.lan unreachable
+W (721909) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (721910) nina_client: === Poll Summary ===
+I (721913) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (721919) nina_client: Target: , Filter: 
+I (721923) nina_client: Exposure: 0.0s (0.0/0.0)
+I (721927) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (721933) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (722591) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (722939) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (727140) nina_client: astromele2.lan unreachable
+I (727140) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (728140) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (729115) nina_client: desktop-bdt978m.lan unreachable
+I (729115) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (729474) nina_client: astromele1.lan unreachable
+I (729474) nina_client: === Poll Summary ===
+I (729474) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (729477) nina_client: Target: , Filter: 
+I (729481) nina_client: Exposure: 0.0s (0.0/0.0)
+I (729485) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (729490) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (730116) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (730159) tasks: Auto-rotate: switched to page 5
+I (730501) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (730618) transport_ws: Error connecting to host astromele2.lan:1888
+E (730618) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (730630) nina_ws: WS[1]: Error
+I (730633) websocket_client: Reconnect after 86400000 ms
+W (730638) nina_ws: WS[1]: Disconnected from NINA
+I (731191) tasks: Page switched to 5
+W (734688) nina_client: astromele2.lan unreachable
+I (734688) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (736657) nina_client: desktop-bdt978m.lan unreachable
+I (736657) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (737044) nina_client: astromele1.lan unreachable
+W (739263) perf: uxTaskGetSystemState returned 0 tasks
+I (739263) perf: ╔══════════════════════════════════════════════════════════════╗
+I (739275) perf: ║              PERFORMANCE REPORT                             ║
+I (739282) perf: ╚══════════════════════════════════════════════════════════════╝
+I (739301) perf: ── Poll Cycle ──
+I (739304) perf:   poll_cycle_total         avg=   13.0  min=    5.9  max= 3057.2  last=    7.1 ms  [n=728]
+I (739314) perf:   effective_interval       avg= 1004.2  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=727]
+I (739323) perf: ── Endpoint Fetchers ──
+I (739328) perf:   equipment_bundle         avg=  614.7  min=   10.3  max= 6568.5  last= 4186.6 ms  [n=250]
+I (739337) perf:   camera                   (no samples)
+I (739342) perf:   guider                   (no samples)
+I (739347) perf:   mount                    (no samples)
+I (739352) perf:   focuser                  (no samples)
+I (739357) perf:   sequence                 avg= 2498.9  min=   23.5  max= 6899.6  last= 6515.6 ms  [n=30]
+I (739367) perf:   switch                   (no samples)
+I (739372) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (739381) perf:   filter                   (no samples)
+I (739386) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (739395) perf: ── Network ──
+I (739399) perf:   http_request             avg=  791.8  min=    0.4  max= 7045.4  last= 4186.5 ms  [n=324]
+I (739408) perf:   HTTP requests:  10 (interval) / 406 (total)
+I (739414) perf:   HTTP retries:   10 (interval) / 143 (total)
+I (739419) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (739425) perf:   HTTP unreachable:10 (interval) / 142 (total)
+I (739430) perf:   WS events:      0 (interval) / 39 (total)
+I (739436) perf: ── JSON Parsing ──
+I (739440) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (739449) perf:   json_sequence            (no samples)
+I (739454) perf:   json_config_color        (no samples)
+I (739459) perf:   Parse calls:    0 (interval) / 263 (total)
+I (739465) perf: ── UI Updates ──
+I (739468) perf:   ui_update_total          avg=    1.7  min=    0.0  max=   29.8  last=    0.2 ms  [n=501]
+I (739478) perf:   ui_lock_wait             avg=    1.6  min=    0.0  max=   29.8  last=    0.2 ms  [n=501]
+I (739487) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=278]
+I (739497) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=223]
+I (739506) perf: ── Latency ──
+I (739510) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (739519) perf: ── JPEG ──
+I (739522) perf:   jpeg_decode              (no samples)
+I (739527) perf:   jpeg_fetch               (no samples)
+I (739532) perf: ── Spotify ──
+I (739536) perf:   spotify_poll_cycle       (no samples)
+I (739541) perf:   spotify_api_fetch        (no samples)
+I (739546) perf:   spotify_art_fetch        (no samples)
+I (739551) perf:   spotify_art_decode       (no samples)
+I (739556) perf:   spotify_ui_update        (no samples)
+I (739561) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (739566) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (739572) perf:   Spotify art:      0 (interval) / 0 (total)
+I (739577) perf: ── WiFi ──
+I (739581) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (739587) perf:   RSSI: cur=-60  avg=-59  min=-64  max=-57 dBm  [n=30]
+I (739594) perf:   Disconnects:    0 (interval) / 0 (total)
+I (739599) perf: ── Memory ──
+I (739602) perf:   Internal heap:  free=81599  min_ever=56907  largest_block=31744  frag_ratio=0.389
+I (739611) perf:   PSRAM:          free=20905256  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (739621) perf: ── Task Stacks ──
+I (739625) perf:   data_task HWM:  8080 bytes free
+I (739629) perf:   input_task HWM: 5484 bytes free
+I (739634) perf:   spotify_task HWM: 7164 bytes free
+W (743607) nina_client: astromele1.lan unreachable
+W (743607) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (743608) nina_client: === Poll Summary ===
+I (743612) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (743617) nina_client: Target: , Filter: 
+I (743621) nina_client: Exposure: 0.0s (0.0/0.0)
+I (743625) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (743631) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (744637) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (746692) tasks: Auto-rotate: switched to page 4
+I (747716) tasks: Page switched to 4 (summary)
+W (751161) nina_client: astromele1.lan unreachable
+I (751161) nina_client: === Poll Summary ===
+I (751161) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (751164) nina_client: Target: , Filter: 
+I (751168) nina_client: Exposure: 0.0s (0.0/0.0)
+I (751172) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (751177) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (751199) nina_client: astromele2.lan unreachable
+I (751199) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (751200) websocket_client: Started
+I (751202) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (752184) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (753181) nina_client: desktop-bdt978m.lan unreachable
+I (753181) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (757742) nina_client: astromele2.lan unreachable
+I (757742) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (758694) nina_client: astromele1.lan unreachable
+I (758742) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (759730) nina_client: desktop-bdt978m.lan unreachable
+I (759730) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (760731) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (761205) transport_ws: Error connecting to host astromele2.lan:1888
+E (761205) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (761217) nina_ws: WS[1]: Error
+I (761220) websocket_client: Reconnect after 86400000 ms
+W (761225) nina_ws: WS[1]: Disconnected from NINA
+I (762841) tasks: Auto-rotate: switched to page 5
+I (763872) tasks: Page switched to 5
+W (765232) nina_client: astromele1.lan unreachable
+W (765232) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (765233) nina_client: === Poll Summary ===
+I (765237) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (765242) nina_client: Target: , Filter: 
+I (765246) nina_client: Exposure: 0.0s (0.0/0.0)
+I (765250) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (765256) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (765264) nina_client: astromele2.lan unreachable
+I (765267) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (766263) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (767273) nina_client: desktop-bdt978m.lan unreachable
+I (767273) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (769928) perf: uxTaskGetSystemState returned 0 tasks
+I (769928) perf: ╔══════════════════════════════════════════════════════════════╗
+I (769940) perf: ║              PERFORMANCE REPORT                             ║
+I (769947) perf: ╚══════════════════════════════════════════════════════════════╝
+I (769966) perf: ── Poll Cycle ──
+I (769969) perf:   poll_cycle_total         avg=   12.8  min=    5.9  max= 3057.2  last=    7.0 ms  [n=758]
+I (769979) perf:   effective_interval       avg= 1005.0  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=757]
+I (769988) perf: ── Endpoint Fetchers ──
+I (769993) perf:   equipment_bundle         avg=  671.7  min=   10.3  max= 6568.5  last= 1010.3 ms  [n=255]
+I (770002) perf:   camera                   (no samples)
+I (770007) perf:   guider                   (no samples)
+I (770012) perf:   mount                    (no samples)
+I (770017) perf:   focuser                  (no samples)
+I (770022) perf:   sequence                 avg= 2752.1  min=   23.5  max= 6899.6  last= 6538.7 ms  [n=32]
+I (770032) perf:   switch                   (no samples)
+I (770037) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (770046) perf:   filter                   (no samples)
+I (770051) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (770060) perf: ── Network ──
+I (770064) perf:   http_request             avg=  844.9  min=    0.4  max= 7045.4  last= 1010.3 ms  [n=331]
+I (770073) perf:   HTTP requests:  10 (interval) / 416 (total)
+I (770079) perf:   HTTP retries:   11 (interval) / 154 (total)
+I (770084) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (770090) perf:   HTTP unreachable:10 (interval) / 152 (total)
+I (770095) perf:   WS events:      0 (interval) / 39 (total)
+I (770101) perf: ── JSON Parsing ──
+I (770104) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (770114) perf:   json_sequence            (no samples)
+I (770119) perf:   json_config_color        (no samples)
+I (770124) perf:   Parse calls:    0 (interval) / 263 (total)
+I (770129) perf: ── UI Updates ──
+I (770133) perf:   ui_update_total          avg=    1.7  min=    0.0  max=   29.8  last=    0.1 ms  [n=531]
+I (770143) perf:   ui_lock_wait             avg=    1.6  min=    0.0  max=   29.8  last=    0.0 ms  [n=531]
+I (770152) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=292]
+I (770162) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=239]
+I (770171) perf: ── Latency ──
+I (770175) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (770184) perf: ── JPEG ──
+I (770187) perf:   jpeg_decode              (no samples)
+I (770192) perf:   jpeg_fetch               (no samples)
+I (770197) perf: ── Spotify ──
+I (770201) perf:   spotify_poll_cycle       (no samples)
+I (770206) perf:   spotify_api_fetch        (no samples)
+I (770211) perf:   spotify_art_fetch        (no samples)
+I (770216) perf:   spotify_art_decode       (no samples)
+I (770221) perf:   spotify_ui_update        (no samples)
+I (770226) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (770231) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (770237) perf:   Spotify art:      0 (interval) / 0 (total)
+I (770242) perf: ── WiFi ──
+I (770245) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (770252) perf:   RSSI: cur=-60  avg=-59  min=-67  max=-57 dBm  [n=30]
+I (770259) perf:   Disconnects:    0 (interval) / 0 (total)
+I (770264) perf: ── Memory ──
+I (770267) perf:   Internal heap:  free=81575  min_ever=56907  largest_block=31744  frag_ratio=0.389
+I (770276) perf:   PSRAM:          free=20905228  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (770286) perf: ── Task Stacks ──
+I (770290) perf:   data_task HWM:  8080 bytes free
+I (770294) perf:   input_task HWM: 5484 bytes free
+I (770299) perf:   spotify_task HWM: 7164 bytes free
+W (772896) nina_client: astromele1.lan unreachable
+I (772896) nina_client: === Poll Summary ===
+I (772896) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (772899) nina_client: Target: , Filter: 
+I (772903) nina_client: Exposure: 0.0s (0.0/0.0)
+I (772907) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (772912) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (773919) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (779373) tasks: Auto-rotate: switched to page 4
+I (780398) tasks: Page switched to 4 (summary)
+W (780479) nina_client: astromele1.lan unreachable
+W (781815) nina_client: astromele2.lan unreachable
+I (781815) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (781816) websocket_client: Started
+I (781818) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (783786) nina_client: desktop-bdt978m.lan unreachable
+I (783786) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (787027) nina_client: astromele1.lan unreachable
+W (787027) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (787028) nina_client: === Poll Summary ===
+I (787032) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (787037) nina_client: Target: , Filter: 
+I (787041) nina_client: Exposure: 0.0s (0.0/0.0)
+I (787045) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (787051) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (788057) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (788381) nina_client: astromele2.lan unreachable
+I (788381) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (789381) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (790311) nina_client: desktop-bdt978m.lan unreachable
+I (790311) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (791312) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (791821) transport_ws: Error connecting to host astromele2.lan:1888
+E (791821) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (791833) nina_ws: WS[1]: Error
+I (791836) websocket_client: Reconnect after 86400000 ms
+W (791841) nina_ws: WS[1]: Disconnected from NINA
+W (794587) nina_client: astromele1.lan unreachable
+I (794587) nina_client: === Poll Summary ===
+I (794587) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (794590) nina_client: Target: , Filter: 
+I (794594) nina_client: Exposure: 0.0s (0.0/0.0)
+I (794598) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (794603) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (795522) tasks: Auto-rotate: switched to page 5
+I (795621) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (795915) nina_client: astromele2.lan unreachable
+I (795915) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (796554) tasks: Page switched to 5
+W (797826) nina_client: desktop-bdt978m.lan unreachable
+I (797826) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (800594) perf: uxTaskGetSystemState returned 0 tasks
+I (800594) perf: ╔══════════════════════════════════════════════════════════════╗
+I (800606) perf: ║              PERFORMANCE REPORT                             ║
+I (800613) perf: ╚══════════════════════════════════════════════════════════════╝
+I (800632) perf: ── Poll Cycle ──
+I (800635) perf:   poll_cycle_total         avg=   12.7  min=    5.9  max= 3057.2  last=    7.0 ms  [n=788]
+I (800645) perf:   effective_interval       avg= 1005.6  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=787]
+I (800654) perf: ── Endpoint Fetchers ──
+I (800659) perf:   equipment_bundle         avg=  702.6  min=   10.3  max= 6568.5  last=  293.8 ms  [n=260]
+I (800668) perf:   camera                   (no samples)
+I (800673) perf:   guider                   (no samples)
+I (800678) perf:   mount                    (no samples)
+I (800683) perf:   focuser                  (no samples)
+I (800688) perf:   sequence                 avg= 2867.2  min=   23.5  max= 6899.6  last= 6548.6 ms  [n=33]
+I (800698) perf:   switch                   (no samples)
+I (800703) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (800712) perf:   filter                   (no samples)
+I (800717) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (800726) perf: ── Network ──
+I (800730) perf:   http_request             avg=  868.1  min=    0.4  max= 7045.4  last=  911.4 ms  [n=340]
+I (800739) perf:   HTTP requests:  11 (interval) / 427 (total)
+I (800745) perf:   HTTP retries:   11 (interval) / 165 (total)
+I (800750) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (800756) perf:   HTTP unreachable:10 (interval) / 162 (total)
+I (800761) perf:   WS events:      0 (interval) / 39 (total)
+I (800767) perf: ── JSON Parsing ──
+I (800770) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (800780) perf:   json_sequence            (no samples)
+I (800785) perf:   json_config_color        (no samples)
+I (800790) perf:   Parse calls:    0 (interval) / 263 (total)
+I (800795) perf: ── UI Updates ──
+I (800799) perf:   ui_update_total          avg=    1.6  min=    0.0  max=   29.8  last=    0.1 ms  [n=561]
+I (800809) perf:   ui_lock_wait             avg=    1.6  min=    0.0  max=   29.8  last=    0.0 ms  [n=561]
+I (800818) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=306]
+I (800828) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.1 ms  [n=255]
+I (800837) perf: ── Latency ──
+I (800841) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (800850) perf: ── JPEG ──
+I (800853) perf:   jpeg_decode              (no samples)
+I (800858) perf:   jpeg_fetch               (no samples)
+I (800863) perf: ── Spotify ──
+I (800867) perf:   spotify_poll_cycle       (no samples)
+I (800872) perf:   spotify_api_fetch        (no samples)
+I (800877) perf:   spotify_art_fetch        (no samples)
+I (800882) perf:   spotify_art_decode       (no samples)
+I (800887) perf:   spotify_ui_update        (no samples)
+I (800892) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (800897) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (800903) perf:   Spotify art:      0 (interval) / 0 (total)
+I (800908) perf: ── WiFi ──
+I (800911) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (800918) perf:   RSSI: cur=-59  avg=-59  min=-62  max=-58 dBm  [n=30]
+I (800925) perf:   Disconnects:    0 (interval) / 0 (total)
+I (800930) perf: ── Memory ──
+I (800933) perf:   Internal heap:  free=79143  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (800942) perf:   PSRAM:          free=20904652  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (800952) perf: ── Task Stacks ──
+I (800956) perf:   data_task HWM:  8080 bytes free
+I (800960) perf:   input_task HWM: 5484 bytes free
+I (800965) perf:   spotify_task HWM: 7164 bytes free
+W (802170) nina_client: astromele1.lan unreachable
+W (803426) nina_client: astromele2.lan unreachable
+I (803426) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (803427) websocket_client: Started
+W (808733) nina_client: astromele1.lan unreachable
+W (808733) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (808734) nina_client: === Poll Summary ===
+I (808738) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (808743) nina_client: Target: , Filter: 
+I (808747) nina_client: Exposure: 0.0s (0.0/0.0)
+I (808751) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (808757) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (809763) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (812055) tasks: Auto-rotate: switched to page 4
+I (813079) tasks: Page switched to 4 (summary)
+I (813079) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (813471) transport_ws: Error connecting to host astromele2.lan:1888
+E (813471) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (813483) nina_ws: WS[1]: Error
+I (813486) websocket_client: Reconnect after 86400000 ms
+W (813491) nina_ws: WS[1]: Disconnected from NINA
+W (814410) nina_client: desktop-bdt978m.lan unreachable
+I (814410) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (816291) nina_client: astromele1.lan unreachable
+I (816291) nina_client: === Poll Summary ===
+I (816291) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (816294) nina_client: Target: , Filter: 
+I (816298) nina_client: Exposure: 0.0s (0.0/0.0)
+I (816302) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (816307) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (817314) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (819637) nina_client: astromele2.lan unreachable
+I (819637) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (819637) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (819645) websocket_client: Started
+I (820647) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (820928) nina_client: desktop-bdt978m.lan unreachable
+I (820928) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (821929) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (823835) nina_client: astromele1.lan unreachable
+W (827176) nina_client: astromele2.lan unreachable
+I (827176) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (828176) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (828203) tasks: Auto-rotate: switched to page 5
+W (828473) nina_client: desktop-bdt978m.lan unreachable
+I (828473) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (829235) tasks: Page switched to 5
+E (829669) transport_ws: Error connecting to host astromele2.lan:1888
+E (829669) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (829681) nina_ws: WS[1]: Error
+I (829684) websocket_client: Reconnect after 86400000 ms
+W (829689) nina_ws: WS[1]: Disconnected from NINA
+W (831102) nina_client: astromele1.lan unreachable
+W (831102) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (831103) nina_client: === Poll Summary ===
+I (831107) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (831112) nina_client: Target: , Filter: 
+I (831116) nina_client: Exposure: 0.0s (0.0/0.0)
+I (831120) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (831126) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (831259) perf: uxTaskGetSystemState returned 0 tasks
+I (831259) perf: ╔══════════════════════════════════════════════════════════════╗
+I (831271) perf: ║              PERFORMANCE REPORT                             ║
+I (831278) perf: ╚══════════════════════════════════════════════════════════════╝
+I (831297) perf: ── Poll Cycle ──
+I (831300) perf:   poll_cycle_total         avg=   12.5  min=    5.9  max= 3057.2  last=    6.9 ms  [n=818]
+I (831310) perf:   effective_interval       avg= 1006.2  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=817]
+I (831319) perf: ── Endpoint Fetchers ──
+I (831324) perf:   equipment_bundle         avg=  714.6  min=   10.3  max= 6568.5  last=  297.5 ms  [n=265]
+I (831333) perf:   camera                   (no samples)
+I (831338) perf:   guider                   (no samples)
+I (831343) perf:   mount                    (no samples)
+I (831348) perf:   focuser                  (no samples)
+I (831353) perf:   sequence                 avg= 3098.5  min=   23.5  max= 7267.7  last= 7267.7 ms  [n=35]
+I (831363) perf:   switch                   (no samples)
+I (831368) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (831377) perf:   filter                   (no samples)
+I (831382) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (831391) perf: ── Network ──
+I (831395) perf:   http_request             avg=  886.4  min=    0.4  max= 7045.4  last= 1628.4 ms  [n=350]
+I (831404) perf:   HTTP requests:  11 (interval) / 438 (total)
+I (831410) perf:   HTTP retries:   9 (interval) / 174 (total)
+I (831415) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (831420) perf:   HTTP unreachable:11 (interval) / 173 (total)
+I (831426) perf:   WS events:      0 (interval) / 39 (total)
+I (831431) perf: ── JSON Parsing ──
+I (831435) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (831445) perf:   json_sequence            (no samples)
+I (831450) perf:   json_config_color        (no samples)
+I (831455) perf:   Parse calls:    0 (interval) / 263 (total)
+I (831460) perf: ── UI Updates ──
+I (831464) perf:   ui_update_total          avg=    1.6  min=    0.0  max=   29.8  last=    0.1 ms  [n=591]
+I (831474) perf:   ui_lock_wait             avg=    1.6  min=    0.0  max=   29.8  last=    0.0 ms  [n=591]
+I (831483) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=320]
+I (831492) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=271]
+I (831502) perf: ── Latency ──
+I (831505) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (831515) perf: ── JPEG ──
+I (831518) perf:   jpeg_decode              (no samples)
+I (831523) perf:   jpeg_fetch               (no samples)
+I (831528) perf: ── Spotify ──
+I (831532) perf:   spotify_poll_cycle       (no samples)
+I (831537) perf:   spotify_api_fetch        (no samples)
+I (831542) perf:   spotify_art_fetch        (no samples)
+I (831547) perf:   spotify_art_decode       (no samples)
+I (831552) perf:   spotify_ui_update        (no samples)
+I (831557) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (831562) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (831568) perf:   Spotify art:      0 (interval) / 0 (total)
+I (831573) perf: ── WiFi ──
+I (831576) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (831583) perf:   RSSI: cur=-60  avg=-59  min=-61  max=-55 dBm  [n=30]
+I (831589) perf:   Disconnects:    0 (interval) / 0 (total)
+I (831595) perf: ── Memory ──
+I (831598) perf:   Internal heap:  free=79103  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (831607) perf:   PSRAM:          free=20904684  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (831617) perf: ── Task Stacks ──
+I (831620) perf:   data_task HWM:  8080 bytes free
+I (831625) perf:   input_task HWM: 5484 bytes free
+I (831630) perf:   spotify_task HWM: 7164 bytes free
+I (832132) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (834944) nina_client: astromele2.lan unreachable
+I (834944) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (834944) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (834952) websocket_client: Started
+W (836056) nina_client: desktop-bdt978m.lan unreachable
+W (838645) nina_client: astromele1.lan unreachable
+I (838645) nina_client: === Poll Summary ===
+I (838645) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (838648) nina_client: Target: , Filter: 
+I (838652) nina_client: Exposure: 0.0s (0.0/0.0)
+I (838656) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (838661) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (839668) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (844736) tasks: Auto-rotate: switched to page 4
+E (845006) transport_ws: Error connecting to host astromele2.lan:1888
+E (845006) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (845018) nina_ws: WS[1]: Error
+I (845021) websocket_client: Reconnect after 86400000 ms
+W (845026) nina_ws: WS[1]: Disconnected from NINA
+I (845761) tasks: Page switched to 4 (summary)
+I (845761) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (846217) nina_client: astromele1.lan unreachable
+W (851519) nina_client: astromele2.lan unreachable
+I (851519) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (851520) websocket_client: Started
+I (851522) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (852345) nina_client: desktop-bdt978m.lan unreachable
+I (852345) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (852986) nina_client: astromele1.lan unreachable
+W (852986) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (852987) nina_client: === Poll Summary ===
+I (852991) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (852996) nina_client: Target: , Filter: 
+I (853000) nina_client: Exposure: 0.0s (0.0/0.0)
+I (853004) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (853010) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (853346) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (854016) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (858060) nina_client: astromele2.lan unreachable
+I (858060) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (859060) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (859861) nina_client: desktop-bdt978m.lan unreachable
+I (859861) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (860595) nina_client: astromele1.lan unreachable
+I (860595) nina_client: === Poll Summary ===
+I (860595) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (860598) nina_client: Target: , Filter: 
+I (860602) nina_client: Exposure: 0.0s (0.0/0.0)
+I (860606) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (860611) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (860862) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (860885) tasks: Auto-rotate: switched to page 5
+E (861526) transport_ws: Error connecting to host astromele2.lan:1888
+E (861526) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (861538) nina_ws: WS[1]: Error
+I (861541) websocket_client: Reconnect after 86400000 ms
+W (861546) nina_ws: WS[1]: Disconnected from NINA
+I (861632) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (861917) tasks: Page switched to 5
+W (861925) perf: uxTaskGetSystemState returned 0 tasks
+I (861925) perf: ╔══════════════════════════════════════════════════════════════╗
+I (861937) perf: ║              PERFORMANCE REPORT                             ║
+I (861945) perf: ╚══════════════════════════════════════════════════════════════╝
+I (861963) perf: ── Poll Cycle ──
+I (861967) perf:   poll_cycle_total         avg=   12.4  min=    5.9  max= 3057.2  last=    7.3 ms  [n=848]
+I (861976) perf:   effective_interval       avg= 1006.8  min=    7.5  max= 4058.0  last= 1037.0 ms  [n=847]
+I (861986) perf: ── Endpoint Fetchers ──
+I (861990) perf:   equipment_bundle         avg=  734.4  min=   10.3  max= 6568.5  last=  801.3 ms  [n=270]
+I (861999) perf:   camera                   (no samples)
+I (862004) perf:   guider                   (no samples)
+I (862009) perf:   mount                    (no samples)
+I (862014) perf:   focuser                  (no samples)
+I (862020) perf:   sequence                 avg= 3200.5  min=   23.5  max= 7267.7  last= 6769.6 ms  [n=36]
+I (862029) perf:   switch                   (no samples)
+I (862034) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (862043) perf:   filter                   (no samples)
+I (862048) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (862058) perf: ── Network ──
+I (862061) perf:   http_request             avg=  911.5  min=    0.4  max= 7045.4  last=  801.3 ms  [n=356]
+I (862070) perf:   HTTP requests:  11 (interval) / 449 (total)
+I (862076) perf:   HTTP retries:   10 (interval) / 185 (total)
+I (862082) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (862087) perf:   HTTP unreachable:10 (interval) / 183 (total)
+I (862093) perf:   WS events:      0 (interval) / 39 (total)
+I (862098) perf: ── JSON Parsing ──
+I (862102) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (862111) perf:   json_sequence            (no samples)
+I (862116) perf:   json_config_color        (no samples)
+I (862121) perf:   Parse calls:    0 (interval) / 263 (total)
+I (862127) perf: ── UI Updates ──
+I (862131) perf:   ui_update_total          avg=    1.6  min=    0.0  max=   29.8  last=    0.1 ms  [n=621]
+I (862140) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=621]
+I (862149) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=334]
+I (862159) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=287]
+I (862168) perf: ── Latency ──
+I (862172) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (862181) perf: ── JPEG ──
+I (862184) perf:   jpeg_decode              (no samples)
+I (862189) perf:   jpeg_fetch               (no samples)
+I (862194) perf: ── Spotify ──
+I (862198) perf:   spotify_poll_cycle       (no samples)
+I (862203) perf:   spotify_api_fetch        (no samples)
+I (862208) perf:   spotify_art_fetch        (no samples)
+I (862213) perf:   spotify_art_decode       (no samples)
+I (862218) perf:   spotify_ui_update        (no samples)
+I (862223) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (862229) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (862234) perf:   Spotify art:      0 (interval) / 0 (total)
+I (862240) perf: ── WiFi ──
+I (862243) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (862250) perf:   RSSI: cur=-60  avg=-59  min=-61  max=-56 dBm  [n=30]
+I (862256) perf:   Disconnects:    0 (interval) / 0 (total)
+I (862261) perf: ── Memory ──
+I (862265) perf:   Internal heap:  free=76691  min_ever=56907  largest_block=31744  frag_ratio=0.414
+I (862273) perf:   PSRAM:          free=20904104  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (862283) perf: ── Task Stacks ──
+I (862287) perf:   data_task HWM:  8080 bytes free
+I (862291) perf:   input_task HWM: 5484 bytes free
+I (862296) perf:   spotify_task HWM: 7164 bytes free
+W (865579) nina_client: astromele2.lan unreachable
+I (865579) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (867395) nina_client: desktop-bdt978m.lan unreachable
+I (867395) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (868150) nina_client: astromele1.lan unreachable
+W (874689) nina_client: astromele1.lan unreachable
+W (874689) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (874690) nina_client: === Poll Summary ===
+I (874694) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (874699) nina_client: Target: , Filter: 
+I (874703) nina_client: Exposure: 0.0s (0.0/0.0)
+I (874707) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (874713) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (875719) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (877419) tasks: Auto-rotate: switched to page 4
+I (878442) tasks: Page switched to 4 (summary)
+W (882099) nina_client: astromele2.lan unreachable
+I (882099) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (882100) websocket_client: Started
+I (882102) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (882259) nina_client: astromele1.lan unreachable
+I (882259) nina_client: === Poll Summary ===
+I (882259) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (882262) nina_client: Target: , Filter: 
+I (882266) nina_client: Exposure: 0.0s (0.0/0.0)
+I (882270) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (882275) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (883282) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (883914) nina_client: desktop-bdt978m.lan unreachable
+I (883914) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (888692) nina_client: astromele2.lan unreachable
+I (888692) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (889692) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (889850) nina_client: astromele1.lan unreachable
+W (891092) nina_client: desktop-bdt978m.lan unreachable
+I (891092) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (892093) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (892138) transport_ws: Error connecting to host astromele2.lan:1888
+E (892138) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (892150) nina_ws: WS[1]: Error
+I (892153) websocket_client: Reconnect after 86400000 ms
+W (892158) nina_ws: WS[1]: Disconnected from NINA
+W (892562) perf: uxTaskGetSystemState returned 0 tasks
+I (892562) perf: ╔══════════════════════════════════════════════════════════════╗
+I (892574) perf: ║              PERFORMANCE REPORT                             ║
+I (892581) perf: ╚══════════════════════════════════════════════════════════════╝
+I (892600) perf: ── Poll Cycle ──
+I (892603) perf:   poll_cycle_total         avg=   12.2  min=    5.9  max= 3057.2  last=    7.0 ms  [n=878]
+I (892613) perf:   effective_interval       avg= 1007.3  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=877]
+I (892622) perf: ── Endpoint Fetchers ──
+I (892627) perf:   equipment_bundle         avg=  756.7  min=   10.3  max= 6568.5  last=  158.3 ms  [n=274]
+I (892636) perf:   camera                   (no samples)
+I (892641) perf:   guider                   (no samples)
+I (892646) perf:   mount                    (no samples)
+I (892651) perf:   focuser                  (no samples)
+I (892656) perf:   sequence                 avg= 3290.7  min=   23.5  max= 7267.7  last= 6539.6 ms  [n=37]
+I (892666) perf:   switch                   (no samples)
+I (892671) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (892680) perf:   filter                   (no samples)
+I (892685) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (892694) perf: ── Network ──
+I (892698) perf:   http_request             avg=  952.3  min=    0.4  max= 7045.4  last= 1242.0 ms  [n=364]
+I (892707) perf:   HTTP requests:  10 (interval) / 459 (total)
+I (892713) perf:   HTTP retries:   9 (interval) / 194 (total)
+I (892718) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (892723) perf:   HTTP unreachable:10 (interval) / 193 (total)
+I (892729) perf:   WS events:      0 (interval) / 39 (total)
+I (892734) perf: ── JSON Parsing ──
+I (892738) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (892748) perf:   json_sequence            (no samples)
+I (892753) perf:   json_config_color        (no samples)
+I (892758) perf:   Parse calls:    0 (interval) / 263 (total)
+I (892763) perf: ── UI Updates ──
+I (892767) perf:   ui_update_total          avg=    1.6  min=    0.0  max=   29.8  last=    0.0 ms  [n=651]
+I (892777) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=651]
+I (892786) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=349]
+I (892796) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=302]
+I (892805) perf: ── Latency ──
+I (892808) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (892818) perf: ── JPEG ──
+I (892821) perf:   jpeg_decode              (no samples)
+I (892826) perf:   jpeg_fetch               (no samples)
+I (892831) perf: ── Spotify ──
+I (892835) perf:   spotify_poll_cycle       (no samples)
+I (892840) perf:   spotify_api_fetch        (no samples)
+I (892845) perf:   spotify_art_fetch        (no samples)
+I (892850) perf:   spotify_art_decode       (no samples)
+I (892855) perf:   spotify_ui_update        (no samples)
+I (892860) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (892865) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (892871) perf:   Spotify art:      0 (interval) / 0 (total)
+I (892876) perf: ── WiFi ──
+I (892879) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (892886) perf:   RSSI: cur=-60  avg=-59  min=-64  max=-56 dBm  [n=30]
+I (892893) perf:   Disconnects:    0 (interval) / 0 (total)
+I (892898) perf: ── Memory ──
+I (892901) perf:   Internal heap:  free=76623  min_ever=56907  largest_block=31744  frag_ratio=0.414
+I (892910) perf:   PSRAM:          free=20904068  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (892920) perf: ── Task Stacks ──
+I (892924) perf:   data_task HWM:  8080 bytes free
+I (892928) perf:   input_task HWM: 5484 bytes free
+I (892933) perf:   spotify_task HWM: 7164 bytes free
+I (893942) tasks: Auto-rotate: switched to page 5
+I (894968) tasks: Page switched to 5
+W (896376) nina_client: astromele2.lan unreachable
+I (896376) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (896537) nina_client: astromele1.lan unreachable
+W (896537) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (896538) nina_client: === Poll Summary ===
+I (896542) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (896547) nina_client: Target: , Filter: 
+I (896551) nina_client: Exposure: 0.0s (0.0/0.0)
+I (896555) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (896561) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (897567) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (898737) nina_client: desktop-bdt978m.lan unreachable
+I (898737) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (904078) nina_client: astromele1.lan unreachable
+I (904078) nina_client: === Poll Summary ===
+I (904078) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (904081) nina_client: Target: , Filter: 
+I (904085) nina_client: Exposure: 0.0s (0.0/0.0)
+I (904089) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (904094) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (905101) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (910094) tasks: Auto-rotate: switched to page 4
+I (911124) tasks: Page switched to 4 (summary)
+W (911643) nina_client: astromele1.lan unreachable
+W (912980) nina_client: astromele2.lan unreachable
+I (912980) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (912981) websocket_client: Started
+I (912983) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (915273) nina_client: desktop-bdt978m.lan unreachable
+I (915273) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (918192) nina_client: astromele1.lan unreachable
+W (918192) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (918193) nina_client: === Poll Summary ===
+I (918197) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (918202) nina_client: Target: , Filter: 
+I (918206) nina_client: Exposure: 0.0s (0.0/0.0)
+I (918210) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (918216) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (919222) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (919543) nina_client: astromele2.lan unreachable
+I (919543) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (920543) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (921810) nina_client: desktop-bdt978m.lan unreachable
+I (921810) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (922811) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (923026) transport_ws: Error connecting to host astromele2.lan:1888
+E (923026) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (923038) nina_ws: WS[1]: Error
+I (923041) websocket_client: Reconnect after 86400000 ms
+W (923046) nina_ws: WS[1]: Disconnected from NINA
+W (923228) perf: uxTaskGetSystemState returned 0 tasks
+I (923228) perf: ╔══════════════════════════════════════════════════════════════╗
+I (923240) perf: ║              PERFORMANCE REPORT                             ║
+I (923247) perf: ╚══════════════════════════════════════════════════════════════╝
+I (923266) perf: ── Poll Cycle ──
+I (923269) perf:   poll_cycle_total         avg=   12.1  min=    5.9  max= 3057.2  last=    7.0 ms  [n=908]
+I (923279) perf:   effective_interval       avg= 1007.8  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=907]
+I (923288) perf: ── Endpoint Fetchers ──
+I (923293) perf:   equipment_bundle         avg=  791.8  min=   10.3  max= 6568.5  last= 1267.3 ms  [n=279]
+I (923302) perf:   camera                   (no samples)
+I (923307) perf:   guider                   (no samples)
+I (923312) perf:   mount                    (no samples)
+I (923317) perf:   focuser                  (no samples)
+I (923322) perf:   sequence                 avg= 3461.4  min=   23.5  max= 7267.7  last= 6549.5 ms  [n=39]
+I (923332) perf:   switch                   (no samples)
+I (923337) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (923346) perf:   filter                   (no samples)
+I (923351) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (923360) perf: ── Network ──
+I (923364) perf:   http_request             avg=  976.1  min=    0.4  max= 7045.4  last= 1267.3 ms  [n=372]
+I (923373) perf:   HTTP requests:  10 (interval) / 469 (total)
+I (923379) perf:   HTTP retries:   10 (interval) / 205 (total)
+I (923384) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (923390) perf:   HTTP unreachable:10 (interval) / 203 (total)
+I (923395) perf:   WS events:      0 (interval) / 39 (total)
+I (923401) perf: ── JSON Parsing ──
+I (923404) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (923414) perf:   json_sequence            (no samples)
+I (923419) perf:   json_config_color        (no samples)
+I (923424) perf:   Parse calls:    0 (interval) / 263 (total)
+I (923429) perf: ── UI Updates ──
+I (923433) perf:   ui_update_total          avg=    1.6  min=    0.0  max=   29.8  last=    0.0 ms  [n=681]
+I (923443) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=681]
+I (923452) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=365]
+I (923462) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=316]
+I (923471) perf: ── Latency ──
+I (923475) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (923484) perf: ── JPEG ──
+I (923487) perf:   jpeg_decode              (no samples)
+I (923492) perf:   jpeg_fetch               (no samples)
+I (923497) perf: ── Spotify ──
+I (923501) perf:   spotify_poll_cycle       (no samples)
+I (923506) perf:   spotify_api_fetch        (no samples)
+I (923511) perf:   spotify_art_fetch        (no samples)
+I (923516) perf:   spotify_art_decode       (no samples)
+I (923521) perf:   spotify_ui_update        (no samples)
+I (923526) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (923531) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (923537) perf:   Spotify art:      0 (interval) / 0 (total)
+I (923542) perf: ── WiFi ──
+I (923545) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (923552) perf:   RSSI: cur=-59  avg=-59  min=-61  max=-57 dBm  [n=30]
+I (923559) perf:   Disconnects:    0 (interval) / 0 (total)
+I (923564) perf: ── Memory ──
+I (923567) perf:   Internal heap:  free=76643  min_ever=56907  largest_block=31744  frag_ratio=0.414
+I (923576) perf:   PSRAM:          free=20904080  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (923586) perf: ── Task Stacks ──
+I (923590) perf:   data_task HWM:  8080 bytes free
+I (923594) perf:   input_task HWM: 5484 bytes free
+I (923599) perf:   spotify_task HWM: 7164 bytes free
+W (925784) nina_client: astromele1.lan unreachable
+I (925784) nina_client: === Poll Summary ===
+I (925784) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (925787) nina_client: Target: , Filter: 
+I (925791) nina_client: Exposure: 0.0s (0.0/0.0)
+I (925795) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (925800) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (926624) tasks: Auto-rotate: switched to page 5
+I (926815) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (927079) nina_client: astromele2.lan unreachable
+I (927079) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (927649) tasks: Page switched to 5
+W (929374) nina_client: desktop-bdt978m.lan unreachable
+I (929374) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (933354) nina_client: astromele1.lan unreachable
+W (934611) nina_client: astromele2.lan unreachable
+I (934611) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (934612) websocket_client: Started
+W (939893) nina_client: astromele1.lan unreachable
+W (939893) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (939894) nina_client: === Poll Summary ===
+I (939898) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (939903) nina_client: Target: , Filter: 
+I (939907) nina_client: Exposure: 0.0s (0.0/0.0)
+I (939911) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (939917) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (940923) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (942777) tasks: Auto-rotate: switched to page 4
+I (943806) tasks: Page switched to 4 (summary)
+I (943806) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (944631) transport_ws: Error connecting to host astromele2.lan:1888
+E (944631) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (944643) nina_ws: WS[1]: Error
+I (944646) websocket_client: Reconnect after 86400000 ms
+W (944651) nina_ws: WS[1]: Disconnected from NINA
+W (945992) nina_client: desktop-bdt978m.lan unreachable
+I (945992) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (947456) nina_client: astromele1.lan unreachable
+I (947456) nina_client: === Poll Summary ===
+I (947456) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (947459) nina_client: Target: , Filter: 
+I (947463) nina_client: Exposure: 0.0s (0.0/0.0)
+I (947467) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (947472) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (948479) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (950372) nina_client: astromele2.lan unreachable
+I (950372) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (950372) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (950379) websocket_client: Started
+I (951382) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (952637) nina_client: desktop-bdt978m.lan unreachable
+I (952637) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (953638) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (953894) perf: uxTaskGetSystemState returned 0 tasks
+I (953894) perf: ╔══════════════════════════════════════════════════════════════╗
+I (953906) perf: ║              PERFORMANCE REPORT                             ║
+I (953913) perf: ╚══════════════════════════════════════════════════════════════╝
+I (953932) perf: ── Poll Cycle ──
+I (953935) perf:   poll_cycle_total         avg=   12.0  min=    5.9  max= 3057.2  last=    6.9 ms  [n=938]
+I (953945) perf:   effective_interval       avg= 1008.2  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=937]
+I (953954) perf: ── Endpoint Fetchers ──
+I (953959) perf:   equipment_bundle         avg=  805.5  min=   10.3  max= 6568.5  last= 1255.3 ms  [n=284]
+I (953968) perf:   camera                   (no samples)
+I (953973) perf:   guider                   (no samples)
+I (953978) perf:   mount                    (no samples)
+I (953983) perf:   focuser                  (no samples)
+I (953988) perf:   sequence                 avg= 3538.3  min=   23.5  max= 7267.7  last= 6539.6 ms  [n=40]
+I (953997) perf:   switch                   (no samples)
+I (954003) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (954012) perf:   filter                   (no samples)
+I (954017) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (954026) perf: ── Network ──
+I (954030) perf:   http_request             avg=  987.2  min=    0.4  max= 7045.4  last= 1255.3 ms  [n=381]
+I (954039) perf:   HTTP requests:  10 (interval) / 479 (total)
+I (954045) perf:   HTTP retries:   9 (interval) / 215 (total)
+I (954050) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (954055) perf:   HTTP unreachable:10 (interval) / 213 (total)
+I (954061) perf:   WS events:      0 (interval) / 39 (total)
+I (954066) perf: ── JSON Parsing ──
+I (954070) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (954080) perf:   json_sequence            (no samples)
+I (954085) perf:   json_config_color        (no samples)
+I (954090) perf:   Parse calls:    0 (interval) / 263 (total)
+I (954095) perf: ── UI Updates ──
+I (954099) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=711]
+I (954109) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=711]
+I (954118) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=381]
+I (954127) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=330]
+I (954137) perf: ── Latency ──
+I (954140) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (954150) perf: ── JPEG ──
+I (954153) perf:   jpeg_decode              (no samples)
+I (954158) perf:   jpeg_fetch               (no samples)
+I (954163) perf: ── Spotify ──
+I (954166) perf:   spotify_poll_cycle       (no samples)
+I (954172) perf:   spotify_api_fetch        (no samples)
+I (954177) perf:   spotify_art_fetch        (no samples)
+I (954182) perf:   spotify_art_decode       (no samples)
+I (954187) perf:   spotify_ui_update        (no samples)
+I (954192) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (954197) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (954203) perf:   Spotify art:      0 (interval) / 0 (total)
+I (954208) perf: ── WiFi ──
+I (954211) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (954218) perf:   RSSI: cur=-58  avg=-59  min=-62  max=-55 dBm  [n=30]
+I (954224) perf:   Disconnects:    0 (interval) / 0 (total)
+I (954230) perf: ── Memory ──
+I (954233) perf:   Internal heap:  free=76507  min_ever=56907  largest_block=31744  frag_ratio=0.415
+I (954242) perf:   PSRAM:          free=20903476  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (954252) perf: ── Task Stacks ──
+I (954255) perf:   data_task HWM:  8080 bytes free
+I (954260) perf:   input_task HWM: 5484 bytes free
+I (954264) perf:   spotify_task HWM: 7164 bytes free
+W (955044) nina_client: astromele1.lan unreachable
+W (957913) nina_client: astromele2.lan unreachable
+I (957913) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (958913) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (959306) tasks: Auto-rotate: switched to page 5
+W (960202) nina_client: desktop-bdt978m.lan unreachable
+I (960202) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (960331) tasks: Page switched to 5
+E (960406) transport_ws: Error connecting to host astromele2.lan:1888
+E (960406) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (960418) nina_ws: WS[1]: Error
+I (960421) websocket_client: Reconnect after 86400000 ms
+W (960426) nina_ws: WS[1]: Disconnected from NINA
+W (961560) nina_client: astromele1.lan unreachable
+W (961560) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (961561) nina_client: === Poll Summary ===
+I (961565) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (961570) nina_client: Target: , Filter: 
+I (961574) nina_client: Exposure: 0.0s (0.0/0.0)
+I (961578) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (961584) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (962590) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (965521) nina_client: astromele2.lan unreachable
+I (965521) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (965521) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (965529) websocket_client: Started
+W (967763) nina_client: desktop-bdt978m.lan unreachable
+W (969205) nina_client: astromele1.lan unreachable
+I (969205) nina_client: === Poll Summary ===
+I (969205) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (969208) nina_client: Target: , Filter: 
+I (969212) nina_client: Exposure: 0.0s (0.0/0.0)
+I (969216) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (969221) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (970228) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (975458) tasks: Auto-rotate: switched to page 4
+E (975562) transport_ws: Error connecting to host astromele2.lan:1888
+E (975562) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (975574) nina_ws: WS[1]: Error
+I (975577) websocket_client: Reconnect after 86400000 ms
+W (975582) nina_ws: WS[1]: Disconnected from NINA
+I (976487) tasks: Page switched to 4 (summary)
+I (976487) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (976757) nina_client: astromele1.lan unreachable
+W (982077) nina_client: astromele2.lan unreachable
+I (982077) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (982078) websocket_client: Started
+I (982080) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (983025) nina_client: desktop-bdt978m.lan unreachable
+I (983025) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (983317) nina_client: astromele1.lan unreachable
+W (983317) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (983318) nina_client: === Poll Summary ===
+I (983321) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (983327) nina_client: Target: , Filter: 
+I (983331) nina_client: Exposure: 0.0s (0.0/0.0)
+I (983335) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (983341) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (984026) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (984347) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (984559) perf: uxTaskGetSystemState returned 0 tasks
+I (984559) perf: ╔══════════════════════════════════════════════════════════════╗
+I (984571) perf: ║              PERFORMANCE REPORT                             ║
+I (984578) perf: ╚══════════════════════════════════════════════════════════════╝
+I (984597) perf: ── Poll Cycle ──
+I (984600) perf:   poll_cycle_total         avg=   11.9  min=    5.9  max= 3057.2  last=    6.9 ms  [n=968]
+I (984610) perf:   effective_interval       avg= 1008.7  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=967]
+I (984619) perf: ── Endpoint Fetchers ──
+I (984624) perf:   equipment_bundle         avg=  815.2  min=   10.3  max= 6568.5  last=  938.0 ms  [n=289]
+I (984633) perf:   camera                   (no samples)
+I (984638) perf:   guider                   (no samples)
+I (984643) perf:   mount                    (no samples)
+I (984648) perf:   focuser                  (no samples)
+I (984653) perf:   sequence                 avg= 3681.2  min=   23.5  max= 7267.7  last= 6560.7 ms  [n=42]
+I (984663) perf:   switch                   (no samples)
+I (984668) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (984677) perf:   filter                   (no samples)
+I (984682) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (984691) perf: ── Network ──
+I (984695) perf:   http_request             avg= 1006.5  min=    0.4  max= 7045.4  last=  938.0 ms  [n=389]
+I (984704) perf:   HTTP requests:  11 (interval) / 490 (total)
+I (984710) perf:   HTTP retries:   10 (interval) / 225 (total)
+I (984715) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (984721) perf:   HTTP unreachable:11 (interval) / 224 (total)
+I (984726) perf:   WS events:      0 (interval) / 39 (total)
+I (984732) perf: ── JSON Parsing ──
+I (984735) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (984745) perf:   json_sequence            (no samples)
+I (984750) perf:   json_config_color        (no samples)
+I (984755) perf:   Parse calls:    0 (interval) / 263 (total)
+I (984760) perf: ── UI Updates ──
+I (984764) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=741]
+I (984774) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=741]
+I (984783) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=397]
+I (984793) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=344]
+I (984802) perf: ── Latency ──
+I (984805) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (984815) perf: ── JPEG ──
+I (984818) perf:   jpeg_decode              (no samples)
+I (984823) perf:   jpeg_fetch               (no samples)
+I (984828) perf: ── Spotify ──
+I (984832) perf:   spotify_poll_cycle       (no samples)
+I (984837) perf:   spotify_api_fetch        (no samples)
+I (984842) perf:   spotify_art_fetch        (no samples)
+I (984847) perf:   spotify_art_decode       (no samples)
+I (984852) perf:   spotify_ui_update        (no samples)
+I (984857) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (984862) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (984868) perf:   Spotify art:      0 (interval) / 0 (total)
+I (984873) perf: ── WiFi ──
+I (984876) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (984883) perf:   RSSI: cur=-58  avg=-59  min=-63  max=-54 dBm  [n=30]
+I (984890) perf:   Disconnects:    0 (interval) / 0 (total)
+I (984895) perf: ── Memory ──
+I (984898) perf:   Internal heap:  free=76547  min_ever=56907  largest_block=31744  frag_ratio=0.415
+I (984907) perf:   PSRAM:          free=20903504  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (984917) perf: ── Task Stacks ──
+I (984921) perf:   data_task HWM:  8080 bytes free
+I (984925) perf:   input_task HWM: 5484 bytes free
+I (984930) perf:   spotify_task HWM: 7164 bytes free
+W (988630) nina_client: astromele2.lan unreachable
+I (988630) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (989630) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (990540) nina_client: desktop-bdt978m.lan unreachable
+I (990540) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (990927) nina_client: astromele1.lan unreachable
+I (990927) nina_client: === Poll Summary ===
+I (990927) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (990930) nina_client: Target: , Filter: 
+I (990934) nina_client: Exposure: 0.0s (0.0/0.0)
+I (990938) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (990943) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (991541) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (991973) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (991987) tasks: Auto-rotate: switched to page 5
+E (992083) transport_ws: Error connecting to host astromele2.lan:1888
+E (992083) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (992095) nina_ws: WS[1]: Error
+I (992098) websocket_client: Reconnect after 86400000 ms
+W (992103) nina_ws: WS[1]: Disconnected from NINA
+I (993013) tasks: Page switched to 5
+W (996145) nina_client: astromele2.lan unreachable
+I (996145) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (998079) nina_client: desktop-bdt978m.lan unreachable
+I (998079) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (998485) nina_client: astromele1.lan unreachable
+W (1005006) nina_client: astromele1.lan unreachable
+W (1005006) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1005007) nina_client: === Poll Summary ===
+I (1005011) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1005016) nina_client: Target: , Filter: 
+I (1005020) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1005025) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1005030) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1006037) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1008140) tasks: Auto-rotate: switched to page 4
+I (1009169) tasks: Page switched to 4 (summary)
+W (1012635) nina_client: astromele1.lan unreachable
+I (1012635) nina_client: === Poll Summary ===
+I (1012635) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1012638) nina_client: Target: , Filter: 
+I (1012642) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1012646) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1012652) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1012757) nina_client: astromele2.lan unreachable
+I (1012757) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1012758) websocket_client: Started
+I (1012760) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1013659) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1014737) nina_client: desktop-bdt978m.lan unreachable
+I (1014737) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1015225) perf: uxTaskGetSystemState returned 0 tasks
+I (1015225) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1015237) perf: ║              PERFORMANCE REPORT                             ║
+I (1015245) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1015263) perf: ── Poll Cycle ──
+I (1015267) perf:   poll_cycle_total         avg=   11.8  min=    5.9  max= 3057.2  last=    7.4 ms  [n=998]
+I (1015277) perf:   effective_interval       avg= 1009.1  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=997]
+I (1015286) perf: ── Endpoint Fetchers ──
+I (1015291) perf:   equipment_bundle         avg=  858.5  min=   10.3  max= 6598.3  last= 6598.3 ms  [n=293]
+I (1015300) perf:   camera                   (no samples)
+I (1015305) perf:   guider                   (no samples)
+I (1015310) perf:   mount                    (no samples)
+I (1015316) perf:   focuser                  (no samples)
+I (1015321) perf:   sequence                 avg= 3747.3  min=   23.5  max= 7267.7  last= 6521.8 ms  [n=43]
+I (1015330) perf:   switch                   (no samples)
+I (1015335) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1015345) perf:   filter                   (no samples)
+I (1015350) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1015359) perf: ── Network ──
+I (1015363) perf:   http_request             avg= 1045.4  min=    0.4  max= 7045.4  last= 1078.3 ms  [n=395]
+I (1015372) perf:   HTTP requests:  10 (interval) / 500 (total)
+I (1015378) perf:   HTTP retries:   10 (interval) / 235 (total)
+I (1015384) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1015389) perf:   HTTP unreachable:10 (interval) / 234 (total)
+I (1015395) perf:   WS events:      0 (interval) / 39 (total)
+I (1015400) perf: ── JSON Parsing ──
+I (1015404) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1015414) perf:   json_sequence            (no samples)
+I (1015419) perf:   json_config_color        (no samples)
+I (1015424) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1015429) perf: ── UI Updates ──
+I (1015433) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=771]
+I (1015443) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=771]
+I (1015452) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=413]
+I (1015462) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=358]
+I (1015471) perf: ── Latency ──
+I (1015475) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1015484) perf: ── JPEG ──
+I (1015488) perf:   jpeg_decode              (no samples)
+I (1015493) perf:   jpeg_fetch               (no samples)
+I (1015498) perf: ── Spotify ──
+I (1015502) perf:   spotify_poll_cycle       (no samples)
+I (1015507) perf:   spotify_api_fetch        (no samples)
+I (1015512) perf:   spotify_art_fetch        (no samples)
+I (1015517) perf:   spotify_art_decode       (no samples)
+I (1015522) perf:   spotify_ui_update        (no samples)
+I (1015527) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1015533) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1015538) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1015544) perf: ── WiFi ──
+I (1015547) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1015554) perf:   RSSI: cur=-58  avg=-59  min=-64  max=-55 dBm  [n=30]
+I (1015561) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1015566) perf: ── Memory ──
+I (1015569) perf:   Internal heap:  free=76527  min_ever=56907  largest_block=31744  frag_ratio=0.415
+I (1015578) perf:   PSRAM:          free=20903488  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1015588) perf: ── Task Stacks ──
+I (1015592) perf:   data_task HWM:  8080 bytes free
+I (1015597) perf:   input_task HWM: 5484 bytes free
+I (1015601) perf:   spotify_task HWM: 7164 bytes free
+W (1019352) nina_client: astromele2.lan unreachable
+I (1019352) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1020209) nina_client: astromele1.lan unreachable
+I (1020352) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1021295) nina_client: desktop-bdt978m.lan unreachable
+I (1021295) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1022296) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1022777) transport_ws: Error connecting to host astromele2.lan:1888
+E (1022777) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1022789) nina_ws: WS[1]: Error
+I (1022792) websocket_client: Reconnect after 86400000 ms
+W (1022797) nina_ws: WS[1]: Disconnected from NINA
+I (1024675) tasks: Auto-rotate: switched to page 5
+I (1025710) tasks: Page switched to 5
+W (1026789) nina_client: astromele1.lan unreachable
+W (1026789) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1026790) nina_client: === Poll Summary ===
+I (1026794) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1026799) nina_client: Target: , Filter: 
+I (1026803) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1026808) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1026813) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1026892) nina_client: astromele2.lan unreachable
+I (1026892) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1027820) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1028811) nina_client: desktop-bdt978m.lan unreachable
+I (1028811) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1034334) nina_client: astromele1.lan unreachable
+I (1034334) nina_client: === Poll Summary ===
+I (1034334) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1034337) nina_client: Target: , Filter: 
+I (1034341) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1034345) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1034351) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1035358) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1040836) tasks: Auto-rotate: switched to page 4
+I (1041867) tasks: Page switched to 4 (summary)
+W (1041901) nina_client: astromele1.lan unreachable
+W (1043438) nina_client: astromele2.lan unreachable
+I (1043438) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1043439) websocket_client: Started
+I (1043442) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1045323) nina_client: desktop-bdt978m.lan unreachable
+I (1045323) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1045907) perf: uxTaskGetSystemState returned 0 tasks
+I (1045907) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1045919) perf: ║              PERFORMANCE REPORT                             ║
+I (1045927) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1045945) perf: ── Poll Cycle ──
+I (1045949) perf:   poll_cycle_total         avg=   11.7  min=    5.9  max= 3057.2  last=    7.3 ms  [n=1028]
+I (1045959) perf:   effective_interval       avg= 1009.5  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1027]
+I (1045968) perf: ── Endpoint Fetchers ──
+I (1045973) perf:   equipment_bundle         avg=  903.5  min=   10.3  max= 6598.3  last= 6543.3 ms  [n=298]
+I (1045982) perf:   camera                   (no samples)
+I (1045988) perf:   guider                   (no samples)
+I (1045993) perf:   mount                    (no samples)
+I (1045998) perf:   focuser                  (no samples)
+I (1046003) perf:   sequence                 avg= 3811.7  min=   23.5  max= 7267.7  last= 6580.8 ms  [n=44]
+I (1046012) perf:   switch                   (no samples)
+I (1046017) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1046027) perf:   filter                   (no samples)
+I (1046032) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1046041) perf: ── Network ──
+I (1046045) perf:   http_request             avg= 1070.8  min=    0.4  max= 7045.4  last= 1874.6 ms  [n=402]
+I (1046054) perf:   HTTP requests:  10 (interval) / 510 (total)
+I (1046060) perf:   HTTP retries:   11 (interval) / 246 (total)
+I (1046066) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1046071) perf:   HTTP unreachable:10 (interval) / 244 (total)
+I (1046077) perf:   WS events:      0 (interval) / 39 (total)
+I (1046082) perf: ── JSON Parsing ──
+I (1046086) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1046096) perf:   json_sequence            (no samples)
+I (1046101) perf:   json_config_color        (no samples)
+I (1046106) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1046112) perf: ── UI Updates ──
+I (1046115) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=801]
+I (1046125) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=801]
+I (1046135) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=429]
+I (1046144) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=372]
+I (1046154) perf: ── Latency ──
+I (1046157) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1046167) perf: ── JPEG ──
+I (1046170) perf:   jpeg_decode              (no samples)
+I (1046175) perf:   jpeg_fetch               (no samples)
+I (1046180) perf: ── Spotify ──
+I (1046184) perf:   spotify_poll_cycle       (no samples)
+I (1046189) perf:   spotify_api_fetch        (no samples)
+I (1046194) perf:   spotify_art_fetch        (no samples)
+I (1046199) perf:   spotify_art_decode       (no samples)
+I (1046204) perf:   spotify_ui_update        (no samples)
+I (1046209) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1046215) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1046220) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1046226) perf: ── WiFi ──
+I (1046229) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1046236) perf:   RSSI: cur=-59  avg=-59  min=-61  max=-57 dBm  [n=30]
+I (1046243) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1046248) perf: ── Memory ──
+I (1046252) perf:   Internal heap:  free=76503  min_ever=56907  largest_block=31744  frag_ratio=0.415
+I (1046260) perf:   PSRAM:          free=20903476  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1046270) perf: ── Task Stacks ──
+I (1046274) perf:   data_task HWM:  8080 bytes free
+I (1046279) perf:   input_task HWM: 5484 bytes free
+I (1046283) perf:   spotify_task HWM: 7164 bytes free
+W (1048422) nina_client: astromele1.lan unreachable
+W (1048422) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1048423) nina_client: === Poll Summary ===
+I (1048427) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1048432) nina_client: Target: , Filter: 
+I (1048436) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1048441) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1048446) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1049453) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1049993) nina_client: astromele2.lan unreachable
+I (1049993) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1050993) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1051836) nina_client: desktop-bdt978m.lan unreachable
+I (1051836) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1052837) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1053487) transport_ws: Error connecting to host astromele2.lan:1888
+E (1053487) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1053499) nina_ws: WS[1]: Error
+I (1053502) websocket_client: Reconnect after 86400000 ms
+W (1053507) nina_ws: WS[1]: Disconnected from NINA
+W (1055972) nina_client: astromele1.lan unreachable
+I (1055972) nina_client: === Poll Summary ===
+I (1055972) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1055975) nina_client: Target: , Filter: 
+I (1055979) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1055983) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1055989) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1057002) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1057373) tasks: Auto-rotate: switched to page 5
+W (1057526) nina_client: astromele2.lan unreachable
+I (1057526) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1058408) tasks: Page switched to 5
+W (1059388) nina_client: desktop-bdt978m.lan unreachable
+I (1059388) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1063517) nina_client: astromele1.lan unreachable
+W (1065123) nina_client: astromele2.lan unreachable
+I (1065123) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1065124) websocket_client: Started
+W (1070104) nina_client: astromele1.lan unreachable
+W (1070104) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1070105) nina_client: === Poll Summary ===
+I (1070109) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1070114) nina_client: Target: , Filter: 
+I (1070118) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1070123) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1070128) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1071135) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1073534) tasks: Auto-rotate: switched to page 4
+I (1074564) tasks: Page switched to 4 (summary)
+I (1074564) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1075129) transport_ws: Error connecting to host astromele2.lan:1888
+E (1075129) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1075141) nina_ws: WS[1]: Error
+I (1075144) websocket_client: Reconnect after 86400000 ms
+W (1075149) nina_ws: WS[1]: Disconnected from NINA
+W (1075971) nina_client: desktop-bdt978m.lan unreachable
+I (1075971) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1076588) perf: uxTaskGetSystemState returned 0 tasks
+I (1076588) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1076600) perf: ║              PERFORMANCE REPORT                             ║
+I (1076608) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1076626) perf: ── Poll Cycle ──
+I (1076630) perf:   poll_cycle_total         avg=   11.7  min=    5.9  max= 3057.2  last=    7.3 ms  [n=1058]
+I (1076640) perf:   effective_interval       avg= 1009.8  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1057]
+I (1076649) perf: ── Endpoint Fetchers ──
+I (1076654) perf:   equipment_bundle         avg=  908.2  min=   10.3  max= 6598.3  last=  523.9 ms  [n=302]
+I (1076663) perf:   camera                   (no samples)
+I (1076668) perf:   guider                   (no samples)
+I (1076674) perf:   mount                    (no samples)
+I (1076679) perf:   focuser                  (no samples)
+I (1076684) perf:   sequence                 avg= 3930.9  min=   23.5  max= 7267.7  last= 6587.8 ms  [n=46]
+I (1076693) perf:   switch                   (no samples)
+I (1076698) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1076708) perf:   filter                   (no samples)
+I (1076713) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1076722) perf: ── Network ──
+I (1076726) perf:   http_request             avg= 1078.2  min=    0.4  max= 7045.4  last= 1406.5 ms  [n=411]
+I (1076735) perf:   HTTP requests:  10 (interval) / 520 (total)
+I (1076741) perf:   HTTP retries:   10 (interval) / 256 (total)
+I (1076747) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1076752) perf:   HTTP unreachable:10 (interval) / 254 (total)
+I (1076758) perf:   WS events:      0 (interval) / 39 (total)
+I (1076763) perf: ── JSON Parsing ──
+I (1076767) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1076777) perf:   json_sequence            (no samples)
+I (1076782) perf:   json_config_color        (no samples)
+I (1076787) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1076793) perf: ── UI Updates ──
+I (1076796) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=831]
+I (1076806) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=831]
+I (1076815) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=445]
+I (1076825) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=386]
+I (1076835) perf: ── Latency ──
+I (1076838) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1076848) perf: ── JPEG ──
+I (1076851) perf:   jpeg_decode              (no samples)
+I (1076856) perf:   jpeg_fetch               (no samples)
+I (1076861) perf: ── Spotify ──
+I (1076865) perf:   spotify_poll_cycle       (no samples)
+I (1076870) perf:   spotify_api_fetch        (no samples)
+I (1076875) perf:   spotify_art_fetch        (no samples)
+I (1076880) perf:   spotify_art_decode       (no samples)
+I (1076885) perf:   spotify_ui_update        (no samples)
+I (1076890) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1076896) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1076901) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1076907) perf: ── WiFi ──
+I (1076910) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1076917) perf:   RSSI: cur=-60  avg=-59  min=-63  max=-56 dBm  [n=30]
+I (1076924) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1076929) perf: ── Memory ──
+I (1076932) perf:   Internal heap:  free=76695  min_ever=56907  largest_block=31744  frag_ratio=0.414
+I (1076941) perf:   PSRAM:          free=20904072  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1076951) perf: ── Task Stacks ──
+I (1076955) perf:   data_task HWM:  8080 bytes free
+I (1076960) perf:   input_task HWM: 5484 bytes free
+I (1076964) perf:   spotify_task HWM: 7164 bytes free
+W (1077647) nina_client: astromele1.lan unreachable
+I (1077647) nina_client: === Poll Summary ===
+I (1077647) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1077650) nina_client: Target: , Filter: 
+I (1077654) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1077658) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1077664) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1078671) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1081101) nina_client: astromele2.lan unreachable
+I (1081101) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1081101) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1081109) websocket_client: Started
+I (1082112) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1082493) nina_client: desktop-bdt978m.lan unreachable
+I (1082493) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1083494) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1085227) nina_client: astromele1.lan unreachable
+W (1088636) nina_client: astromele2.lan unreachable
+I (1088636) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1089636) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1090021) nina_client: desktop-bdt978m.lan unreachable
+I (1090021) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1090070) tasks: Auto-rotate: switched to page 5
+I (1091022) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1091090) tasks: Page switched to 5
+E (1091167) transport_ws: Error connecting to host astromele2.lan:1888
+E (1091167) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1091179) nina_ws: WS[1]: Error
+I (1091182) websocket_client: Reconnect after 86400000 ms
+W (1091187) nina_ws: WS[1]: Disconnected from NINA
+W (1091768) nina_client: astromele1.lan unreachable
+W (1091768) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1091769) nina_client: === Poll Summary ===
+I (1091773) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1091778) nina_client: Target: , Filter: 
+I (1091782) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1091787) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1091792) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1092799) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1096164) nina_client: astromele2.lan unreachable
+I (1096164) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1097546) nina_client: desktop-bdt978m.lan unreachable
+I (1097546) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1099358) nina_client: astromele1.lan unreachable
+I (1099358) nina_client: === Poll Summary ===
+I (1099358) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1099361) nina_client: Target: , Filter: 
+I (1099365) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1099369) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1099375) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1100382) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1106215) tasks: Auto-rotate: switched to page 4
+W (1106946) nina_client: astromele1.lan unreachable
+I (1107246) tasks: Page switched to 4 (summary)
+I (1107246) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1107254) perf: uxTaskGetSystemState returned 0 tasks
+I (1107255) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1107269) perf: ║              PERFORMANCE REPORT                             ║
+I (1107277) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1107295) perf: ── Poll Cycle ──
+I (1107299) perf:   poll_cycle_total         avg=   11.6  min=    5.9  max= 3057.2  last=    7.7 ms  [n=1088]
+I (1107309) perf:   effective_interval       avg= 1010.2  min=    7.5  max= 4058.0  last= 1037.0 ms  [n=1087]
+I (1107318) perf: ── Endpoint Fetchers ──
+I (1107323) perf:   equipment_bundle         avg=  941.2  min=   10.3  max= 6598.3  last= 6564.5 ms  [n=309]
+I (1107332) perf:   camera                   (no samples)
+I (1107337) perf:   guider                   (no samples)
+I (1107343) perf:   mount                    (no samples)
+I (1107348) perf:   focuser                  (no samples)
+I (1107353) perf:   sequence                 avg= 3986.5  min=   23.5  max= 7267.7  last= 6541.8 ms  [n=47]
+I (1107362) perf:   switch                   (no samples)
+I (1107367) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1107377) perf:   filter                   (no samples)
+I (1107382) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1107391) perf: ── Network ──
+I (1107395) perf:   http_request             avg= 1090.6  min=    0.4  max= 7045.4  last=  778.2 ms  [n=420]
+I (1107404) perf:   HTTP requests:  11 (interval) / 531 (total)
+I (1107410) perf:   HTTP retries:   10 (interval) / 266 (total)
+I (1107416) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1107421) perf:   HTTP unreachable:11 (interval) / 265 (total)
+I (1107427) perf:   WS events:      0 (interval) / 39 (total)
+I (1107432) perf: ── JSON Parsing ──
+I (1107436) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1107446) perf:   json_sequence            (no samples)
+I (1107451) perf:   json_config_color        (no samples)
+I (1107456) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1107462) perf: ── UI Updates ──
+I (1107465) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=861]
+I (1107475) perf:   ui_lock_wait             avg=    1.5  min=    0.0  max=   29.8  last=    0.0 ms  [n=861]
+I (1107484) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=461]
+I (1107494) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=400]
+I (1107504) perf: ── Latency ──
+I (1107507) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1107517) perf: ── JPEG ──
+I (1107520) perf:   jpeg_decode              (no samples)
+I (1107525) perf:   jpeg_fetch               (no samples)
+I (1107530) perf: ── Spotify ──
+I (1107534) perf:   spotify_poll_cycle       (no samples)
+I (1107539) perf:   spotify_api_fetch        (no samples)
+I (1107544) perf:   spotify_art_fetch        (no samples)
+I (1107549) perf:   spotify_art_decode       (no samples)
+I (1107554) perf:   spotify_ui_update        (no samples)
+I (1107559) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1107565) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1107570) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1107576) perf: ── WiFi ──
+I (1107579) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1107586) perf:   RSSI: cur=-60  avg=-59  min=-61  max=-54 dBm  [n=30]
+I (1107593) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1107598) perf: ── Memory ──
+I (1107601) perf:   Internal heap:  free=76723  min_ever=56907  largest_block=31744  frag_ratio=0.414
+I (1107610) perf:   PSRAM:          free=20904556  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1107620) perf: ── Task Stacks ──
+I (1107624) perf:   data_task HWM:  8080 bytes free
+I (1107629) perf:   input_task HWM: 5484 bytes free
+I (1107633) perf:   spotify_task HWM: 7164 bytes free
+W (1112697) nina_client: astromele2.lan unreachable
+I (1112697) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1112698) websocket_client: Started
+I (1112701) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1113502) nina_client: astromele1.lan unreachable
+W (1113502) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1113503) nina_client: === Poll Summary ===
+I (1113507) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1113512) nina_client: Target: , Filter: 
+I (1113516) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1113521) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1113526) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1113857) nina_client: desktop-bdt978m.lan unreachable
+I (1113857) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1114533) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1114858) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1119254) nina_client: astromele2.lan unreachable
+I (1119254) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1120254) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1121047) nina_client: astromele1.lan unreachable
+I (1121047) nina_client: === Poll Summary ===
+I (1121047) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1121050) nina_client: Target: , Filter: 
+I (1121054) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1121058) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1121064) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1121372) nina_client: desktop-bdt978m.lan unreachable
+I (1121372) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1122085) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1122373) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1122748) transport_ws: Error connecting to host astromele2.lan:1888
+E (1122748) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+I (1122755) tasks: Auto-rotate: switched to page 5
+W (1122760) nina_ws: WS[1]: Error
+I (1122767) websocket_client: Reconnect after 86400000 ms
+W (1122773) nina_ws: WS[1]: Disconnected from NINA
+I (1123787) tasks: Page switched to 5
+W (1126791) nina_client: astromele2.lan unreachable
+I (1126791) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1128630) nina_client: astromele1.lan unreachable
+W (1128936) nina_client: desktop-bdt978m.lan unreachable
+I (1128936) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1135263) nina_client: astromele1.lan unreachable
+W (1135263) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1135264) nina_client: === Poll Summary ===
+I (1135268) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1135273) nina_client: Target: , Filter: 
+I (1135277) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1135282) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1135287) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1136294) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1137907) perf: uxTaskGetSystemState returned 0 tasks
+I (1137907) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1137919) perf: ║              PERFORMANCE REPORT                             ║
+I (1137927) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1137945) perf: ── Poll Cycle ──
+I (1137949) perf:   poll_cycle_total         avg=   11.5  min=    5.9  max= 3057.2  last=    7.2 ms  [n=1118]
+I (1137959) perf:   effective_interval       avg= 1010.5  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1117]
+I (1137968) perf: ── Endpoint Fetchers ──
+I (1137973) perf:   equipment_bundle         avg=  963.5  min=   10.3  max= 6598.3  last= 4418.3 ms  [n=313]
+I (1137982) perf:   camera                   (no samples)
+I (1137987) perf:   guider                   (no samples)
+I (1137993) perf:   mount                    (no samples)
+I (1137998) perf:   focuser                  (no samples)
+I (1138003) perf:   sequence                 avg= 4093.0  min=   23.5  max= 7267.7  last= 6633.8 ms  [n=49]
+I (1138012) perf:   switch                   (no samples)
+I (1138017) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1138027) perf:   filter                   (no samples)
+I (1138032) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1138041) perf: ── Network ──
+I (1138045) perf:   http_request             avg= 1113.2  min=    0.4  max= 7045.4  last=  306.0 ms  [n=426]
+I (1138054) perf:   HTTP requests:  9 (interval) / 540 (total)
+I (1138060) perf:   HTTP retries:   10 (interval) / 276 (total)
+I (1138065) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1138071) perf:   HTTP unreachable:10 (interval) / 275 (total)
+I (1138077) perf:   WS events:      0 (interval) / 39 (total)
+I (1138082) perf: ── JSON Parsing ──
+I (1138086) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1138096) perf:   json_sequence            (no samples)
+I (1138101) perf:   json_config_color        (no samples)
+I (1138106) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1138111) perf: ── UI Updates ──
+I (1138115) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.1 ms  [n=891]
+I (1138125) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=891]
+I (1138134) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=476]
+I (1138144) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=415]
+I (1138153) perf: ── Latency ──
+I (1138157) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1138166) perf: ── JPEG ──
+I (1138170) perf:   jpeg_decode              (no samples)
+I (1138175) perf:   jpeg_fetch               (no samples)
+I (1138180) perf: ── Spotify ──
+I (1138184) perf:   spotify_poll_cycle       (no samples)
+I (1138189) perf:   spotify_api_fetch        (no samples)
+I (1138194) perf:   spotify_art_fetch        (no samples)
+I (1138199) perf:   spotify_art_decode       (no samples)
+I (1138204) perf:   spotify_ui_update        (no samples)
+I (1138209) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1138215) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1138220) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1138226) perf: ── WiFi ──
+I (1138229) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1138236) perf:   RSSI: cur=-60  avg=-60  min=-73  max=-59 dBm  [n=30]
+I (1138242) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1138248) perf: ── Memory ──
+I (1138251) perf:   Internal heap:  free=79115  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (1138260) perf:   PSRAM:          free=20904684  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1138270) perf: ── Task Stacks ──
+I (1138274) perf:   data_task HWM:  8080 bytes free
+I (1138278) perf:   input_task HWM: 5484 bytes free
+I (1138283) perf:   spotify_task HWM: 7164 bytes free
+I (1139294) tasks: Auto-rotate: switched to page 4
+I (1140313) tasks: Page switched to 4 (summary)
+W (1142807) nina_client: astromele1.lan unreachable
+I (1142807) nina_client: === Poll Summary ===
+I (1142807) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1142810) nina_client: Target: , Filter: 
+I (1142814) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1142818) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1142824) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1143303) nina_client: astromele2.lan unreachable
+I (1143303) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1143304) websocket_client: Started
+I (1143306) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1143831) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1145468) nina_client: desktop-bdt978m.lan unreachable
+I (1145468) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1149838) nina_client: astromele2.lan unreachable
+I (1149838) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1150380) nina_client: astromele1.lan unreachable
+I (1150838) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1151991) nina_client: desktop-bdt978m.lan unreachable
+I (1151991) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1152992) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1153320) transport_ws: Error connecting to host astromele2.lan:1888
+E (1153320) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1153332) nina_ws: WS[1]: Error
+I (1153335) websocket_client: Reconnect after 86400000 ms
+W (1153340) nina_ws: WS[1]: Disconnected from NINA
+I (1155438) tasks: Auto-rotate: switched to page 5
+I (1156469) tasks: Page switched to 5
+W (1156901) nina_client: astromele1.lan unreachable
+W (1156901) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1156902) nina_client: === Poll Summary ===
+I (1156906) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1156911) nina_client: Target: , Filter: 
+I (1156915) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1156920) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1156925) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1157401) nina_client: astromele2.lan unreachable
+I (1157401) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1157932) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1159541) nina_client: desktop-bdt978m.lan unreachable
+I (1159541) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1164478) nina_client: astromele1.lan unreachable
+I (1164478) nina_client: === Poll Summary ===
+I (1164478) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1164481) nina_client: Target: , Filter: 
+I (1164485) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1164489) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1164495) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1165502) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1168573) perf: uxTaskGetSystemState returned 0 tasks
+I (1168573) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1168585) perf: ║              PERFORMANCE REPORT                             ║
+I (1168593) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1168611) perf: ── Poll Cycle ──
+I (1168615) perf:   poll_cycle_total         avg=   11.4  min=    5.9  max= 3057.2  last=    7.3 ms  [n=1148]
+I (1168625) perf:   effective_interval       avg= 1010.8  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1147]
+I (1168634) perf: ── Endpoint Fetchers ──
+I (1168639) perf:   equipment_bundle         avg= 1005.1  min=   10.3  max= 6598.3  last= 1609.3 ms  [n=318]
+I (1168648) perf:   camera                   (no samples)
+I (1168653) perf:   guider                   (no samples)
+I (1168659) perf:   mount                    (no samples)
+I (1168664) perf:   focuser                  (no samples)
+I (1168669) perf:   sequence                 avg= 4141.5  min=   23.5  max= 7267.7  last= 6521.8 ms  [n=50]
+I (1168678) perf:   switch                   (no samples)
+I (1168683) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1168693) perf:   filter                   (no samples)
+I (1168698) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1168707) perf: ── Network ──
+I (1168711) perf:   http_request             avg= 1136.0  min=    0.4  max= 7045.4  last= 1609.3 ms  [n=432]
+I (1168720) perf:   HTTP requests:  10 (interval) / 550 (total)
+I (1168726) perf:   HTTP retries:   11 (interval) / 287 (total)
+I (1168732) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1168737) perf:   HTTP unreachable:10 (interval) / 285 (total)
+I (1168743) perf:   WS events:      0 (interval) / 39 (total)
+I (1168748) perf: ── JSON Parsing ──
+I (1168752) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1168762) perf:   json_sequence            (no samples)
+I (1168767) perf:   json_config_color        (no samples)
+I (1168772) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1168778) perf: ── UI Updates ──
+I (1168781) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.1 ms  [n=921]
+I (1168791) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=921]
+I (1168800) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=490]
+I (1168810) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=431]
+I (1168820) perf: ── Latency ──
+I (1168823) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1168833) perf: ── JPEG ──
+I (1168836) perf:   jpeg_decode              (no samples)
+I (1168841) perf:   jpeg_fetch               (no samples)
+I (1168846) perf: ── Spotify ──
+I (1168850) perf:   spotify_poll_cycle       (no samples)
+I (1168855) perf:   spotify_api_fetch        (no samples)
+I (1168860) perf:   spotify_art_fetch        (no samples)
+I (1168865) perf:   spotify_art_decode       (no samples)
+I (1168870) perf:   spotify_ui_update        (no samples)
+I (1168875) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1168881) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1168886) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1168892) perf: ── WiFi ──
+I (1168895) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1168902) perf:   RSSI: cur=-62  avg=-60  min=-63  max=-58 dBm  [n=30]
+I (1168909) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1168914) perf: ── Memory ──
+I (1168917) perf:   Internal heap:  free=79115  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (1168926) perf:   PSRAM:          free=20904660  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1168936) perf: ── Task Stacks ──
+I (1168940) perf:   data_task HWM:  8080 bytes free
+I (1168945) perf:   input_task HWM: 5484 bytes free
+I (1168949) perf:   spotify_task HWM: 7164 bytes free
+I (1171976) tasks: Auto-rotate: switched to page 4
+W (1172091) nina_client: astromele1.lan unreachable
+I (1172994) tasks: Page switched to 4 (summary)
+W (1173971) nina_client: astromele2.lan unreachable
+I (1173971) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1173972) websocket_client: Started
+I (1173975) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1176063) nina_client: desktop-bdt978m.lan unreachable
+I (1176063) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1178614) nina_client: astromele1.lan unreachable
+W (1178614) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1178615) nina_client: === Poll Summary ===
+I (1178619) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1178624) nina_client: Target: , Filter: 
+I (1178628) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1178633) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1178638) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1179645) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1180547) nina_client: astromele2.lan unreachable
+I (1180547) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1181547) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1182608) nina_client: desktop-bdt978m.lan unreachable
+I (1182608) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1183609) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1183979) transport_ws: Error connecting to host astromele2.lan:1888
+E (1183979) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1183991) nina_ws: WS[1]: Error
+I (1183994) websocket_client: Reconnect after 86400000 ms
+W (1183999) nina_ws: WS[1]: Disconnected from NINA
+W (1186222) nina_client: astromele1.lan unreachable
+I (1186222) nina_client: === Poll Summary ===
+I (1186222) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1186225) nina_client: Target: , Filter: 
+I (1186229) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1186233) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1186239) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1187298) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1188092) nina_client: astromele2.lan unreachable
+I (1188092) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1188120) tasks: Auto-rotate: switched to page 5
+I (1189092) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1189151) tasks: Page switched to 5
+W (1190153) nina_client: desktop-bdt978m.lan unreachable
+I (1190153) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1193850) nina_client: astromele1.lan unreachable
+W (1195728) nina_client: astromele2.lan unreachable
+I (1195728) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1195729) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1195736) websocket_client: Started
+W (1199239) perf: uxTaskGetSystemState returned 0 tasks
+I (1199239) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1199251) perf: ║              PERFORMANCE REPORT                             ║
+I (1199259) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1199277) perf: ── Poll Cycle ──
+I (1199281) perf:   poll_cycle_total         avg=   11.4  min=    5.9  max= 3057.2  last=    7.3 ms  [n=1178]
+I (1199291) perf:   effective_interval       avg= 1011.1  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1177]
+I (1199300) perf: ── Endpoint Fetchers ──
+I (1199305) perf:   equipment_bundle         avg= 1026.7  min=   10.3  max= 6598.3  last= 1061.3 ms  [n=324]
+I (1199314) perf:   camera                   (no samples)
+I (1199319) perf:   guider                   (no samples)
+I (1199325) perf:   mount                    (no samples)
+I (1199330) perf:   focuser                  (no samples)
+I (1199335) perf:   sequence                 avg= 4188.3  min=   23.5  max= 7267.7  last= 6523.7 ms  [n=51]
+I (1199344) perf:   switch                   (no samples)
+I (1199349) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1199359) perf:   filter                   (no samples)
+I (1199364) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1199373) perf: ── Network ──
+I (1199377) perf:   http_request             avg= 1149.6  min=    0.4  max= 7045.4  last= 1878.0 ms  [n=442]
+I (1199386) perf:   HTTP requests:  10 (interval) / 560 (total)
+I (1199392) perf:   HTTP retries:   11 (interval) / 298 (total)
+I (1199398) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1199403) perf:   HTTP unreachable:11 (interval) / 296 (total)
+I (1199409) perf:   WS events:      0 (interval) / 39 (total)
+I (1199414) perf: ── JSON Parsing ──
+I (1199418) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1199428) perf:   json_sequence            (no samples)
+I (1199433) perf:   json_config_color        (no samples)
+I (1199438) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1199444) perf: ── UI Updates ──
+I (1199447) perf:   ui_update_total          avg=    1.5  min=    0.0  max=   29.8  last=    0.1 ms  [n=951]
+I (1199457) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=951]
+I (1199466) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.0 ms  [n=504]
+I (1199476) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=447]
+I (1199486) perf: ── Latency ──
+I (1199489) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1199499) perf: ── JPEG ──
+I (1199502) perf:   jpeg_decode              (no samples)
+I (1199507) perf:   jpeg_fetch               (no samples)
+I (1199512) perf: ── Spotify ──
+I (1199516) perf:   spotify_poll_cycle       (no samples)
+I (1199521) perf:   spotify_api_fetch        (no samples)
+I (1199526) perf:   spotify_art_fetch        (no samples)
+I (1199531) perf:   spotify_art_decode       (no samples)
+I (1199536) perf:   spotify_ui_update        (no samples)
+I (1199541) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1199547) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1199552) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1199558) perf: ── WiFi ──
+I (1199561) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1199568) perf:   RSSI: cur=-60  avg=-60  min=-64  max=-58 dBm  [n=30]
+I (1199575) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1199580) perf: ── Memory ──
+I (1199583) perf:   Internal heap:  free=81455  min_ever=56907  largest_block=31744  frag_ratio=0.390
+I (1199592) perf:   PSRAM:          free=20904680  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1199602) perf: ── Task Stacks ──
+I (1199606) perf:   data_task HWM:  8080 bytes free
+I (1199611) perf:   input_task HWM: 5484 bytes free
+I (1199615) perf:   spotify_task HWM: 7164 bytes free
+W (1200380) nina_client: astromele1.lan unreachable
+W (1200380) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1200381) nina_client: === Poll Summary ===
+I (1200385) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1200390) nina_client: Target: , Filter: 
+I (1200394) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1200399) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1200404) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1201411) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1204658) tasks: Auto-rotate: switched to page 4
+I (1205676) tasks: Page switched to 4 (summary)
+I (1205676) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1205790) transport_ws: Error connecting to host astromele2.lan:1888
+E (1205790) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1205802) nina_ws: WS[1]: Error
+I (1205805) websocket_client: Reconnect after 86400000 ms
+W (1205810) nina_ws: WS[1]: Disconnected from NINA
+W (1206671) nina_client: desktop-bdt978m.lan unreachable
+I (1206671) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1207931) nina_client: astromele1.lan unreachable
+I (1207931) nina_client: === Poll Summary ===
+I (1207931) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1207934) nina_client: Target: , Filter: 
+I (1207938) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1207942) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1207948) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1208955) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1212205) nina_client: astromele2.lan unreachable
+I (1212205) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1212206) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1212213) websocket_client: Started
+W (1213214) nina_client: desktop-bdt978m.lan unreachable
+I (1213214) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1213216) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1214215) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1215509) nina_client: astromele1.lan unreachable
+W (1219784) nina_client: astromele2.lan unreachable
+I (1219784) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1220784) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1220802) nina_client: desktop-bdt978m.lan unreachable
+I (1220802) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1220803) tasks: Auto-rotate: switched to page 5
+I (1221803) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1221832) tasks: Page switched to 5
+W (1222031) nina_client: astromele1.lan unreachable
+W (1222031) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1222032) nina_client: === Poll Summary ===
+I (1222036) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1222041) nina_client: Target: , Filter: 
+I (1222045) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1222050) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1222055) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+E (1222240) transport_ws: Error connecting to host astromele2.lan:1888
+E (1222240) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1222252) nina_ws: WS[1]: Error
+I (1222255) websocket_client: Reconnect after 86400000 ms
+W (1222260) nina_ws: WS[1]: Disconnected from NINA
+I (1223062) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1227320) nina_client: astromele2.lan unreachable
+I (1227320) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1227321) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1227328) websocket_client: Started
+W (1228348) nina_client: desktop-bdt978m.lan unreachable
+I (1228348) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1229600) nina_client: astromele1.lan unreachable
+I (1229600) nina_client: === Poll Summary ===
+I (1229600) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1229603) nina_client: Target: , Filter: 
+I (1229607) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1229611) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1229617) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1229904) perf: uxTaskGetSystemState returned 0 tasks
+I (1229904) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1229916) perf: ║              PERFORMANCE REPORT                             ║
+I (1229923) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1229942) perf: ── Poll Cycle ──
+I (1229946) perf:   poll_cycle_total         avg=   11.3  min=    5.9  max= 3057.2  last=    6.8 ms  [n=1208]
+I (1229955) perf:   effective_interval       avg= 1011.4  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1207]
+I (1229965) perf: ── Endpoint Fetchers ──
+I (1229969) perf:   equipment_bundle         avg= 1041.7  min=   10.3  max= 6598.3  last= 4258.3 ms  [n=329]
+I (1229979) perf:   camera                   (no samples)
+I (1229984) perf:   guider                   (no samples)
+I (1229989) perf:   mount                    (no samples)
+I (1229994) perf:   focuser                  (no samples)
+I (1229999) perf:   sequence                 avg= 4276.5  min=   23.5  max= 7267.7  last= 6522.8 ms  [n=53]
+I (1230009) perf:   switch                   (no samples)
+I (1230014) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1230023) perf:   filter                   (no samples)
+I (1230028) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1230038) perf: ── Network ──
+I (1230041) perf:   http_request             avg= 1161.7  min=    0.4  max= 7045.4  last= 4258.3 ms  [n=451]
+I (1230051) perf:   HTTP requests:  11 (interval) / 571 (total)
+I (1230056) perf:   HTTP retries:   11 (interval) / 309 (total)
+I (1230062) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1230068) perf:   HTTP unreachable:12 (interval) / 308 (total)
+I (1230073) perf:   WS events:      0 (interval) / 39 (total)
+I (1230079) perf: ── JSON Parsing ──
+I (1230083) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1230092) perf:   json_sequence            (no samples)
+I (1230097) perf:   json_config_color        (no samples)
+I (1230102) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1230108) perf: ── UI Updates ──
+I (1230112) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=981]
+I (1230121) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=981]
+I (1230131) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=518]
+I (1230141) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=463]
+I (1230150) perf: ── Latency ──
+I (1230154) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1230163) perf: ── JPEG ──
+I (1230166) perf:   jpeg_decode              (no samples)
+I (1230171) perf:   jpeg_fetch               (no samples)
+I (1230177) perf: ── Spotify ──
+I (1230180) perf:   spotify_poll_cycle       (no samples)
+I (1230185) perf:   spotify_api_fetch        (no samples)
+I (1230190) perf:   spotify_art_fetch        (no samples)
+I (1230196) perf:   spotify_art_decode       (no samples)
+I (1230201) perf:   spotify_ui_update        (no samples)
+I (1230206) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1230211) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1230217) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1230222) perf: ── WiFi ──
+I (1230226) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1230233) perf:   RSSI: cur=-59  avg=-59  min=-61  max=-57 dBm  [n=30]
+I (1230239) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1230244) perf: ── Memory ──
+I (1230248) perf:   Internal heap:  free=83895  min_ever=56907  largest_block=31744  frag_ratio=0.378
+I (1230257) perf:   PSRAM:          free=20905260  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1230267) perf: ── Task Stacks ──
+I (1230271) perf:   data_task HWM:  8080 bytes free
+I (1230275) perf:   input_task HWM: 5484 bytes free
+I (1230280) perf:   spotify_task HWM: 7164 bytes free
+I (1230624) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1237144) nina_client: astromele1.lan unreachable
+E (1237333) transport_ws: Error connecting to host astromele2.lan:1888
+E (1237333) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+I (1237339) tasks: Auto-rotate: switched to page 4
+W (1237345) nina_ws: WS[1]: Error
+I (1237352) websocket_client: Reconnect after 86400000 ms
+W (1237358) nina_ws: WS[1]: Disconnected from NINA
+I (1238374) tasks: Page switched to 4 (summary)
+W (1243717) nina_client: astromele1.lan unreachable
+W (1243717) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1243718) nina_client: === Poll Summary ===
+I (1243722) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1243727) nina_client: Target: , Filter: 
+I (1243731) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1243736) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1243741) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1243869) nina_client: astromele2.lan unreachable
+I (1243869) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1243870) websocket_client: Started
+I (1243872) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1244748) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1244867) nina_client: desktop-bdt978m.lan unreachable
+I (1244867) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1250510) nina_client: astromele2.lan unreachable
+I (1250510) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1251434) nina_client: astromele1.lan unreachable
+I (1251434) nina_client: === Poll Summary ===
+I (1251434) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+W (1251436) nina_client: desktop-bdt978m.lan unreachable
+I (1251437) nina_client: Target: , Filter: 
+I (1251441) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1251445) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1251451) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1251463) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1251510) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1252470) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1252478) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1253499) tasks: Auto-rotate: switched to page 5
+E (1253892) transport_ws: Error connecting to host astromele2.lan:1888
+E (1253892) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1253904) nina_ws: WS[1]: Error
+I (1253907) websocket_client: Reconnect after 86400000 ms
+W (1253912) nina_ws: WS[1]: Disconnected from NINA
+I (1254530) tasks: Page switched to 5
+W (1258088) nina_client: astromele2.lan unreachable
+I (1258088) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1258992) nina_client: desktop-bdt978m.lan unreachable
+I (1258992) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1258993) nina_client: astromele1.lan unreachable
+W (1260586) perf: uxTaskGetSystemState returned 0 tasks
+I (1260586) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1260598) perf: ║              PERFORMANCE REPORT                             ║
+I (1260606) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1260624) perf: ── Poll Cycle ──
+I (1260628) perf:   poll_cycle_total         avg=   11.2  min=    5.9  max= 3057.2  last=    7.3 ms  [n=1238]
+I (1260638) perf:   effective_interval       avg= 1011.6  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1237]
+I (1260647) perf: ── Endpoint Fetchers ──
+I (1260652) perf:   equipment_bundle         avg= 1085.9  min=   10.3  max= 6598.3  last= 5610.2 ms  [n=332]
+I (1260661) perf:   camera                   (no samples)
+I (1260666) perf:   guider                   (no samples)
+I (1260671) perf:   mount                    (no samples)
+I (1260677) perf:   focuser                  (no samples)
+I (1260682) perf:   sequence                 avg= 4319.0  min=   23.5  max= 7267.7  last= 6573.8 ms  [n=54]
+I (1260691) perf:   switch                   (no samples)
+I (1260696) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1260706) perf:   filter                   (no samples)
+I (1260711) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1260720) perf: ── Network ──
+I (1260724) perf:   http_request             avg= 1200.0  min=    0.4  max= 7045.4  last= 5610.2 ms  [n=456]
+I (1260733) perf:   HTTP requests:  11 (interval) / 582 (total)
+I (1260739) perf:   HTTP retries:   10 (interval) / 319 (total)
+I (1260745) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1260750) perf:   HTTP unreachable:10 (interval) / 318 (total)
+I (1260756) perf:   WS events:      0 (interval) / 39 (total)
+I (1260761) perf: ── JSON Parsing ──
+I (1260765) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1260775) perf:   json_sequence            (no samples)
+I (1260780) perf:   json_config_color        (no samples)
+I (1260785) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1260790) perf: ── UI Updates ──
+I (1260794) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1011]
+I (1260804) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1011]
+I (1260814) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.0 ms  [n=532]
+I (1260823) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.1 ms  [n=479]
+I (1260833) perf: ── Latency ──
+I (1260836) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1260846) perf: ── JPEG ──
+I (1260849) perf:   jpeg_decode              (no samples)
+I (1260854) perf:   jpeg_fetch               (no samples)
+I (1260859) perf: ── Spotify ──
+I (1260863) perf:   spotify_poll_cycle       (no samples)
+I (1260868) perf:   spotify_api_fetch        (no samples)
+I (1260873) perf:   spotify_art_fetch        (no samples)
+I (1260878) perf:   spotify_art_decode       (no samples)
+I (1260883) perf:   spotify_ui_update        (no samples)
+I (1260888) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1260894) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1260899) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1260905) perf: ── WiFi ──
+I (1260908) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1260915) perf:   RSSI: cur=-59  avg=-59  min=-66  max=-57 dBm  [n=30]
+I (1260922) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1260927) perf: ── Memory ──
+I (1260931) perf:   Internal heap:  free=81583  min_ever=56907  largest_block=31744  frag_ratio=0.389
+I (1260940) perf:   PSRAM:          free=20905252  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1260949) perf: ── Task Stacks ──
+I (1260953) perf:   data_task HWM:  8080 bytes free
+I (1260958) perf:   input_task HWM: 5484 bytes free
+I (1260962) perf:   spotify_task HWM: 7164 bytes free
+W (1265543) nina_client: astromele1.lan unreachable
+W (1265543) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1265544) nina_client: === Poll Summary ===
+I (1265548) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1265553) nina_client: Target: , Filter: 
+I (1265557) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1265562) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1265567) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1266574) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1270037) tasks: Auto-rotate: switched to page 4
+I (1271055) tasks: Page switched to 4 (summary)
+W (1273114) nina_client: astromele1.lan unreachable
+I (1273114) nina_client: === Poll Summary ===
+I (1273114) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1273117) nina_client: Target: , Filter: 
+I (1273121) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1273125) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1273131) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1274138) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1274630) nina_client: astromele2.lan unreachable
+I (1274630) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1274631) websocket_client: Started
+I (1274633) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1275516) nina_client: desktop-bdt978m.lan unreachable
+I (1275516) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1280698) nina_client: astromele1.lan unreachable
+W (1281178) nina_client: astromele2.lan unreachable
+I (1281178) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1282028) nina_client: desktop-bdt978m.lan unreachable
+I (1282028) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1282178) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1283029) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1284637) transport_ws: Error connecting to host astromele2.lan:1888
+E (1284637) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1284649) nina_ws: WS[1]: Error
+I (1284652) websocket_client: Reconnect after 86400000 ms
+W (1284657) nina_ws: WS[1]: Disconnected from NINA
+I (1286180) tasks: Auto-rotate: switched to page 5
+I (1287211) tasks: Page switched to 5
+W (1287225) nina_client: astromele1.lan unreachable
+W (1287225) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1287226) nina_client: === Poll Summary ===
+I (1287230) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1287235) nina_client: Target: , Filter: 
+I (1287239) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1287244) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1287249) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1288256) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1288692) nina_client: astromele2.lan unreachable
+I (1288692) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1289589) nina_client: desktop-bdt978m.lan unreachable
+I (1289589) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1291251) perf: uxTaskGetSystemState returned 0 tasks
+I (1291251) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1291263) perf: ║              PERFORMANCE REPORT                             ║
+I (1291271) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1291289) perf: ── Poll Cycle ──
+I (1291293) perf:   poll_cycle_total         avg=   11.2  min=    5.9  max= 3057.2  last=    7.2 ms  [n=1268]
+I (1291303) perf:   effective_interval       avg= 1011.9  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1267]
+I (1291312) perf: ── Endpoint Fetchers ──
+I (1291317) perf:   equipment_bundle         avg= 1112.4  min=   10.3  max= 6598.3  last=  436.3 ms  [n=335]
+I (1291326) perf:   camera                   (no samples)
+I (1291331) perf:   guider                   (no samples)
+I (1291336) perf:   mount                    (no samples)
+I (1291342) perf:   focuser                  (no samples)
+I (1291347) perf:   sequence                 avg= 4398.3  min=   23.5  max= 7267.7  last= 6527.8 ms  [n=56]
+I (1291356) perf:   switch                   (no samples)
+I (1291361) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1291371) perf:   filter                   (no samples)
+I (1291376) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1291385) perf: ── Network ──
+I (1291389) perf:   http_request             avg= 1227.4  min=    0.4  max= 7045.4  last=  436.3 ms  [n=464]
+I (1291398) perf:   HTTP requests:  10 (interval) / 592 (total)
+I (1291404) perf:   HTTP retries:   11 (interval) / 330 (total)
+I (1291410) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1291415) perf:   HTTP unreachable:10 (interval) / 328 (total)
+I (1291421) perf:   WS events:      0 (interval) / 39 (total)
+I (1291426) perf: ── JSON Parsing ──
+I (1291430) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1291440) perf:   json_sequence            (no samples)
+I (1291445) perf:   json_config_color        (no samples)
+I (1291450) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1291455) perf: ── UI Updates ──
+I (1291459) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1041]
+I (1291469) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1041]
+I (1291479) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=546]
+I (1291488) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=495]
+I (1291498) perf: ── Latency ──
+I (1291501) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1291511) perf: ── JPEG ──
+I (1291514) perf:   jpeg_decode              (no samples)
+I (1291519) perf:   jpeg_fetch               (no samples)
+I (1291524) perf: ── Spotify ──
+I (1291528) perf:   spotify_poll_cycle       (no samples)
+I (1291533) perf:   spotify_api_fetch        (no samples)
+I (1291538) perf:   spotify_art_fetch        (no samples)
+I (1291543) perf:   spotify_art_decode       (no samples)
+I (1291548) perf:   spotify_ui_update        (no samples)
+I (1291553) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1291559) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1291564) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1291570) perf: ── WiFi ──
+I (1291573) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1291580) perf:   RSSI: cur=-58  avg=-58  min=-59  max=-53 dBm  [n=30]
+I (1291587) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1291592) perf: ── Memory ──
+I (1291596) perf:   Internal heap:  free=81559  min_ever=56907  largest_block=31744  frag_ratio=0.389
+I (1291604) perf:   PSRAM:          free=20905260  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1291614) perf: ── Task Stacks ──
+I (1291618) perf:   data_task HWM:  8080 bytes free
+I (1291623) perf:   input_task HWM: 5484 bytes free
+I (1291627) perf:   spotify_task HWM: 7164 bytes free
+W (1294847) nina_client: astromele1.lan unreachable
+I (1294847) nina_client: === Poll Summary ===
+I (1294847) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1294850) nina_client: Target: , Filter: 
+I (1294854) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1294858) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1294864) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1295871) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1302406) nina_client: astromele1.lan unreachable
+I (1302718) tasks: Auto-rotate: switched to page 4
+I (1303737) tasks: Page switched to 4 (summary)
+W (1305246) nina_client: astromele2.lan unreachable
+I (1305246) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1305247) websocket_client: Started
+I (1305250) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1306102) nina_client: desktop-bdt978m.lan unreachable
+I (1306102) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1308931) nina_client: astromele1.lan unreachable
+W (1308931) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1308932) nina_client: === Poll Summary ===
+I (1308936) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1308941) nina_client: Target: , Filter: 
+I (1308945) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1308950) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1308955) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1309962) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1311862) nina_client: astromele2.lan unreachable
+I (1311862) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1312662) nina_client: desktop-bdt978m.lan unreachable
+I (1312662) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1312862) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1313663) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1315253) transport_ws: Error connecting to host astromele2.lan:1888
+E (1315253) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1315265) nina_ws: WS[1]: Error
+I (1315268) websocket_client: Reconnect after 86400000 ms
+W (1315273) nina_ws: WS[1]: Disconnected from NINA
+W (1316475) nina_client: astromele1.lan unreachable
+I (1316475) nina_client: === Poll Summary ===
+I (1316475) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1316478) nina_client: Target: , Filter: 
+I (1316482) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1316486) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1316492) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1317550) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1318862) tasks: Auto-rotate: switched to page 5
+W (1319411) nina_client: astromele2.lan unreachable
+I (1319411) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1319893) tasks: Page switched to 5
+W (1320241) nina_client: desktop-bdt978m.lan unreachable
+I (1320241) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1321917) perf: uxTaskGetSystemState returned 0 tasks
+I (1321917) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1321929) perf: ║              PERFORMANCE REPORT                             ║
+I (1321937) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1321955) perf: ── Poll Cycle ──
+I (1321959) perf:   poll_cycle_total         avg=   11.1  min=    5.9  max= 3057.2  last=    7.3 ms  [n=1298]
+I (1321969) perf:   effective_interval       avg= 1012.1  min=    7.5  max= 4058.0  last= 1008.0 ms  [n=1297]
+I (1321978) perf: ── Endpoint Fetchers ──
+I (1321983) perf:   equipment_bundle         avg= 1138.0  min=   10.3  max= 6598.3  last= 1860.8 ms  [n=339]
+I (1321992) perf:   camera                   (no samples)
+I (1321997) perf:   guider                   (no samples)
+I (1322003) perf:   mount                    (no samples)
+I (1322008) perf:   focuser                  (no samples)
+I (1322013) perf:   sequence                 avg= 4435.6  min=   23.5  max= 7267.7  last= 6525.8 ms  [n=57]
+I (1322022) perf:   switch                   (no samples)
+I (1322027) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1322037) perf:   filter                   (no samples)
+I (1322042) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1322051) perf: ── Network ──
+I (1322055) perf:   http_request             avg= 1242.9  min=    0.4  max= 7045.4  last= 1860.8 ms  [n=471]
+I (1322064) perf:   HTTP requests:  11 (interval) / 603 (total)
+I (1322070) perf:   HTTP retries:   10 (interval) / 340 (total)
+I (1322076) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1322081) perf:   HTTP unreachable:10 (interval) / 338 (total)
+I (1322087) perf:   WS events:      0 (interval) / 39 (total)
+I (1322092) perf: ── JSON Parsing ──
+I (1322096) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1322106) perf:   json_sequence            (no samples)
+I (1322111) perf:   json_config_color        (no samples)
+I (1322116) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1322122) perf: ── UI Updates ──
+I (1322125) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1071]
+I (1322135) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1071]
+I (1322145) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=560]
+I (1322154) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=511]
+I (1322164) perf: ── Latency ──
+I (1322167) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1322177) perf: ── JPEG ──
+I (1322180) perf:   jpeg_decode              (no samples)
+I (1322185) perf:   jpeg_fetch               (no samples)
+I (1322190) perf: ── Spotify ──
+I (1322194) perf:   spotify_poll_cycle       (no samples)
+I (1322199) perf:   spotify_api_fetch        (no samples)
+I (1322204) perf:   spotify_art_fetch        (no samples)
+I (1322209) perf:   spotify_art_decode       (no samples)
+I (1322214) perf:   spotify_ui_update        (no samples)
+I (1322219) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1322225) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1322231) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1322236) perf: ── WiFi ──
+I (1322239) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1322246) perf:   RSSI: cur=-59  avg=-58  min=-59  max=-56 dBm  [n=30]
+I (1322253) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1322258) perf: ── Memory ──
+I (1322262) perf:   Internal heap:  free=79131  min_ever=56907  largest_block=31744  frag_ratio=0.401
+I (1322271) perf:   PSRAM:          free=20904668  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1322280) perf: ── Task Stacks ──
+I (1322284) perf:   data_task HWM:  8080 bytes free
+I (1322289) perf:   input_task HWM: 5484 bytes free
+I (1322293) perf:   spotify_task HWM: 7164 bytes free
+W (1324190) nina_client: astromele1.lan unreachable
+W (1326954) nina_client: astromele2.lan unreachable
+I (1326954) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1326955) websocket_client: Started
+W (1330757) nina_client: astromele1.lan unreachable
+W (1330757) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1330758) nina_client: === Poll Summary ===
+I (1330762) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1330767) nina_client: Target: , Filter: 
+I (1330771) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1330776) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1330781) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1331788) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1335400) tasks: Auto-rotate: switched to page 4
+I (1336418) tasks: Page switched to 4 (summary)
+I (1336418) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1336782) nina_client: desktop-bdt978m.lan unreachable
+I (1336782) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1336960) transport_ws: Error connecting to host astromele2.lan:1888
+E (1336960) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1336972) nina_ws: WS[1]: Error
+I (1336975) websocket_client: Reconnect after 86400000 ms
+W (1336980) nina_ws: WS[1]: Disconnected from NINA
+W (1338416) nina_client: astromele1.lan unreachable
+I (1338416) nina_client: === Poll Summary ===
+I (1338416) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1338419) nina_client: Target: , Filter: 
+I (1338423) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1338427) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1338433) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1339440) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1342952) nina_client: astromele2.lan unreachable
+I (1342952) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1342952) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1342960) websocket_client: Started
+W (1343301) nina_client: desktop-bdt978m.lan unreachable
+I (1343301) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1343963) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1344302) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1346037) nina_client: astromele1.lan unreachable
+W (1350500) nina_client: astromele2.lan unreachable
+I (1350500) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1350835) nina_client: desktop-bdt978m.lan unreachable
+I (1350835) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1351500) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1351543) tasks: Auto-rotate: switched to page 5
+I (1351836) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1352575) tasks: Page switched to 5
+W (1352578) nina_client: astromele1.lan unreachable
+W (1352578) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1352579) nina_client: === Poll Summary ===
+W (1352583) perf: uxTaskGetSystemState returned 0 tasks
+I (1352583) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1352588) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1352594) nina_client: Target: , Filter: 
+I (1352612) perf: ║              PERFORMANCE REPORT                             ║
+I (1352616) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1352624) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1352628) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1352647) perf: ── Poll Cycle ──
+I (1352652) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1352656) perf:   poll_cycle_total         avg=   11.1  min=    5.9  max= 3057.2  last=    7.6 ms  [n=1328]
+I (1352673) perf:   effective_interval       avg= 1012.4  min=    7.5  max= 4058.0  last= 1037.0 ms  [n=1327]
+I (1352682) perf: ── Endpoint Fetchers ──
+I (1352687) perf:   equipment_bundle         avg= 1148.1  min=   10.3  max= 6598.3  last= 1735.3 ms  [n=342]
+I (1352696) perf:   camera                   (no samples)
+I (1352701) perf:   guider                   (no samples)
+I (1352706) perf:   mount                    (no samples)
+I (1352711) perf:   focuser                  (no samples)
+I (1352717) perf:   sequence                 avg= 4507.4  min=   23.5  max= 7267.7  last= 6542.4 ms  [n=59]
+I (1352726) perf:   switch                   (no samples)
+I (1352731) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1352741) perf:   filter                   (no samples)
+I (1352746) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1352755) perf: ── Network ──
+I (1352759) perf:   http_request             avg= 1260.2  min=    0.4  max= 7045.4  last=  742.2 ms  [n=480]
+I (1352768) perf:   HTTP requests:  11 (interval) / 614 (total)
+I (1352774) perf:   HTTP retries:   10 (interval) / 350 (total)
+I (1352779) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1352785) perf:   HTTP unreachable:11 (interval) / 349 (total)
+I (1352791) perf:   WS events:      0 (interval) / 39 (total)
+I (1352796) perf: ── JSON Parsing ──
+I (1352800) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1352810) perf:   json_sequence            (no samples)
+I (1352815) perf:   json_config_color        (no samples)
+I (1352820) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1352825) perf: ── UI Updates ──
+I (1352829) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1101]
+I (1352839) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1101]
+I (1352848) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=574]
+I (1352858) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=527]
+I (1352868) perf: ── Latency ──
+I (1352871) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1352881) perf: ── JPEG ──
+I (1352884) perf:   jpeg_decode              (no samples)
+I (1352889) perf:   jpeg_fetch               (no samples)
+I (1352894) perf: ── Spotify ──
+I (1352898) perf:   spotify_poll_cycle       (no samples)
+I (1352903) perf:   spotify_api_fetch        (no samples)
+I (1352908) perf:   spotify_art_fetch        (no samples)
+I (1352913) perf:   spotify_art_decode       (no samples)
+I (1352918) perf:   spotify_ui_update        (no samples)
+I (1352923) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1352929) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1352934) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1352940) perf: ── WiFi ──
+I (1352943) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1352950) perf:   RSSI: cur=-59  avg=-58  min=-60  max=-56 dBm  [n=30]
+I (1352957) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1352962) perf: ── Memory ──
+I (1352965) perf:   Internal heap:  free=78991  min_ever=56907  largest_block=31744  frag_ratio=0.402
+I (1352974) perf:   PSRAM:          free=20904096  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1352984) perf: ── Task Stacks ──
+I (1352988) perf:   data_task HWM:  8080 bytes free
+I (1352993) perf:   input_task HWM: 5484 bytes free
+I (1352997) perf:   spotify_task HWM: 7164 bytes free
+E (1353037) transport_ws: Error connecting to host astromele2.lan:1888
+E (1353037) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1353049) nina_ws: WS[1]: Error
+I (1353052) websocket_client: Reconnect after 86400000 ms
+W (1353057) nina_ws: WS[1]: Disconnected from NINA
+I (1353663) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1358016) nina_client: astromele2.lan unreachable
+I (1358016) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1358398) nina_client: desktop-bdt978m.lan unreachable
+I (1358398) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1360176) nina_client: astromele1.lan unreachable
+I (1360176) nina_client: === Poll Summary ===
+I (1360176) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1360179) nina_client: Target: , Filter: 
+I (1360183) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1360187) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1360193) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1361200) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1367805) nina_client: astromele1.lan unreachable
+I (1368120) tasks: Auto-rotate: switched to page 4
+I (1369148) tasks: Page switched to 4 (summary)
+W (1374564) nina_client: astromele1.lan unreachable
+W (1374564) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1374565) nina_client: === Poll Summary ===
+I (1374569) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1374575) nina_client: Target: , Filter: 
+I (1374578) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1374583) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1374588) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1374676) nina_client: astromele2.lan unreachable
+I (1374676) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1374677) websocket_client: Started
+I (1374679) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1374977) nina_client: desktop-bdt978m.lan unreachable
+I (1374977) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1375595) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1375676) rpc_req: Scan start Req
+
+I (1379891) RPC_WRAP: ESP Event: StaScanDone
+I (1379940) ota_github: Using OTA-installed version for comparison: v1.0.40-dev.1
+I (1379940) ota_github: Checking GitHub for updates (current: v1.0.40-dev.1, channel: pre-release)
+W (1381247) nina_client: astromele2.lan unreachable
+I (1381247) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1381579) nina_client: desktop-bdt978m.lan unreachable
+I (1381579) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1381943) ota_github: GitHub API response: 34428 bytes
+I (1381954) ota_github: Update available: v1.0.42-dev.1 (pre-release: yes)
+I (1381957) ota_github: Resolving OTA download URL...
+I (1382869) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1382870) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1382871) nina_client: astromele1.lan unreachable
+I (1382876) nina_client: === Poll Summary ===
+I (1382880) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1382886) nina_client: Target: , Filter: 
+I (1382890) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1382894) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1382900) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1383254) ota_github: Resolved OTA URL via 302 redirect
+W (1383924) perf: uxTaskGetSystemState returned 0 tasks
+I (1383924) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1383936) perf: ║              PERFORMANCE REPORT                             ║
+I (1383944) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1383962) perf: ── Poll Cycle ──
+I (1383966) perf:   poll_cycle_total         avg=   13.7  min=    5.9  max= 3685.8  last=    7.4 ms  [n=1355]
+I (1383976) perf:   effective_interval       avg= 1015.3  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1354]
+I (1383985) perf: ── Endpoint Fetchers ──
+I (1383990) perf:   equipment_bundle         avg= 1182.9  min=    4.6  max= 6605.3  last=    4.6 ms  [n=346]
+I (1383992) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1383999) perf:   camera                   (no samples)
+I (1384011) perf:   guider                   (no samples)
+I (1384016) perf:   mount                    (no samples)
+I (1384022) perf:   focuser                  (no samples)
+I (1384027) perf:   sequence                 avg= 4545.0  min=   23.5  max= 7267.7  last= 6760.0 ms  [n=60]
+I (1384036) perf:   switch                   (no samples)
+I (1384041) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1384051) perf:   filter                   (no samples)
+I (1384056) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1384065) perf: ── Network ──
+I (1384069) perf:   http_request             avg= 1292.2  min=    0.4  max= 7045.4  last=    4.6 ms  [n=486]
+I (1384078) perf:   HTTP requests:  11 (interval) / 625 (total)
+I (1384084) perf:   HTTP retries:   10 (interval) / 360 (total)
+I (1384090) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1384095) perf:   HTTP unreachable:10 (interval) / 359 (total)
+I (1384101) perf:   WS events:      0 (interval) / 39 (total)
+I (1384106) perf: ── JSON Parsing ──
+I (1384110) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1384120) perf:   json_sequence            (no samples)
+I (1384125) perf:   json_config_color        (no samples)
+I (1384130) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1384135) perf: ── UI Updates ──
+I (1384139) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1128]
+I (1384149) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1128]
+I (1384159) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=589]
+I (1384168) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=539]
+I (1384178) perf: ── Latency ──
+I (1384181) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1384191) perf: ── JPEG ──
+I (1384194) perf:   jpeg_decode              (no samples)
+I (1384199) perf:   jpeg_fetch               (no samples)
+I (1384204) perf: ── Spotify ──
+I (1384208) perf:   spotify_poll_cycle       (no samples)
+I (1384213) perf:   spotify_api_fetch        (no samples)
+I (1384218) perf:   spotify_art_fetch        (no samples)
+I (1384223) perf:   spotify_art_decode       (no samples)
+I (1384228) perf:   spotify_ui_update        (no samples)
+I (1384233) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1384239) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1384244) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1384250) perf: ── WiFi ──
+I (1384253) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1384260) perf:   RSSI: cur=-57  avg=-58  min=-77  max=-57 dBm  [n=27]
+I (1384267) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1384272) perf: ── Memory ──
+I (1384276) perf:   Internal heap:  free=78539  min_ever=53671  largest_block=31744  frag_ratio=0.404
+I (1384284) perf:   PSRAM:          free=20902840  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1384294) perf: ── Task Stacks ──
+I (1384298) perf:   data_task HWM:  8080 bytes free
+I (1384303) perf:   input_task HWM: 5484 bytes free
+I (1384307) perf:   spotify_task HWM: 7164 bytes free
+E (1384683) transport_ws: Error connecting to host astromele2.lan:1888
+E (1384683) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1384695) nina_ws: WS[1]: Error
+I (1384698) websocket_client: Reconnect after 86400000 ms
+W (1384703) nina_ws: WS[1]: Disconnected from NINA
+I (1385317) tasks: Auto-rotate: switched to page 5
+I (1386347) tasks: Page switched to 5
+W (1389432) nina_client: desktop-bdt978m.lan unreachable
+I (1389432) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1389433) nina_client: astromele2.lan unreachable
+I (1389438) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1390881) nina_client: astromele1.lan unreachable
+W (1397563) nina_client: astromele1.lan unreachable
+W (1397563) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1397564) nina_client: === Poll Summary ===
+I (1397568) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1397573) nina_client: Target: , Filter: 
+I (1397577) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1397582) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1397587) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1398594) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1401473) tasks: Auto-rotate: switched to page 4
+I (1402504) tasks: Page switched to 4 (summary)
+W (1405132) nina_client: astromele1.lan unreachable
+I (1405132) nina_client: === Poll Summary ===
+I (1405132) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1405135) nina_client: Target: , Filter: 
+I (1405139) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1405143) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1405149) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1405970) nina_client: astromele2.lan unreachable
+I (1405970) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1405971) websocket_client: Started
+I (1405974) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1406007) nina_client: desktop-bdt978m.lan unreachable
+I (1406007) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1406156) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1412498) nina_client: astromele2.lan unreachable
+I (1412498) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1412579) nina_client: desktop-bdt978m.lan unreachable
+I (1412579) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1412692) nina_client: astromele1.lan unreachable
+I (1413498) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1413580) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1414608) perf: uxTaskGetSystemState returned 0 tasks
+I (1414608) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1414620) perf: ║              PERFORMANCE REPORT                             ║
+I (1414628) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1414646) perf: ── Poll Cycle ──
+I (1414650) perf:   poll_cycle_total         avg=   13.6  min=    5.9  max= 3685.8  last=    7.2 ms  [n=1385]
+I (1414660) perf:   effective_interval       avg= 1015.5  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1384]
+I (1414669) perf: ── Endpoint Fetchers ──
+I (1414674) perf:   equipment_bundle         avg= 1225.1  min=    4.6  max= 6605.3  last= 6342.3 ms  [n=349]
+I (1414683) perf:   camera                   (no samples)
+I (1414688) perf:   guider                   (no samples)
+I (1414693) perf:   mount                    (no samples)
+I (1414699) perf:   focuser                  (no samples)
+I (1414704) perf:   sequence                 avg= 4580.0  min=   23.5  max= 7267.7  last= 6682.8 ms  [n=61]
+I (1414713) perf:   switch                   (no samples)
+I (1414718) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1414728) perf:   filter                   (no samples)
+I (1414733) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1414742) perf: ── Network ──
+I (1414746) perf:   http_request             avg= 1328.2  min=    0.4  max= 7045.4  last= 6342.3 ms  [n=491]
+I (1414755) perf:   HTTP requests:  10 (interval) / 635 (total)
+I (1414761) perf:   HTTP retries:   10 (interval) / 370 (total)
+I (1414767) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1414772) perf:   HTTP unreachable:10 (interval) / 369 (total)
+I (1414778) perf:   WS events:      0 (interval) / 39 (total)
+I (1414783) perf: ── JSON Parsing ──
+I (1414787) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1414797) perf:   json_sequence            (no samples)
+I (1414802) perf:   json_config_color        (no samples)
+I (1414807) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1414812) perf: ── UI Updates ──
+I (1414816) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1158]
+I (1414826) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1158]
+I (1414836) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=605]
+I (1414845) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=553]
+I (1414855) perf: ── Latency ──
+I (1414858) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1414868) perf: ── JPEG ──
+I (1414871) perf:   jpeg_decode              (no samples)
+I (1414876) perf:   jpeg_fetch               (no samples)
+I (1414881) perf: ── Spotify ──
+I (1414885) perf:   spotify_poll_cycle       (no samples)
+I (1414890) perf:   spotify_api_fetch        (no samples)
+I (1414895) perf:   spotify_art_fetch        (no samples)
+I (1414900) perf:   spotify_art_decode       (no samples)
+I (1414905) perf:   spotify_ui_update        (no samples)
+I (1414910) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1414916) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1414921) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1414927) perf: ── WiFi ──
+I (1414930) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1414937) perf:   RSSI: cur=-59  avg=-58  min=-66  max=-57 dBm  [n=30]
+I (1414944) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1414949) perf: ── Memory ──
+I (1414953) perf:   Internal heap:  free=76063  min_ever=53671  largest_block=31744  frag_ratio=0.417
+I (1414961) perf:   PSRAM:          free=20902348  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1414971) perf: ── Task Stacks ──
+I (1414975) perf:   data_task HWM:  8080 bytes free
+I (1414980) perf:   input_task HWM: 5484 bytes free
+I (1414984) perf:   spotify_task HWM: 7164 bytes free
+E (1415978) transport_ws: Error connecting to host astromele2.lan:1888
+E (1415978) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1415990) nina_ws: WS[1]: Error
+I (1415993) websocket_client: Reconnect after 86400000 ms
+W (1415998) nina_ws: WS[1]: Disconnected from NINA
+I (1418010) tasks: Auto-rotate: switched to page 5
+I (1419045) tasks: Page switched to 5
+W (1419252) nina_client: astromele1.lan unreachable
+W (1419252) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1419253) nina_client: === Poll Summary ===
+I (1419257) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1419263) nina_client: Target: , Filter: 
+I (1419266) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1419271) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1419276) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1420031) nina_client: astromele2.lan unreachable
+I (1420031) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1420133) nina_client: desktop-bdt978m.lan unreachable
+I (1420133) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1420283) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1426814) nina_client: astromele1.lan unreachable
+I (1426814) nina_client: === Poll Summary ===
+I (1426814) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1426817) nina_client: Target: , Filter: 
+I (1426821) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1426825) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1426831) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1427838) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1434171) tasks: Auto-rotate: switched to page 4
+W (1434499) nina_client: astromele1.lan unreachable
+I (1435201) tasks: Page switched to 4 (summary)
+W (1436881) nina_client: astromele2.lan unreachable
+W (1436881) nina_client: desktop-bdt978m.lan unreachable
+I (1436881) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1436882) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1436894) websocket_client: Started
+I (1436897) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1441129) nina_client: astromele1.lan unreachable
+W (1441129) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1441130) nina_client: === Poll Summary ===
+I (1441134) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1441139) nina_client: Target: , Filter: 
+I (1441143) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1441148) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1441153) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1442160) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1443429) nina_client: astromele2.lan unreachable
+I (1443429) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1443430) nina_client: desktop-bdt978m.lan unreachable
+I (1443435) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1444430) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1444442) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1445289) perf: uxTaskGetSystemState returned 0 tasks
+I (1445289) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1445301) perf: ║              PERFORMANCE REPORT                             ║
+I (1445309) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1445327) perf: ── Poll Cycle ──
+I (1445331) perf:   poll_cycle_total         avg=   13.6  min=    5.9  max= 3685.8  last=    7.1 ms  [n=1415]
+I (1445341) perf:   effective_interval       avg= 1015.6  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1414]
+I (1445350) perf: ── Endpoint Fetchers ──
+I (1445355) perf:   equipment_bundle         avg= 1270.5  min=    4.6  max= 6661.4  last= 1269.5 ms  [n=353]
+I (1445364) perf:   camera                   (no samples)
+I (1445369) perf:   guider                   (no samples)
+I (1445374) perf:   mount                    (no samples)
+I (1445379) perf:   focuser                  (no samples)
+I (1445385) perf:   sequence                 avg= 4644.0  min=   23.5  max= 7267.7  last= 6630.7 ms  [n=63]
+I (1445394) perf:   switch                   (no samples)
+I (1445399) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1445409) perf:   filter                   (no samples)
+I (1445414) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1445423) perf: ── Network ──
+I (1445427) perf:   http_request             avg= 1361.4  min=    0.4  max= 7045.4  last= 1269.5 ms  [n=497]
+I (1445436) perf:   HTTP requests:  10 (interval) / 645 (total)
+I (1445442) perf:   HTTP retries:   11 (interval) / 381 (total)
+I (1445447) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1445453) perf:   HTTP unreachable:10 (interval) / 379 (total)
+I (1445459) perf:   WS events:      0 (interval) / 39 (total)
+I (1445464) perf: ── JSON Parsing ──
+I (1445468) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1445478) perf:   json_sequence            (no samples)
+I (1445483) perf:   json_config_color        (no samples)
+I (1445488) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1445493) perf: ── UI Updates ──
+I (1445497) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.2 ms  [n=1188]
+I (1445507) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.1 ms  [n=1188]
+I (1445516) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=621]
+I (1445526) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=567]
+I (1445536) perf: ── Latency ──
+I (1445539) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1445549) perf: ── JPEG ──
+I (1445552) perf:   jpeg_decode              (no samples)
+I (1445557) perf:   jpeg_fetch               (no samples)
+I (1445562) perf: ── Spotify ──
+I (1445566) perf:   spotify_poll_cycle       (no samples)
+I (1445571) perf:   spotify_api_fetch        (no samples)
+I (1445576) perf:   spotify_art_fetch        (no samples)
+I (1445581) perf:   spotify_art_decode       (no samples)
+I (1445586) perf:   spotify_ui_update        (no samples)
+I (1445591) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1445597) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1445602) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1445608) perf: ── WiFi ──
+I (1445611) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1445618) perf:   RSSI: cur=-59  avg=-58  min=-63  max=-54 dBm  [n=30]
+I (1445625) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1445630) perf: ── Memory ──
+I (1445633) perf:   Internal heap:  free=78563  min_ever=53671  largest_block=31744  frag_ratio=0.404
+I (1445642) perf:   PSRAM:          free=20902924  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1445652) perf: ── Task Stacks ──
+I (1445656) perf:   data_task HWM:  8080 bytes free
+I (1445661) perf:   input_task HWM: 5484 bytes free
+I (1445665) perf:   spotify_task HWM: 7164 bytes free
+E (1446921) transport_ws: Error connecting to host astromele2.lan:1888
+E (1446921) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1446933) nina_ws: WS[1]: Error
+I (1446936) websocket_client: Reconnect after 86400000 ms
+W (1446941) nina_ws: WS[1]: Disconnected from NINA
+W (1448742) nina_client: astromele1.lan unreachable
+I (1448742) nina_client: === Poll Summary ===
+I (1448742) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1448745) nina_client: Target: , Filter: 
+I (1448749) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1448753) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1448759) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1449798) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1450707) tasks: Auto-rotate: switched to page 5
+W (1451022) nina_client: desktop-bdt978m.lan unreachable
+I (1451022) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1451023) nina_client: astromele2.lan unreachable
+I (1451028) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1451727) tasks: Page switched to 5
+W (1456317) nina_client: astromele1.lan unreachable
+W (1458571) nina_client: desktop-bdt978m.lan unreachable
+W (1458571) nina_client: astromele2.lan unreachable
+I (1458571) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1458577) websocket_client: Started
+W (1462857) nina_client: astromele1.lan unreachable
+W (1462857) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1462858) nina_client: === Poll Summary ===
+I (1462862) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1462867) nina_client: Target: , Filter: 
+I (1462871) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1462876) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1462881) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1463888) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1466854) tasks: Auto-rotate: switched to page 4
+I (1467883) tasks: Page switched to 4 (summary)
+I (1467883) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1467925) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1468609) transport_ws: Error connecting to host astromele2.lan:1888
+E (1468609) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1468621) nina_ws: WS[1]: Error
+I (1468624) websocket_client: Reconnect after 86400000 ms
+W (1468629) nina_ws: WS[1]: Disconnected from NINA
+W (1470412) nina_client: astromele1.lan unreachable
+I (1470412) nina_client: === Poll Summary ===
+I (1470412) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1470415) nina_client: Target: , Filter: 
+I (1470419) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1470423) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1470429) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1471436) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1474442) nina_client: astromele2.lan unreachable
+I (1474442) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1474443) nina_client: desktop-bdt978m.lan unreachable
+I (1474443) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1474451) websocket_client: Started
+I (1474454) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1475461) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1475465) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1475956) perf: uxTaskGetSystemState returned 0 tasks
+I (1475956) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1475968) perf: ║              PERFORMANCE REPORT                             ║
+I (1475976) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1475994) perf: ── Poll Cycle ──
+I (1475998) perf:   poll_cycle_total         avg=   13.5  min=    5.9  max= 3685.8  last=    7.3 ms  [n=1445]
+I (1476008) perf:   effective_interval       avg= 1015.8  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1444]
+I (1476017) perf: ── Endpoint Fetchers ──
+I (1476022) perf:   equipment_bundle         avg= 1287.1  min=    4.6  max= 6661.4  last= 3006.5 ms  [n=357]
+I (1476031) perf:   camera                   (no samples)
+I (1476036) perf:   guider                   (no samples)
+I (1476042) perf:   mount                    (no samples)
+I (1476047) perf:   focuser                  (no samples)
+I (1476052) perf:   sequence                 avg= 4673.6  min=   23.5  max= 7267.7  last= 6540.8 ms  [n=64]
+I (1476061) perf:   switch                   (no samples)
+I (1476066) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1476076) perf:   filter                   (no samples)
+I (1476081) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1476090) perf: ── Network ──
+I (1476094) perf:   http_request             avg= 1380.0  min=    0.4  max= 7045.4  last= 3006.5 ms  [n=503]
+I (1476103) perf:   HTTP requests:  10 (interval) / 655 (total)
+I (1476109) perf:   HTTP retries:   10 (interval) / 391 (total)
+I (1476115) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1476120) perf:   HTTP unreachable:10 (interval) / 389 (total)
+I (1476126) perf:   WS events:      0 (interval) / 39 (total)
+I (1476131) perf: ── JSON Parsing ──
+I (1476135) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1476145) perf:   json_sequence            (no samples)
+I (1476150) perf:   json_config_color        (no samples)
+I (1476155) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1476161) perf: ── UI Updates ──
+I (1476164) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1218]
+I (1476174) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1218]
+I (1476184) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=637]
+I (1476193) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=581]
+I (1476203) perf: ── Latency ──
+I (1476206) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1476216) perf: ── JPEG ──
+I (1476219) perf:   jpeg_decode              (no samples)
+I (1476224) perf:   jpeg_fetch               (no samples)
+I (1476229) perf: ── Spotify ──
+I (1476233) perf:   spotify_poll_cycle       (no samples)
+I (1476238) perf:   spotify_api_fetch        (no samples)
+I (1476243) perf:   spotify_art_fetch        (no samples)
+I (1476248) perf:   spotify_art_decode       (no samples)
+I (1476253) perf:   spotify_ui_update        (no samples)
+I (1476258) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1476264) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1476270) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1476275) perf: ── WiFi ──
+I (1476278) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1476285) perf:   RSSI: cur=-59  avg=-58  min=-59  max=-54 dBm  [n=30]
+I (1476292) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1476297) perf: ── Memory ──
+I (1476301) perf:   Internal heap:  free=75991  min_ever=53671  largest_block=31744  frag_ratio=0.418
+I (1476310) perf:   PSRAM:          free=20902336  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1476319) perf: ── Task Stacks ──
+I (1476323) perf:   data_task HWM:  8080 bytes free
+I (1476328) perf:   input_task HWM: 5484 bytes free
+I (1476332) perf:   spotify_task HWM: 7164 bytes free
+W (1477985) nina_client: astromele1.lan unreachable
+W (1481989) nina_client: desktop-bdt978m.lan unreachable
+I (1481989) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1482007) nina_client: astromele2.lan unreachable
+I (1482007) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1482990) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1483007) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1483390) tasks: Auto-rotate: switched to page 5
+I (1484424) tasks: Page switched to 5
+E (1484474) transport_ws: Error connecting to host astromele2.lan:1888
+E (1484474) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1484486) nina_ws: WS[1]: Error
+I (1484489) websocket_client: Reconnect after 86400000 ms
+W (1484494) nina_ws: WS[1]: Disconnected from NINA
+W (1484506) nina_client: astromele1.lan unreachable
+W (1484506) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1484511) nina_client: === Poll Summary ===
+I (1484515) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1484520) nina_client: Target: , Filter: 
+I (1484524) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1484529) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1484534) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1485541) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1489988) nina_client: desktop-bdt978m.lan unreachable
+I (1489988) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1489989) nina_client: astromele2.lan unreachable
+I (1489994) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1490001) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1490008) websocket_client: Started
+W (1492383) nina_client: astromele1.lan unreachable
+I (1492383) nina_client: === Poll Summary ===
+I (1492383) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1492386) nina_client: Target: , Filter: 
+I (1492390) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1492394) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1492400) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1493407) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1499550) tasks: Auto-rotate: switched to page 4
+W (1499935) nina_client: astromele1.lan unreachable
+E (1500169) transport_ws: Error connecting to host astromele2.lan:1888
+E (1500169) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1500181) nina_ws: WS[1]: Error
+I (1500184) websocket_client: Reconnect after 86400000 ms
+W (1500189) nina_ws: WS[1]: Disconnected from NINA
+I (1500581) tasks: Page switched to 4 (summary)
+W (1506486) nina_client: astromele1.lan unreachable
+W (1506486) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1506487) nina_client: === Poll Summary ===
+I (1506491) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1506496) nina_client: Target: , Filter: 
+I (1506500) nina_client: Exposure: 0.0s (0.0/0.0)
+W (1506502) nina_client: desktop-bdt978m.lan unreachable
+I (1506505) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1506510) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1506522) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1506563) nina_client: astromele2.lan unreachable
+I (1506563) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1506564) websocket_client: Started
+I (1506567) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1506637) perf: uxTaskGetSystemState returned 0 tasks
+I (1506637) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1506649) perf: ║              PERFORMANCE REPORT                             ║
+I (1506657) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1506675) perf: ── Poll Cycle ──
+I (1506679) perf:   poll_cycle_total         avg=   13.4  min=    5.9  max= 3685.8  last=    7.3 ms  [n=1475]
+I (1506689) perf:   effective_interval       avg= 1015.9  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1474]
+I (1506698) perf: ── Endpoint Fetchers ──
+I (1506703) perf:   equipment_bundle         avg= 1313.9  min=    4.6  max= 6661.4  last= 6528.4 ms  [n=360]
+I (1506712) perf:   camera                   (no samples)
+I (1506717) perf:   guider                   (no samples)
+I (1506723) perf:   mount                    (no samples)
+I (1506728) perf:   focuser                  (no samples)
+I (1506733) perf:   sequence                 avg= 4730.2  min=   23.5  max= 7267.7  last= 6551.7 ms  [n=66]
+I (1506742) perf:   switch                   (no samples)
+I (1506747) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1506757) perf:   filter                   (no samples)
+I (1506762) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1506771) perf: ── Network ──
+I (1506775) perf:   http_request             avg= 1411.1  min=    0.4  max= 7045.4  last=   34.2 ms  [n=510]
+I (1506784) perf:   HTTP requests:  10 (interval) / 665 (total)
+I (1506790) perf:   HTTP retries:   10 (interval) / 401 (total)
+I (1506796) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1506801) perf:   HTTP unreachable:11 (interval) / 400 (total)
+I (1506807) perf:   WS events:      0 (interval) / 39 (total)
+I (1506812) perf: ── JSON Parsing ──
+I (1506816) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1506826) perf:   json_sequence            (no samples)
+I (1506831) perf:   json_config_color        (no samples)
+I (1506836) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1506842) perf: ── UI Updates ──
+I (1506845) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1248]
+I (1506855) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1248]
+I (1506865) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=653]
+I (1506874) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=595]
+I (1506884) perf: ── Latency ──
+I (1506887) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1506897) perf: ── JPEG ──
+I (1506900) perf:   jpeg_decode              (no samples)
+I (1506905) perf:   jpeg_fetch               (no samples)
+I (1506910) perf: ── Spotify ──
+I (1506914) perf:   spotify_poll_cycle       (no samples)
+I (1506919) perf:   spotify_api_fetch        (no samples)
+I (1506924) perf:   spotify_art_fetch        (no samples)
+I (1506929) perf:   spotify_art_decode       (no samples)
+I (1506934) perf:   spotify_ui_update        (no samples)
+I (1506939) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1506945) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1506951) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1506956) perf: ── WiFi ──
+I (1506959) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1506966) perf:   RSSI: cur=-58  avg=-58  min=-65  max=-54 dBm  [n=30]
+I (1506973) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1506978) perf: ── Memory ──
+I (1506982) perf:   Internal heap:  free=78499  min_ever=53671  largest_block=31744  frag_ratio=0.404
+I (1506991) perf:   PSRAM:          free=20902920  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1507000) perf: ── Task Stacks ──
+I (1507004) perf:   data_task HWM:  8080 bytes free
+I (1507009) perf:   input_task HWM: 5484 bytes free
+I (1507013) perf:   spotify_task HWM: 7164 bytes free
+I (1507517) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1513049) nina_client: desktop-bdt978m.lan unreachable
+I (1513049) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1513113) nina_client: astromele2.lan unreachable
+I (1513113) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1514050) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1514079) nina_client: astromele1.lan unreachable
+I (1514079) nina_client: === Poll Summary ===
+I (1514079) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1514082) nina_client: Target: , Filter: 
+I (1514086) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1514090) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1514096) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1514113) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1515156) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1516087) tasks: Auto-rotate: switched to page 5
+E (1516570) transport_ws: Error connecting to host astromele2.lan:1888
+E (1516570) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1516582) nina_ws: WS[1]: Error
+I (1516585) websocket_client: Reconnect after 86400000 ms
+W (1516590) nina_ws: WS[1]: Disconnected from NINA
+I (1517122) tasks: Page switched to 5
+W (1520601) nina_client: desktop-bdt978m.lan unreachable
+I (1520601) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1520625) nina_client: astromele2.lan unreachable
+I (1520625) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1521732) nina_client: astromele1.lan unreachable
+W (1528265) nina_client: astromele1.lan unreachable
+W (1528265) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1528266) nina_client: === Poll Summary ===
+I (1528270) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1528276) nina_client: Target: , Filter: 
+I (1528279) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1528284) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1528289) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1529296) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1532248) tasks: Auto-rotate: switched to page 4
+I (1533278) tasks: Page switched to 4 (summary)
+W (1535857) nina_client: astromele1.lan unreachable
+I (1535857) nina_client: === Poll Summary ===
+I (1535857) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1535860) nina_client: Target: , Filter: 
+I (1535864) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1535868) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1535874) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1536881) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1537194) nina_client: astromele2.lan unreachable
+W (1537194) nina_client: desktop-bdt978m.lan unreachable
+I (1537194) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1537195) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1537207) websocket_client: Started
+I (1537210) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1537318) perf: uxTaskGetSystemState returned 0 tasks
+I (1537318) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1537330) perf: ║              PERFORMANCE REPORT                             ║
+I (1537338) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1537356) perf: ── Poll Cycle ──
+I (1537360) perf:   poll_cycle_total         avg=   13.3  min=    5.9  max= 3685.8  last=    7.4 ms  [n=1505]
+I (1537370) perf:   effective_interval       avg= 1016.0  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1504]
+I (1537379) perf: ── Endpoint Fetchers ──
+I (1537384) perf:   equipment_bundle         avg= 1347.7  min=    4.6  max= 6661.4  last= 6561.3 ms  [n=364]
+I (1537393) perf:   camera                   (no samples)
+I (1537399) perf:   guider                   (no samples)
+I (1537404) perf:   mount                    (no samples)
+I (1537409) perf:   focuser                  (no samples)
+I (1537414) perf:   sequence                 avg= 4757.1  min=   23.5  max= 7267.7  last= 6533.9 ms  [n=67]
+I (1537423) perf:   switch                   (no samples)
+I (1537428) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1537438) perf:   filter                   (no samples)
+I (1537443) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1537452) perf: ── Network ──
+I (1537456) perf:   http_request             avg= 1439.4  min=    0.4  max= 7045.4  last=  313.6 ms  [n=516]
+I (1537465) perf:   HTTP requests:  11 (interval) / 676 (total)
+I (1537471) perf:   HTTP retries:   10 (interval) / 411 (total)
+I (1537477) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1537482) perf:   HTTP unreachable:10 (interval) / 410 (total)
+I (1537488) perf:   WS events:      0 (interval) / 39 (total)
+I (1537493) perf: ── JSON Parsing ──
+I (1537497) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1537507) perf:   json_sequence            (no samples)
+I (1537512) perf:   json_config_color        (no samples)
+I (1537517) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1537523) perf: ── UI Updates ──
+I (1537526) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1278]
+I (1537536) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1278]
+I (1537546) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=669]
+I (1537555) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=609]
+I (1537565) perf: ── Latency ──
+I (1537568) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1537578) perf: ── JPEG ──
+I (1537581) perf:   jpeg_decode              (no samples)
+I (1537586) perf:   jpeg_fetch               (no samples)
+I (1537591) perf: ── Spotify ──
+I (1537595) perf:   spotify_poll_cycle       (no samples)
+I (1537600) perf:   spotify_api_fetch        (no samples)
+I (1537605) perf:   spotify_art_fetch        (no samples)
+I (1537610) perf:   spotify_art_decode       (no samples)
+I (1537615) perf:   spotify_ui_update        (no samples)
+I (1537621) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1537626) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1537632) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1537637) perf: ── WiFi ──
+I (1537641) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1537647) perf:   RSSI: cur=-58  avg=-58  min=-61  max=-57 dBm  [n=30]
+I (1537654) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1537659) perf: ── Memory ──
+I (1537663) perf:   Internal heap:  free=76063  min_ever=53671  largest_block=31744  frag_ratio=0.417
+I (1537672) perf:   PSRAM:          free=20902324  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1537681) perf: ── Task Stacks ──
+I (1537685) perf:   data_task HWM:  8080 bytes free
+I (1537690) perf:   input_task HWM: 5484 bytes free
+I (1537695) perf:   spotify_task HWM: 7164 bytes free
+W (1543415) nina_client: astromele1.lan unreachable
+W (1543757) nina_client: desktop-bdt978m.lan unreachable
+I (1543757) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1543758) nina_client: astromele2.lan unreachable
+I (1543763) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1544758) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1544770) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1547249) transport_ws: Error connecting to host astromele2.lan:1888
+E (1547249) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1547261) nina_ws: WS[1]: Error
+I (1547264) websocket_client: Reconnect after 86400000 ms
+W (1547269) nina_ws: WS[1]: Disconnected from NINA
+I (1548784) tasks: Auto-rotate: switched to page 5
+I (1549820) tasks: Page switched to 5
+W (1549969) nina_client: astromele1.lan unreachable
+W (1549969) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1549970) nina_client: === Poll Summary ===
+I (1549974) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1549980) nina_client: Target: , Filter: 
+I (1549983) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1549988) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1549993) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1551000) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1551552) nina_client: desktop-bdt978m.lan unreachable
+I (1551552) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1551553) nina_client: astromele2.lan unreachable
+I (1551558) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1557550) nina_client: astromele1.lan unreachable
+I (1557550) nina_client: === Poll Summary ===
+I (1557550) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1557553) nina_client: Target: , Filter: 
+I (1557557) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1557561) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1557567) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1558574) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1564946) tasks: Auto-rotate: switched to page 4
+W (1565094) nina_client: astromele1.lan unreachable
+I (1565976) tasks: Page switched to 4 (summary)
+W (1568000) perf: uxTaskGetSystemState returned 0 tasks
+I (1568000) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1568012) perf: ║              PERFORMANCE REPORT                             ║
+I (1568020) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1568038) perf: ── Poll Cycle ──
+I (1568042) perf:   poll_cycle_total         avg=   13.2  min=    5.9  max= 3685.8  last=    7.2 ms  [n=1535]
+I (1568052) perf:   effective_interval       avg= 1016.2  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1534]
+I (1568061) perf: ── Endpoint Fetchers ──
+I (1568066) perf:   equipment_bundle         avg= 1372.9  min=    4.6  max= 6661.4  last= 6520.4 ms  [n=367]
+I (1568075) perf:   camera                   (no samples)
+I (1568080) perf:   guider                   (no samples)
+I (1568085) perf:   mount                    (no samples)
+I (1568091) perf:   focuser                  (no samples)
+I (1568096) perf:   sequence                 avg= 4783.5  min=   23.5  max= 7267.7  last= 6554.9 ms  [n=68]
+W (1568098) nina_client: desktop-bdt978m.lan unreachable
+I (1568105) perf:   switch                   (no samples)
+I (1568110) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1568115) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1568131) perf:   filter                   (no samples)
+W (1568136) nina_client: astromele2.lan unreachable
+I (1568137) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1568141) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1568151) perf: ── Network ──
+I (1568158) websocket_client: Started
+I (1568161) perf:   http_request             avg= 1456.2  min=    0.4  max= 7045.4  last=   19.1 ms  [n=523]
+I (1568164) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1568174) perf:   HTTP requests:  9 (interval) / 685 (total)
+I (1568186) perf:   HTTP retries:   11 (interval) / 422 (total)
+I (1568192) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1568197) perf:   HTTP unreachable:10 (interval) / 420 (total)
+I (1568203) perf:   WS events:      0 (interval) / 39 (total)
+I (1568208) perf: ── JSON Parsing ──
+I (1568212) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1568222) perf:   json_sequence            (no samples)
+I (1568227) perf:   json_config_color        (no samples)
+I (1568232) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1568238) perf: ── UI Updates ──
+I (1568241) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1308]
+I (1568251) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1308]
+I (1568261) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=685]
+I (1568270) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=623]
+I (1568280) perf: ── Latency ──
+I (1568283) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1568293) perf: ── JPEG ──
+I (1568296) perf:   jpeg_decode              (no samples)
+I (1568301) perf:   jpeg_fetch               (no samples)
+I (1568306) perf: ── Spotify ──
+I (1568310) perf:   spotify_poll_cycle       (no samples)
+I (1568315) perf:   spotify_api_fetch        (no samples)
+I (1568320) perf:   spotify_art_fetch        (no samples)
+I (1568325) perf:   spotify_art_decode       (no samples)
+I (1568330) perf:   spotify_ui_updal) / 0 (total)
+I (1568347) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1568352) perf: ── WiFi ──
+I (1568356) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1568362) perf:   RSSI: cur=-59  avg=-58  min=-60  max=-52 dBm  [n=30]
+I (1568369) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1568374) perf: ── Memory ──
+I (1568378) perf:   Internal heap:  free=76191  min_ever=53671  largest_block=31744  frag_ratio=0.417
+I (1568387) perf:   PSRAM:          free=20902924  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1568396) perf: ── Task Stacks ──
+I (1568400) perf:   data_task HWM:  8080 bytes free
+I (1568405) perf:   input_task HWM: 5484 bytes free
+I (1568410) perf:   spotify_task HWM: 7164 bytes free
+W (1571607) nina_client: astromele1.lan unreachable
+W (1571607) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1571608) nina_client: === Poll Summary ===
+I (1571612) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1571617) nina_client: Target: , Filter: 
+I (1571621) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1571626) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1571631) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1572638) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1574650) nina_client: desktop-bdt978m.lan unreachable
+I (1574650) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1574783) nina_client: astromele2.lan unreachable
+I (1574783) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1575651) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1575783) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1578176) transport_ws: Error connecting to host astromele2.lan:1888
+E (1578176) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1578188) nina_ws: WS[1]: Error
+I (1578191) websocket_client: Reconnect after 86400000 ms
+W (1578196) nina_ws: WS[1]: Disconnected from NINA
+W (1579185) nina_client: astromele1.lan unreachable
+I (1579185) nina_client: === Poll Summary ===
+I (1579185) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1579188) nina_client: Target: , Filter: 
+I (1579192) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1579196) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1579202) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1580218) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1581515) tasks: Auto-rotate: switched to page 5
+W (1582163) nina_client: desktop-bdt978m.lan unreachable
+I (1582163) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1582300) nina_client: astromele2.lan unreachable
+I (1582300) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1582549) tasks: Page switched to 5
+W (1586777) nina_client: astromele1.lan unreachable
+W (1589702) nina_client: desktop-bdt978m.lan unreachable
+W (1589843) nina_client: astromele2.lan unreachable
+I (1589843) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1589844) websocket_client: Started
+W (1593329) nina_client: astromele1.lan unreachable
+W (1593329) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1593330) nina_client: === Poll Summary ===
+I (1593334) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1593339) nina_client: Target: , Filter: 
+I (1593343) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1593348) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1593353) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1594360) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1597675) tasks: Auto-rotate: switched to page 4
+I (1598706) tasks: Page switched to 4 (summary)
+I (1598706) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1598712) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1598714) perf: uxTaskGetSystemState returned 0 tasks
+I (1598718) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1598736) perf: ║              PERFORMANCE REPORT                             ║
+I (1598744) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1598762) perf: ── Poll Cycle ──
+I (1598766) perf:   poll_cycle_total         avg=   13.1  min=    5.9  max= 3685.8  last=    7.6 ms  [n=1565]
+I (1598776) perf:   effective_interval       avg= 1016.3  min=    7.5  max= 4687.0  last= 1037.0 ms  [n=1564]
+I (1598785) perf: ── Endpoint Fetchers ──
+I (1598790) perf:   equipment_bundle         avg= 1381.6  min=    4.6  max= 6661.4  last= 1944.7 ms  [n=370]
+I (1598799) perf:   camera                   (no samples)
+I (1598804) perf:   guider                   (no samples)
+I (1598809) perf:   mount                    (no samples)
+I (1598814) perf:   focuser                  (no samples)
+I (1598820) perf:   sequence                 avg= 4833.5  min=   23.5  max= 7267.7  last= 6552.8 ms  [n=70]
+I (1598829) perf:   switch                   (no samples)
+I (1598834) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1598844) perf:   filter                   (no samples)
+I (1598849) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1598858) perf: ── Network ──
+I (1598862) perf:   http_request             avg= 1472.1  min=    0.4  max= 7045.4  last= 2925.0 ms  [n=529]
+I (1598871) perf:   HTTP requests:  10 (interval) / 696 (total)
+I (1598877) perf:   HTTP retries:   10 (interval) / 432 (total)
+I (1598882) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1598888) perf:   HTTP unreachable:10 (interval) / 430 (total)
+I (1598894) perf:   WS events:      0 (interval) / 39 (total)
+I (1598899) perf: ── JSON Parsing ──
+I (1598903) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1598913) perf:   json_sequence            (no samples)
+I (1598918) perf:   json_config_color        (no samples)
+I (1598923) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1598928) perf: ── UI Updates ──
+I (1598932) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1338]
+I (1598942) perf:   ui_lock_wait             avg=    1.4  min=    0.0  max=   29.8  last=    0.0 ms  [n=1338]
+I (1598951) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=701]
+I (1598961) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=637]
+I (1598971) perf: ── Latency ──
+I (1598974) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1598984) perf: ── JPEG ──
+I (1598987) perf:   jpeg_decode              (no samples)
+I (1598992) perf:   jpeg_fetch               (no samples)
+I (1598997) perf: ── Spotify ──
+I (1599001) perf:   spotify_poll_cycle       (no samples)
+I (1599006) perf:   spotify_api_fetch        (no samples)
+I (1599011) perf:   spotify_art_fetch        (no samples)
+I (1599016) perf:   spotify_art_decode       (no samples)
+I (1599021) perf:   spotify_ui_update        (no samples)
+I (1599026) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1599032) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1599037) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1599043) perf: ── WiFi ──
+I (1599046) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1599053) perf:   RSSI: cur=-59  avg=-59  min=-67  max=-55 dBm  [n=30]
+I (1599060) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1599065) perf: ── Memory ──
+I (1599068) perf:   Internal heap:  free=76143  min_ever=53671  largest_block=31744  frag_ratio=0.417
+I (1599077) perf:   PSRAM:          free=20903012  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1599087) perf: ── Task Stacks ──
+I (1599091) perf:   data_task HWM:  8080 bytes free
+I (1599096) perf:   input_task HWM: 5484 bytes free
+I (1599100) perf:   spotify_task HWM: 7164 bytes free
+E (1599882) transport_ws: Error connecting to host astromele2.lan:1888
+E (1599882) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1599894) nina_ws: WS[1]: Error
+I (1599897) websocket_client: Reconnect after 86400000 ms
+W (1599902) nina_ws: WS[1]: Disconnected from NINA
+W (1600977) nina_client: astromele1.lan unreachable
+I (1600977) nina_client: === Poll Summary ===
+I (1600977) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1600980) nina_client: Target: , Filter: 
+I (1600984) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1600988) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1600994) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1602001) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1605222) nina_client: astromele2.lan unreachable
+I (1605222) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1605223) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1605230) websocket_client: Started
+W (1605233) nina_client: desktop-bdt978m.lan unreachable
+I (1605238) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1606233) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1606245) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1608546) nina_client: astromele1.lan unreachable
+W (1612790) nina_client: astromele2.lan unreachable
+I (1612790) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1612791) nina_client: desktop-bdt978m.lan unreachable
+I (1612796) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1613791) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1613803) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1614222) tasks: Auto-rotate: switched to page 5
+W (1615097) nina_client: astromele1.lan unreachable
+W (1615097) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1615098) nina_client: === Poll Summary ===
+I (1615102) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1615108) nina_client: Target: , Filter: 
+I (1615111) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1615116) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1615121) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+E (1615239) transport_ws: Error connecting to host astromele2.lan:1888
+E (1615239) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+I (1615247) tasks: Page switched to 5
+W (1615251) nina_ws: WS[1]: Error
+I (1615257) websocket_client: Reconnect after 86400000 ms
+W (1615262) nina_ws: WS[1]: Disconnected from NINA
+I (1616128) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1620373) nina_client: astromele2.lan unreachable
+I (1620373) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1620374) nina_client: desktop-bdt978m.lan unreachable
+I (1620374) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1620383) websocket_client: Started
+I (1620385) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1622687) nina_client: astromele1.lan unreachable
+I (1622687) nina_client: === Poll Summary ===
+I (1622687) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1622690) nina_client: Target: , Filter: 
+I (1622694) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1622698) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1622704) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1623711) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1629387) perf: uxTaskGetSystemState returned 0 tasks
+I (1629387) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1629399) perf: ║              PERFORMANCE REPORT                             ║
+I (1629407) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1629425) perf: ── Poll Cycle ──
+I (1629429) perf:   poll_cycle_total         avg=   13.1  min=    5.9  max= 3685.8  last=    7.2 ms  [n=1595]
+I (1629439) perf:   effective_interval       avg= 1016.4  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1594]
+I (1629448) perf: ── Endpoint Fetchers ──
+I (1629453) perf:   equipment_bundle         avg= 1399.0  min=    4.6  max= 6661.4  last= 4245.5 ms  [n=374]
+I (1629462) perf:   camera                   (no samples)
+I (1629467) perf:   guider                   (no samples)
+I (1629472) perf:   mount                    (no samples)
+I (1629478) perf:   focuser                  (no samples)
+I (1629483) perf:   sequence                 avg= 4857.7  min=   23.5  max= 7267.7  last= 6551.9 ms  [n=71]
+I (1629492) perf:   switch                   (no samples)
+I (1629497) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1629507) perf:   filter                   (no samples)
+I (1629512) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1629521) perf: ── Network ──
+I (1629525) perf:   http_request             avg= 1488.5  min=    0.4  max= 7045.4  last= 4245.5 ms  [n=535]
+I (1629534) perf:   HTTP requests:  8 (interval) / 704 (total)
+I (1629540) perf:   HTTP retries:   10 (interval) / 442 (total)
+I (1629545) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1629551) perf:   HTTP unreachable:10 (interval) / 440 (total)
+I (1629557) perf:   WS events:      0 (interval) / 39 (total)
+I (1629562) perf: ── JSON Parsing ──
+I (1629566) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1629576) perf:   json_sequence            (no samples)
+I (1629581) perf:   json_config_color        (no samples)
+I (1629586) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1629591) perf: ── UI Updates ──
+I (1629595) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1368]
+I (1629605) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1368]
+I (1629614) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=716]
+I (1629624) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=652]
+I (1629634) perf: ── Latency ──
+I (1629637) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1629647) perf: ── JPEG ──
+I (1629650) perf:   jpeg_decode              (no samples)
+I (1629655) perf:   jpeg_fetch               (no samples)
+I (1629660) perf: ── Spotify ──
+I (1629664) perf:   spotify_poll_cycle       (no samples)
+I (1629669) perf:   spotify_api_fetch        (no samples)
+I (1629674) perf:   spotify_art_fetch        (no samples)
+I (1629679) perf:   spotify_art_decode       (no samples)
+I (1629684) perf:   spotify_ui_update        (no samples)
+I (1629689) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1629695) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1629700) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1629706) perf: ── WiFi ──
+I (1629709) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1629716) perf:   RSSI: cur=-60  avg=-58  min=-60  max=-57 dBm  [n=30]
+I (1629723) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1629728) perf: ── Memory ──
+I (1629731) perf:   Internal heap:  free=80987  min_ever=53671  largest_block=31744  frag_ratio=0.392
+I (1629740) perf:   PSRAM:          free=20903504  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1629750) perf: ── Task Stacks ──
+I (1629754) perf:   data_task HWM:  8076 bytes free
+I (1629759) perf:   input_task HWM: 5484 bytes free
+I (1629763) perf:   spotify_task HWM: 7164 bytes free
+W (1630298) nina_client: astromele1.lan unreachable
+E (1630397) transport_ws: Error connecting to host astromele2.lan:1888
+E (1630397) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1630409) nina_ws: WS[1]: Error
+I (1630412) websocket_client: Reconnect after 86400000 ms
+W (1630417) nina_ws: WS[1]: Disconnected from NINA
+I (1630774) tasks: Auto-rotate: switched to page 4
+I (1631805) tasks: Page switched to 4 (summary)
+W (1636839) nina_client: astromele1.lan unreachable
+W (1636839) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1636840) nina_client: === Poll Summary ===
+I (1636844) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1636849) nina_client: Target: , Filter: 
+I (1636853) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1636858) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1636863) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1636948) nina_client: astromele2.lan unreachable
+W (1636948) nina_client: desktop-bdt978m.lan unreachable
+I (1636948) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1636949) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1636961) websocket_client: Started
+I (1636963) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1637870) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1643512) nina_client: desktop-bdt978m.lan unreachable
+I (1643512) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1643513) nina_client: astromele2.lan unreachable
+I (1643517) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1644409) nina_client: astromele1.lan unreachable
+I (1644409) nina_client: === Poll Summary ===
+I (1644409) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1644412) nina_client: Target: , Filter: 
+I (1644416) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1644420) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1644426) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1644513) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1644524) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1645481) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1646930) tasks: Auto-rotate: switched to page 5
+E (1646988) transport_ws: Error connecting to host astromele2.lan:1888
+E (1646988) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1647000) nina_ws: WS[1]: Error
+I (1647003) websocket_client: Reconnect after 86400000 ms
+W (1647008) nina_ws: WS[1]: Disconnected from NINA
+I (1647961) tasks: Page switched to 5
+W (1651090) nina_client: astromele2.lan unreachable
+I (1651090) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1651091) nina_client: desktop-bdt978m.lan unreachable
+I (1651096) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1652001) nina_client: astromele1.lan unreachable
+W (1658544) nina_client: astromele1.lan unreachable
+W (1658544) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1658545) nina_client: === Poll Summary ===
+I (1658549) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1658554) nina_client: Target: , Filter: 
+I (1658558) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1658563) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1658568) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1659575) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1660066) perf: uxTaskGetSystemState returned 0 tasks
+I (1660066) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1660078) perf: ║              PERFORMANCE REPORT                             ║
+I (1660086) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1660104) perf: ── Poll Cycle ──
+I (1660108) perf:   poll_cycle_total         avg=   13.0  min=    5.9  max= 3685.8  last=    7.4 ms  [n=1625]
+I (1660118) perf:   effective_interval       avg= 1016.6  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1624]
+I (1660127) perf: ── Endpoint Fetchers ──
+I (1660132) perf:   equipment_bundle         avg= 1435.2  min=    4.6  max= 6661.4  last= 5609.0 ms  [n=377]
+I (1660141) perf:   camera                   (no samples)
+I (1660147) perf:   guider                   (no samples)
+I (1660152) perf:   mount                    (no samples)
+I (1660157) perf:   focuser                  (no samples)
+I (1660162) perf:   sequence                 avg= 4903.9  min=   23.5  max= 7267.7  last= 6543.6 ms  [n=73]
+I (1660171) perf:   switch                   (no samples)
+I (1660176) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1660186) perf:   filter                   (no samples)
+I (1660191) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1660200) perf: ── Network ──
+I (1660204) perf:   http_request             avg= 1531.7  min=    0.4  max= 7045.4  last= 6542.7 ms  [n=540]
+I (1660213) perf:   HTTP requests:  11 (interval) / 715 (total)
+I (1660219) perf:   HTTP retries:   10 (interval) / 452 (total)
+I (1660225) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1660230) perf:   HTTP unreachable:11 (interval) / 451 (total)
+I (1660236) perf:   WS events:      0 (interval) / 39 (total)
+I (1660241) perf: ── JSON Parsing ──
+I (1660245) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1660255) perf:   json_sequence            (no samples)
+I (1660260) perf:   json_config_color        (no samples)
+I (1660265) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1660271) perf: ── UI Updates ──
+I (1660274) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1398]
+I (1660284) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1398]
+I (1660294) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=730]
+I (1660303) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=668]
+I (1660313) perf: ── Latency ──
+I (1660316) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1660326) perf: ── JPEG ──
+I (1660329) perf:   jpeg_decode              (no samples)
+I (1660334) perf:   jpeg_fetch               (no samples)
+I (1660339) perf: ── Spotify ──
+I (1660343) perf:   spotify_poll_cycle       (no samples)
+I (1660348) perf:   spotify_api_fetch        (no samples)
+I (1660353) perf:   spotify_art_fetch        (no samples)
+I (1660358) perf:   spotify_art_decode       (no samples)
+I (1660363) perf:   spotify_ui_update        (no samples)
+I (1660369) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1660374) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1660380) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1660385) perf: ── WiFi ──
+I (1660389) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1660395) perf:   RSSI: cur=-60  avg=-58  min=-60  max=-57 dBm  [n=30]
+I (1660402) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1660407) perf: ── Memory ──
+I (1660411) perf:   Internal heap:  free=81155  min_ever=53671  largest_block=31744  frag_ratio=0.391
+I (1660420) perf:   PSRAM:          free=20904076  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1660429) perf: ── Task Stacks ──
+I (1660433) perf:   data_task HWM:  8076 bytes free
+I (1660438) perf:   input_task HWM: 5484 bytes free
+I (1660443) perf:   spotify_task HWM: 7164 bytes free
+I (1663469) tasks: Auto-rotate: switched to page 4
+I (1664486) tasks: Page switched to 4 (summary)
+W (1666136) nina_client: astromele1.lan unreachable
+I (1666136) nina_client: === Poll Summary ===
+I (1666136) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1666139) nina_client: Target: , Filter: 
+I (1666143) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1666147) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1666153) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1667160) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1667634) nina_client: astromele2.lan unreachable
+I (1667634) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1667635) websocket_client: Started
+I (1667637) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1667668) nina_client: desktop-bdt978m.lan unreachable
+I (1667668) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1673794) nina_client: astromele1.lan unreachable
+W (1674395) nina_client: desktop-bdt978m.lan unreachable
+I (1674395) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1674396) nina_client: astromele2.lan unreachable
+I (1674400) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1675396) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1675407) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1677858) transport_ws: Error connecting to host astromele2.lan:1888
+E (1677858) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1677870) nina_ws: WS[1]: Error
+I (1677873) websocket_client: Reconnect after 86400000 ms
+W (1677878) nina_ws: WS[1]: Disconnected from NINA
+I (1679611) tasks: Auto-rotate: switched to page 5
+W (1680382) nina_client: astromele1.lan unreachable
+W (1680382) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1680383) nina_client: === Poll Summary ===
+I (1680387) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1680393) nina_client: Target: , Filter: 
+I (1680396) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1680401) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1680406) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1680642) tasks: Page switched to 5
+I (1681413) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1681930) nina_client: desktop-bdt978m.lan unreachable
+I (1681930) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1682010) nina_client: astromele2.lan unreachable
+I (1682010) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1687942) nina_client: astromele1.lan unreachable
+I (1687942) nina_client: === Poll Summary ===
+I (1687942) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1687945) nina_client: Target: , Filter: 
+I (1687949) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1687953) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1687959) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1688966) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1690730) perf: uxTaskGetSystemState returned 0 tasks
+I (1690730) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1690742) perf: ║              PERFORMANCE REPORT                             ║
+I (1690750) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1690768) perf: ── Poll Cycle ──
+I (1690772) perf:   poll_cycle_total         avg=   12.9  min=    5.9  max= 3685.8  last=    7.3 ms  [n=1655]
+I (1690782) perf:   effective_interval       avg= 1016.7  min=    7.5  max= 4687.0  last= 1008.0 ms  [n=1654]
+I (1690791) perf: ── Endpoint Fetchers ──
+I (1690796) perf:   equipment_bundle         avg= 1458.6  min=    4.6  max= 6661.4  last=  517.3 ms  [n=380]
+I (1690805) perf:   camera                   (no samples)
+I (1690810) perf:   guider                   (no samples)
+I (1690816) perf:   mount                    (no samples)
+I (1690821) perf:   focuser                  (no samples)
+I (1690826) perf:   sequence                 avg= 4926.7  min=   23.5  max= 7267.7  last= 6588.9 ms  [n=74]
+I (1690835) perf:   switch                   (no samples)
+I (1690840) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1690850) perf:   filter                   (no samples)
+I (1690855) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1690864) perf: ── Network ──
+I (1690868) perf:   http_request             avg= 1544.5  min=    0.4  max= 7045.4  last=  517.3 ms  [n=547]
+I (1690877) perf:   HTTP requests:  10 (interval) / 725 (total)
+I (1690883) perf:   HTTP retries:   10 (interval) / 462 (total)
+I (1690889) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1690894) perf:   HTTP unreachable:10 (interval) / 461 (total)
+I (1690900) perf:   WS events:      0 (interval) / 39 (total)
+I (1690905) perf: ── JSON Parsing ──
+I (1690909) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1690919) perf:   json_sequence            (no samples)
+I (1690924) perf:   json_config_color        (no samples)
+I (1690929) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1690935) perf: ── UI Updates ──
+I (1690938) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1428]
+I (1690948) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1428]
+I (1690958) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=744]
+I (1690967) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=684]
+I (1690977) perf: ── Latency ──
+I (1690980) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1690990) perf: ── JPEG ──
+I (1690993) perf:   jpeg_decode              (no samples)
+I (1690998) perf:   jpeg_fetch               (no samples)
+I (1691003) perf: ── Spotify ──
+I (1691007) perf:   spotify_poll_cycle       (no samples)
+I (1691012) perf:   spotify_api_fetch        (no samples)
+I (1691017) perf:   spotify_art_fetch        (no samples)
+I (1691022) perf:   spotify_art_decode       (no samples)
+I (1691027) perf:   spotify_ui_update        (no samples)
+I (1691032) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1691038) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1691044) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1691049) perf: ── WiFi ──
+I (1691052) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1691059) perf:   RSSI: cur=-59  avg=-59  min=-63  max=-58 dBm  [n=30]
+I (1691066) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1691071) perf: ── Memory ──
+I (1691075) perf:   Internal heap:  free=81135  min_ever=53671  largest_block=31744  frag_ratio=0.391
+I (1691084) perf:   PSRAM:          free=20904096  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1691093) perf: ── Task Stacks ──
+I (1691097) perf:   data_task HWM:  8076 bytes free
+I (1691102) perf:   input_task HWM: 5484 bytes free
+I (1691106) perf:   spotify_task HWM: 7164 bytes free
+W (1695535) nina_client: astromele1.lan unreachable
+I (1696149) tasks: Auto-rotate: switched to page 4
+I (1697168) tasks: Page switched to 4 (summary)
+W (1698454) nina_client: desktop-bdt978m.lan unreachable
+I (1698454) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1698557) nina_client: astromele2.lan unreachable
+I (1698557) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1698558) websocket_client: Started
+I (1698561) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1702062) nina_client: astromele1.lan unreachable
+W (1702062) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1702063) nina_client: === Poll Summary ===
+I (1702067) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1702072) nina_client: Target: , Filter: 
+I (1702076) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1702081) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1702086) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1703093) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1704973) nina_client: desktop-bdt978m.lan unreachable
+I (1704973) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1705100) nina_client: astromele2.lan unreachable
+I (1705100) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1705974) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1706100) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1708580) transport_ws: Error connecting to host astromele2.lan:1888
+E (1708580) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1708592) nina_ws: WS[1]: Error
+I (1708595) websocket_client: Reconnect after 86400000 ms
+W (1708600) nina_ws: WS[1]: Disconnected from NINA
+W (1709651) nina_client: astromele1.lan unreachable
+I (1709651) nina_client: === Poll Summary ===
+I (1709651) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1709654) nina_client: Target: , Filter: 
+I (1709658) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1709662) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1709668) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1710715) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1712293) tasks: Auto-rotate: switched to page 5
+W (1712500) nina_client: desktop-bdt978m.lan unreachable
+I (1712500) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1712610) nina_client: astromele2.lan unreachable
+I (1712610) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1713324) tasks: Page switched to 5
+W (1717235) nina_client: astromele1.lan unreachable
+W (1720026) nina_client: desktop-bdt978m.lan unreachable
+W (1720161) nina_client: astromele2.lan unreachable
+I (1720161) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1720162) websocket_client: Started
+W (1720363) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (1720363) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (1720365) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (1720373) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (1721398) perf: uxTaskGetSystemState returned 0 tasks
+I (1721398) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1721410) perf: ║              PERFORMANCE REPORT                             ║
+I (1721418) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1721436) perf: ── Poll Cycle ──
+I (1721440) perf:   poll_cycle_total         avg=   12.8  min=    5.9  max= 3685.8  last=    7.9 ms  [n=1685]
+I (1721449) perf:   effective_interval       avg= 1016.8  min=    7.5  max= 4687.0  last= 1009.0 ms  [n=1684]
+I (1721459) perf: ── Endpoint Fetchers ──
+I (1721463) perf:   equipment_bundle         avg= 1479.3  min=    4.6  max= 6661.4  last= 1784.6 ms  [n=384]
+I (1721473) perf:   camera                   (no samples)
+I (1721478) perf:   guider                   (no samples)
+I (1721483) perf:   mount                    (no samples)
+I (1721488) perf:   focuser                  (no samples)
+I (1721493) perf:   sequence                 avg= 4948.0  min=   23.5  max= 7267.7  last= 6527.8 ms  [n=75]
+I (1721503) perf:   switch                   (no samples)
+I (1721508) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1721517) perf:   filter                   (no samples)
+I (1721523) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1721532) perf: ── Network ──
+I (1721535) perf:   http_request             avg= 1562.0  min=    0.4  max= 7045.4  last= 2791.0 ms  [n=556]
+I (1721545) perf:   HTTP requests:  12 (interval) / 737 (total)
+I (1721551) perf:   HTTP retries:   13 (interval) / 475 (total)
+I (1721556) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1721562) perf:   HTTP unreachable:12 (interval) / 473 (total)
+I (1721567) perf:   WS events:      0 (interval) / 39 (total)
+I (1721573) perf: ── JSON Parsing ──
+I (1721577) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1721586) perf:   json_sequence            (no samples)
+I (1721592) perf:   json_config_color        (no samples)
+I (1721597) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1721602) perf: ── UI Updates ──
+I (1721606) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1458]
+I (1721616) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1458]
+I (1721625) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=758]
+I (1721635) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=700]
+I (1721644) perf: ── Latency ──
+I (1721648) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1721657) perf: ── JPEG ──
+I (1721661) perf:   jpeg_decode              (no samples)
+I (1721666) perf:   jpeg_fetch               (no samples)
+I (1721671) perf: ── Spotify ──
+I (1721675) perf:   spotify_poll_cycle       (no samples)
+I (1721680) perf:   spotify_api_fetch        (no samples)
+I (1721685) perf:   spotify_art_fetch        (no samples)
+I (1721690) perf:   spotify_art_decode       (no samples)
+I (1721695) perf:   spotify_ui_update        (no samples)
+I (1721700) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1721706) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1721711) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1721717) perf: ── WiFi ──
+I (1721720) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1721727) perf:   RSSI: cur=-59  avg=-58  min=-60  max=-57 dBm  [n=30]
+I (1721733) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1721739) perf: ── Memory ──
+I (1721742) perf:   Internal heap:  free=80579  min_ever=53671  largest_block=31744  frag_ratio=0.394
+I (1721751) perf:   PSRAM:          free=20897976  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1721761) perf: ── Task Stacks ──
+I (1721765) perf:   data_task HWM:  8076 bytes free
+I (1721769) perf:   input_task HWM: 5484 bytes free
+I (1721774) perf:   spotify_task HWM: 7164 bytes free
+I (1722716) rpc_req: Scan start Req
+
+W (1723777) nina_client: astromele1.lan unreachable
+W (1723777) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1723778) nina_client: === Poll Summary ===
+I (1723782) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1723787) nina_client: Target: , Filter: 
+I (1723791) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1723796) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1723801) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1724808) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1726930) RPC_WRAP: ESP Event: StaScanDone
+I (1726973) ota_github: Using OTA-installed version for comparison: v1.0.40-dev.1
+I (1726973) ota_github: Checking GitHub for updates (current: v1.0.40-dev.1, channel: pre-release)
+I (1728945) tasks: Auto-rotate: switched to page 4
+I (1729953) tasks: Page switched to 4 (summary)
+I (1729953) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1729981) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1730167) transport_ws: Error connecting to host astromele2.lan:1888
+E (1730167) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1730179) nina_ws: WS[1]: Error
+I (1730182) websocket_client: Reconnect after 86400000 ms
+W (1730187) nina_ws: WS[1]: Disconnected from NINA
+I (1731156) ota_github: GitHub API response: 34428 bytes
+I (1731167) ota_github: Update available: v1.0.42-dev.1 (pre-release: yes)
+I (1731170) ota_github: Resolving OTA download URL...
+W (1732299) nina_client: astromele1.lan unreachable
+I (1732299) nina_client: === Poll Summary ===
+I (1732299) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1732302) nina_client: Target: , Filter: 
+I (1732306) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1732310) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1732316) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1732527) ota_github: Resolved OTA URL via 302 redirect
+I (1733323) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1736494) nina_client: astromele2.lan unreachable
+I (1736494) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1736494) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1736502) websocket_client: Started
+W (1736569) nina_client: desktop-bdt978m.lan unreachable
+I (1736569) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1737505) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1737570) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1739875) nina_client: astromele1.lan unreachable
+W (1744054) nina_client: astromele2.lan unreachable
+I (1744054) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1744122) nina_client: desktop-bdt978m.lan unreachable
+I (1744122) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1745054) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1745079) tasks: Auto-rotate: switched to page 5
+I (1745123) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1746102) tasks: Page switched to 5
+W (1746413) nina_client: astromele1.lan unreachable
+W (1746413) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1746414) nina_client: === Poll Summary ===
+I (1746418) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1746423) nina_client: Target: , Filter: 
+I (1746427) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1746432) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1746437) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+E (1746517) transport_ws: Error connecting to host astromele2.lan:1888
+E (1746517) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1746529) nina_ws: WS[1]: Error
+I (1746532) websocket_client: Reconnect after 86400000 ms
+W (1746537) nina_ws: WS[1]: Disconnected from NINA
+I (1747444) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1751600) nina_client: astromele2.lan unreachable
+I (1751600) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1751601) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1751608) websocket_client: Started
+W (1751645) nina_client: desktop-bdt978m.lan unreachable
+I (1751645) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1752158) perf: uxTaskGetSystemState returned 0 tasks
+I (1752158) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1752170) perf: ║              PERFORMANCE REPORT                             ║
+I (1752178) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1752196) perf: ── Poll Cycle ──
+I (1752200) perf:   poll_cycle_total         avg=   15.2  min=    5.9  max= 4150.9  last=    7.4 ms  [n=1711]
+I (1752210) perf:   effective_interval       avg= 1019.3  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1710]
+I (1752219) perf: ── Endpoint Fetchers ──
+I (1752224) perf:   equipment_bundle         avg= 1494.9  min=    4.6  max= 6661.4  last= 4156.3 ms  [n=388]
+I (1752233) perf:   camera                   (no samples)
+I (1752239) perf:   guider                   (no samples)
+I (1752244) perf:   mount                    (no samples)
+I (1752249) perf:   focuser                  (no samples)
+I (1752254) perf:   sequence                 avg= 4989.4  min=   23.5  max= 7267.7  last= 6538.8 ms  [n=77]
+I (1752263) perf:   switch                   (no samples)
+I (1752268) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1752278) perf:   filter                   (no samples)
+I (1752283) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1752292) perf: ── Network ──
+I (1752296) perf:   http_request             avg= 1576.4  min=    0.4  max= 7045.4  last= 4156.3 ms  [n=562]
+I (1752305) perf:   HTTP requests:  10 (interval) / 747 (total)
+I (1752311) perf:   HTTP retries:   10 (interval) / 485 (total)
+I (1752317) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1752322) perf:   HTTP unreachable:10 (interval) / 483 (total)
+I (1752328) perf:   WS events:      0 (interval) / 39 (total)
+I (1752333) perf: ── JSON Parsing ──
+I (1752337) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1752347) perf:   json_sequence            (no samples)
+I (1752352) perf:   json_config_color        (no samples)
+I (1752357) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1752363) perf: ── UI Updates ──
+I (1752366) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   29.8  last=    0.1 ms  [n=1484]
+I (1752376) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   29.8  last=    0.0 ms  [n=1484]
+I (1752386) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=768]
+I (1752395) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=716]
+I (1752405) perf: ── Latency ──
+I (1752408) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1752418) perf: ── JPEG ──
+I (1752421) perf:   jpeg_decode              (no samples)
+I (1752426) perf:   jpeg_fetch               (no samples)
+I (1752431) perf: ── Spotify ──
+I (1752435) perf:   spotify_poll_cycle       (no samples)
+I (1752440) perf:   spotify_api_fetch        (no samples)
+I (1752445) perf:   spotify_art_fetch        (no samples)
+I (1752450) perf:   spotify_art_decode       (no samples)
+I (1752455) perf:   spotify_ui_update        (no samples)
+I (1752461) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1752466) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1752472) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1752477) perf: ── WiFi ──
+I (1752480) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1752487) perf:   RSSI: cur=-58  avg=-59  min=-67  max=-57 dBm  [n=26]
+I (1752494) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1752499) perf: ── Memory ──
+I (1752503) perf:   Internal heap:  free=81003  min_ever=53015  largest_block=31744  frag_ratio=0.392
+I (1752512) perf:   PSRAM:          free=20903540  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1752521) perf: ── Task Stacks ──
+I (1752525) perf:   data_task HWM:  8076 bytes free
+I (1752530) perf:   input_task HWM: 5484 bytes free
+I (1752534) perf:   spotify_task HWM: 7164 bytes free
+W (1753998) nina_client: astromele1.lan unreachable
+I (1753998) nina_client: === Poll Summary ===
+I (1753998) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1754001) nina_client: Target: , Filter: 
+I (1754005) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1754009) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1754015) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1755022) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1761561) nina_client: astromele1.lan unreachable
+I (1761609) tasks: Auto-rotate: switched to page 4
+E (1761618) transport_ws: Error connecting to host astromele2.lan:1888
+E (1761618) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1761630) nina_ws: WS[1]: Error
+I (1761633) websocket_client: Reconnect after 86400000 ms
+W (1761639) nina_ws: WS[1]: Disconnected from NINA
+I (1762659) tasks: Page switched to 4 (summary)
+W (1768091) nina_client: astromele1.lan unreachable
+W (1768091) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1768092) nina_client: === Poll Summary ===
+I (1768096) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1768101) nina_client: Target: , Filter: 
+I (1768105) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1768110) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1768115) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1768184) nina_client: astromele2.lan unreachable
+W (1768184) nina_client: desktop-bdt978m.lan unreachable
+I (1768184) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1768185) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1768197) websocket_client: Started
+I (1768199) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1769122) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1774743) nina_client: astromele2.lan unreachable
+I (1774743) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1774744) nina_client: desktop-bdt978m.lan unreachable
+I (1774749) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1775706) nina_client: astromele1.lan unreachable
+I (1775706) nina_client: === Poll Summary ===
+I (1775706) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1775709) nina_client: Target: , Filter: 
+I (1775713) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1775717) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1775723) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1775744) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1775756) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1776759) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1777785) tasks: Auto-rotate: switched to page 5
+E (1778210) transport_ws: Error connecting to host astromele2.lan:1888
+E (1778210) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1778222) nina_ws: WS[1]: Error
+I (1778225) websocket_client: Reconnect after 86400000 ms
+W (1778230) nina_ws: WS[1]: Disconnected from NINA
+I (1778816) tasks: Page switched to 5
+W (1782330) nina_client: desktop-bdt978m.lan unreachable
+I (1782330) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1782337) nina_client: astromele2.lan unreachable
+I (1782337) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1782856) perf: uxTaskGetSystemState returned 0 tasks
+I (1782856) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1782868) perf: ║              PERFORMANCE REPORT                             ║
+I (1782876) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1782894) perf: ── Poll Cycle ──
+I (1782898) perf:   poll_cycle_total         avg=   15.1  min=    5.9  max= 4150.9  last=    7.3 ms  [n=1741]
+I (1782908) perf:   effective_interval       avg= 1019.4  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1740]
+I (1782917) perf: ── Endpoint Fetchers ──
+I (1782922) perf:   equipment_bundle         avg= 1528.8  min=    4.6  max= 6661.4  last= 5570.5 ms  [n=391]
+I (1782931) perf:   camera                   (no samples)
+I (1782936) perf:   guider                   (no samples)
+I (1782942) perf:   mount                    (no samples)
+I (1782947) perf:   focuser                  (no samples)
+I (1782952) perf:   sequence                 avg= 5009.1  min=   23.5  max= 7267.7  last= 6530.8 ms  [n=78]
+I (1782961) perf:   switch                   (no samples)
+I (1782966) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1782976) perf:   filter                   (no samples)
+I (1782981) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1782990) perf: ── Network ──
+I (1782994) perf:   http_request             avg= 1607.9  min=    0.4  max= 7045.4  last= 5570.5 ms  [n=566]
+I (1783003) perf:   HTTP requests:  10 (interval) / 757 (total)
+I (1783009) perf:   HTTP retries:   10 (interval) / 495 (total)
+I (1783015) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1783020) perf:   HTTP unreachable:10 (interval) / 493 (total)
+I (1783026) perf:   WS events:      0 (interval) / 39 (total)
+I (1783031) perf: ── JSON Parsing ──
+I (1783035) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1783045) perf:   json_sequence            (no samples)
+I (1783050) perf:   json_config_color        (no samples)
+I (1783055) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1783061) perf: ── UI Updates ──
+I (1783064) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.1 ms  [n=1514]
+I (1783074) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1514]
+I (1783084) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=782]
+I (1783093) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=732]
+I (1783103) perf: ── Latency ──
+I (1783106) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1783116) perf: ── JPEG ──
+I (1783119) perf:   jpeg_decode              (no samples)
+I (1783124) perf:   jpeg_fetch               (no samples)
+I (1783129) perf: ── Spotify ──
+I (1783133) perf:   spotify_poll_cycle       (no samples)
+I (1783138) perf:   spotify_api_fetch        (no samples)
+I (1783143) perf:   spotify_art_fetch        (no samples)
+I (1783148) perf:   spotify_art_decode       (no samples)
+I (1783153) perf:   spotify_ui_update        (no samples)
+I (1783158) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1783164) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1783170) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1783175) perf: ── WiFi ──
+I (1783178) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1783185) perf:   RSSI: cur=-58  avg=-58  min=-60  max=-55 dBm  [n=30]
+I (1783192) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1783197) perf: ── Memory ──
+I (1783201) perf:   Internal heap:  free=81151  min_ever=53015  largest_block=31744  frag_ratio=0.391
+I (1783210) perf:   PSRAM:          free=20904124  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1783219) perf: ── Task Stacks ──
+I (1783223) perf:   data_task HWM:  8076 bytes free
+I (1783228) perf:   input_task HWM: 5484 bytes free
+I (1783232) perf:   spotify_task HWM: 7164 bytes free
+W (1783275) nina_client: astromele1.lan unreachable
+W (1789946) nina_client: astromele1.lan unreachable
+W (1789946) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1789947) nina_client: === Poll Summary ===
+I (1789951) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1789956) nina_client: Target: , Filter: 
+I (1789960) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1789965) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1789970) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1790977) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1794323) tasks: Auto-rotate: switched to page 4
+I (1795341) tasks: Page switched to 4 (summary)
+W (1798020) nina_client: astromele1.lan unreachable
+I (1798020) nina_client: === Poll Summary ===
+I (1798020) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1798023) nina_client: Target: , Filter: 
+I (1798027) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1798031) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1798037) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1799044) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1799681) nina_client: desktop-bdt978m.lan unreachable
+I (1799681) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1799681) nina_client: astromele2.lan unreachable
+I (1799687) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1799694) websocket_client: Started
+I (1799697) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1806088) nina_client: astromele1.lan unreachable
+W (1807848) nina_client: astromele2.lan unreachable
+I (1807848) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1807919) nina_client: desktop-bdt978m.lan unreachable
+I (1807919) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1808848) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1808920) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1810466) tasks: Auto-rotate: switched to page 5
+E (1811071) transport_ws: Error connecting to host astromele2.lan:1888
+E (1811071) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1811083) nina_ws: WS[1]: Error
+I (1811086) websocket_client: Reconnect after 86400000 ms
+W (1811091) nina_ws: WS[1]: Disconnected from NINA
+I (1811497) tasks: Page switched to 5
+W (1813521) perf: uxTaskGetSystemState returned 0 tasks
+I (1813521) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1813533) perf: ║              PERFORMANCE REPORT                             ║
+I (1813541) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1813559) perf: ── Poll Cycle ──
+I (1813563) perf:   poll_cycle_total         avg=   15.0  min=    5.9  max= 4150.9  last=    7.3 ms  [n=1771]
+I (1813573) perf:   effective_interval       avg= 1019.4  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1770]
+I (1813582) perf: ── Endpoint Fetchers ──
+I (1813587) perf:   equipment_bundle         avg= 1555.1  min=    4.6  max= 7043.3  last= 6384.6 ms  [n=393]
+I (1813596) perf:   camera                   (no samples)
+I (1813601) perf:   guider                   (no samples)
+I (1813607) perf:   mount                    (no samples)
+I (1813612) perf:   focuser                  (no samples)
+I (1813617) perf:   sequence                 avg= 5030.2  min=   23.5  max= 7267.7  last= 6671.7 ms  [n=79]
+I (1813626) perf:   switch                   (no samples)
+I (1813631) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1813641) perf:   filter                   (no samples)
+I (1813646) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1813655) perf: ── Network ──
+I (1813659) perf:   http_request             avg= 1627.5  min=    0.4  max= 7045.4  last= 1760.0 ms  [n=572]
+I (1813668) perf:   HTTP requests:  10 (interval) / 767 (total)
+I (1813674) perf:   HTTP retries:   10 (interval) / 505 (total)
+I (1813680) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1813685) perf:   HTTP unreachable:8 (interval) / 501 (total)
+I (1813691) perf:   WS events:      0 (interval) / 39 (total)
+I (1813696) perf: ── JSON Parsing ──
+I (1813700) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1813710) perf:   json_sequence            (no samples)
+I (1813715) perf:   json_config_color        (no samples)
+I (1813720) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1813725) perf: ── UI Updates ──
+I (1813729) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.1 ms  [n=1544]
+I (1813739) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1544]
+I (1813749) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=796]
+I (1813758) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=748]
+I (1813768) perf: ── Latency ──
+I (1813771) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1813781) perf: ── JPEG ──
+I (1813784) perf:   jpeg_decode              (no samples)
+I (1813789) perf:   jpeg_fetch               (no samples)
+I (1813794) perf: ── Spotify ──
+I (1813798) perf:   spotify_poll_cycle       (no samples)
+I (1813803) perf:   spotify_api_fetch        (no samples)
+I (1813808) perf:   spotify_art_fetch        (no samples)
+I (1813813) perf:   spotify_art_decode       (no samples)
+I (1813818) perf:   spotify_ui_update        (no samples)
+I (1813823) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1813829) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1813835) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1813840) perf: ── WiFi ──
+I (1813843) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1813850) perf:   RSSI: cur=-58  avg=-58  min=-61  max=-56 dBm  [n=30]
+I (1813857) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1813862) perf: ── Memory ──
+I (1813866) perf:   Internal heap:  free=76231  min_ever=53015  largest_block=31744  frag_ratio=0.416
+I (1813875) perf:   PSRAM:          free=20902948  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1813884) perf: ── Task Stacks ──
+I (1813888) perf:   data_task HWM:  8076 bytes free
+W (1813891) nina_client: astromele1.lan unreachable
+I (1813893) perf:   input_task HWM: 5484 bytes free
+W (1813897) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1813902) perf:   spotify_task HWM: 7164 bytes free
+I (1813909) nina_client: === Poll Summary ===
+I (1813918) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1813924) nina_client: Target: , Filter: 
+I (1813928) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1813932) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1813938) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1814945) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1815640) nina_client: astromele2.lan unreachable
+I (1815640) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1815641) nina_client: desktop-bdt978m.lan unreachable
+I (1815646) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1821564) nina_client: astromele1.lan unreachable
+I (1827016) tasks: Auto-rotate: switched to page 4
+I (1828039) tasks: Page switched to 4 (summary)
+W (1828204) nina_client: astromele1.lan unreachable
+W (1828204) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1828205) nina_client: === Poll Summary ===
+I (1828209) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1828214) nina_client: Target: , Filter: 
+I (1828218) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1828223) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1828228) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1829235) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1832644) nina_client: desktop-bdt978m.lan unreachable
+I (1832644) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1832833) nina_client: astromele2.lan unreachable
+I (1832833) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1832834) websocket_client: Started
+I (1832836) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1836233) nina_client: astromele1.lan unreachable
+I (1836233) nina_client: === Poll Summary ===
+I (1836233) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1836236) nina_client: Target: , Filter: 
+I (1836240) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1836244) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1836250) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1837281) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1839359) nina_client: desktop-bdt978m.lan unreachable
+I (1839359) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1839479) nina_client: astromele2.lan unreachable
+I (1839479) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1840360) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1840479) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1842926) transport_ws: Error connecting to host astromele2.lan:1888
+E (1842926) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1842938) nina_ws: WS[1]: Error
+I (1842941) websocket_client: Reconnect after 86400000 ms
+W (1842946) nina_ws: WS[1]: Disconnected from NINA
+I (1843164) tasks: Auto-rotate: switched to page 5
+W (1843887) nina_client: astromele1.lan unreachable
+I (1844195) tasks: Page switched to 5
+W (1844203) perf: uxTaskGetSystemState returned 0 tasks
+I (1844203) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1844216) perf: ║              PERFORMANCE REPORT                             ║
+I (1844223) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1844242) perf: ── Poll Cycle ──
+I (1844245) perf:   poll_cycle_total         avg=   14.9  min=    5.9  max= 4150.9  last=    7.6 ms  [n=1801]
+I (1844255) perf:   effective_interval       avg= 1019.5  min=    7.5  max= 5152.0  last= 1036.0 ms  [n=1800]
+I (1844265) perf: ── Endpoint Fetchers ──
+I (1844269) perf:   equipment_bundle         avg= 1563.6  min=    4.6  max= 7043.3  last= 3408.3 ms  [n=397]
+I (1844279) perf:   camera                   (no samples)
+I (1844284) perf:   guider                   (no samples)
+I (1844289) perf:   mount                    (no samples)
+I (1844294) perf:   focuser                  (no samples)
+I (1844299) perf:   sequence                 avg= 5084.5  min=   23.5  max= 7821.4  last= 6640.9 ms  [n=81]
+I (1844309) perf:   switch                   (no samples)
+I (1844314) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1844323) perf:   filter                   (no samples)
+I (1844328) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1844338) perf: ── Network ──
+I (1844341) perf:   http_request             avg= 1640.5  min=    0.4  max= 7045.4  last= 3408.3 ms  [n=580]
+I (1844351) perf:   HTTP requests:  11 (interval) / 778 (total)
+I (1844356) perf:   HTTP retries:   10 (interval) / 515 (total)
+I (1844362) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1844367) perf:   HTTP unreachable:10 (interval) / 512 (total)
+I (1844373) perf:   WS events:      0 (interval) / 39 (total)
+I (1844379) perf: ── JSON Parsing ──
+I (1844383) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1844392) perf:   json_sequence            (no samples)
+I (1844397) perf:   json_config_color        (no samples)
+I (1844402) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1844408) perf: ── UI Updates ──
+I (1844412) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.1 ms  [n=1574]
+I (1844421) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1574]
+I (1844431) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=810]
+I (1844441) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=764]
+I (1844450) perf: ── Latency ──
+I (1844454) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1844463) perf: ── JPEG ──
+I (1844466) perf:   jpeg_decode              (no samples)
+I (1844471) perf:   jpeg_fetch               (no samples)
+I (1844477) perf: ── Spotify ──
+I (1844480) perf:   spotify_poll_cycle       (no samples)
+I (1844485) perf:   spotify_api_fetch        (no samples)
+I (1844490) perf:   spotify_art_fetch        (no samples)
+I (1844496) perf:   spotify_art_decode       (no samples)
+I (1844501) perf:   spotify_ui_update        (no samples)
+I (1844506) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1844511) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1844517) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1844522) perf: ── WiFi ──
+I (1844526) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1844533) perf:   RSSI: cur=-59  avg=-59  min=-61  max=-57 dBm  [n=30]
+I (1844539) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1844544) perf: ── Memory ──
+I (1844548) perf:   Internal heap:  free=76243  min_ever=53015  largest_block=31744  frag_ratio=0.416
+I (1844557) perf:   PSRAM:          free=20902944  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1844567) perf: ── Task Stacks ──
+I (1844571) perf:   data_task HWM:  8076 bytes free
+I (1844575) perf:   input_task HWM: 5484 bytes free
+I (1844580) perf:   spotify_task HWM: 7164 bytes free
+W (1846878) nina_client: desktop-bdt978m.lan unreachable
+I (1846878) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1846999) nina_client: astromele2.lan unreachable
+I (1846999) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1850564) nina_client: astromele1.lan unreachable
+W (1850564) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1850565) nina_client: === Poll Summary ===
+I (1850569) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1850574) nina_client: Target: , Filter: 
+I (1850578) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1850583) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1850588) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1851595) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1858119) nina_client: astromele1.lan unreachable
+I (1858119) nina_client: === Poll Summary ===
+I (1858119) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1858122) nina_client: Target: , Filter: 
+I (1858126) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1858130) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1858136) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1859143) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1859702) tasks: Auto-rotate: switched to page 4
+I (1860720) tasks: Page switched to 4 (summary)
+W (1863435) nina_client: desktop-bdt978m.lan unreachable
+I (1863435) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1863552) nina_client: astromele2.lan unreachable
+I (1863552) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1863553) websocket_client: Started
+I (1863555) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1865708) nina_client: astromele1.lan unreachable
+W (1870208) nina_client: desktop-bdt978m.lan unreachable
+I (1870208) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1870210) nina_client: astromele2.lan unreachable
+I (1870213) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1871209) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1871220) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1872471) nina_client: astromele1.lan unreachable
+W (1872471) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1872472) nina_client: === Poll Summary ===
+I (1872476) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1872481) nina_client: Target: , Filter: 
+I (1872485) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1872490) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1872495) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1873502) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1873612) transport_ws: Error connecting to host astromele2.lan:1888
+E (1873612) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1873624) nina_ws: WS[1]: Error
+I (1873627) websocket_client: Reconnect after 86400000 ms
+W (1873632) nina_ws: WS[1]: Disconnected from NINA
+W (1874840) perf: uxTaskGetSystemState returned 0 tasks
+I (1874840) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1874852) perf: ║              PERFORMANCE REPORT                             ║
+I (1874860) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1874878) perf: ── Poll Cycle ──
+I (1874882) perf:   poll_cycle_total         avg=   14.8  min=    5.9  max= 4150.9  last=    7.3 ms  [n=1831]
+I (1874892) perf:   effective_interval       avg= 1019.5  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1830]
+I (1874901) perf: ── Endpoint Fetchers ──
+I (1874906) perf:   equipment_bundle         avg= 1577.5  min=    4.6  max= 7043.3  last= 2145.7 ms  [n=399]
+I (1874915) perf:   camera                   (no samples)
+I (1874920) perf:   guider                   (no samples)
+I (1874926) perf:   mount                    (no samples)
+I (1874931) perf:   focuser                  (no samples)
+I (1874936) perf:   sequence                 avg= 5124.0  min=   23.5  max= 7821.4  last= 6763.8 ms  [n=83]
+I (1874945) perf:   switch                   (no samples)
+I (1874950) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1874960) perf:   filter                   (no samples)
+I (1874965) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1874974) perf: ── Network ──
+I (1874978) perf:   http_request             avg= 1648.9  min=    0.4  max= 7045.4  last= 1251.3 ms  [n=587]
+I (1874987) perf:   HTTP requests:  10 (interval) / 788 (total)
+I (1874993) perf:   HTTP retries:   8 (interval) / 523 (total)
+I (1874999) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1875004) perf:   HTTP unreachable:10 (interval) / 522 (total)
+I (1875010) perf:   WS events:      0 (interval) / 39 (total)
+I (1875015) perf: ── JSON Parsing ──
+I (1875019) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1875029) perf:   json_sequence            (no samples)
+I (1875034) perf:   json_config_color        (no samples)
+I (1875039) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1875044) perf: ── UI Updates ──
+I (1875048) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1604]
+I (1875058) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1604]
+I (1875068) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=825]
+I (1875077) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=779]
+I (1875087) perf: ── Latency ──
+I (1875090) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1875100) perf: ── JPEG ──
+I (1875103) perf:   jpeg_decode              (no samples)
+I (1875108) perf:   jpeg_fetch               (no samples)
+I (1875113) perf: ── Spotify ──
+I (1875117) perf:   spotify_poll_cycle       (no samples)
+I (1875122) perf:   spotify_api_fetch        (no samples)
+I (1875127) perf:   spotify_art_fetch        (no samples)
+I (1875132) perf:   spotify_art_decode       (no samples)
+I (1875137) perf:   spotify_ui_update        (no samples)
+I (1875142) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1875148) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1875153) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1875159) perf: ── WiFi ──
+I (1875162) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1875169) perf:   RSSI: cur=-60  avg=-59  min=-69  max=-58 dBm  [n=30]
+I (1875176) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1875181) perf: ── Memory ──
+I (1875185) perf:   Internal heap:  free=76231  min_ever=53015  largest_block=31744  frag_ratio=0.416
+I (1875194) perf:   PSRAM:          free=20902948  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1875203) perf: ── Task Stacks ──
+I (1875207) perf:   data_task HWM:  8076 bytes free
+I (1875212) perf:   input_task HWM: 5484 bytes free
+I (1875216) perf:   spotify_task HWM: 7164 bytes free
+I (1876226) tasks: Auto-rotate: switched to page 5
+I (1877246) tasks: Page switched to 5
+W (1881391) nina_client: astromele1.lan unreachable
+I (1881391) nina_client: === Poll Summary ===
+I (1881391) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1881394) nina_client: Target: , Filter: 
+I (1881398) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1881402) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1881408) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1881587) nina_client: astromele2.lan unreachable
+I (1881587) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1881588) nina_client: desktop-bdt978m.lan unreachable
+I (1881588) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1881596) websocket_client: Started
+I (1881599) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1882415) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1886685) web_server: WiFi networks updated via wifi_networks array
+I (1886744) app_config: Config saved
+I (1886744) web_server: Config saved to NVS
+W (1889051) nina_client: astromele1.lan unreachable
+E (1891679) transport_ws: Error connecting to host astromele2.lan:1888
+E (1891679) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1891691) nina_ws: WS[1]: Error
+I (1891694) websocket_client: Reconnect after 86400000 ms
+W (1891699) nina_ws: WS[1]: Disconnected from NINA
+I (1892372) tasks: Auto-rotate: switched to page 4
+I (1893402) tasks: Page switched to 4 (summary)
+W (1896038) nina_client: astromele1.lan unreachable
+W (1896038) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1896039) nina_client: === Poll Summary ===
+I (1896043) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1896048) nina_client: Target: , Filter: 
+I (1896052) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1896057) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1896062) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1897069) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1898786) nina_client: desktop-bdt978m.lan unreachable
+I (1898786) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1899412) nina_client: astromele2.lan unreachable
+I (1899412) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1899413) websocket_client: Started
+I (1899415) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1904020) nina_client: astromele1.lan unreachable
+I (1904020) nina_client: === Poll Summary ===
+I (1904020) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1904023) nina_client: Target: , Filter: 
+I (1904027) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1904031) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1904037) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1905114) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1905506) perf: uxTaskGetSystemState returned 0 tasks
+I (1905506) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1905518) perf: ║              PERFORMANCE REPORT                             ║
+I (1905526) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1905544) perf: ── Poll Cycle ──
+I (1905548) perf:   poll_cycle_total         avg=   14.7  min=    5.9  max= 4150.9  last=    7.3 ms  [n=1861]
+I (1905558) perf:   effective_interval       avg= 1019.5  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1860]
+I (1905567) perf: ── Endpoint Fetchers ──
+I (1905572) perf:   equipment_bundle         avg= 1613.3  min=    4.6  max= 7889.3  last= 4597.7 ms  [n=402]
+I (1905581) perf:   camera                   (no samples)
+I (1905586) perf:   guider                   (no samples)
+I (1905592) perf:   mount                    (no samples)
+I (1905597) perf:   focuser                  (no samples)
+I (1905602) perf:   sequence                 avg= 5146.1  min=   23.5  max= 7821.4  last= 6987.7 ms  [n=84]
+I (1905611) perf:   switch                   (no samples)
+I (1905616) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1905626) perf:   filter                   (no samples)
+I (1905631) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1905640) perf: ── Network ──
+I (1905644) perf:   http_request             avg= 1675.1  min=    0.4  max= 7889.3  last= 4597.6 ms  [n=593]
+W (1905652) nina_client: desktop-bdt978m.lan unreachable
+I (1905653) perf:   HTTP requests:  8 (interval) / 796 (total)
+I (1905658) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1905664) perf:   HTTP retries:   10 (interval) / 533 (total)
+I (1905677) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1905682) perf:   HTTP unreachable:9 (interval) / 531 (total)
+I (1905688) perf:   WS events:      0 (interval) / 39 (total)
+I (1905693) perf: ── JSON Parsing ──
+I (1905697) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1905707) perf:   json_sequence            (no samples)
+I (1905712) perf:   json_config_color        (no samples)
+I (1905717) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1905722) perf: ── UI Updates ──
+I (1905726) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1634]
+I (1905736) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1634]
+I (1905746) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=841]
+I (1905755) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=793]
+I (1905765) perf: ── Latency ──
+I (1905768) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1905778) perf: ── JPEG ──
+I (1905781) perf:   jpeg_decode              (no samples)
+I (1905786) perf:   jpeg_fetch               (no samples)
+I (1905791) perf: ── Spotify ──
+I (1905795) perf:   spotify_poll_cycle       (no samples)
+I (1905800) perf:   spotify_api_fetch        (no samples)
+I (1905805) perf:   spotify_art_fetch        (no samples)
+I (1905810) perf:   spotify_art_decode       (no samples)
+I (1905815) perf:   spotify_ui_update        (no samples)
+I (1905820) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1905826) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1905831) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1905837) perf: ── WiFi ──
+I (1905840) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1905847) perf:   RSSI: cur=-60  avg=-60  min=-74  max=-54 dBm  [n=30]
+I (1905854) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1905859) perf: ── Memory ──
+I (1905863) perf:   Internal heap:  free=76275  min_ever=53015  largest_block=31744  frag_ratio=0.416
+I (1905871) perf:   PSRAM:          free=20902852  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1905881) perf: ── Task Stacks ──
+I (1905885) perf:   data_task HWM:  8076 bytes free
+I (1905890) perf:   input_task HWM: 5484 bytes free
+I (1905894) perf:   spotify_task HWM: 7164 bytes free
+W (1906118) nina_client: astromele2.lan unreachable
+I (1906118) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1906671) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1907118) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1908921) tasks: Auto-rotate: switched to page 5
+E (1909568) transport_ws: Error connecting to host astromele2.lan:1888
+E (1909568) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1909580) nina_ws: WS[1]: Error
+I (1909583) websocket_client: Reconnect after 86400000 ms
+W (1909588) nina_ws: WS[1]: Disconnected from NINA
+I (1909943) tasks: Page switched to 5
+W (1912725) nina_client: astromele1.lan unreachable
+W (1913335) nina_client: desktop-bdt978m.lan unreachable
+I (1913335) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1914640) nina_client: astromele2.lan unreachable
+I (1914640) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1914641) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1914648) websocket_client: Started
+W (1919266) nina_client: astromele1.lan unreachable
+W (1919266) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1919267) nina_client: === Poll Summary ===
+I (1919271) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1919276) nina_client: Target: , Filter: 
+I (1919280) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1919285) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1919290) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1920297) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (1924711) transport_ws: Error connecting to host astromele2.lan:1888
+E (1924711) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1924723) nina_ws: WS[1]: Error
+I (1924726) websocket_client: Reconnect after 86400000 ms
+W (1924731) nina_ws: WS[1]: Disconnected from NINA
+I (1925070) tasks: Auto-rotate: switched to page 4
+I (1926100) tasks: Page switched to 4 (summary)
+W (1926843) nina_client: astromele1.lan unreachable
+W (1929901) nina_client: desktop-bdt978m.lan unreachable
+I (1929901) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1931170) nina_client: astromele2.lan unreachable
+I (1931170) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1931171) websocket_client: Started
+I (1931174) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1933408) nina_client: astromele1.lan unreachable
+W (1933408) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1933409) nina_client: === Poll Summary ===
+I (1933413) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1933418) nina_client: Target: , Filter: 
+I (1933422) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1933427) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1933432) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1934439) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1936188) perf: uxTaskGetSystemState returned 0 tasks
+I (1936188) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1936200) perf: ║              PERFORMANCE REPORT                             ║
+I (1936208) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1936226) perf: ── Poll Cycle ──
+I (1936230) perf:   poll_cycle_total         avg=   14.6  min=    5.9  max= 4150.9  last=    7.3 ms  [n=1891]
+I (1936240) perf:   effective_interval       avg= 1019.6  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1890]
+I (1936249) perf: ── Endpoint Fetchers ──
+I (1936254) perf:   equipment_bundle         avg= 1632.7  min=    4.6  max= 7889.3  last= 6546.3 ms  [n=405]
+I (1936263) perf:   camera                   (no samples)
+I (1936268) perf:   guider                   (no samples)
+I (1936274) perf:   mount                    (no samples)
+I (1936279) perf:   focuser                  (no samples)
+I (1936284) perf:   sequence                 avg= 5178.9  min=   23.5  max= 7821.4  last= 6565.8 ms  [n=86]
+I (1936293) perf:   switch                   (no samples)
+I (1936298) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1936308) perf:   filter                   (no samples)
+I (1936313) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1936322) perf: ── Network ──
+I (1936326) perf:   http_request             avg= 1681.4  min=    0.4  max= 7889.3  last= 2227.6 ms  [n=600]
+I (1936335) perf:   HTTP requests:  10 (interval) / 806 (total)
+I (1936341) perf:   HTTP retries:   10 (interval) / 543 (total)
+I (1936347) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1936352) perf:   HTTP unreachable:9 (interval) / 540 (total)
+I (1936358) perf:   WS events:      0 (interval) / 39 (total)
+I (1936363) perf: ── JSON Parsing ──
+I (1936367) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1936377) perf:   json_sequence            (no samples)
+I (1936382) perf:   json_config_color        (no samples)
+I (1936387) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1936392) perf: ── UI Updates ──
+I (1936396) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1664]
+I (1936406) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1664]
+I (1936416) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=857]
+I (1936425) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=807]
+I (1936435) perf: ── Latency ──
+I (1936438) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1936448) perf: ── JPEG ──
+I (1936451) perf:   jpeg_decode              (no samples)
+I (1936456) perf:   jpeg_fetch               (no samples)
+I (1936461) perf: ── Spotify ──
+I (1936465) perf:   spotify_poll_cycle       (no samples)
+W (1936467) nina_client: desktop-bdt978m.lan unreachable
+I (1936470) perf:   spotify_api_fetch        (no samples)
+I (1936475) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1936480) perf:   spotify_art_fetch        (no samples)
+I (1936492) perf:   spotify_art_decode       (no samples)
+I (1936497) perf:   spotify_ui_update        (no samples)
+I (1936502) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1936508) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1936514) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1936519) perf: ── WiFi ──
+I (1936522) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1936529) perf:   RSSI: cur=-60  avg=-59  min=-66  max=-58 dBm  [n=30]
+I (1936536) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1936541) perf: ── Memory ──
+I (1936545) perf:   Internal heap:  free=76139  min_ever=53015  largest_block=31744  frag_ratio=0.417
+I (1936554) perf:   PSRAM:          free=20902396  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1936563) perf: ── Task Stacks ──
+I (1936567) perf:   data_task HWM:  8076 bytes free
+I (1936572) perf:   input_task HWM: 5484 bytes free
+I (1936576) perf:   spotify_task HWM: 7164 bytes free
+I (1937487) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1937691) nina_client: astromele2.lan unreachable
+I (1937691) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1938691) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1940956) nina_client: astromele1.lan unreachable
+I (1940956) nina_client: === Poll Summary ===
+I (1940956) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1940959) nina_client: Target: , Filter: 
+I (1940963) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1940967) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1940973) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+E (1941185) transport_ws: Error connecting to host astromele2.lan:1888
+E (1941185) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1941197) nina_ws: WS[1]: Error
+I (1941200) websocket_client: Reconnect after 86400000 ms
+W (1941205) nina_ws: WS[1]: Disconnected from NINA
+I (1941618) tasks: Auto-rotate: switched to page 5
+I (1941980) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1942641) tasks: Page switched to 5
+W (1944052) nina_client: desktop-bdt978m.lan unreachable
+I (1944052) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1945232) nina_client: astromele2.lan unreachable
+I (1945232) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1948549) nina_client: astromele1.lan unreachable
+W (1955095) nina_client: astromele1.lan unreachable
+W (1955095) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1955096) nina_client: === Poll Summary ===
+I (1955100) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1955105) nina_client: Target: , Filter: 
+I (1955109) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1955114) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1955119) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1956126) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1957767) tasks: Auto-rotate: switched to page 4
+I (1958797) tasks: Page switched to 4 (summary)
+W (1960612) nina_client: desktop-bdt978m.lan unreachable
+I (1960612) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1961773) nina_client: astromele2.lan unreachable
+I (1961773) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1961774) websocket_client: Started
+I (1961777) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1962686) nina_client: astromele1.lan unreachable
+I (1962686) nina_client: === Poll Summary ===
+I (1962686) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1962689) nina_client: Target: , Filter: 
+I (1962693) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1962697) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1962703) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1963710) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1966870) perf: uxTaskGetSystemState returned 0 tasks
+I (1966870) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1966882) perf: ║              PERFORMANCE REPORT                             ║
+I (1966890) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1966908) perf: ── Poll Cycle ──
+I (1966912) perf:   poll_cycle_total         avg=   14.5  min=    5.9  max= 4150.9  last=    7.2 ms  [n=1921]
+I (1966922) perf:   effective_interval       avg= 1019.6  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1920]
+I (1966931) perf: ── Endpoint Fetchers ──
+I (1966936) perf:   equipment_bundle         avg= 1631.0  min=    4.6  max= 7889.3  last=  902.6 ms  [n=410]
+I (1966945) perf:   camera                   (no samples)
+I (1966950) perf:   guider                   (no samples)
+I (1966955) perf:   mount                    (no samples)
+I (1966961) perf:   focuser                  (no samples)
+I (1966966) perf:   sequence                 avg= 5194.6  min=   23.5  max= 7821.4  last= 6546.8 ms  [n=87]
+I (1966975) perf:   switch                   (no samples)
+I (1966980) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1966990) perf:   filter                   (no samples)
+I (1966995) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1967004) perf: ── Network ──
+I (1967008) perf:   http_request             avg= 1682.6  min=    0.4  max= 7889.3  last=  902.6 ms  [n=608]
+I (1967017) perf:   HTTP requests:  10 (interval) / 816 (total)
+I (1967023) perf:   HTTP retries:   11 (interval) / 554 (total)
+I (1967029) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1967034) perf:   HTTP unreachable:9 (interval) / 550 (total)
+I (1967040) perf:   WS events:      0 (interval) / 39 (total)
+I (1967045) perf: ── JSON Parsing ──
+I (1967049) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1967059) perf:   json_sequence            (no samples)
+I (1967064) perf:   json_config_color        (no samples)
+I (1967069) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1967074) perf: ── UI Updates ──
+I (1967078) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1694]
+I (1967088) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1694]
+I (1967098) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=873]
+I (1967107) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=821]
+I (1967117) perf: ── Latency ──
+I (1967120) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1967130) perf: ── JPEG ──
+I (1967133) perf:   jpeg_decode              (no samples)
+I (1967138) perf:   jpeg_fetch               (no samples)
+I (1967143) perf: ── Spotify ──
+I (1967147) perf:   spotify_poll_cycle       (no samples)
+I (1967152) perf:   spotify_api_fetch        (no samples)
+I (1967157) perf:   spotify_art_fetch        (no samples)
+I (1967162) perf:   spotify_art_decode       (no samples)
+I (1967167) perf:   spotify_ui_update        (no samples)
+W (1967169) nina_client: desktop-bdt978m.lan unreachable
+I (1967172) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1967178) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1967183) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1967188) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1967201) perf: ── WiFi ──
+I (1967204) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1967211) perf:   RSSI: cur=-60  avg=-60  min=-61  max=-59 dBm  [n=30]
+I (1967218) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1967223) perf: ── Memory ──
+I (1967227) perf:   Internal heap:  free=78651  min_ever=53015  largest_block=31744  frag_ratio=0.404
+I (1967235) perf:   PSRAM:          free=20902948  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1967245) perf: ── Task Stacks ──
+I (1967249) perf:   data_task HWM:  8076 bytes free
+I (1967254) perf:   input_task HWM: 5484 bytes free
+I (1967258) perf:   spotify_task HWM: 7164 bytes free
+I (1968195) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1968310) nina_client: astromele2.lan unreachable
+I (1968310) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1969310) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1971195) nina_client: astromele1.lan unreachable
+E (1971804) transport_ws: Error connecting to host astromele2.lan:1888
+E (1971804) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (1971816) nina_ws: WS[1]: Error
+I (1971819) websocket_client: Reconnect after 86400000 ms
+W (1971824) nina_ws: WS[1]: Disconnected from NINA
+I (1974316) tasks: Auto-rotate: switched to page 5
+W (1975150) nina_client: desktop-bdt978m.lan unreachable
+I (1975150) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1975339) tasks: Page switched to 5
+W (1976059) nina_client: astromele2.lan unreachable
+I (1976059) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1977805) nina_client: astromele1.lan unreachable
+W (1977805) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1977806) nina_client: === Poll Summary ===
+I (1977810) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1977815) nina_client: Target: , Filter: 
+I (1977819) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1977824) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1977829) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (1978840) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1982716) nina_client: desktop-bdt978m.lan unreachable
+W (1985426) nina_client: astromele1.lan unreachable
+I (1990465) tasks: Auto-rotate: switched to page 4
+I (1991495) tasks: Page switched to 4 (summary)
+I (1991524) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1991954) nina_client: astromele1.lan unreachable
+W (1991954) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (1991955) nina_client: === Poll Summary ===
+I (1991959) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1991964) nina_client: Target: , Filter: 
+I (1991968) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1991973) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1991978) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (1992573) nina_client: astromele2.lan unreachable
+I (1992573) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (1992574) websocket_client: Started
+I (1992577) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (1992985) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1997551) perf: uxTaskGetSystemState returned 0 tasks
+I (1997551) perf: ╔══════════════════════════════════════════════════════════════╗
+I (1997563) perf: ║              PERFORMANCE REPORT                             ║
+I (1997571) perf: ╚══════════════════════════════════════════════════════════════╝
+I (1997589) perf: ── Poll Cycle ──
+I (1997593) perf:   poll_cycle_total         avg=   14.4  min=    5.9  max= 4150.9  last=    7.3 ms  [n=1951]
+I (1997603) perf:   effective_interval       avg= 1019.7  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1950]
+I (1997612) perf: ── Endpoint Fetchers ──
+I (1997617) perf:   equipment_bundle         avg= 1644.4  min=    4.6  max= 7889.3  last= 6585.9 ms  [n=414]
+I (1997626) perf:   camera                   (no samples)
+I (1997631) perf:   guider                   (no samples)
+I (1997637) perf:   mount                    (no samples)
+I (1997642) perf:   focuser                  (no samples)
+I (1997647) perf:   sequence                 avg= 5225.5  min=   23.5  max= 7821.4  last= 6528.6 ms  [n=89]
+I (1997656) perf:   switch                   (no samples)
+I (1997661) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (1997671) perf:   filter                   (no samples)
+I (1997676) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (1997685) perf: ── Network ──
+I (1997689) perf:   http_request             avg= 1688.5  min=    0.4  max= 7889.3  last=  429.7 ms  [n=615]
+I (1997698) perf:   HTTP requests:  10 (interval) / 826 (total)
+I (1997704) perf:   HTTP retries:   10 (interval) / 564 (total)
+I (1997710) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (1997715) perf:   HTTP unreachable:9 (interval) / 560 (total)
+I (1997721) perf:   WS events:      0 (interval) / 39 (total)
+I (1997726) perf: ── JSON Parsing ──
+I (1997730) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (1997740) perf:   json_sequence            (no samples)
+I (1997745) perf:   json_config_color        (no samples)
+I (1997750) perf:   Parse calls:    0 (interval) / 263 (total)
+I (1997755) perf: ── UI Updates ──
+I (1997759) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1724]
+I (1997769) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1724]
+I (1997779) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=889]
+I (1997788) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=835]
+I (1997798) perf: ── Latency ──
+I (1997801) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (1997811) perf: ── JPEG ──
+I (1997814) perf:   jpeg_decode              (no samples)
+I (1997819) perf:   jpeg_fetch               (no samples)
+I (1997824) perf: ── Spotify ──
+I (1997828) perf:   spotify_poll_cycle       (no samples)
+I (1997833) perf:   spotify_api_fetch        (no samples)
+I (1997838) perf:   spotify_art_fetch        (no samples)
+I (1997843) perf:   spotify_art_decode       (no samples)
+I (1997848) perf:   spotify_ui_update        (no samples)
+I (1997853) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (1997859) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (1997865) perf:   Spotify art:      0 (interval) / 0 (total)
+I (1997870) perf: ── WiFi ──
+I (1997873) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (1997880) perf:   RSSI: cur=-60  avg=-60  min=-62  max=-57 dBm  [n=30]
+I (1997887) perf:   Disconnects:    0 (interval) / 0 (total)
+I (1997892) perf: ── Memory ──
+I (1997896) perf:   Internal heap:  free=76171  min_ever=53015  largest_block=31744  frag_ratio=0.417
+I (1997905) perf:   PSRAM:          free=20902396  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (1997914) perf: ── Task Stacks ──
+I (1997918) perf:   data_task HWM:  8076 bytes free
+I (1997923) perf:   input_task HWM: 5484 bytes free
+I (1997927) perf:   spotify_task HWM: 7164 bytes free
+W (1998166) nina_client: desktop-bdt978m.lan unreachable
+I (1998166) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (1999167) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (1999201) nina_client: astromele2.lan unreachable
+I (1999201) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (1999718) nina_client: astromele1.lan unreachable
+I (1999718) nina_client: === Poll Summary ===
+I (1999718) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (1999721) nina_client: Target: , Filter: 
+I (1999725) nina_client: Exposure: 0.0s (0.0/0.0)
+I (1999729) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (1999735) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2000201) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2000742) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (2002664) transport_ws: Error connecting to host astromele2.lan:1888
+E (2002664) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2002676) nina_ws: WS[1]: Error
+I (2002679) websocket_client: Reconnect after 86400000 ms
+W (2002684) nina_ws: WS[1]: Disconnected from NINA
+W (2005699) nina_client: desktop-bdt978m.lan unreachable
+I (2005699) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2006700) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2006713) nina_client: astromele2.lan unreachable
+I (2006713) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2007001) tasks: Auto-rotate: switched to page 5
+W (2007290) nina_client: astromele1.lan unreachable
+I (2007713) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2008036) tasks: Page switched to 5
+W (2013254) nina_client: desktop-bdt978m.lan unreachable
+I (2013254) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2013854) nina_client: astromele1.lan unreachable
+W (2013854) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2013855) nina_client: === Poll Summary ===
+I (2013859) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2013864) nina_client: Target: , Filter: 
+I (2013868) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2013873) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2013878) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (2014258) nina_client: astromele2.lan unreachable
+I (2014258) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2014259) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2014266) websocket_client: Started
+I (2014885) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2021420) nina_client: astromele1.lan unreachable
+I (2021420) nina_client: === Poll Summary ===
+I (2021420) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2021423) nina_client: Target: , Filter: 
+I (2021427) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2021431) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2021437) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2022444) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2023162) tasks: Auto-rotate: switched to page 4
+I (2024193) tasks: Page switched to 4 (summary)
+I (2024203) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (2024271) transport_ws: Error connecting to host astromele2.lan:1888
+E (2024271) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2024283) nina_ws: WS[1]: Error
+I (2024286) websocket_client: Reconnect after 86400000 ms
+W (2024291) nina_ws: WS[1]: Disconnected from NINA
+W (2028233) perf: uxTaskGetSystemState returned 0 tasks
+I (2028233) perf: ╔══════════════════════════════════════════════════════════════╗
+I (2028245) perf: ║              PERFORMANCE REPORT                             ║
+I (2028253) perf: ╚══════════════════════════════════════════════════════════════╝
+I (2028271) perf: ── Poll Cycle ──
+I (2028275) perf:   poll_cycle_total         avg=   14.3  min=    5.9  max= 4150.9  last=    7.2 ms  [n=1981]
+I (2028285) perf:   effective_interval       avg= 1019.7  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=1980]
+I (2028294) perf: ── Endpoint Fetchers ──
+I (2028299) perf:   equipment_bundle         avg= 1673.9  min=    4.6  max= 7889.3  last= 6535.3 ms  [n=420]
+I (2028308) perf:   camera                   (no samples)
+I (2028313) perf:   guider                   (no samples)
+I (2028319) perf:   mount                    (no samples)
+I (2028324) perf:   focuser                  (no samples)
+I (2028329) perf:   sequence                 avg= 5240.4  min=   23.5  max= 7821.4  last= 6564.6 ms  [n=90]
+I (2028338) perf:   switch                   (no samples)
+I (2028343) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (2028353) perf:   filter                   (no samples)
+I (2028358) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (2028367) perf: ── Network ──
+I (2028371) perf:   http_request             avg= 1708.0  min=    0.4  max= 7889.3  last= 6535.3 ms  [n=621]
+I (2028380) perf:   HTTP requests:  10 (interval) / 836 (total)
+I (2028386) perf:   HTTP retries:   10 (interval) / 574 (total)
+I (2028392) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (2028397) perf:   HTTP unreachable:10 (interval) / 570 (total)
+I (2028403) perf:   WS events:      0 (interval) / 39 (total)
+I (2028408) perf: ── JSON Parsing ──
+I (2028412) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (2028422) perf:   json_sequence            (no samples)
+I (2028427) perf:   json_config_color        (no samples)
+I (2028432) perf:   Parse calls:    0 (interval) / 263 (total)
+I (2028438) perf: ── UI Updates ──
+I (2028441) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1754]
+I (2028451) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1754]
+I (2028461) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=905]
+I (2028470) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=849]
+I (2028480) perf: ── Latency ──
+I (2028483) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (2028493) perf: ── JPEG ──
+I (2028496) perf:   jpeg_decode              (no samples)
+I (2028501) perf:   jpeg_fetch               (no samples)
+I (2028506) perf: ── Spotify ──
+I (2028510) perf:   spotify_poll_cycle       (no samples)
+I (2028515) perf:   spotify_api_fetch        (no samples)
+I (2028520) perf:   spotify_art_fetch        (no samples)
+I (2028525) perf:   spotify_art_decode       (no samples)
+I (2028530) perf:   spotify_ui_update        (no samples)
+I (2028535) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (2028541) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (2028547) perf:   Spotify art:      0 (interval) / 0 (total)
+I (2028552) perf: ── WiFi ──
+I (2028555) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (2028562) perf:   RSSI: cur=-59  avg=-60  min=-61  max=-58 dBm  [n=30]
+I (2028569) perf:   Disconnects:    0 (interval) / 0 (total)
+I (2028574) perf: ── Memory ──
+I (2028578) perf:   Internal heap:  free=76371  min_ever=53015  largest_block=31744  frag_ratio=0.416
+I (2028587) perf:   PSRAM:          free=20903436  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (2028596) perf: ── Task Stacks ──
+I (2028600) perf:   data_task HWM:  8076 bytes free
+I (2028605) perf:   input_task HWM: 5484 bytes free
+I (2028609) perf:   spotify_task HWM: 7164 bytes free
+W (2029006) nina_client: astromele1.lan unreachable
+W (2029839) nina_client: desktop-bdt978m.lan unreachable
+I (2029839) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2032736) nina_client: astromele2.lan unreachable
+I (2032736) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2032737) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2032744) websocket_client: Started
+I (2033747) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2036298) nina_client: astromele1.lan unreachable
+W (2036298) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2036299) nina_client: === Poll Summary ===
+I (2036303) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2036308) nina_client: Target: , Filter: 
+I (2036312) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2036317) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2036322) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (2036524) nina_client: desktop-bdt978m.lan unreachable
+I (2036524) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2037329) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2037525) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2039699) tasks: Auto-rotate: switched to page 5
+W (2040393) nina_client: astromele2.lan unreachable
+I (2040393) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2040734) tasks: Page switched to 5
+E (2042787) transport_ws: Error connecting to host astromele2.lan:1888
+E (2042787) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2042799) nina_ws: WS[1]: Error
+I (2042802) websocket_client: Reconnect after 86400000 ms
+W (2042807) nina_ws: WS[1]: Disconnected from NINA
+W (2043977) nina_client: astromele1.lan unreachable
+I (2043977) nina_client: === Poll Summary ===
+I (2043977) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2043980) nina_client: Target: , Filter: 
+I (2043984) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2043988) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2043994) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (2044082) nina_client: desktop-bdt978m.lan unreachable
+I (2044082) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2045007) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2047948) nina_client: astromele2.lan unreachable
+I (2047948) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2047949) websocket_client: Started
+W (2051554) nina_client: astromele1.lan unreachable
+I (2055860) tasks: Auto-rotate: switched to page 4
+I (2056890) tasks: Page switched to 4 (summary)
+I (2056890) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (2057954) transport_ws: Error connecting to host astromele2.lan:1888
+E (2057954) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2057966) nina_ws: WS[1]: Error
+I (2057969) websocket_client: Reconnect after 86400000 ms
+W (2057974) nina_ws: WS[1]: Disconnected from NINA
+W (2058184) nina_client: astromele1.lan unreachable
+W (2058184) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2058185) nina_client: === Poll Summary ===
+I (2058189) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2058194) nina_client: Target: , Filter: 
+I (2058198) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2058203) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2058208) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (2058914) perf: uxTaskGetSystemState returned 0 tasks
+I (2058914) perf: ╔══════════════════════════════════════════════════════════════╗
+I (2058926) perf: ║              PERFORMANCE REPORT                             ║
+I (2058934) perf: ╚══════════════════════════════════════════════════════════════╝
+I (2058952) perf: ── Poll Cycle ──
+I (2058956) perf:   poll_cycle_total         avg=   14.3  min=    5.9  max= 4150.9  last=    7.2 ms  [n=2011]
+I (2058966) perf:   effective_interval       avg= 1019.8  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=2010]
+I (2058975) perf: ── Endpoint Fetchers ──
+I (2058980) perf:   equipment_bundle         avg= 1701.0  min=    4.6  max= 7889.3  last= 6546.7 ms  [n=425]
+I (2058989) perf:   camera                   (no samples)
+I (2058994) perf:   guider                   (no samples)
+I (2059000) perf:   mount                    (no samples)
+I (2059005) perf:   focuser                  (no samples)
+I (2059010) perf:   sequence                 avg= 5277.8  min=   23.5  max= 7821.4  last= 6630.8 ms  [n=92]
+I (2059019) perf:   switch                   (no samples)
+I (2059024) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (2059034) perf:   filter                   (no samples)
+I (2059039) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (2059048) perf: ── Network ──
+I (2059052) perf:   http_request             avg= 1719.3  min=    0.4  max= 7889.3  last= 1293.5 ms  [n=629]
+I (2059061) perf:   HTTP requests:  10 (interval) / 846 (total)
+I (2059067) perf:   HTTP retries:   9 (interval) / 583 (total)
+I (2059072) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (2059078) perf:   HTTP unreachable:11 (interval) / 581 (total)
+I (2059084) perf:   WS events:      0 (interval) / 39 (total)
+I (2059089) perf: ── JSON Parsing ──
+I (2059093) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (2059103) perf:   json_sequence            (no samples)
+I (2059108) perf:   json_config_color        (no samples)
+I (2059113) perf:   Parse calls:    0 (interval) / 263 (total)
+I (2059118) perf: ── UI Updates ──
+I (2059122) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1784]
+I (2059132) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1784]
+I (2059142) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=921]
+I (2059151) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=863]
+I (2059161) perf: ── Latency ──
+I (2059164) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (2059174) perf: ── JPEG ──
+I (2059177) perf:   jpeg_decode              (no samples)
+I (2059182) perf:   jpeg_fetch               (no samples)
+I (2059187) perf: ── Spotify ──
+I (2059191) perf:   spotify_poll_cycle       (no samples)
+I (2059196) perf:   spotify_api_fetch        (no samples)
+I (2059201) perf:   spotify_art_fetch        (no samples)
+I (2059206) perf:   spotify_art_decode       (no samples)
+I (2059211) perf:   spotify_ui_update        (no samples)
+I (2059215) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2059216) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (2059229) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (2059234) perf:   Spotify art:      0 (interval) / 0 (total)
+I (2059240) perf: ── WiFi ──
+I (2059243) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (2059250) perf:   RSSI: cur=-60  avg=-60  min=-61  max=-59 dBm  [n=30]
+I (2059256) perf:   Disconnects:    0 (interval) / 0 (total)
+I (2059262) perf: ── Memory ──
+I (2059265) perf:   Internal heap:  free=78807  min_ever=53015  largest_block=31744  frag_ratio=0.403
+I (2059274) perf:   PSRAM:          free=20903548  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (2059284) perf: ── Task Stacks ──
+I (2059288) perf:   data_task HWM:  8076 bytes free
+I (2059292) perf:   input_task HWM: 5484 bytes free
+I (2059297) perf:   spotify_task HWM: 7164 bytes free
+W (2060660) nina_client: desktop-bdt978m.lan unreachable
+I (2060660) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2063451) nina_client: astromele2.lan unreachable
+I (2063451) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2063452) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2063459) websocket_client: Started
+I (2064462) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2065763) nina_client: astromele1.lan unreachable
+I (2065763) nina_client: === Poll Summary ===
+I (2065763) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2065766) nina_client: Target: , Filter: 
+I (2065770) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2065774) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2065780) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2066787) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2067226) nina_client: desktop-bdt978m.lan unreachable
+I (2067226) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2068227) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2068282) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (2068282) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (2071018) nina_client: astromele2.lan unreachable
+I (2071018) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2072018) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2072403) tasks: Auto-rotate: switched to page 5
+W (2073335) nina_client: astromele1.lan unreachable
+I (2073432) tasks: Page switched to 5
+E (2073493) transport_ws: Error connecting to host astromele2.lan:1888
+E (2073493) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2073505) nina_ws: WS[1]: Error
+I (2073508) websocket_client: Reconnect after 86400000 ms
+W (2073513) nina_ws: WS[1]: Disconnected from NINA
+W (2074769) nina_client: desktop-bdt978m.lan unreachable
+I (2074769) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2078568) nina_client: astromele2.lan unreachable
+I (2078568) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2078569) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2078576) websocket_client: Started
+W (2079906) nina_client: astromele1.lan unreachable
+W (2079906) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2079907) nina_client: === Poll Summary ===
+I (2079911) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2079916) nina_client: Target: , Filter: 
+I (2079920) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2079925) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2079930) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2080937) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2087514) nina_client: astromele1.lan unreachable
+I (2087514) nina_client: === Poll Summary ===
+I (2087514) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2087517) nina_client: Target: , Filter: 
+I (2087521) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2087525) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2087531) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2088538) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2088558) tasks: Auto-rotate: switched to page 4
+E (2088588) transport_ws: Error connecting to host astromele2.lan:1888
+E (2088588) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2088600) nina_ws: WS[1]: Error
+I (2088603) websocket_client: Reconnect after 86400000 ms
+W (2088608) nina_ws: WS[1]: Disconnected from NINA
+I (2089588) tasks: Page switched to 4 (summary)
+W (2089596) perf: uxTaskGetSystemState returned 0 tasks
+I (2089596) perf: ╔══════════════════════════════════════════════════════════════╗
+I (2089609) perf: ║              PERFORMANCE REPORT                             ║
+I (2089616) perf: ╚══════════════════════════════════════════════════════════════╝
+I (2089635) perf: ── Poll Cycle ──
+I (2089638) perf:   poll_cycle_total         avg=   14.2  min=    5.9  max= 4150.9  last=    7.6 ms  [n=2041]
+I (2089648) perf:   effective_interval       avg= 1019.8  min=    7.5  max= 5152.0  last= 1036.0 ms  [n=2040]
+I (2089658) perf: ── Endpoint Fetchers ──
+I (2089662) perf:   equipment_bundle         avg= 1712.6  min=    4.6  max= 7889.3  last= 6577.3 ms  [n=431]
+I (2089672) perf:   camera                   (no samples)
+I (2089677) perf:   guider                   (no samples)
+I (2089682) perf:   mount                    (no samples)
+I (2089687) perf:   focuser                  (no samples)
+I (2089692) perf:   sequence                 avg= 5291.7  min=   23.5  max= 7821.4  last= 6571.7 ms  [n=93]
+I (2089702) perf:   switch                   (no samples)
+I (2089707) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (2089716) perf:   filter                   (no samples)
+I (2089721) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (2089731) perf: ── Network ──
+I (2089734) perf:   http_request             avg= 1720.1  min=    0.4  max= 7889.3  last= 2744.4 ms  [n=637]
+I (2089744) perf:   HTTP requests:  10 (interval) / 857 (total)
+I (2089749) perf:   HTTP retries:   10 (interval) / 593 (total)
+I (2089755) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (2089760) perf:   HTTP unreachable:10 (interval) / 591 (total)
+I (2089766) perf:   WS events:      0 (interval) / 39 (total)
+I (2089772) perf: ── JSON Parsing ──
+I (2089776) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (2089785) perf:   json_sequence            (no samples)
+I (2089790) perf:   json_config_color        (no samples)
+I (2089795) perf:   Parse calls:    0 (interval) / 263 (total)
+I (2089801) perf: ── UI Updates ──
+I (2089805) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.0 ms  [n=1814]
+I (2089814) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1814]
+I (2089824) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=937]
+I (2089834) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=877]
+I (2089843) perf: ── Latency ──
+I (2089847) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (2089856) perf: ── JPEG ──
+I (2089859) perf:   jpeg_decode              (no samples)
+I (2089864) perf:   jpeg_fetch               (no samples)
+I (2089870) perf: ── Spotify ──
+I (2089873) perf:   spotify_poll_cycle       (no samples)
+I (2089878) perf:   spotify_api_fetch        (no samples)
+I (2089883) perf:   spotify_art_fetch        (no samples)
+I (2089889) perf:   spotify_art_decode       (no samples)
+I (2089894) perf:   spotify_ui_update        (no samples)
+I (2089899) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (2089904) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (2089910) perf:   Spotify art:      0 (interval) / 0 (total)
+I (2089915) perf: ── WiFi ──
+I (2089919) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (2089926) perf:   RSSI: cur=-60  avg=-60  min=-66  max=-53 dBm  [n=30]
+I (2089932) perf:   Disconnects:    0 (interval) / 0 (total)
+I (2089937) perf: ── Memory ──
+I (2089941) perf:   Internal heap:  free=76459  min_ever=53015  largest_block=31744  frag_ratio=0.415
+I (2089950) perf:   PSRAM:          free=20903508  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (2089960) perf: ── Task Stacks ──
+I (2089964) perf:   data_task HWM:  8076 bytes free
+I (2089968) perf:   input_task HWM: 5484 bytes free
+I (2089973) perf:   spotify_task HWM: 7164 bytes free
+W (2091919) nina_client: desktop-bdt978m.lan unreachable
+I (2091919) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2096328) nina_client: astromele1.lan unreachable
+W (2096329) nina_client: astromele2.lan unreachable
+I (2096329) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2096334) websocket_client: Started
+I (2096336) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2099882) nina_client: desktop-bdt978m.lan unreachable
+I (2099882) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2100883) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2103068) nina_client: astromele1.lan unreachable
+W (2103068) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2103069) nina_client: === Poll Summary ===
+I (2103073) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2103079) nina_client: Target: , Filter: 
+I (2103082) nina_client: Exposure: 0.0s (0.0/0.0)
+W (2103085) nina_client: astromele2.lan unreachable
+I (2103087) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2103092) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2103104) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2104099) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2104111) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2105095) tasks: Auto-rotate: switched to page 5
+I (2106129) tasks: Page switched to 5
+E (2106487) transport_ws: Error connecting to host astromele2.lan:1888
+E (2106487) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2106499) nina_ws: WS[1]: Error
+I (2106502) websocket_client: Reconnect after 86400000 ms
+W (2106507) nina_ws: WS[1]: Disconnected from NINA
+W (2107468) nina_client: desktop-bdt978m.lan unreachable
+I (2107468) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2110660) nina_client: astromele2.lan unreachable
+I (2110660) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2110661) nina_client: astromele1.lan unreachable
+W (2117186) nina_client: astromele1.lan unreachable
+W (2117186) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2117187) nina_client: === Poll Summary ===
+I (2117191) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2117196) nina_client: Target: , Filter: 
+I (2117200) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2117205) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2117210) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2118229) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2120248) perf: uxTaskGetSystemState returned 0 tasks
+I (2120248) perf: ╔══════════════════════════════════════════════════════════════╗
+I (2120260) perf: ║              PERFORMANCE REPORT                             ║
+I (2120268) perf: ╚══════════════════════════════════════════════════════════════╝
+I (2120286) perf: ── Poll Cycle ──
+I (2120290) perf:   poll_cycle_total         avg=   14.1  min=    5.9  max= 4150.9  last=    7.3 ms  [n=2071]
+I (2120300) perf:   effective_interval       avg= 1019.8  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=2070]
+I (2120309) perf: ── Endpoint Fetchers ──
+I (2120314) perf:   equipment_bundle         avg= 1728.0  min=    4.6  max= 7889.3  last= 3357.3 ms  [n=435]
+I (2120323) perf:   camera                   (no samples)
+I (2120328) perf:   guider                   (no samples)
+I (2120334) perf:   mount                    (no samples)
+I (2120339) perf:   focuser                  (no samples)
+I (2120344) perf:   sequence                 avg= 5319.9  min=   23.5  max= 7821.4  last= 6521.7 ms  [n=95]
+I (2120353) perf:   switch                   (no samples)
+I (2120358) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (2120368) perf:   filter                   (no samples)
+I (2120373) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (2120382) perf: ── Network ──
+I (2120386) perf:   http_request             avg= 1737.1  min=    0.4  max= 7889.3  last= 6520.9 ms  [n=644]
+I (2120395) perf:   HTTP requests:  9 (interval) / 866 (total)
+I (2120401) perf:   HTTP retries:   9 (interval) / 602 (total)
+I (2120406) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (2120412) perf:   HTTP unreachable:10 (interval) / 601 (total)
+I (2120418) perf:   WS events:      0 (interval) / 39 (total)
+I (2120423) perf: ── JSON Parsing ──
+I (2120427) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (2120437) perf:   json_sequence            (no samples)
+I (2120442) perf:   json_config_color        (no samples)
+I (2120447) perf:   Parse calls:    0 (interval) / 263 (total)
+I (2120452) perf: ── UI Updates ──
+I (2120456) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.1 ms  [n=1844]
+I (2120466) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1844]
+I (2120475) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=952]
+I (2120485) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=892]
+I (2120495) perf: ── Latency ──
+I (2120498) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (2120508) perf: ── JPEG ──
+I (2120511) perf:   jpeg_decode              (no samples)
+I (2120516) perf:   jpeg_fetch               (no samples)
+I (2120521) perf: ── Spotify ──
+I (2120525) perf:   spotify_poll_cycle       (no samples)
+I (2120530) perf:   spotify_api_fetch        (no samples)
+I (2120535) perf:   spotify_art_fetch        (no samples)
+I (2120540) perf:   spotify_art_decode       (no samples)
+I (2120545) perf:   spotify_ui_update        (no samples)
+I (2120550) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (2120556) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (2120561) perf:   Spotify art:      0 (interval) / 0 (total)
+I (2120567) perf: ── WiFi ──
+I (2120570) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (2120577) perf:   RSSI: cur=-61  avg=-60  min=-71  max=-55 dBm  [n=30]
+I (2120584) perf:   Disconnects:    0 (interval) / 0 (total)
+I (2120589) perf: ── Memory ──
+I (2120592) perf:   Internal heap:  free=78967  min_ever=53015  largest_block=31744  frag_ratio=0.402
+I (2120601) perf:   PSRAM:          free=20904092  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (2120611) perf: ── Task Stacks ──
+I (2120615) perf:   data_task HWM:  8076 bytes free
+I (2120620) perf:   input_task HWM: 5484 bytes free
+I (2120624) perf:   spotify_task HWM: 7164 bytes free
+I (2121635) tasks: Auto-rotate: switched to page 4
+I (2122655) tasks: Page switched to 4 (summary)
+W (2124025) nina_client: desktop-bdt978m.lan unreachable
+I (2124025) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2124758) nina_client: astromele1.lan unreachable
+I (2124758) nina_client: === Poll Summary ===
+I (2124758) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2124761) nina_client: Target: , Filter: 
+I (2124765) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2124769) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2124775) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2125782) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2127227) nina_client: astromele2.lan unreachable
+I (2127227) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2127228) websocket_client: Started
+I (2127230) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2130595) nina_client: desktop-bdt978m.lan unreachable
+I (2130595) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2131596) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2132338) nina_client: astromele1.lan unreachable
+W (2133773) nina_client: astromele2.lan unreachable
+I (2133773) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2134773) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (2137266) transport_ws: Error connecting to host astromele2.lan:1888
+E (2137266) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2137278) nina_ws: WS[1]: Error
+I (2137281) websocket_client: Reconnect after 86400000 ms
+W (2137286) nina_ws: WS[1]: Disconnected from NINA
+I (2137780) tasks: Auto-rotate: switched to page 5
+W (2138118) nina_client: desktop-bdt978m.lan unreachable
+I (2138118) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2138811) tasks: Page switched to 5
+W (2138891) nina_client: astromele1.lan unreachable
+W (2138891) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2138892) nina_client: === Poll Summary ===
+I (2138896) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2138901) nina_client: Target: , Filter: 
+I (2138905) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2138910) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2138915) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2139922) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2141367) nina_client: astromele2.lan unreachable
+I (2141367) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2145674) nina_client: desktop-bdt978m.lan unreachable
+W (2146479) nina_client: astromele1.lan unreachable
+I (2146479) nina_client: === Poll Summary ===
+I (2146479) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2146482) nina_client: Target: , Filter: 
+I (2146486) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2146490) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2146496) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2147503) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2150915) perf: uxTaskGetSystemState returned 0 tasks
+I (2150915) perf: ╔══════════════════════════════════════════════════════════════╗
+I (2150927) perf: ║              PERFORMANCE REPORT                             ║
+I (2150935) perf: ╚══════════════════════════════════════════════════════════════╝
+I (2150953) perf: ── Poll Cycle ──
+I (2150957) perf:   poll_cycle_total         avg=   14.0  min=    5.9  max= 4150.9  last=    7.2 ms  [n=2101]
+I (2150967) perf:   effective_interval       avg= 1019.9  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=2100]
+I (2150976) perf: ── Endpoint Fetchers ──
+I (2150981) perf:   equipment_bundle         avg= 1730.2  min=    4.6  max= 7889.3  last= 1445.3 ms  [n=440]
+I (2150990) perf:   camera                   (no samples)
+I (2150995) perf:   guider                   (no samples)
+I (2151000) perf:   mount                    (no samples)
+I (2151006) perf:   focuser                  (no samples)
+I (2151011) perf:   sequence                 avg= 5332.8  min=   23.5  max= 7821.4  last= 6553.8 ms  [n=96]
+I (2151020) perf:   switch                   (no samples)
+I (2151025) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (2151035) perf:   filter                   (no samples)
+I (2151040) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (2151049) perf: ── Network ──
+I (2151053) perf:   http_request             avg= 1740.1  min=    0.4  max= 7889.3  last= 1445.3 ms  [n=652]
+I (2151062) perf:   HTTP requests:  10 (interval) / 876 (total)
+I (2151068) perf:   HTTP retries:   10 (interval) / 613 (total)
+I (2151074) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (2151079) perf:   HTTP unreachable:11 (interval) / 612 (total)
+I (2151085) perf:   WS events:      0 (interval) / 39 (total)
+I (2151090) perf: ── JSON Parsing ──
+I (2151094) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (2151104) perf:   json_sequence            (no samples)
+I (2151109) perf:   json_config_color        (no samples)
+I (2151114) perf:   Parse calls:    0 (interval) / 263 (total)
+I (2151119) perf: ── UI Updates ──
+I (2151123) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.1 ms  [n=1874]
+I (2151133) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1874]
+I (2151143) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=966]
+I (2151152) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=908]
+I (2151162) perf: ── Latency ──
+I (2151165) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (2151175) perf: ── JPEG ──
+I (2151178) perf:   jpeg_decode              (no samples)
+I (2151183) perf:   jpeg_fetch               (no samples)
+I (2151188) perf: ── Spotify ──
+I (2151192) perf:   spotify_poll_cycle       (no samples)
+I (2151197) perf:   spotify_api_fetch        (no samples)
+I (2151202) perf:   spotify_art_fetch        (no samples)
+I (2151207) perf:   spotify_art_decode       (no samples)
+I (2151212) perf:   spotify_ui_update        (no samples)
+I (2151217) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (2151223) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (2151229) perf:   Spotify art:      0 (interval) / 0 (total)
+I (2151234) perf: ── WiFi ──
+I (2151237) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (2151244) perf:   RSSI: cur=-61  avg=-60  min=-62  max=-55 dBm  [n=30]
+I (2151251) perf:   Disconnects:    0 (interval) / 0 (total)
+I (2151256) perf: ── Memory ──
+I (2151260) perf:   Internal heap:  free=81439  min_ever=53015  largest_block=31744  frag_ratio=0.390
+I (2151269) perf:   PSRAM:          free=20904684  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (2151278) perf: ── Task Stacks ──
+I (2151282) perf:   data_task HWM:  8076 bytes free
+I (2151287) perf:   input_task HWM: 5484 bytes free
+I (2151291) perf:   spotify_task HWM: 7164 bytes free
+I (2154318) tasks: Auto-rotate: switched to page 4
+W (2154644) nina_client: astromele1.lan unreachable
+I (2155336) tasks: Page switched to 4 (summary)
+I (2155336) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2157962) nina_client: astromele2.lan unreachable
+I (2157962) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2157963) websocket_client: Started
+I (2157965) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2161185) nina_client: astromele1.lan unreachable
+W (2161185) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2161186) nina_client: === Poll Summary ===
+I (2161190) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2161195) nina_client: Target: , Filter: 
+I (2161199) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2161204) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2161209) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (2161859) nina_client: desktop-bdt978m.lan unreachable
+I (2161859) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2162216) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2162860) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2164515) nina_client: astromele2.lan unreachable
+I (2164515) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2165515) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (2167994) transport_ws: Error connecting to host astromele2.lan:1888
+E (2167994) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2168006) nina_ws: WS[1]: Error
+I (2168009) websocket_client: Reconnect after 86400000 ms
+W (2168014) nina_ws: WS[1]: Disconnected from NINA
+W (2168975) nina_client: astromele1.lan unreachable
+I (2168975) nina_client: === Poll Summary ===
+I (2168975) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2168978) nina_client: Target: , Filter: 
+I (2168982) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2168986) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2168992) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+W (2169432) nina_client: desktop-bdt978m.lan unreachable
+I (2169432) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2169999) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2170433) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2170462) tasks: Auto-rotate: switched to page 5
+I (2171493) tasks: Page switched to 5
+W (2172094) nina_client: astromele2.lan unreachable
+I (2172094) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2176559) nina_client: astromele1.lan unreachable
+W (2176996) nina_client: desktop-bdt978m.lan unreachable
+I (2176996) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2181581) perf: uxTaskGetSystemState returned 0 tasks
+I (2181581) perf: ╔══════════════════════════════════════════════════════════════╗
+I (2181593) perf: ║              PERFORMANCE REPORT                             ║
+I (2181601) perf: ╚══════════════════════════════════════════════════════════════╝
+I (2181619) perf: ── Poll Cycle ──
+I (2181623) perf:   poll_cycle_total         avg=   13.9  min=    5.9  max= 4150.9  last=    7.3 ms  [n=2131]
+I (2181633) perf:   effective_interval       avg= 1019.9  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=2130]
+I (2181642) perf: ── Endpoint Fetchers ──
+I (2181647) perf:   equipment_bundle         avg= 1750.8  min=    4.6  max= 7889.3  last= 1661.4 ms  [n=445]
+I (2181656) perf:   camera                   (no samples)
+I (2181661) perf:   guider                   (no samples)
+I (2181667) perf:   mount                    (no samples)
+I (2181672) perf:   focuser                  (no samples)
+I (2181677) perf:   sequence                 avg= 5345.2  min=   23.5  max= 7821.4  last= 6541.7 ms  [n=97]
+I (2181686) perf:   switch                   (no samples)
+I (2181691) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (2181701) perf:   filter                   (no samples)
+I (2181706) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (2181715) perf: ── Network ──
+I (2181719) perf:   http_request             avg= 1746.4  min=    0.4  max= 7889.3  last=  436.9 ms  [n=659]
+I (2181728) perf:   HTTP requests:  10 (interval) / 886 (total)
+I (2181734) perf:   HTTP retries:   10 (interval) / 624 (total)
+I (2181740) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (2181745) perf:   HTTP unreachable:10 (interval) / 622 (total)
+I (2181751) perf:   WS events:      0 (interval) / 39 (total)
+I (2181756) perf: ── JSON Parsing ──
+I (2181760) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (2181770) perf:   json_sequence            (no samples)
+I (2181775) perf:   json_config_color        (no samples)
+I (2181780) perf:   Parse calls:    0 (interval) / 263 (total)
+I (2181786) perf: ── UI Updates ──
+I (2181789) perf:   ui_update_total          avg=    1.4  min=    0.0  max=   42.1  last=    0.1 ms  [n=1904]
+I (2181799) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1904]
+I (2181809) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=980]
+I (2181818) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=924]
+I (2181828) perf: ── Latency ──
+I (2181831) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (2181841) perf: ── JPEG ──
+I (2181844) perf:   jpeg_decode              (no samples)
+I (2181849) perf:   jpeg_fetch               (no samples)
+I (2181854) perf: ── Spotify ──
+I (2181858) perf:   spotify_poll_cycle       (no samples)
+I (2181863) perf:   spotify_api_fetch        (no samples)
+I (2181868) perf:   spotify_art_fetch        (no samples)
+I (2181873) perf:   spotify_art_decode       (no samples)
+I (2181878) perf:   spotify_ui_update        (no samples)
+I (2181883) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (2181889) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (2181895) perf:   Spotify art:      0 (interval) / 0 (total)
+I (2181900) perf: ── WiFi ──
+I (2181903) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (2181910) perf:   RSSI: cur=-60  avg=-60  min=-62  max=-59 dBm  [n=30]
+I (2181917) perf:   Disconnects:    0 (interval) / 0 (total)
+I (2181922) perf: ── Memory ──
+I (2181926) perf:   Internal heap:  free=81415  min_ever=53015  largest_block=31744  frag_ratio=0.390
+I (2181935) perf:   PSRAM:          free=20904684  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (2181944) perf: ── Task Stacks ──
+I (2181948) perf:   data_task HWM:  8076 bytes free
+I (2181953) perf:   input_task HWM: 5484 bytes free
+I (2181957) perf:   spotify_task HWM: 7164 bytes free
+W (2183106) nina_client: astromele1.lan unreachable
+W (2183106) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2183107) nina_client: === Poll Summary ===
+I (2183111) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2183116) nina_client: Target: , Filter: 
+I (2183120) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2183125) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2183130) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2184145) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2187000) tasks: Auto-rotate: switched to page 4
+I (2188018) tasks: Page switched to 4 (summary)
+W (2188685) nina_client: astromele2.lan unreachable
+I (2188685) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2188686) websocket_client: Started
+I (2188689) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2190276) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (2190707) nina_client: astromele1.lan unreachable
+I (2190707) nina_client: === Poll Summary ===
+I (2190707) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2190710) nina_client: Target: , Filter: 
+I (2190714) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2190718) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2190724) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2191731) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2193582) nina_client: desktop-bdt978m.lan unreachable
+I (2193582) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2195235) nina_client: astromele2.lan unreachable
+I (2195235) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2196235) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2198385) nina_client: astromele1.lan unreachable
+E (2198729) transport_ws: Error connecting to host astromele2.lan:1888
+E (2198729) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2198741) nina_ws: WS[1]: Error
+I (2198744) websocket_client: Reconnect after 86400000 ms
+W (2198749) nina_ws: WS[1]: Disconnected from NINA
+W (2200154) nina_client: desktop-bdt978m.lan unreachable
+I (2200154) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2201155) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2201761) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (2202890) nina_client: astromele2.lan unreachable
+I (2202890) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2202977) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+W (2203068) httpd_uri: httpd_uri: URI '/api/connections' not found
+W (2203068) httpd_txrx: httpd_resp_send_err: 404 Not Found - Nothing matches the given URI
+W (2203071) httpd_sess: httpd_sess_delete: error enabling SO_LINGER (109)
+I (2203143) tasks: Auto-rotate: switched to page 5
+I (2203890) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2204174) tasks: Page switched to 5
+W (2204940) nina_client: astromele1.lan unreachable
+W (2204940) nina_seq: Sequence data unavailable - exposure counts will not be shown
+I (2204941) nina_client: === Poll Summary ===
+I (2204945) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2204950) nina_client: Target: , Filter: 
+I (2204954) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2204959) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2204964) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2205971) nina_client: === Polling NINA data (bundled: equipment/info) ===
+W (2207718) nina_client: desktop-bdt978m.lan unreachable
+I (2207718) tasks: Poll[3] (active): connected=0, status=OFFLINE, target=, ws=0
+W (2210907) nina_client: astromele2.lan unreachable
+I (2210907) tasks: Poll[2] (active): connected=0, status=OFFLINE, target=, ws=0
+I (2210908) nina_ws: WS[1]: Connecting to ws://astromele2.lan:1888/v2/socket
+I (2210915) websocket_client: Started
+W (2212246) perf: uxTaskGetSystemState returned 0 tasks
+I (2212246) perf: ╔══════════════════════════════════════════════════════════════╗
+I (2212258) perf: ║              PERFORMANCE REPORT                             ║
+I (2212266) perf: ╚══════════════════════════════════════════════════════════════╝
+I (2212284) perf: ── Poll Cycle ──
+I (2212288) perf:   poll_cycle_total         avg=   13.9  min=    5.9  max= 4150.9  last=    7.3 ms  [n=2161]
+I (2212298) perf:   effective_interval       avg= 1019.9  min=    7.5  max= 5152.0  last= 1008.0 ms  [n=2160]
+I (2212307) perf: ── Endpoint Fetchers ──
+I (2212312) perf:   equipment_bundle         avg= 1752.0  min=    4.6  max= 7889.3  last= 1747.3 ms  [n=450]
+I (2212321) perf:   camera                   (no samples)
+I (2212326) perf:   guider                   (no samples)
+I (2212332) perf:   mount                    (no samples)
+I (2212337) perf:   focuser                  (no samples)
+I (2212342) perf:   sequence                 avg= 5369.6  min=   23.5  max= 7821.4  last= 6555.8 ms  [n=99]
+I (2212351) perf:   switch                   (no samples)
+I (2212356) perf:   image_history            avg=   43.8  min=   29.7  max=   57.9  last=   29.7 ms  [n=2]
+I (2212366) perf:   filter                   (no samples)
+I (2212371) perf:   profile                  avg=  780.3  min=  780.3  max=  780.3  last=  780.3 ms  [n=1]
+I (2212380) perf: ── Network ──
+I (2212384) perf:   http_request             avg= 1745.2  min=    0.4  max= 7889.3  last= 1747.3 ms  [n=669]
+I (2212393) perf:   HTTP requests:  11 (interval) / 897 (total)
+I (2212399) perf:   HTTP retries:   11 (interval) / 635 (total)
+I (2212405) perf:   HTTP failures:  0 (interval) / 0 (total)
+I (2212410) perf:   HTTP unreachable:11 (interval) / 633 (total)
+I (2212416) perf:   WS events:      0 (interval) / 39 (total)
+I (2212421) perf: ── JSON Parsing ──
+I (2212425) perf:   json_parse               avg=    3.0  min=    0.1  max=    9.1  last=    3.5 ms  [n=263]
+I (2212435) perf:   json_sequence            (no samples)
+I (2212440) perf:   json_config_color        (no samples)
+I (2212445) perf:   Parse calls:    0 (interval) / 263 (total)
+I (2212451) perf: ── UI Updates ──
+I (2212454) perf:   ui_update_total          avg=    1.3  min=    0.0  max=   42.1  last=    0.1 ms  [n=1934]
+I (2212464) perf:   ui_lock_wait             avg=    1.3  min=    0.0  max=   41.9  last=    0.0 ms  [n=1934]
+I (2212474) perf:   ui_dashboard             avg=    0.1  min=    0.0  max=    1.8  last=    0.1 ms  [n=994]
+I (2212483) perf:   ui_summary               avg=    0.0  min=    0.0  max=    0.4  last=    0.0 ms  [n=940]
+I (2212493) perf: ── Latency ──
+I (2212496) perf:   ws_to_ui                 avg=    9.6  min=    0.2  max=   32.4  last=   10.3 ms  [n=14]
+I (2212506) perf: ── JPEG ──
+I (2212509) perf:   jpeg_decode              (no samples)
+I (2212514) perf:   jpeg_fetch               (no samples)
+I (2212519) perf: ── Spotify ──
+I (2212523) perf:   spotify_poll_cycle       (no samples)
+I (2212528) perf:   spotify_api_fetch        (no samples)
+I (2212533) perf:   spotify_art_fetch        (no samples)
+I (2212538) perf:   spotify_art_decode       (no samples)
+I (2212543) perf:   spotify_ui_update        (no samples)
+I (2212548) perf:   Spotify polls:    0 (interval) / 0 (total)
+I (2212554) perf:   Spotify errors:   0 (interval) / 0 (total)
+I (2212560) perf:   Spotify art:      0 (interval) / 0 (total)
+I (2212565) perf: ── WiFi ──
+I (2212568) perf:   SSID: Silence of the LANs  BSSID: 48:22:54:df:a9:9a  Ch: 6
+I (2212575) perf:   RSSI: cur=-61  avg=-60  min=-66  max=-59 dBm  [n=30]
+I (2212582) perf:   Disconnects:    0 (interval) / 0 (total)
+I (2212587) perf: ── Memory ──
+I (2212591) perf:   Internal heap:  free=81303  min_ever=53015  largest_block=31744  frag_ratio=0.390
+I (2212600) perf:   PSRAM:          free=20903888  min_ever=15259512  largest_block=20447232  frag_ratio=0.978
+I (2212609) perf: ── Task Stacks ──
+I (2212613) perf:   data_task HWM:  8076 bytes free
+I (2212618) perf:   input_task HWM: 5484 bytes free
+I (2212622) perf:   spotify_task HWM: 7164 bytes free
+W (2212743) nina_client: astromele1.lan unreachable
+I (2212743) nina_client: === Poll Summary ===
+I (2212743) nina_client: Connected: 1, Profile: 140APO_533_AM5n
+I (2212746) nina_client: Target: , Filter: 
+I (2212750) nina_client: Exposure: 0.0s (0.0/0.0)
+I (2212754) nina_client: Guiding: 0.00", HFR: 0.00, Stars: 0
+I (2212760) tasks: Poll[1] (active): connected=1, status=OFFLINE, target=, ws=1
+I (2213767) nina_client: === Polling NINA data (bundled: equipment/info) ===
+I (2219681) tasks: Auto-rotate: switched to page 4
+W (2220386) nina_client: astromele1.lan unreachable
+I (2220700) tasks: Page switched to 4 (summary)
+I (2220704) nina_client: === Polling NINA data (bundled: equipment/info) ===
+E (2220958) transport_ws: Error connecting to host astromele2.lan:1888
+E (2220958) websocket_client: esp_transport_connect() failed with -1, transport_error=ESP_ERR_ESP_TLS_CONNECTION_TIMEOUT, tls_error_code=0, tls_flags=0, esp_ws_handshake_status_code=0, errno=119
+W (2220970) nina_ws: WS[1]: Error
+I (2220973) websocket_client: Reconnect after 86400000 ms
+W (2220978) nina_ws: WS[1]: Disconnected from NINA
+W (2224283) nina_client: desktop-bdt978m.lan unreachable
+I (2224283) nina_client: === Polling NINA data (bundled: equipment/info) ===


### PR DESCRIPTION
### Summary
The device now displays a live status panel for Spotify instead of a static logo animation. This panel shows the current setup and connection state, providing clearer feedback. The update also fixes a Spotify authentication issue and improves how the device detects NINA API connectivity.

### Changes
*   The Spotify display now shows a live status panel with setup and connection information, replacing the previous logo animation.
*   Resolves a timing issue that could prevent Spotify authentication from starting correctly.
*   Strengthens the detection of NINA API connectivity to ensure more stable operation.

---
<sub>Analyzed **3** commit(s) | Updated: 2026-06-02T07:24:59.848Z | Generated by GitHub Actions</sub>