### PR TITLE
feat: improve moon orientation accuracy, UI behavior improvements

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -5,7 +5,7 @@ idf_component_register(
     SRCS main.c tasks.c power_mgmt.c jpeg_utils.c stb_image.c perf_monitor.c ota_github.c
          nina_connection.c nina_client.c nina_api_fetchers.c nina_sequence.c nina_websocket.c
          allsky_client.c goes_client.c weather_client.c moon_ephemeris.c moon_render.c moon_sphere.cpp moon_interaction.c spotify_auth.c spotify_client.c demo_data.c
-         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_image_display.c web_handlers_auth.c web_handlers_wifi.c web_handlers_logs.c log_capture.c mqtt_ha.c
+         app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_image_display.c web_handlers_auth.c web_handlers_wifi.c web_handlers_logs.c log_capture.c crash_log.c mqtt_ha.c
          ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_image_display.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
          ui/nina_toast.c ui/nina_event_log.c ui/nina_alerts.c ui/nina_safety.c ui/nina_session_stats.c ui/lv_font_material_safety.c ui/lv_font_superscript_24.c ui/lv_font_playfair_228.c ui/lv_font_playfair_90.c ui/lv_font_overpass_27.c ui/lv_font_overpass_16.c
          ui/nina_setup_screen.c ui/nina_idle_indicator.c
@@ -36,6 +36,11 @@ target_link_libraries(${COMPONENT_LIB} PRIVATE ${JPEG_LIB})
 # line here would disable that and drop driver/ppa.h, esp_http_server.h, etc.).
 idf_component_get_property(TGX_LIB tgx COMPONENT_LIB)
 target_link_libraries(${COMPONENT_LIB} PRIVATE ${TGX_LIB})
+
+# Crash-text capture (Layer B): wrap the panic output character path so the
+# panic banner/backtrace is mirrored into an RTC_NOINIT ring before reboot.
+# __wrap_panic_print_char / __real_panic_print_char live in crash_log.c.
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=panic_print_char")
 
 # Build-time generated version header (git tag, sha, branch)
 target_include_directories(${COMPONENT_LIB} PRIVATE ${CMAKE_BINARY_DIR}/generated)

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -798,6 +798,9 @@ static void set_defaults(app_config_t *cfg) {
     cfg->moon_spin_mode = 0;         // 0=rubber band snap-back (preserves existing behavior)
     cfg->moon_spin_return_s = 10;    // free-spin hold before auto-return, clamp [3,60]
 
+    // Crash log defaults
+    cfg->crash_log_retention_days = 30;  // auto-purge crash records older than 30 days (0 = never)
+
     // Auth is on by default — protects device from open-LAN access
     cfg->auth_enabled = true;
 }
@@ -1784,6 +1787,9 @@ static void migrate_from_v37(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->moon_spin_mode = 0;
     cfg->moon_spin_return_s = 10;
 
+    /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
+    cfg->crash_log_retention_days = 30;
+
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v37 to v%d", APP_CONFIG_VERSION);
 }
@@ -1801,6 +1807,9 @@ static void migrate_from_v38(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->moon_spin_mode = 0;
     cfg->moon_spin_return_s = 10;
 
+    /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
+    cfg->crash_log_retention_days = 30;
+
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v38 to v%d", APP_CONFIG_VERSION);
 }
@@ -1815,8 +1824,24 @@ static void migrate_from_v39(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->moon_spin_mode = 0;
     cfg->moon_spin_return_s = 10;
 
+    /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
+    cfg->crash_log_retention_days = 30;
+
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v39 to v%d", APP_CONFIG_VERSION);
+}
+
+static void migrate_from_v40(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v40_t) ? raw_size : sizeof(app_config_v40_t);
+    memcpy(cfg, raw, copy);
+
+    /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
+    cfg->crash_log_retention_days = 30;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v40 to v%d", APP_CONFIG_VERSION);
 }
 
 static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg)
@@ -1824,6 +1849,14 @@ static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg
     set_defaults(cfg);
     size_t copy = raw_size < sizeof(app_config_v36_t) ? raw_size : sizeof(app_config_v36_t);
     memcpy(cfg, raw, copy);
+
+    /* NOTE: this and the older migrations below only memcpy `copy` bytes — the
+     * size of their snapshot struct. Any field appended to app_config_t *after*
+     * that snapshot struct ends (e.g. crash_log_retention_days, added in v41)
+     * lies past `copy`, so it is never overwritten and keeps the value
+     * set_defaults() assigned. Those trailing fields therefore need no explicit
+     * per-migration assignment here. The newer migrations (v37+) set them
+     * explicitly only for documentation. */
 
     /* moon_drag_light_mode field: new in v37 — defaults already set by set_defaults() */
     cfg->moon_drag_light_mode = 0;
@@ -2541,14 +2574,20 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 40) {
+        /* v40 → v41: added crash_log_retention_days */
+        migrate_from_v40(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 39) {
-        /* v39 → v40: added moon_spin_mode + moon_spin_return_s */
+        /* v39 → v41: added moon_spin fields + crash_log_retention_days */
         migrate_from_v39(raw, stored_size, &s_config);
         validate_config(&s_config);
         nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
         nvs_commit(handle);
     } else if (version_check == 38) {
-        /* v38 → v40: added moon_north_up + moon touch-spin fields */
+        /* v38 → v41: added moon_north_up + moon touch-spin + crash_log_retention_days */
         migrate_from_v38(raw, stored_size, &s_config);
         validate_config(&s_config);
         nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -786,12 +786,12 @@ static void set_defaults(app_config_t *cfg) {
     cfg->image_display_crop = false; // crop/zoom image to fill & hide baked-in labels
     cfg->moon_drag_light_mode = 0;   // 0=true phase, 1=explore (moon drag-to-rotate lighting)
 
-    // Moon sphere orientation tuning defaults
+    // Moon sphere orientation tuning defaults (tuned baseline from a reference device)
     cfg->moon_flip_u = 0;            // mirror texture longitude E<->W
-    cfg->moon_flip_v = 1;            // flip texture latitude N<->S (default 1: corrects N-S for the NASA equirect map)
-    cfg->moon_roll_offset = 0.0f;    // degrees, clamp [-180,180]
+    cfg->moon_flip_v = 0;            // flip texture latitude N<->S
+    cfg->moon_roll_offset = -7.0f;   // degrees, clamp [-180,180]
     cfg->moon_yaw_offset = 0.0f;     // degrees, clamp [-180,180]
-    cfg->moon_pitch_offset = 0.0f;   // degrees, clamp [-90,90]
+    cfg->moon_pitch_offset = -5.0f;  // degrees, clamp [-90,90]
     cfg->moon_north_up = 1;          // 0=true sky tilt, 1=always upright/north-up
 
     // Moon touch-spin return behavior defaults
@@ -1775,10 +1775,10 @@ static void migrate_from_v37(const void *raw, size_t raw_size, app_config_t *cfg
 
     /* Moon orientation tuning fields: new in v38 — defaults already set by set_defaults() */
     cfg->moon_flip_u = 0;
-    cfg->moon_flip_v = 1;
-    cfg->moon_roll_offset = 0.0f;
+    cfg->moon_flip_v = 0;
+    cfg->moon_roll_offset = -7.0f;
     cfg->moon_yaw_offset = 0.0f;
-    cfg->moon_pitch_offset = 0.0f;
+    cfg->moon_pitch_offset = -5.0f;
 
     /* moon_north_up field: new in v39 — default already set by set_defaults() */
     cfg->moon_north_up = 1;
@@ -1863,10 +1863,10 @@ static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg
 
     /* Moon orientation tuning fields: new in v38 — defaults already set by set_defaults() */
     cfg->moon_flip_u = 0;
-    cfg->moon_flip_v = 1;
-    cfg->moon_roll_offset = 0.0f;
+    cfg->moon_flip_v = 0;
+    cfg->moon_roll_offset = -7.0f;
     cfg->moon_yaw_offset = 0.0f;
-    cfg->moon_pitch_offset = 0.0f;
+    cfg->moon_pitch_offset = -5.0f;
 
     /* moon_north_up field: new in v39 — default already set by set_defaults() */
     cfg->moon_north_up = 1;

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -796,7 +796,7 @@ static void set_defaults(app_config_t *cfg) {
 
     // Moon touch-spin return behavior defaults
     cfg->moon_spin_mode = 0;         // 0=rubber band snap-back (preserves existing behavior)
-    cfg->moon_spin_return_s = 10;    // free-spin hold before auto-return, clamp [3,60]
+    cfg->moon_spin_return_s = 3;     // free-spin hold before auto-return, clamp [3,60]
 
     // Crash log defaults
     cfg->crash_log_retention_days = 30;  // auto-purge crash records older than 30 days (0 = never)
@@ -1785,7 +1785,7 @@ static void migrate_from_v37(const void *raw, size_t raw_size, app_config_t *cfg
 
     /* Moon touch-spin fields: new in v40 — defaults already set by set_defaults() */
     cfg->moon_spin_mode = 0;
-    cfg->moon_spin_return_s = 10;
+    cfg->moon_spin_return_s = 3;
 
     /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
     cfg->crash_log_retention_days = 30;
@@ -1805,7 +1805,7 @@ static void migrate_from_v38(const void *raw, size_t raw_size, app_config_t *cfg
 
     /* Moon touch-spin fields: new in v40 — defaults already set by set_defaults() */
     cfg->moon_spin_mode = 0;
-    cfg->moon_spin_return_s = 10;
+    cfg->moon_spin_return_s = 3;
 
     /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
     cfg->crash_log_retention_days = 30;
@@ -1822,7 +1822,7 @@ static void migrate_from_v39(const void *raw, size_t raw_size, app_config_t *cfg
 
     /* Moon touch-spin fields: new in v40 — defaults already set by set_defaults() */
     cfg->moon_spin_mode = 0;
-    cfg->moon_spin_return_s = 10;
+    cfg->moon_spin_return_s = 3;
 
     /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
     cfg->crash_log_retention_days = 30;
@@ -1873,7 +1873,7 @@ static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg
 
     /* Moon touch-spin fields: new in v40 — defaults already set by set_defaults() */
     cfg->moon_spin_mode = 0;
-    cfg->moon_spin_return_s = 10;
+    cfg->moon_spin_return_s = 3;
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v36 to v%d", APP_CONFIG_VERSION);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -171,7 +171,7 @@ typedef struct {
     // Added after v39 — must stay at end to preserve NVS binary compatibility
     // Moon touch-spin return behavior
     uint8_t  moon_spin_mode;         // 0=rubber band snap-back (default), 1=free spin (hold then return)
-    uint8_t  moon_spin_return_s;     // free-spin hold before auto-return, clamp [3,60] (default 10)
+    uint8_t  moon_spin_return_s;     // free-spin hold before auto-return, clamp [3,60] (default 3)
 
     // Added after v40 — must stay at end to preserve NVS binary compatibility
     uint8_t  crash_log_retention_days; // Auto-purge crash records older than N days (0 = never, default 30)

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,7 +13,7 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 40
+#define APP_CONFIG_VERSION 41
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -172,6 +172,9 @@ typedef struct {
     // Moon touch-spin return behavior
     uint8_t  moon_spin_mode;         // 0=rubber band snap-back (default), 1=free spin (hold then return)
     uint8_t  moon_spin_return_s;     // free-spin hold before auto-return, clamp [3,60] (default 10)
+
+    // Added after v40 — must stay at end to preserve NVS binary compatibility
+    uint8_t  crash_log_retention_days; // Auto-purge crash records older than N days (0 = never, default 30)
 } app_config_t;
 
 // v17 snapshot — AllSky fields without allsky_enabled
@@ -1621,6 +1624,104 @@ typedef struct {
     float    moon_pitch_offset;
     uint8_t  moon_north_up;
 } app_config_v39_t;
+
+// v40 snapshot — layout before crash_log_retention_days was added (v39 layout + moon touch-spin fields)
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+} app_config_v40_t;
 
 // WiFi credentials are stored in app_config_t.wifi_networks[3] (up to 3
 // priority-ordered networks). The AP provides headless access for initial

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1692,6 +1692,31 @@
           <pre id="logsView" class="logs-view"></pre>
         </div>
       </div>
+
+      <div class="card nocollapse">
+        <div class="card-title">Crash Logs</div>
+        <div class="logs-layout">
+          <div class="logs-controls">
+            <div class="field-hint" style="margin:0 0 4px">Persistent crash history (survives reboot). Reset reason for every abnormal restart, with serial panic text when available. Newest 20 records kept.</div>
+            <button class="btn btn-outline" id="refreshCrashlogBtn" onclick="refreshCrashlog()">Refresh</button>
+            <a class="btn btn-outline" href="/api/crashlog" style="text-align:center">Download</a>
+            <button class="btn btn-outline" id="clearCrashlogBtn" onclick="clearCrashlog()">Clear</button>
+            <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:6px">
+              <span class="field-hint" style="margin:0">Auto-clear after</span>
+              <select class="input" id="crashlog_retention" style="max-width:110px">
+                <option value="0">Never</option>
+                <option value="7">7 days</option>
+                <option value="14">14 days</option>
+                <option value="30">30 days</option>
+                <option value="60">60 days</option>
+                <option value="90">90 days</option>
+              </select>
+            </div>
+            <div class="field-hint" id="crashlogStatus" style="margin:4px 0 0">Not loaded yet.</div>
+          </div>
+          <div id="crashlogView" class="logs-view"></div>
+        </div>
+      </div>
     </div>
 
     <!-- ==================== TAB 7: BACKUP ==================== -->
@@ -2018,6 +2043,7 @@
       if(name==='logs'){
         if(typeof refreshLogs==='function') refreshLogs();
         if(typeof syncLogsAutoRefresh==='function') syncLogsAutoRefresh();
+        if(typeof refreshCrashlog==='function') refreshCrashlog();
       } else {
         if(typeof stopLogsAutoRefresh==='function') stopLogsAutoRefresh();
       }
@@ -2396,7 +2422,8 @@
         idle_page_override_enabled:!!$('idle_page_override_enabled').checked,
         idle_page_override_target:parseInt($('idle_page_override_target').value),
         idle_page_persistent:!!$('idle_page_persistent').checked,
-        idle_indicator_enabled:!!$('idle_indicator_enabled').checked
+        idle_indicator_enabled:!!$('idle_indicator_enabled').checked,
+        crash_log_retention_days:parseInt($('crashlog_retention').value,10)||0
       };
 
       var nets=[];
@@ -2591,6 +2618,9 @@
       if($('idle_page_persistent')) $('idle_page_persistent').checked=!!data.idle_page_persistent;
       if($('idle_indicator_enabled')) $('idle_indicator_enabled').checked=data.idle_indicator_enabled!==false;
       toggleIdleOverride();
+
+      // Crash log retention (days; 0 = never). Default 30 when absent.
+      if($('crashlog_retention')) $('crashlog_retention').value=(data.crash_log_retention_days!=null?data.crash_log_retention_days:30);
 
       // Authentication toggle — reflect in UI and hide sign-out button when off
       var authOn = (data.auth_enabled!==false);
@@ -3959,7 +3989,7 @@
       });
       /* If Logs is the restored active tab on page load, the early switchTab()
          ran before these functions existed (guarded by typeof), so populate now. */
-      if(logsTabActive()){ refreshLogs(); syncLogsAutoRefresh(); }
+      if(logsTabActive()){ refreshLogs(); syncLogsAutoRefresh(); refreshCrashlog(); }
     })();
 
     /* Pause auto-refresh when the page is hidden; resume when visible on Logs tab. */
@@ -3979,6 +4009,125 @@
           refreshLogs();
         })
         .catch(function(e){ showToast('Clear logs failed: '+e.message,'error'); })
+        .finally(function(){ btn.disabled=false; btn.textContent=prev; });
+    }
+
+    /* ---- Crash Logs ---- */
+
+    /* Format a crash record's timestamp: wall-clock when ts>0, else uptime note. */
+    function crashWhen(rec){
+      if(rec.ts && rec.ts>0){
+        try{ return new Date(rec.ts*1000).toLocaleString(); }catch(e){}
+        return 'ts '+rec.ts;
+      }
+      var u=(rec.uptime_s!=null)?rec.uptime_s:0;
+      return 'uptime '+u+'s (no clock)';
+    }
+
+    /* Build one crash entry as DOM nodes (textContent avoids HTML injection from
+       the captured panic text). */
+    function buildCrashEntry(rec){
+      var wrap=document.createElement('div');
+      wrap.style.cssText='border:1px solid var(--border);border-radius:var(--radius-sm);'
+        +'padding:10px 12px;margin-bottom:10px;background:rgba(0,0,0,0.25)';
+
+      var head=document.createElement('div');
+      head.style.cssText='display:flex;flex-wrap:wrap;gap:6px 14px;align-items:baseline;'
+        +'font-family:inherit;color:var(--text)';
+
+      var reason=document.createElement('strong');
+      reason.textContent=rec.reason_str||('reason '+(rec.reason!=null?rec.reason:'?'));
+      reason.style.cssText='font-size:0.82rem';
+      head.appendChild(reason);
+
+      var when=document.createElement('span');
+      when.textContent=crashWhen(rec);
+      when.style.cssText='color:var(--text-secondary);font-size:0.75rem';
+      head.appendChild(when);
+
+      var counts=document.createElement('span');
+      var c=(rec.crash_count!=null)?rec.crash_count:'?';
+      var b=(rec.boot_count!=null)?rec.boot_count:'?';
+      counts.textContent='crash #'+c+' · boot #'+b;
+      counts.style.cssText='color:var(--text-hint);font-size:0.72rem';
+      head.appendChild(counts);
+
+      wrap.appendChild(head);
+
+      var panic=(rec.panic||'').trim();
+      if(panic){
+        var det=document.createElement('details');
+        det.style.cssText='margin-top:6px';
+        var sum=document.createElement('summary');
+        sum.textContent='Panic text';
+        sum.style.cssText='cursor:pointer;font-size:0.74rem;color:var(--text-secondary)';
+        det.appendChild(sum);
+        var pre=document.createElement('pre');
+        pre.textContent=panic;
+        pre.style.cssText='margin:6px 0 0;white-space:pre-wrap;word-break:break-word;'
+          +'font-size:0.7rem;line-height:1.35;max-height:260px;overflow:auto;'
+          +'color:var(--text-secondary)';
+        det.appendChild(pre);
+        wrap.appendChild(det);
+      } else {
+        var none=document.createElement('div');
+        none.textContent='No panic text captured (reset-reason only).';
+        none.style.cssText='margin-top:4px;font-size:0.72rem;color:var(--text-hint)';
+        wrap.appendChild(none);
+      }
+      return wrap;
+    }
+
+    function refreshCrashlog(){
+      var view=$('crashlogView');
+      if(!view) return;
+      var btn=$('refreshCrashlogBtn');
+      if(btn) btn.disabled=true;
+      fetch('/api/crashlog')
+        .then(function(r){
+          if(!r.ok) throw new Error('HTTP '+r.status);
+          return r.text();
+        })
+        .then(function(text){
+          view.textContent='';
+          var lines=text.split('\n');
+          var recs=[];
+          for(var i=0;i<lines.length;i++){
+            var ln=lines[i].trim();
+            if(!ln) continue;
+            try{ recs.push(JSON.parse(ln)); }catch(e){ /* skip malformed line */ }
+          }
+          if(recs.length===0){
+            var empty=document.createElement('div');
+            empty.textContent='No crashes recorded.';
+            empty.style.cssText='color:var(--text-hint);font-size:0.8rem';
+            view.appendChild(empty);
+            $('crashlogStatus').textContent='Updated '+new Date().toLocaleTimeString()+' · 0 records';
+            return;
+          }
+          /* Newest first for display (file is newest-last). */
+          recs.reverse();
+          recs.forEach(function(rec){ view.appendChild(buildCrashEntry(rec)); });
+          $('crashlogStatus').textContent='Updated '+new Date().toLocaleTimeString()+' · '+recs.length+' record'+(recs.length===1?'':'s');
+        })
+        .catch(function(e){
+          showToast('Load crash logs failed: '+e.message,'error');
+          $('crashlogStatus').textContent='Load failed at '+new Date().toLocaleTimeString()+': '+e.message;
+        })
+        .finally(function(){ if(btn) btn.disabled=false; });
+    }
+
+    function clearCrashlog(){
+      if(!confirm('Clear the crash history? This cannot be undone.')) return;
+      var btn=$('clearCrashlogBtn');
+      btn.disabled=true; var prev=btn.textContent; btn.textContent='Clearing...';
+      fetch('/api/crashlog/clear',{method:'POST'})
+        .then(function(r){
+          if(!r.ok) throw new Error('Clear failed');
+          showToast('Crash logs cleared','success');
+          refreshCrashlog();
+        })
+        .catch(function(e){ showToast('Clear crash logs failed: '+e.message,'error'); })
         .finally(function(){ btn.disabled=false; btn.textContent=prev; });
     }
 

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -87,20 +87,66 @@
     /* Non-collapsible cards (e.g. Logs): no chevron, no pointer affordance */
     .card.nocollapse > .card-title { cursor: default; }
     .card.nocollapse > .card-title::after { display: none; }
-    /* Logs tab: break out wider than the 960px content column */
-    #tab-logs .card { width: min(1180px, 94vw); margin-left: 50%; transform: translateX(-50%); }
+    /* Logs tab: break out wider than the 960px content column, and fit the window
+       as a flex column so only the viewport scrolls (not the page). */
+    #tab-logs .card {
+      width: min(1180px, 94vw); margin-left: 50%; transform: translateX(-50%);
+      display: flex; flex-direction: column; box-sizing: border-box;
+      max-height: calc(100vh - 208px);
+    }
     .logs-layout { display: flex; gap: 18px; align-items: stretch; }
     .logs-controls { flex: 0 0 220px; display: flex; flex-direction: column; gap: 12px; }
     .logs-controls .btn { width: 100%; }
+    /* Logs card: horizontal toolbar layout */
+    .logs-toolbar {
+      display: flex; flex-wrap: wrap; align-items: center; gap: 10px;
+      margin: 0 0 12px;
+    }
+    .logs-toolbar .btn {
+      width: auto;
+      min-height: 0; padding: 7px 18px;
+      font-size: 0.8rem; font-weight: 500;
+      border-radius: var(--radius-sm);
+      text-decoration: none;
+    }
+    .logs-toolbar-actions { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+    .logs-toolbar-slot { margin-left: auto; display: flex; flex-wrap: wrap; align-items: center; gap: 14px; }
+    /* Segmented source toggle (Device | Crash) */
+    .log-seg {
+      display: inline-flex; border: 1px solid var(--border);
+      border-radius: var(--radius-sm); overflow: hidden; margin: 0;
+    }
+    /* Meta row: hint left, status right; sits between toolbar and viewport. */
+    .logs-meta {
+      display: flex; flex-wrap: wrap; align-items: baseline;
+      gap: 4px 14px; margin: 0 0 10px;
+    }
+    .logs-meta .field-hint { margin: 0; }
+    #logsStatus, #crashlogStatus { margin-left: auto; }
+    .log-seg-btn {
+      background: none; border: none; cursor: pointer; font-family: inherit;
+      color: var(--text-secondary); padding: 7px 18px; font-size: 0.8rem;
+      font-weight: 500; transition: all 0.2s ease; white-space: nowrap;
+    }
+    .log-seg-btn + .log-seg-btn { border-left: 1px solid var(--border); }
+    .log-seg-btn:hover { color: var(--text); background: rgba(var(--accent-rgb), 0.08); }
+    .log-seg-btn.active {
+      color: #f4f4f5; background: rgba(var(--accent-rgb), 0.18);
+      box-shadow: inset 0 0 12px rgba(var(--accent-rgb), 0.12);
+    }
     .logs-view {
-      flex: 1; min-width: 0; margin: 0;
-      height: calc(100vh - 240px); min-height: 420px; overflow: auto;
+      min-width: 0; margin: 0; overflow: auto;
+      flex: 1 1 auto; min-height: 0;
       white-space: pre-wrap; word-break: break-word;
       font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
       font-size: 0.72rem; line-height: 1.4; color: var(--text-secondary);
       background: rgba(0, 0, 0, 0.35); border: 1px solid var(--border);
       border-radius: var(--radius-sm); padding: 12px;
     }
+    /* Both viewports fill the leftover flex space and scroll internally. */
+    #logsView.logs-view { height: auto; min-height: 0; }
+    #crashlogView.logs-view { max-height: none; min-height: 0; }
+    .logs-view.hidden { display: none; }
     .content { max-width: 960px; margin: 0 auto; padding: 28px 24px 100px; }
     .field { margin-bottom: 20px; }
     .field:last-child { margin-bottom: 0; }
@@ -569,11 +615,14 @@
       .toast { top: auto; bottom: calc(var(--bottom-nav-height) + var(--save-bar-height) + env(safe-area-inset-bottom, 0px) + 16px); right: 16px; }
       .row.stack-mobile { flex-direction: column; }
 
-      /* Logs: stack controls above the viewer on narrow screens, drop the breakout */
-      #tab-logs .card { width: auto; margin-left: 0; transform: none; }
+      /* Logs: stack controls above the viewer on narrow screens, drop the breakout.
+         Page scroll is acceptable on mobile, so the card is a plain block here. */
+      #tab-logs .card { width: auto; margin-left: 0; transform: none; max-height: none; display: block; }
       .logs-layout { flex-direction: column; }
       .logs-controls { flex: 0 0 auto; }
-      .logs-view { height: 60vh; min-height: 300px; }
+      .logs-toolbar-slot { margin-left: 0; }
+      #logsView.logs-view { height: 60vh; min-height: 300px; }
+      #crashlogView.logs-view { height: auto; max-height: 60vh; }
 
       /* Card titles */
       .card-title { font-size: 0.9rem; }
@@ -1667,41 +1716,37 @@
     <div id="tab-logs" class="tab-panel">
 
       <div class="card nocollapse">
-        <div class="card-title">Device Logs</div>
-        <div class="logs-layout">
-          <div class="logs-controls">
-            <div class="field-hint" style="margin:0 0 4px">Console output captured since boot (in-memory, 512 KB ring buffer, oldest lines dropped when full).</div>
-            <button class="btn btn-outline" id="refreshLogsBtn" onclick="refreshLogs()">Refresh</button>
-            <a class="btn btn-outline" href="/api/logs" style="text-align:center">Download</a>
-            <button class="btn btn-outline" id="clearLogsBtn" onclick="clearLogs()">Clear</button>
-            <div class="toggle-row" style="margin-top:6px">
-              <span class="toggle-label">Auto-refresh</span>
-              <label class="toggle"><input type="checkbox" id="logsAutoRefresh"><span class="toggle-track"></span></label>
-            </div>
-            <div style="display:flex;align-items:center;justify-content:space-between;gap:10px">
-              <span class="field-hint" style="margin:0">Interval</span>
-              <select class="input" id="logsRefreshInterval" style="max-width:90px">
-                <option value="2">2s</option>
-                <option value="5" selected>5s</option>
-                <option value="10">10s</option>
-                <option value="30">30s</option>
-              </select>
-            </div>
-            <div class="field-hint" id="logsStatus" style="margin:4px 0 0">Not loaded yet.</div>
-          </div>
-          <pre id="logsView" class="logs-view"></pre>
-        </div>
-      </div>
+        <div class="card-title">Logs</div>
 
-      <div class="card nocollapse">
-        <div class="card-title">Crash Logs</div>
-        <div class="logs-layout">
-          <div class="logs-controls">
-            <div class="field-hint" style="margin:0 0 4px">Persistent crash history (survives reboot). Reset reason for every abnormal restart, with serial panic text when available. Newest 20 records kept.</div>
-            <button class="btn btn-outline" id="refreshCrashlogBtn" onclick="refreshCrashlog()">Refresh</button>
-            <a class="btn btn-outline" href="/api/crashlog" style="text-align:center">Download</a>
-            <button class="btn btn-outline" id="clearCrashlogBtn" onclick="clearCrashlog()">Clear</button>
-            <div style="display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:6px">
+        <div class="logs-toolbar">
+          <div class="log-seg" role="tablist">
+            <button class="log-seg-btn active" id="logSegDevice" onclick="setLogSource('device')">Device</button>
+            <button class="log-seg-btn" id="logSegCrash" onclick="setLogSource('crash')">Crash</button>
+          </div>
+          <div class="logs-toolbar-actions">
+            <button class="btn btn-outline" id="logsRefreshBtn" onclick="logsRefreshActive()">Refresh</button>
+            <a class="btn btn-outline" id="logsDownloadLink" href="/api/logs" style="text-align:center">Download</a>
+            <button class="btn btn-outline" id="logsClearBtn" onclick="logsClearActive()">Clear</button>
+          </div>
+          <div class="logs-toolbar-slot">
+            <!-- Device source controls -->
+            <div id="logsDeviceCtl" style="display:flex;flex-wrap:wrap;align-items:center;gap:14px">
+              <div class="toggle-row" style="margin:0;border:0;padding:0">
+                <span class="toggle-label">Auto-refresh</span>
+                <label class="toggle"><input type="checkbox" id="logsAutoRefresh"><span class="toggle-track"></span></label>
+              </div>
+              <div style="display:flex;align-items:center;gap:8px">
+                <span class="field-hint" style="margin:0">Interval</span>
+                <select class="input" id="logsRefreshInterval" style="max-width:90px">
+                  <option value="2">2s</option>
+                  <option value="5" selected>5s</option>
+                  <option value="10">10s</option>
+                  <option value="30">30s</option>
+                </select>
+              </div>
+            </div>
+            <!-- Crash source controls -->
+            <div id="logsCrashCtl" style="display:none;align-items:center;gap:8px">
               <span class="field-hint" style="margin:0">Auto-clear after</span>
               <select class="input" id="crashlog_retention" style="max-width:110px">
                 <option value="0">Never</option>
@@ -1712,10 +1757,17 @@
                 <option value="90">90 days</option>
               </select>
             </div>
-            <div class="field-hint" id="crashlogStatus" style="margin:4px 0 0">Not loaded yet.</div>
           </div>
-          <div id="crashlogView" class="logs-view"></div>
         </div>
+
+        <div class="logs-meta">
+          <span class="field-hint" id="logsHint">Console output captured since boot (in-memory, 512 KB ring buffer, oldest lines dropped when full).</span>
+          <span class="field-hint" id="logsStatus">Not loaded yet.</span>
+          <span class="field-hint" id="crashlogStatus" style="display:none">Not loaded yet.</span>
+        </div>
+
+        <pre id="logsView" class="logs-view"></pre>
+        <div id="crashlogView" class="logs-view hidden"></div>
       </div>
     </div>
 
@@ -2041,9 +2093,10 @@
       setAccent(name);
       try{localStorage.setItem('nina_tab',name);}catch(e){}
       if(name==='logs'){
-        if(typeof refreshLogs==='function') refreshLogs();
-        if(typeof syncLogsAutoRefresh==='function') syncLogsAutoRefresh();
-        if(typeof refreshCrashlog==='function') refreshCrashlog();
+        /* Re-enter the currently selected source; refreshes it and (for device)
+           resumes auto-refresh. Falls back to direct calls if not yet defined. */
+        if(typeof setLogSource==='function') setLogSource(typeof activeLogSource!=='undefined'?activeLogSource:'device');
+        else if(typeof refreshLogs==='function') refreshLogs();
       } else {
         if(typeof stopLogsAutoRefresh==='function') stopLogsAutoRefresh();
       }
@@ -3923,16 +3976,66 @@
     /* ---- Diagnostic Logs ---- */
 
     var _logsTimer=null;
+    var activeLogSource='device';
 
     function logsTabActive(){
       var p=$('tab-logs');
       return !!(p && p.classList.contains('active'));
     }
 
+    /* Hint text per source (no em dashes in user-facing strings). */
+    var LOG_HINTS={
+      device:'Console output captured since boot (in-memory, 512 KB ring buffer, oldest lines dropped when full).',
+      crash:'Persistent crash history (survives reboot). Reset reason for every abnormal restart, with serial panic text when available. Newest 20 records kept.'
+    };
+
+    /* Switch the unified Logs card between the device and crash sources. Toggles
+       segment buttons, viewports, control groups, status lines, hint, the shared
+       Download href, and refreshes the now-active source. */
+    function setLogSource(src){
+      if(src!=='crash') src='device';
+      activeLogSource=src;
+      var dev=(src==='device');
+
+      var segDev=$('logSegDevice'), segCrash=$('logSegCrash');
+      if(segDev) segDev.classList.toggle('active',dev);
+      if(segCrash) segCrash.classList.toggle('active',!dev);
+
+      var lv=$('logsView'), cv=$('crashlogView');
+      if(lv) lv.classList.toggle('hidden',!dev);
+      if(cv) cv.classList.toggle('hidden',dev);
+
+      var devCtl=$('logsDeviceCtl'), crashCtl=$('logsCrashCtl');
+      if(devCtl) devCtl.style.display=dev?'flex':'none';
+      if(crashCtl) crashCtl.style.display=dev?'none':'flex';
+
+      var ls=$('logsStatus'), cs=$('crashlogStatus');
+      if(ls) ls.style.display=dev?'':'none';
+      if(cs) cs.style.display=dev?'none':'';
+
+      var hint=$('logsHint');
+      if(hint) hint.textContent=LOG_HINTS[src];
+
+      var dl=$('logsDownloadLink');
+      if(dl) dl.href=dev?'/api/logs':'/api/crashlog';
+
+      /* Auto-refresh only applies to the device source. */
+      if(dev){ syncLogsAutoRefresh(); refreshLogs(); }
+      else { stopLogsAutoRefresh(); refreshCrashlog(); }
+    }
+
+    /* Shared toolbar buttons route to the active source. */
+    function logsRefreshActive(){
+      if(activeLogSource==='crash') refreshCrashlog(); else refreshLogs();
+    }
+    function logsClearActive(){
+      if(activeLogSource==='crash') clearCrashlog(); else clearLogs();
+    }
+
     function refreshLogs(){
       var view=$('logsView');
       if(!view) return;
-      var btn=$('refreshLogsBtn');
+      var btn=(activeLogSource==='device')?$('logsRefreshBtn'):null;
       if(btn) btn.disabled=true;
       /* Was the view scrolled to (near) the bottom before we replaced content? */
       var nearBottom = (view.scrollHeight - view.scrollTop - view.clientHeight) < 40;
@@ -3955,9 +4058,9 @@
     }
 
     function logsAutoRefreshTick(){
-      /* Skip polling when the tab is not visible or the document is hidden,
-         to avoid pulling the whole 512 KB buffer needlessly. */
-      if(document.hidden || !logsTabActive()) return;
+      /* Skip polling when the tab is not visible, the document is hidden, or the
+         crash source is showing, to avoid pulling the whole 512 KB buffer needlessly. */
+      if(document.hidden || !logsTabActive() || activeLogSource!=='device') return;
       refreshLogs();
     }
 
@@ -3988,8 +4091,10 @@
         if(cb && cb.checked) startLogsAutoRefresh();
       });
       /* If Logs is the restored active tab on page load, the early switchTab()
-         ran before these functions existed (guarded by typeof), so populate now. */
-      if(logsTabActive()){ refreshLogs(); syncLogsAutoRefresh(); refreshCrashlog(); }
+         ran before these functions existed (guarded by typeof), so populate now.
+         setLogSource('device') wires up the default source and refreshes it; crash
+         data loads lazily the first time the user switches to the crash source. */
+      if(logsTabActive()){ setLogSource('device'); }
     })();
 
     /* Pause auto-refresh when the page is hidden; resume when visible on Logs tab. */
@@ -4000,7 +4105,7 @@
 
     function clearLogs(){
       if(!confirm('Clear the captured device logs? This cannot be undone.')) return;
-      var btn=$('clearLogsBtn');
+      var btn=$('logsClearBtn');
       btn.disabled=true; var prev=btn.textContent; btn.textContent='Clearing...';
       fetch('/api/logs/clear',{method:'POST'})
         .then(function(r){
@@ -4081,7 +4186,7 @@
     function refreshCrashlog(){
       var view=$('crashlogView');
       if(!view) return;
-      var btn=$('refreshCrashlogBtn');
+      var btn=(activeLogSource==='crash')?$('logsRefreshBtn'):null;
       if(btn) btn.disabled=true;
       fetch('/api/crashlog')
         .then(function(r){
@@ -4119,7 +4224,7 @@
 
     function clearCrashlog(){
       if(!confirm('Clear the crash history? This cannot be undone.')) return;
-      var btn=$('clearCrashlogBtn');
+      var btn=$('logsClearBtn');
       btn.disabled=true; var prev=btn.textContent; btn.textContent='Clearing...';
       fetch('/api/crashlog/clear',{method:'POST'})
         .then(function(r){

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -698,7 +698,7 @@
   <nav class="top-nav">
     <div class="brand"><img class="logo" src="/favicon.ico" alt=""> <span id="brandName">NINA Display</span></div>
     <div class="tabs" id="topTabs">
-      <button class="tab-btn active" data-tab="nodes">N.I.N.A.</button>
+      <button class="tab-btn" data-tab="nodes">N.I.N.A.</button>
       <button class="tab-btn" data-tab="allsky">AllSky</button>
       <button class="tab-btn" data-tab="clock">Clock</button>
       <button class="tab-btn" data-tab="spotify">Spotify</button>
@@ -772,7 +772,7 @@
   <main class="content">
 
     <!-- ==================== TAB 2: NODES & DATA ==================== -->
-    <div id="tab-nodes" class="tab-panel active">
+    <div id="tab-nodes" class="tab-panel">
 
       <div class="card" id="instance-overview">
         <div class="card-title">Active N.I.N.A. Instances</div>
@@ -2109,8 +2109,8 @@
     try{
       var saved=localStorage.getItem('nina_tab');
       if(saved&&$('tab-'+saved)) switchTab(saved);
-      else setAccent('nodes');
-    }catch(e){ setAccent('nodes'); }
+      else switchTab('nodes');
+    }catch(e){ switchTab('nodes'); }
 
     /* === Live API Controls === */
     function setTheme(v){postJson('/api/theme',{theme_index:parseInt(v)})}

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1120,8 +1120,8 @@
           <div class="field" style="margin-top:16px" id="moonSpinReturnField">
             <label class="field-label">Return to live view after</label>
             <div class="slider-group">
-              <input type="range" class="slider" id="moon_spin_return_s" min="3" max="60" step="1" value="10" oninput="updateMoonOrientReadout('moon_spin_return');applyImageDisplay();checkDirty()">
-              <span class="slider-val" id="moon_spin_return_val">10s</span>
+              <input type="range" class="slider" id="moon_spin_return_s" min="3" max="60" step="1" value="3" oninput="updateMoonOrientReadout('moon_spin_return');applyImageDisplay();checkDirty()">
+              <span class="slider-val" id="moon_spin_return_val">3s</span>
             </div>
             <div class="field-hint">Only applies in free-spin mode.</div>
           </div>
@@ -2409,7 +2409,7 @@
         moon_yaw_offset:parseFloat($('moon_yaw_offset').value)||0,
         moon_pitch_offset:parseFloat($('moon_pitch_offset').value)||0,
         moon_spin_mode:$('moon_spin_mode').checked?1:0,
-        moon_spin_return_s:parseInt($('moon_spin_return_s').value,10)||10,
+        moon_spin_return_s:parseInt($('moon_spin_return_s').value,10)||3,
         weather_provider:parseInt($('weather_provider').value)||0,
         weather_api_key:$('weather_api_key').value.trim(),
         weather_lat:parseFloat($('weather_lat').value)||0,
@@ -2590,7 +2590,7 @@
       if($('moon_yaw_offset')) $('moon_yaw_offset').value=data.moon_yaw_offset!=null?data.moon_yaw_offset:0;
       if($('moon_pitch_offset')) $('moon_pitch_offset').value=data.moon_pitch_offset!=null?data.moon_pitch_offset:0;
       if($('moon_spin_mode')) $('moon_spin_mode').checked=!!data.moon_spin_mode;
-      if($('moon_spin_return_s')) $('moon_spin_return_s').value=data.moon_spin_return_s!=null?data.moon_spin_return_s:10;
+      if($('moon_spin_return_s')) $('moon_spin_return_s').value=data.moon_spin_return_s!=null?data.moon_spin_return_s:3;
       updateMoonOrientReadout('moon_roll');
       updateMoonOrientReadout('moon_yaw');
       updateMoonOrientReadout('moon_pitch');
@@ -3746,7 +3746,7 @@
         moon_yaw_offset: parseFloat($('moon_yaw_offset').value)||0,
         moon_pitch_offset: parseFloat($('moon_pitch_offset').value)||0,
         moon_spin_mode: $('moon_spin_mode').checked?1:0,
-        moon_spin_return_s: parseInt($('moon_spin_return_s').value,10)||10,
+        moon_spin_return_s: parseInt($('moon_spin_return_s').value,10)||3,
         solar_band: parseInt($('solarBand').value,10)||0
       });
     }

--- a/main/crash_log.c
+++ b/main/crash_log.c
@@ -1,0 +1,437 @@
+/**
+ * @file crash_log.c
+ * @brief Persistent crash history capture (see crash_log.h).
+ *
+ * Storage: one JSON object per line in /spiffs/crashlog.jsonl. JSONL keeps the
+ * append-and-trim path trivial and streams directly to the web Logs tab.
+ *
+ * Record shape (all fields always present):
+ *   {"ts":1717459200,"uptime_s":0,"reason":4,"reason_str":"Panic / exception",
+ *    "crash_count":3,"boot_count":42,"panic":"Guru Meditation Error...\n..."}
+ *   - ts:          wall-clock unix seconds at capture, 0 if NTP not synced.
+ *   - uptime_s:    seconds since boot at capture (always meaningful).
+ *   - reason:      raw esp_reset_reason_t value.
+ *   - reason_str:  human-readable reason string.
+ *   - crash_count: RTC crash counter since last power-on.
+ *   - boot_count:  total boot count from NVS.
+ *   - panic:       captured serial panic text (Layer B), "" if unavailable.
+ */
+
+#include "crash_log.h"
+#include "power_mgmt.h"
+#include "app_config.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+#include "esp_log.h"
+#include "esp_spiffs.h"
+#include "esp_heap_caps.h"
+#include "esp_attr.h"
+#include "cJSON.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <time.h>
+#include <sys/stat.h>
+
+static const char *TAG = "crash_log";
+
+/* ── Layer B: panic-text capture ──────────────────────────────────────────────
+ *
+ * __wrap_panic_print_char() runs in panic context (interrupts disabled, no heap,
+ * no locks). It appends each character to a bounded RTC_NOINIT ring guarded by a
+ * magic value, then forwards to the real implementation so serial output is
+ * unchanged. RTC_NOINIT memory survives the panic-triggered software reset.
+ *
+ * The ring stores the most recent CRASH_PANIC_BUF_SIZE characters; if the panic
+ * banner overflows we keep the tail (which holds the backtrace line on RISC-V).
+ */
+#define CRASH_PANIC_BUF_SIZE  3072
+#define CRASH_PANIC_MAGIC     0xC7A54106u   /* "crash log" sentinel */
+
+typedef struct {
+    uint32_t magic;                     /* CRASH_PANIC_MAGIC when buffer valid */
+    uint32_t len;                       /* bytes written (may exceed size if wrapped) */
+    uint32_t head;                      /* next write index into buf[] */
+    char     buf[CRASH_PANIC_BUF_SIZE];
+} crash_panic_rtc_t;
+
+static RTC_NOINIT_ATTR crash_panic_rtc_t s_panic_rtc;
+
+/* Provided by the linker (-Wl,--wrap=panic_print_char). */
+extern void __real_panic_print_char(char c);
+
+void __wrap_panic_print_char(char c)
+{
+    /* First character of a fresh panic: initialise the ring. We cannot tell the
+     * difference between a continuation and a new panic here, so we only reset
+     * when the magic is absent — crash_log_init() clears the magic after reading,
+     * so the next crash starts clean. */
+    if (s_panic_rtc.magic != CRASH_PANIC_MAGIC) {
+        s_panic_rtc.magic = CRASH_PANIC_MAGIC;
+        s_panic_rtc.len   = 0;
+        s_panic_rtc.head  = 0;
+    }
+
+    s_panic_rtc.buf[s_panic_rtc.head] = c;
+    s_panic_rtc.head = (s_panic_rtc.head + 1u) % CRASH_PANIC_BUF_SIZE;
+    s_panic_rtc.len++;
+
+    __real_panic_print_char(c);
+}
+
+/**
+ * Copy the captured panic text (oldest→newest) into @p out. Returns the number
+ * of characters written (excluding NUL). Returns 0 and out[0]='\0' if no valid
+ * capture is present.
+ */
+static size_t panic_text_extract(char *out, size_t out_size)
+{
+    if (out_size == 0) {
+        return 0;
+    }
+    out[0] = '\0';
+    if (s_panic_rtc.magic != CRASH_PANIC_MAGIC || s_panic_rtc.len == 0) {
+        return 0;
+    }
+
+    size_t total = s_panic_rtc.len;
+    size_t start;
+    if (total <= CRASH_PANIC_BUF_SIZE) {
+        /* No wrap — buffer holds [0 .. head). */
+        start = 0;
+    } else {
+        /* Wrapped — oldest char is at head, newest CRASH_PANIC_BUF_SIZE chars kept. */
+        total = CRASH_PANIC_BUF_SIZE;
+        start = s_panic_rtc.head;
+    }
+
+    size_t copy = total < (out_size - 1) ? total : (out_size - 1);
+    for (size_t i = 0; i < copy; i++) {
+        size_t idx = (start + i) % CRASH_PANIC_BUF_SIZE;
+        out[i] = s_panic_rtc.buf[idx];
+    }
+    out[copy] = '\0';
+    return copy;
+}
+
+/* Invalidate the RTC panic ring so the next crash captures fresh text. */
+static void panic_text_clear(void)
+{
+    s_panic_rtc.magic = 0;
+    s_panic_rtc.len   = 0;
+    s_panic_rtc.head  = 0;
+}
+
+/* ── SPIFFS mount ─────────────────────────────────────────────────────────── */
+
+static bool s_mounted = false;
+
+static bool ensure_mounted(void)
+{
+    if (s_mounted) {
+        return true;
+    }
+
+    /* The "storage" partition ships unformatted; format on first mount. */
+    esp_vfs_spiffs_conf_t conf = {
+        .base_path              = CRASH_LOG_MOUNT_POINT,
+        .partition_label        = "storage",
+        .max_files              = 4,
+        .format_if_mount_failed = true,
+    };
+
+    esp_err_t err = esp_vfs_spiffs_register(&conf);
+    if (err == ESP_OK) {
+        s_mounted = true;
+        size_t total = 0, used = 0;
+        if (esp_spiffs_info("storage", &total, &used) == ESP_OK) {
+            ESP_LOGI(TAG, "SPIFFS mounted: %u/%u bytes used", (unsigned)used, (unsigned)total);
+        }
+        return true;
+    }
+
+    if (err == ESP_ERR_INVALID_STATE) {
+        /* Already registered by something else — treat as mounted. */
+        s_mounted = true;
+        return true;
+    }
+
+    ESP_LOGE(TAG, "SPIFFS mount failed: %s — crash logging disabled this boot",
+             esp_err_to_name(err));
+    return false;
+}
+
+/* ── File helpers ─────────────────────────────────────────────────────────── */
+
+bool crash_log_exists(void)
+{
+    if (!s_mounted) {
+        return false;
+    }
+    struct stat st;
+    return stat(CRASH_LOG_FILE_PATH, &st) == 0 && st.st_size > 0;
+}
+
+FILE *crash_log_open_read(void)
+{
+    if (!s_mounted) {
+        return NULL;
+    }
+    return fopen(CRASH_LOG_FILE_PATH, "r");
+}
+
+esp_err_t crash_log_clear(void)
+{
+    if (!s_mounted) {
+        return ESP_OK;
+    }
+    if (remove(CRASH_LOG_FILE_PATH) != 0) {
+        /* Missing file is not an error — clearing an empty log is a no-op. */
+        struct stat st;
+        if (stat(CRASH_LOG_FILE_PATH, &st) == 0) {
+            ESP_LOGW(TAG, "Failed to remove crash log");
+            return ESP_FAIL;
+        }
+    }
+    ESP_LOGI(TAG, "Crash log cleared");
+    return ESP_OK;
+}
+
+/**
+ * Rewrite the crash log keeping only the lines for which keep_fn() returns true,
+ * limited to the newest @p max_keep entries. Reads the whole file into a PSRAM
+ * buffer, filters, and writes back. The file is small (≤ a few KB), so this is
+ * cheap and avoids partial-write corruption.
+ *
+ * @param max_keep   newest N lines to retain (0 = unlimited beyond keep_fn)
+ * @param min_ts     drop lines whose "ts" is non-zero and < min_ts (0 = no cutoff)
+ */
+static void rewrite_filtered(size_t max_keep, time_t min_ts)
+{
+    if (!s_mounted) {
+        return;
+    }
+
+    struct stat st;
+    if (stat(CRASH_LOG_FILE_PATH, &st) != 0 || st.st_size == 0) {
+        return;  /* nothing to do */
+    }
+
+    size_t sz = (size_t)st.st_size;
+    char *data = heap_caps_malloc(sz + 1, MALLOC_CAP_SPIRAM);
+    if (!data) {
+        ESP_LOGE(TAG, "OOM reading crash log (%u bytes)", (unsigned)sz);
+        return;
+    }
+
+    FILE *f = fopen(CRASH_LOG_FILE_PATH, "r");
+    if (!f) {
+        heap_caps_free(data);
+        return;
+    }
+    size_t got = fread(data, 1, sz, f);
+    fclose(f);
+    data[got] = '\0';
+
+    /* Collect line start pointers (in place; replace '\n' with '\0'). A generous
+     * cap guards against an unexpectedly large file; in practice the ring keeps
+     * the file at ≤ CRASH_LOG_MAX_ENTRIES + 1 lines. */
+    #define CRASH_LOG_PARSE_CAP 256
+    char **lines = heap_caps_malloc(sizeof(char *) * CRASH_LOG_PARSE_CAP, MALLOC_CAP_SPIRAM);
+    if (!lines) {
+        heap_caps_free(data);
+        return;
+    }
+    size_t n = 0;
+    char *p = data;
+    while (p && *p) {
+        char *nl = strchr(p, '\n');
+        if (nl) {
+            *nl = '\0';
+        }
+        if (*p != '\0' && n < CRASH_LOG_PARSE_CAP) {
+            /* Apply retention cutoff: parse "ts" cheaply via cJSON. */
+            bool keep = true;
+            if (min_ts > 0) {
+                cJSON *o = cJSON_Parse(p);
+                if (o) {
+                    cJSON *ts = cJSON_GetObjectItem(o, "ts");
+                    if (cJSON_IsNumber(ts) && ts->valuedouble > 0 &&
+                        (time_t)ts->valuedouble < min_ts) {
+                        keep = false;
+                    }
+                    cJSON_Delete(o);
+                }
+            }
+            if (keep) {
+                lines[n++] = p;
+            }
+        }
+        p = nl ? (nl + 1) : NULL;
+    }
+
+    /* Trim to newest max_keep lines. */
+    size_t first = 0;
+    if (max_keep > 0 && n > max_keep) {
+        first = n - max_keep;
+    }
+
+    FILE *out = fopen(CRASH_LOG_FILE_PATH, "w");
+    if (out) {
+        for (size_t i = first; i < n; i++) {
+            fputs(lines[i], out);
+            fputc('\n', out);
+        }
+        fclose(out);
+    } else {
+        ESP_LOGE(TAG, "Failed to rewrite crash log");
+    }
+
+    heap_caps_free(lines);
+    heap_caps_free(data);
+}
+
+void crash_log_purge_old(uint8_t days)
+{
+    if (days == 0 || !s_mounted) {
+        return;  /* 0 = never purge */
+    }
+
+    time_t now = time(NULL);
+    if (now < 1577836800) {  /* Jan 1 2020 — clock not yet set, skip purge */
+        return;
+    }
+    time_t cutoff = now - (time_t)days * 86400;
+    rewrite_filtered(0 /* keep ring as-is */, cutoff);
+}
+
+/* ── Record append ────────────────────────────────────────────────────────── */
+
+static void append_crash_record(uint32_t reason, const char *panic_text)
+{
+    cJSON *o = cJSON_CreateObject();
+    if (!o) {
+        return;
+    }
+
+    time_t now = time(NULL);
+    bool synced = (now >= 1577836800);  /* Jan 1 2020 */
+    uint32_t uptime_ms = esp_log_timestamp();  /* ms since boot */
+
+    power_mgmt_crash_info_t info = power_mgmt_get_crash_info();
+
+    cJSON_AddNumberToObject(o, "ts", synced ? (double)now : 0.0);
+    cJSON_AddNumberToObject(o, "uptime_s", (double)(uptime_ms / 1000u));
+    cJSON_AddNumberToObject(o, "reason", (double)reason);
+    cJSON_AddStringToObject(o, "reason_str", power_mgmt_reset_reason_str(reason));
+    cJSON_AddNumberToObject(o, "crash_count", (double)info.crash_count);
+    cJSON_AddNumberToObject(o, "boot_count", (double)info.boot_count);
+    cJSON_AddStringToObject(o, "panic", panic_text ? panic_text : "");
+
+    char *line = cJSON_PrintUnformatted(o);
+    cJSON_Delete(o);
+    if (!line) {
+        return;
+    }
+
+    FILE *f = fopen(CRASH_LOG_FILE_PATH, "a");
+    if (f) {
+        fputs(line, f);
+        fputc('\n', f);
+        fclose(f);
+        ESP_LOGW(TAG, "Recorded crash: reason=%lu (%s)",
+                 (unsigned long)reason, power_mgmt_reset_reason_str(reason));
+    } else {
+        ESP_LOGE(TAG, "Failed to append crash record");
+    }
+
+    free(line);
+
+    /* Enforce the ring (newest CRASH_LOG_MAX_ENTRIES). */
+    rewrite_filtered(CRASH_LOG_MAX_ENTRIES, 0);
+}
+
+/* ── Public init ──────────────────────────────────────────────────────────── */
+
+/* State captured by crash_log_init() and consumed by the deferred worker. The
+ * RTC panic text must be extracted and the ring cleared synchronously in
+ * crash_log_init() (RTC reads are instant); SPIFFS work is deferred. */
+static bool      s_crash_pending = false;     /* a crash record is waiting to be written */
+static uint32_t  s_pending_reason = 0;
+static char     *s_pending_panic = NULL;      /* PSRAM buffer, owned by the worker */
+
+/**
+ * One-shot background worker: performs the (potentially ~70s on first boot)
+ * SPIFFS mount/format off the boot critical path, then writes any pending crash
+ * record and runs the retention purge. Self-deletes when done.
+ *
+ * Its stack MUST live in internal RAM. SPIFFS format issues many flash
+ * erase/write operations that execute with the CPU data cache disabled; a stack
+ * in (cached) PSRAM would fault when touched during those operations. Plain
+ * xTaskCreate() allocates the stack in internal RAM — do NOT switch this to a
+ * PSRAM/static-PSRAM stack or xTaskCreateWithCaps(MALLOC_CAP_SPIRAM).
+ */
+static void crash_log_deferred_worker(void *arg)
+{
+    (void)arg;
+
+    if (!ensure_mounted()) {
+        /* Mount failed — drop any pending capture so we don't leak it. */
+        if (s_pending_panic) {
+            heap_caps_free(s_pending_panic);
+            s_pending_panic = NULL;
+        }
+        s_crash_pending = false;
+        vTaskDelete(NULL);
+        return;
+    }
+
+    if (s_crash_pending) {
+        append_crash_record(s_pending_reason, s_pending_panic);
+        if (s_pending_panic) {
+            heap_caps_free(s_pending_panic);
+            s_pending_panic = NULL;
+        }
+        s_crash_pending = false;
+    } else {
+        ESP_LOGI(TAG, "Boot reset reason: %s (no crash recorded)",
+                 power_mgmt_reset_reason_str(s_pending_reason));
+    }
+
+    /* Retention purge on boot. */
+    crash_log_purge_old(app_config_get()->crash_log_retention_days);
+
+    vTaskDelete(NULL);
+}
+
+void crash_log_init(void)
+{
+    /* Read the reset reason and capture panic text from the RTC ring NOW — these
+     * are instant reads. The SPIFFS mount/format (which can take ~70s on first
+     * boot) is deferred to a background task so it never blocks app_main(). */
+    uint32_t reason = power_mgmt_get_last_reset_reason();
+    s_pending_reason = reason;
+
+    if (power_mgmt_reset_is_abnormal(reason)) {
+        /* Pull captured panic text (Layer B) from the RTC ring, if present.
+         * This MUST happen before panic_text_clear() below. */
+        char *panic_text = heap_caps_malloc(CRASH_PANIC_BUF_SIZE + 1, MALLOC_CAP_SPIRAM);
+        if (panic_text) {
+            panic_text_extract(panic_text, CRASH_PANIC_BUF_SIZE + 1);
+        }
+        s_pending_panic = panic_text;   /* may be NULL on OOM; worker tolerates it */
+        s_crash_pending = true;
+    }
+
+    /* Clear the RTC panic ring so the next crash captures fresh text. Safe to do
+     * now: any text we cared about is already copied into s_pending_panic. */
+    panic_text_clear();
+
+    /* Defer SPIFFS mount/format + record write to a background task. Internal-RAM
+     * stack is mandatory (see crash_log_deferred_worker). Low priority on Core 0
+     * keeps it out of the way of UI/network bring-up. */
+    xTaskCreatePinnedToCore(crash_log_deferred_worker, "crash_log_def",
+                            8192, NULL, tskIDLE_PRIORITY + 2, NULL, 0);
+}

--- a/main/crash_log.h
+++ b/main/crash_log.h
@@ -1,0 +1,82 @@
+#pragma once
+
+/**
+ * @file crash_log.h
+ * @brief Persistent crash history capture and storage.
+ *
+ * Two capture layers survive a reboot:
+ *   - Layer A (reset reason): on every boot crash_log_init() inspects the latched
+ *     reset reason (via power_mgmt). Abnormal resets (panic, watchdog, brownout)
+ *     are recorded. This works for every crash type including power loss.
+ *   - Layer B (panic text): __wrap_panic_print_char() mirrors the serial panic
+ *     output into a bounded RTC_NOINIT ring that survives the panic-triggered
+ *     reboot. crash_log_init() attaches that text to the Layer-A record when the
+ *     ring magic is valid (panic/abort only).
+ *
+ * Records are appended one JSON object per line to /spiffs/crashlog.jsonl. The
+ * file is capped to the newest CRASH_LOG_MAX_ENTRIES lines and purged of entries
+ * older than the configured retention window.
+ *
+ * The web layer (web_handlers_*) consumes this module through the public helpers
+ * below — it never opens the file directly.
+ */
+
+#include "esp_err.h"
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* SPIFFS mount point and crash-history file path. */
+#define CRASH_LOG_MOUNT_POINT "/spiffs"
+#define CRASH_LOG_FILE_PATH   CRASH_LOG_MOUNT_POINT "/crashlog.jsonl"
+
+/* Ring size: newest N crash records are retained, oldest dropped. */
+#define CRASH_LOG_MAX_ENTRIES 20
+
+/**
+ * Mount SPIFFS, record a crash entry if this boot followed an abnormal reset,
+ * enforce the ring + retention, then clear the RTC panic buffer.
+ *
+ * Call once from app_main() after app_config_init() and after
+ * power_mgmt_check_crash(). Reads crash_log_retention_days from app_config.
+ * Safe to call even if SPIFFS mount fails — the feature degrades to a no-op and
+ * logs a warning rather than aborting boot.
+ */
+void crash_log_init(void);
+
+/**
+ * Open the crash-history file for reading.
+ *
+ * @return FILE* positioned at the start of /spiffs/crashlog.jsonl, or NULL if the
+ *         file does not exist (no crashes yet) or SPIFFS is unmounted. The caller
+ *         owns the handle and must fclose() it.
+ */
+FILE *crash_log_open_read(void);
+
+/**
+ * @return true if a crash-history file currently exists (one or more records).
+ */
+bool crash_log_exists(void);
+
+/**
+ * Delete the crash-history file. Idempotent — returns ESP_OK whether or not the
+ * file existed.
+ */
+esp_err_t crash_log_clear(void);
+
+/**
+ * Drop crash records older than @p days (wall-clock based; records without a
+ * valid wall-clock timestamp are always kept). @p days == 0 means "never purge"
+ * and is a no-op. Called on boot from crash_log_init() and once daily from the
+ * data task tick.
+ */
+void crash_log_purge_old(uint8_t days);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -36,6 +36,7 @@
 #include "perf_monitor.h"
 #include "nina_connection.h"
 #include "power_mgmt.h"
+#include "crash_log.h"
 #include "spotify_auth.h"
 #include "spotify_client.h"
 #include "weather_client.h"
@@ -558,6 +559,10 @@ void app_main(void)
 
     // Track crash resets (PANIC, WDT) in RTC memory
     power_mgmt_check_crash();
+
+    // Persist a crash record if this boot followed an abnormal reset (mounts
+    // SPIFFS, reads reset reason + RTC panic text, enforces ring + retention).
+    crash_log_init();
 
     nina_connection_init();
 

--- a/main/moon_ephemeris.c
+++ b/main/moon_ephemeris.c
@@ -218,3 +218,239 @@ void moon_state_from_cycle(double cycle, float orient_rad, moon_state_t *out)
     out->axis_P        = 0.0f;
     out->have_location = true;
 }
+
+/* Internal: compute geocentric RA (degrees, 0..360) and Dec (degrees) for a
+ * given UTC time_t.  Mirrors the moon block from moon_compute() without the
+ * orientation / libration work so it can be called cheaply in a sample loop. */
+static void moon_ra_dec_at(time_t utc, double *ra_out, double *dec_out)
+{
+    double d = (double)utc / 86400.0 + 2440587.5 - 2451543.5;
+
+    double oblecl = (23.4393 - 3.563e-7 * d) * DEG;
+
+    /* Sun mean longitude for GMST0 and perturbation terms. */
+    double ws = 282.9404 + 4.70935e-5 * d;
+    double es = 0.016709 - 1.151e-9 * d;
+    double Ms = rev(356.0470 + 0.9856002585 * d);
+    double Es = Ms + RAD * es * sin(Ms*DEG) * (1 + es*cos(Ms*DEG));
+    double xvs = cos(Es*DEG) - es;
+    double yvs = sqrt(1.0 - es*es) * sin(Es*DEG);
+    double vs  = atan2(yvs, xvs) * RAD;
+    double slon = rev(vs + ws);
+    double Ls   = rev(ws + Ms);
+
+    /* Moon orbital elements. */
+    double Nm = 125.1228 - 0.0529538083 * d;
+    double im = 5.1454;
+    double wm = 318.0634 + 0.1643573223 * d;
+    double am = 60.2666;
+    double em = 0.054900;
+    double Mm = rev(115.3654 + 13.0649929509 * d);
+    double Em = Mm + RAD * em * sin(Mm*DEG) * (1 + em*cos(Mm*DEG));
+    Em = Em - (Em - RAD*em*sin(Em*DEG) - Mm) / (1 - em*cos(Em*DEG));
+    double xv = am * (cos(Em*DEG) - em);
+    double yv = am * (sqrt(1.0 - em*em) * sin(Em*DEG));
+    double vm = atan2(yv, xv) * RAD;
+    double rm = sqrt(xv*xv + yv*yv);
+    double xh = rm * (cos(Nm*DEG)*cos((vm+wm)*DEG) - sin(Nm*DEG)*sin((vm+wm)*DEG)*cos(im*DEG));
+    double yh = rm * (sin(Nm*DEG)*cos((vm+wm)*DEG) + cos(Nm*DEG)*sin((vm+wm)*DEG)*cos(im*DEG));
+    double zh = rm * (sin((vm+wm)*DEG)*sin(im*DEG));
+    double mlon = atan2(yh, xh) * RAD;
+    double mlat = atan2(zh, sqrt(xh*xh + yh*yh)) * RAD;
+
+    /* Perturbations. */
+    double Lm = rev(Nm + wm + Mm);
+    double D  = rev(Lm - Ls);
+    double F  = rev(Lm - Nm);
+    mlon += -1.274 * sin((Mm - 2*D)*DEG)
+          +  0.658 * sin((2*D)*DEG)
+          -  0.186 * sin(Ms*DEG)
+          -  0.059 * sin((2*Mm - 2*D)*DEG)
+          -  0.057 * sin((Mm - 2*D + Ms)*DEG)
+          +  0.053 * sin((Mm + 2*D)*DEG)
+          +  0.046 * sin((2*D - Ms)*DEG)
+          +  0.041 * sin((Mm - Ms)*DEG)
+          -  0.035 * sin(D*DEG)
+          -  0.031 * sin((Mm + Ms)*DEG)
+          -  0.015 * sin((2*F - 2*D)*DEG)
+          +  0.011 * sin((Mm - 4*D)*DEG);
+    mlat += -0.173 * sin((F - 2*D)*DEG)
+          -  0.055 * sin((Mm - F - 2*D)*DEG)
+          -  0.046 * sin((Mm + F - 2*D)*DEG)
+          +  0.033 * sin((F + 2*D)*DEG)
+          +  0.017 * sin((2*Mm + F)*DEG);
+    mlon = rev(mlon);
+
+    /* Ecliptic -> equatorial. */
+    double xg = cos(mlon*DEG) * cos(mlat*DEG);
+    double yg = sin(mlon*DEG) * cos(mlat*DEG);
+    double zg = sin(mlat*DEG);
+    double xe  = xg;
+    double ye  = yg*cos(oblecl) - zg*sin(oblecl);
+    double ze  = yg*sin(oblecl) + zg*cos(oblecl);
+    *ra_out  = rev(atan2(ye, xe) * RAD);
+    *dec_out = atan2(ze, sqrt(xe*xe + ye*ye)) * RAD;
+
+    (void)slon; /* true solar longitude not needed here; suppress unused-variable warning */
+}
+
+/* Compute the moon's topocentric-ish altitude (radians) at time t for an
+ * observer at (lon degrees, precomputed sin_lat/cos_lat).  The JD/sidereal
+ * setup uses double; the trig for dec/H/altitude uses float per the P4
+ * single-precision FPU constraint. */
+static float moon_alt_at(time_t t, double lon, float sin_lat, float cos_lat)
+{
+    double ra_deg, dec_deg;
+    moon_ra_dec_at(t, &ra_deg, &dec_deg);
+
+    /* GMST0 via Schlyter: GMST0 = Ls + 180 (degrees), where Ls = ws + Ms. */
+    double d_t     = (double)t / 86400.0 + 2440587.5 - 2451543.5;
+    double ws_t    = 282.9404 + 4.70935e-5 * d_t;
+    double Ms_t    = rev(356.0470 + 0.9856002585 * d_t);
+    double Ls_t    = rev(ws_t + Ms_t);
+    double gmst0_t = rev(Ls_t + 180.0);                  /* degrees */
+
+    double ut_hours_t = fmod((double)t / 3600.0, 24.0);
+    if (ut_hours_t < 0.0) ut_hours_t += 24.0;
+
+    double lst_t  = rev(gmst0_t + 15.0 * ut_hours_t + lon); /* degrees */
+    double H_deg  = lst_t - ra_deg;                          /* hour angle, degrees */
+
+    /* Altitude trig in float (single-precision FPU). */
+    float dec_rad = (float)(dec_deg * (M_PI / 180.0));
+    float H_rad   = (float)(H_deg   * (M_PI / 180.0));
+    float sin_dec = sinf(dec_rad);
+    float cos_dec = cosf(dec_rad);
+    float cos_H   = cosf(H_rad);
+
+    float sin_alt = sin_lat * sin_dec + cos_lat * cos_dec * cos_H;
+    if (sin_alt >  1.0f) sin_alt =  1.0f;
+    if (sin_alt < -1.0f) sin_alt = -1.0f;
+    return asinf(sin_alt);   /* radians */
+}
+
+/* Compute the current/next moon up-period relative to `now`.
+ *
+ * Semantics (relative to the moment `now` is called):
+ *   *set  = first downward horizon crossing AFTER now (end of current/next up-period).
+ *   *rise:
+ *     - moon UP   at now -> most recent upward crossing at or before now
+ *                           (the rise that started the current up-period);
+ *     - moon DOWN at now -> first upward crossing after now (the next rise).
+ *
+ * Search window: [now - 26 h, now + 50 h] at 10-minute steps (456 samples, 76 h).
+ * This window guarantees that at least one full up-period is captured regardless
+ * of where `now` falls in the ~24.8 h lunar day.
+ *
+ * If lat==0.0 && lon==0.0 (location unset), both events are marked invalid.
+ * If no crossing is found in the window, *_valid is false and the time is 0. */
+void moon_rise_set(time_t now, double lat, double lon,
+                   time_t *rise, bool *rise_valid,
+                   time_t *set,  bool *set_valid)
+{
+    *rise_valid = false;
+    *set_valid  = false;
+    *rise       = 0;
+    *set        = 0;
+
+    if (lat == 0.0 && lon == 0.0) {
+        return;  /* location unset */
+    }
+
+    /* Standard moonrise/set horizon: refraction + semidiameter - parallax net. */
+    const float h0_rad = 0.125f * (float)(M_PI / 180.0);
+
+    /* Precompute observer latitude trig once (doubles -> float for altitude loop). */
+    float sin_lat = sinf((float)(lat * (M_PI / 180.0)));
+    float cos_lat = cosf((float)(lat * (M_PI / 180.0)));
+
+    /* Search window: 26 h before now .. 50 h after now (76 h total).
+     * Step = 10 minutes (600 s); 456 + 1 = 457 samples. */
+    const int   STEP_S   = 600;
+    const int   BACK_S   = 26 * 3600;           /* look-back to find current rise */
+    const int   FWRD_S   = 50 * 3600;           /* look-ahead to find next set    */
+    const int   WIN_S    = BACK_S + FWRD_S;
+    const int   N_STEPS  = WIN_S / STEP_S + 1;  /* 457 samples */
+
+    time_t win_start = now - (time_t)BACK_S;
+
+    /* Determine whether the moon is currently above the horizon. */
+    bool up_now = (moon_alt_at(now, lon, sin_lat, cos_lat) >= h0_rad);
+
+    /* Scan crossings across the window, collecting:
+     *   rise_before - latest upward crossing with interpolated_time <= now
+     *   rise_after  - earliest upward crossing with interpolated_time  > now
+     *   set_after   - earliest downward crossing with interpolated_time > now */
+    time_t rise_before = 0, rise_after = 0, set_after = 0;
+    bool   have_rise_before = false, have_rise_after = false, have_set_after = false;
+
+    float prev_alt  = moon_alt_at(win_start, lon, sin_lat, cos_lat);
+
+    for (int i = 1; i < N_STEPS; i++) {
+        time_t t   = win_start + (time_t)(i * STEP_S);
+        float  alt = moon_alt_at(t, lon, sin_lat, cos_lat);
+
+        float prev_v = prev_alt - h0_rad;
+        float cur_v  = alt      - h0_rad;
+
+        if (prev_v < 0.0f && cur_v >= 0.0f) {
+            /* Upward crossing — interpolate. */
+            float  frac    = prev_v / (prev_v - cur_v);   /* 0..1 within step */
+            time_t cross_t = win_start + (time_t)((i - 1) * STEP_S)
+                             + (time_t)(frac * STEP_S + 0.5f);
+
+            if (cross_t <= now) {
+                /* Keep the latest one before/at now. */
+                if (!have_rise_before || cross_t > rise_before) {
+                    rise_before     = cross_t;
+                    have_rise_before = true;
+                }
+            } else {
+                /* Keep only the earliest one after now. */
+                if (!have_rise_after) {
+                    rise_after     = cross_t;
+                    have_rise_after = true;
+                }
+            }
+        } else if (prev_v >= 0.0f && cur_v < 0.0f) {
+            /* Downward crossing — interpolate. */
+            float  frac    = prev_v / (prev_v - cur_v);
+            time_t cross_t = win_start + (time_t)((i - 1) * STEP_S)
+                             + (time_t)(frac * STEP_S + 0.5f);
+
+            /* Keep only the earliest downward crossing after now. */
+            if (cross_t > now && !have_set_after) {
+                set_after     = cross_t;
+                have_set_after = true;
+            }
+        }
+
+        prev_alt = alt;
+    }
+
+    /* Assign rise: if moon is currently up, report the rise that started this
+     * up-period; otherwise report the next upcoming rise. */
+    if (up_now) {
+        if (have_rise_before) {
+            *rise       = rise_before;
+            *rise_valid = true;
+        } else if (have_rise_after) {   /* fallback: window too short to find prior */
+            *rise       = rise_after;
+            *rise_valid = true;
+        }
+    } else {
+        if (have_rise_after) {
+            *rise       = rise_after;
+            *rise_valid = true;
+        } else if (have_rise_before) {  /* fallback: window too short to find next */
+            *rise       = rise_before;
+            *rise_valid = true;
+        }
+    }
+
+    /* Assign set: always the first downward crossing after now. */
+    if (have_set_after) {
+        *set       = set_after;
+        *set_valid = true;
+    }
+}

--- a/main/moon_ephemeris.h
+++ b/main/moon_ephemeris.h
@@ -37,6 +37,24 @@ void moon_compute(time_t utc, double lat, double lon, moon_state_t *out);
  * through the moon cycle. */
 void moon_state_from_cycle(double cycle, float orient_rad, moon_state_t *out);
 
+/* Compute the current/next moon up-period relative to `now`.
+ * lat/lon are observer coordinates in decimal degrees.
+ * If lat==0.0 && lon==0.0 (location unset) both events are marked invalid.
+ *
+ * *set  = first downward horizon crossing AFTER now (end of current or next
+ *         up-period); *set_valid = false if none found in the search window.
+ * *rise:
+ *   - moon UP   at now -> UTC time of the upward crossing that STARTED the
+ *                         current up-period (the most recent rise <= now).
+ *   - moon DOWN at now -> UTC time of the NEXT upward crossing after now.
+ *   *rise_valid = false if no such crossing is found in the search window.
+ *
+ * h0 = +0.125 deg (refraction + parallax approximation).
+ * Search window: [now - 26 h, now + 50 h] at 10-minute steps (76 h total). */
+void moon_rise_set(time_t now, double lat, double lon,
+                   time_t *rise, bool *rise_valid,
+                   time_t *set,  bool *set_valid);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/moon_sphere.cpp
+++ b/main/moon_sphere.cpp
@@ -224,44 +224,55 @@ static bool alloc_texture(int w, int h)
     return true;
 }
 
-/* Apply the RUNTIME texture mirrors to the already-filled texture buffer
+/* RUNTIME texture mirrors applied in place to the already-filled texture buffer
  * (s_tex_buf, s_tex_w x s_tex_h, RGB565). The flip state comes from the live
  * config (cfg->moon_flip_u / cfg->moon_flip_v), NOT the compile-time #defines:
  *  - flip_u mirrors columns (x -> w-1-x): east<->west longitude swap.
  *  - flip_v mirrors rows    (y -> h-1-y): north<->south latitude swap.
  * Both default OFF (config defaults 0), so the base orientation is unchanged on
- * defaults. Records the applied state in s_applied_flip_u/v so render_core can
- * detect a later config change and re-decode. Mirroring runs unconditionally
- * based on the runtime booleans (no #if) so toggling from the web UI works. */
+ * defaults. apply_texture_flips() records the applied state in s_applied_flip_u/v
+ * so render_core can detect a later config change and re-flip the buffer in place
+ * (no JPEG re-decode). The mirror helpers are self-inverse, so toggling an axis
+ * from the web UI is just one more mirror of that axis. */
+/* Mirror the decoded texture columns in place (east<->west, the flip_u axis).
+ * Self-inverse: calling it again restores the original. */
+static void mirror_texture_u(void)
+{
+    for (int y = 0; y < s_tex_h; y++) {
+        uint16_t *row = s_tex_buf + (size_t)y * (size_t)s_tex_w;
+        for (int x = 0; x < s_tex_w / 2; x++) {
+            uint16_t t = row[x];
+            row[x] = row[s_tex_w - 1 - x];
+            row[s_tex_w - 1 - x] = t;
+        }
+    }
+}
+
+/* Mirror the decoded texture rows in place (north<->south, the flip_v axis).
+ * Self-inverse. */
+static void mirror_texture_v(void)
+{
+    for (int y = 0; y < s_tex_h / 2; y++) {
+        uint16_t *a = s_tex_buf + (size_t)y * (size_t)s_tex_w;
+        uint16_t *b = s_tex_buf + (size_t)(s_tex_h - 1 - y) * (size_t)s_tex_w;
+        for (int x = 0; x < s_tex_w; x++) {
+            uint16_t t = a[x];
+            a[x] = b[x];
+            b[x] = t;
+        }
+    }
+}
+
 static void apply_texture_flips(void)
 {
     const app_config_t *cfg = app_config_get();
     int flip_u = (cfg && cfg->moon_flip_u) ? 1 : 0;
     int flip_v = (cfg && cfg->moon_flip_v) ? 1 : 0;
 
-    if (flip_u) {
-        for (int y = 0; y < s_tex_h; y++) {
-            uint16_t *row = s_tex_buf + (size_t)y * (size_t)s_tex_w;
-            for (int x = 0; x < s_tex_w / 2; x++) {
-                uint16_t t = row[x];
-                row[x] = row[s_tex_w - 1 - x];
-                row[s_tex_w - 1 - x] = t;
-            }
-        }
-    }
-    if (flip_v) {
-        for (int y = 0; y < s_tex_h / 2; y++) {
-            uint16_t *a = s_tex_buf + (size_t)y * (size_t)s_tex_w;
-            uint16_t *b = s_tex_buf + (size_t)(s_tex_h - 1 - y) * (size_t)s_tex_w;
-            for (int x = 0; x < s_tex_w; x++) {
-                uint16_t t = a[x];
-                a[x] = b[x];
-                b[x] = t;
-            }
-        }
-    }
+    if (flip_u) mirror_texture_u();
+    if (flip_v) mirror_texture_v();
 
-    /* Remember what is now baked into the buffer for live re-decode detection. */
+    /* Remember what is now baked into the buffer for live re-flip detection. */
     s_applied_flip_u = flip_u;
     s_applied_flip_v = flip_v;
 }
@@ -355,12 +366,14 @@ extern "C" bool moon_sphere_init(void)
     return s_inited;
 }
 
-/* Re-decode the texture if the live flip config differs from what is currently
- * baked into s_tex_buf. Re-runs the real (or placeholder) decode, which calls
- * apply_texture_flips() with the CURRENT config, so flip toggles from the web UI
- * take effect on the next render. Guarded by the init mutex; alloc_texture()
- * frees the old buffer before re-allocating, so there is no leak. No-op when the
- * flip state already matches (the common case, zero cost on the steady path). */
+/* Apply a live flip-config change to the EXISTING decoded texture buffer in
+ * place, with no JPEG re-decode. A flip is a row/column mirror, which is its own
+ * inverse, so toggling an axis = mirroring that axis once. This avoids the large
+ * (~1.5MB) PSRAM decode spike that init_real_texture() incurs; that spike landed
+ * mid-render (on top of the live 720x720 color+z scratch) and could fail with
+ * outofmem under concurrent load (e.g. an OTA check), falling back to the ugly
+ * placeholder. Guarded by the init mutex. No-op when the flip state already
+ * matches (the common steady-state path, zero cost). */
 static void moon_sphere_reflip_if_changed(void)
 {
     const app_config_t *cfg = app_config_get();
@@ -369,11 +382,25 @@ static void moon_sphere_reflip_if_changed(void)
     if (want_u == s_applied_flip_u && want_v == s_applied_flip_v) return;
 
     if (s_init_mtx) xSemaphoreTake(s_init_mtx, portMAX_DELAY);
-    /* Re-check under the lock in case another task already re-decoded. */
+    /* Re-check under the lock in case another task already re-flipped. */
     if (want_u != s_applied_flip_u || want_v != s_applied_flip_v) {
-        /* init_real_texture() / init_placeholder_texture() re-alloc (freeing the
-         * old buffer) and re-apply the now-current flips. */
-        if (!init_real_texture()) init_placeholder_texture();
+        if (s_tex_buf == nullptr) {
+            /* No texture decoded yet (shouldn't happen post-init): do a full
+             * decode, which applies the current flips itself. */
+            if (!init_real_texture()) init_placeholder_texture();
+        } else {
+            /* Apply only the delta in place. Column/row mirrors commute and are
+             * self-inverse, so mirroring the changed axis once reaches the target
+             * state from any prior state. */
+            if (want_u != s_applied_flip_u) {
+                mirror_texture_u();
+                s_applied_flip_u = want_u;
+            }
+            if (want_v != s_applied_flip_v) {
+                mirror_texture_v();
+                s_applied_flip_v = want_v;
+            }
+        }
     }
     if (s_init_mtx) xSemaphoreGive(s_init_mtx);
 }

--- a/main/power_mgmt.c
+++ b/main/power_mgmt.c
@@ -87,14 +87,64 @@ void power_mgmt_check_crash(void)
         s_crash_count = 0;
         s_last_crash_reason = 0;
         ESP_LOGI(TAG, "Power-on reset — crash history cleared");
-    } else if (reason == ESP_RST_PANIC ||
-               reason == ESP_RST_INT_WDT ||
-               reason == ESP_RST_TASK_WDT) {
+    } else if (power_mgmt_reset_is_abnormal((uint32_t)reason)) {
         s_crash_count++;
         s_last_crash_reason = (uint32_t)reason;
-        ESP_LOGW(TAG, "Crash reset detected: reason=%d, crash_count=%lu",
-                 (int)reason, (unsigned long)s_crash_count);
+        ESP_LOGW(TAG, "Crash reset detected: reason=%d (%s), crash_count=%lu",
+                 (int)reason, power_mgmt_reset_reason_str((uint32_t)reason),
+                 (unsigned long)s_crash_count);
     }
+}
+
+const char *power_mgmt_reset_reason_str(uint32_t reason)
+{
+    switch ((esp_reset_reason_t)reason) {
+        case ESP_RST_UNKNOWN:    return "Unknown";
+        case ESP_RST_POWERON:    return "Power-on";
+        case ESP_RST_EXT:        return "External pin";
+        case ESP_RST_SW:         return "Software restart";
+        case ESP_RST_PANIC:      return "Panic / exception";
+        case ESP_RST_INT_WDT:    return "Interrupt watchdog";
+        case ESP_RST_TASK_WDT:   return "Task watchdog";
+        case ESP_RST_WDT:        return "Other watchdog";
+        case ESP_RST_DEEPSLEEP:  return "Deep sleep wake";
+        case ESP_RST_BROWNOUT:   return "Brownout / power loss";
+        case ESP_RST_SDIO:       return "SDIO reset";
+        case ESP_RST_USB:        return "USB peripheral reset";
+        case ESP_RST_JTAG:       return "JTAG reset";
+#if defined(ESP_RST_EFUSE)
+        case ESP_RST_EFUSE:      return "eFuse error";
+#endif
+#if defined(ESP_RST_PWR_GLITCH)
+        case ESP_RST_PWR_GLITCH: return "Power glitch";
+#endif
+#if defined(ESP_RST_CPU_LOCKUP)
+        case ESP_RST_CPU_LOCKUP: return "CPU lockup";
+#endif
+        default:                 return "Unknown";
+    }
+}
+
+bool power_mgmt_reset_is_abnormal(uint32_t reason)
+{
+    switch ((esp_reset_reason_t)reason) {
+        case ESP_RST_PANIC:
+        case ESP_RST_INT_WDT:
+        case ESP_RST_TASK_WDT:
+        case ESP_RST_WDT:
+        case ESP_RST_BROWNOUT:
+#if defined(ESP_RST_CPU_LOCKUP)
+        case ESP_RST_CPU_LOCKUP:
+#endif
+            return true;
+        default:
+            return false;
+    }
+}
+
+uint32_t power_mgmt_get_last_reset_reason(void)
+{
+    return (uint32_t)esp_reset_reason();
 }
 
 power_mgmt_crash_info_t power_mgmt_get_crash_info(void)

--- a/main/power_mgmt.h
+++ b/main/power_mgmt.h
@@ -3,6 +3,7 @@
 #include "esp_err.h"
 #include "esp_sleep.h"
 #include <stdint.h>
+#include <stdbool.h>
 
 /**
  * Initialize power management — enables Dynamic Frequency Scaling.
@@ -53,3 +54,23 @@ void power_mgmt_check_crash(void);
  * Get crash info (crash count, last reason, boot count).
  */
 power_mgmt_crash_info_t power_mgmt_get_crash_info(void);
+
+/**
+ * Map an esp_reset_reason_t value to a short human-readable string.
+ * Always returns a valid non-NULL static string.
+ */
+const char *power_mgmt_reset_reason_str(uint32_t reason);
+
+/**
+ * Return true if the given reset reason represents an abnormal reset
+ * worth recording as a crash (PANIC, INT_WDT, TASK_WDT, WDT, BROWNOUT,
+ * CPU_LOCKUP). Normal resets (power-on, software restart, deep-sleep
+ * wake, external pin) return false.
+ */
+bool power_mgmt_reset_is_abnormal(uint32_t reason);
+
+/**
+ * Convenience wrapper around esp_reset_reason() returning the raw value
+ * as uint32_t (the value latched at this boot).
+ */
+uint32_t power_mgmt_get_last_reset_reason(void);

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -663,6 +663,137 @@ void moon_caption(char *name_out, size_t name_sz, char *pct_out, size_t pct_sz)
     snprintf(pct_out, pct_sz, "%d%%", (int)(s_moon_state.illum * 100.0f + 0.5f));
 }
 
+/* Cached rise/set results — recomputed at most once per 30 s or on location
+ * change.  Avoids running the 457-sample scan on every drag frame. */
+static time_t s_rs_calc_at  = 0;
+static time_t s_rs_rise     = 0;
+static time_t s_rs_set      = 0;
+static bool   s_rs_rise_v   = false;
+static bool   s_rs_set_v    = false;
+static double s_rs_lat      = 1e9;
+static double s_rs_lon      = 1e9;
+
+/* Return the signed difference in LOCAL calendar days between evt and now.
+ * Normalises both instants to local noon before subtracting so DST transitions
+ * within the interval do not produce off-by-one errors. */
+static int local_day_delta(time_t evt, time_t ref)
+{
+    struct tm ta, tb;
+    localtime_r(&evt, &ta);
+    localtime_r(&ref, &tb);
+    ta.tm_hour = 12; ta.tm_min = 0; ta.tm_sec = 0; ta.tm_isdst = -1;
+    tb.tm_hour = 12; tb.tm_min = 0; tb.tm_sec = 0; tb.tm_isdst = -1;
+    time_t na = mktime(&ta);
+    time_t nb = mktime(&tb);
+    return (int)lround((double)(na - nb) / 86400.0);
+}
+
+/* Format a single moon event (rise or set) into `out[sz]`.
+ * Output examples (all fit within 20 bytes including NUL):
+ *   "Rise 14:32"       24h, same day
+ *   "Rise 2:34am +1"   12h, next day
+ *   "Set 09:02 -1"     24h, previous day
+ *   "Rise --:--"       invalid */
+static void fmt_moon_event(char *out, size_t sz, const char *label,
+                           time_t evt, bool valid, time_t now_t, bool use_24h)
+{
+    if (!valid) {
+        snprintf(out, sz, "%s --:--", label);
+        return;
+    }
+
+    struct tm lt;
+    localtime_r(&evt, &lt);
+
+    /* Time string: 5 chars for 24h "HH:MM", up to 7 for 12h "12:34pm". */
+    char tbuf[10];
+    if (use_24h) {
+        strftime(tbuf, sizeof(tbuf), "%H:%M", &lt);
+    } else {
+        int hr = lt.tm_hour % 12;
+        if (hr == 0) hr = 12;
+        snprintf(tbuf, sizeof(tbuf), "%d:%02d%s",
+                 hr, lt.tm_min, lt.tm_hour < 12 ? "am" : "pm");
+    }
+
+    /* Day-offset suffix: "" / " +N" / " -N". Sized for the full int range so
+     * -Werror=format-truncation is satisfied (delta is realistically +/-1..2). */
+    char sfx[16] = "";
+    int  delta   = local_day_delta(evt, now_t);
+    if (delta > 0) {
+        snprintf(sfx, sizeof(sfx), " +%d", delta);
+    } else if (delta < 0) {
+        snprintf(sfx, sizeof(sfx), " %d", delta);   /* "-N" via %d with negative */
+    }
+
+    /* Longest possible result: "Rise 12:34pm +1\0" = 16 chars — fits in 20. */
+    snprintf(out, sz, "%s %s%s", label, tbuf, sfx);
+}
+
+/* Fills the four moon-overlay corner strings.  All buffers must be non-NULL.
+ *   age:  "Age 11.2d"
+ *   next: "Full in 3d" or "New in 18d" (whichever lunar event is sooner);
+ *         "Full <1d" / "New <1d" when less than one day away.
+ *   rise: "Rise 14:32"  or  "Rise --:--" (24h when cfg->weather_time_format==1,
+ *         12h e.g. "Rise 2:34am" otherwise).  A day-offset suffix " +N" / " -N"
+ *         is appended when the event falls on a different local calendar day.
+ *   set:  same format as rise.
+ * Reads cached s_moon_state (lock-free, single writer) for age/next; calls
+ * moon_rise_set() at most once per 30 s (throttled) for the rise/set times. */
+void moon_overlay_info(char *age,  size_t age_sz,
+                       char *next, size_t next_sz,
+                       char *rise, size_t rise_sz,
+                       char *set,  size_t set_sz)
+{
+    const double SYNODIC = 29.530588853;
+
+    /* --- Age --- */
+    double cycle = (double)s_moon_state.cycle;
+    double age_days = cycle * SYNODIC;
+    snprintf(age, age_sz, "Age %.1fd", age_days);
+
+    /* --- Next phase (Full or New, whichever is sooner) --- */
+    double days_to_full = fmod(0.5 - cycle + 1.0, 1.0) * SYNODIC;
+    double days_to_new  = fmod(1.0 - cycle,        1.0) * SYNODIC;
+    /* fmod(1.0 - 0.0, 1.0) == 0.0, which means "already new"; push to a full
+     * cycle so we report "New in 29.5d" rather than "New in 0d". */
+    if (days_to_new < 0.01) days_to_new = SYNODIC;
+
+    if (days_to_full <= days_to_new) {
+        if (days_to_full < 1.0)
+            snprintf(next, next_sz, "Full <1d");
+        else
+            snprintf(next, next_sz, "Full in %.0fd", days_to_full);
+    } else {
+        if (days_to_new < 1.0)
+            snprintf(next, next_sz, "New <1d");
+        else
+            snprintf(next, next_sz, "New in %.0fd", days_to_new);
+    }
+
+    /* --- Rise / Set (throttled) --- */
+    const app_config_t *cfg = app_config_get();
+    double lat = cfg->moon_lat, lon = cfg->moon_lon;
+    if (lat == 0.0 && lon == 0.0) { lat = cfg->weather_lat; lon = cfg->weather_lon; }
+
+    time_t now;
+    time(&now);
+
+    /* Recompute only when the cache is stale (>= 30 s old) or location changed. */
+    if (s_rs_calc_at == 0 || (now - s_rs_calc_at) >= 30 ||
+        lat != s_rs_lat  || lon != s_rs_lon) {
+        moon_rise_set(now, lat, lon, &s_rs_rise, &s_rs_rise_v, &s_rs_set, &s_rs_set_v);
+        s_rs_calc_at = now;
+        s_rs_lat     = lat;
+        s_rs_lon     = lon;
+    }
+
+    bool use_24h = (cfg->weather_time_format == 1);
+
+    fmt_moon_event(rise, rise_sz, "Rise", s_rs_rise, s_rs_rise_v, now, use_24h);
+    fmt_moon_event(set,  set_sz,  "Set",  s_rs_set,  s_rs_set_v,  now, use_24h);
+}
+
 void goes_poll_task(void *arg)
 {
     ESP_LOGI(TAG, "GOES poll task started");
@@ -1076,15 +1207,20 @@ void goes_poll_task(void *arg)
                         goes_data.connected = true;
                         goes_data.last_poll_ms = esp_timer_get_time() / 1000;
                         goes_data_unlock(&goes_data);
-                        /* After a drag the on-screen image is the last settle frame
-                         * (240px @ TRUE_PHASE, PPA-upscaled, already visually close to
-                         * this resting frame). Push this OWNED native-720 resting frame
-                         * now so it REPLACES that frame, rather than waiting on the UI
-                         * cadence whose new-image gate could tie on an equal-millisecond
-                         * timestamp. force_redraw bypasses that gate; the swap is instant
-                         * (matching every other moon frame) so there is no midpoint
-                         * brightness dip as the crisp resting frame comes in. */
-                        if (ran_drag && image_display_page_active &&
+                        /* Push this OWNED native-720 resting frame to the panel
+                         * immediately rather than waiting on the periodic UI cadence
+                         * (data_update_task, up to update_rate_s away) to notice the new
+                         * goes_data timestamp via its new-image gate. This makes
+                         * config-driven re-renders (flip / background / orientation
+                         * toggles from the web UI, which wake this task via
+                         * xTaskNotifyGive) appear as soon as the render completes,
+                         * matching the snappiness of the other live settings. It also
+                         * still REPLACES the post-drag 240px settle frame, whose
+                         * equal-millisecond timestamp the cadence gate could otherwise
+                         * tie on and skip. force_redraw bypasses that gate; the swap is
+                         * instant (matching every other moon frame) so there is no
+                         * midpoint brightness dip. */
+                        if (image_display_page_active &&
                             cfg->image_display_source == 1) {
                             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                                 nina_image_display_force_redraw();

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -51,6 +51,7 @@
 #include <math.h>          /* expf — framerate-independent settle ease */
 #include "perf_monitor.h"
 #include "power_mgmt.h"
+#include "crash_log.h"
 #include "demo_data.h"
 #include "weather_client.h"
 #include "driver/jpeg_decode.h"
@@ -1734,6 +1735,7 @@ void data_update_task(void *arg) {
     }
 
     int64_t last_rotate_ms = 0;
+    int64_t last_crash_purge_ms = 0;  /* daily crash-log retention purge tick */
 
     /* Screen sleep state */
     int64_t all_disconnected_since_ms = 0;  /* 0 = at least one connected recently */
@@ -2331,6 +2333,16 @@ main_loop:
         }
 
         int64_t now_ms = esp_timer_get_time() / 1000;
+
+        /* Once-daily crash-log retention purge (piggybacked on this loop — no
+         * dedicated task). First pass runs ~24 h after boot; the boot-time purge
+         * inside crash_log_init() covers the startup case. */
+        if (last_crash_purge_ms == 0) {
+            last_crash_purge_ms = now_ms;
+        } else if (now_ms - last_crash_purge_ms >= (int64_t)86400 * 1000) {
+            crash_log_purge_old(app_config_get()->crash_log_retention_days);
+            last_crash_purge_ms = now_ms;
+        }
 
         /* Update active/background flags for poll tasks.
          * On summary page all instances are active; on a NINA page only that instance is. */

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -34,9 +34,13 @@ extern _Atomic bool moon_anim_request;
 
 static const char *TAG = "image_display";
 
-/* Overlay label font — overpass_27 is unconditionally compiled into the
- * firmware (see main/CMakeLists.txt), so it avoids any dependency on the
- * LV_FONT_MONTSERRAT_* Kconfig toggles. */
+/* Overlay label font — unconditionally compiled into the firmware
+ * (see main/CMakeLists.txt), so it avoids any dependency on the
+ * LV_FONT_MONTSERRAT_* Kconfig toggles.  All overlay labels (bottom phase /
+ * timestamp and the four moon-corner info labels) use overpass_27 for
+ * readability at desk distance.  At this size the longest strings reach past
+ * the inscribed moon disc; each label's translucent chip background keeps the
+ * text legible where it overlaps the moon. */
 extern const lv_font_t lv_font_overpass_27;
 
 static lv_obj_t *page_container;
@@ -45,6 +49,14 @@ static lv_obj_t *img_back;
 static lv_obj_t *overlay_bar;
 static lv_obj_t *lbl_region;
 static lv_obj_t *lbl_timestamp;
+
+/* Moon-only corner info labels (top-left pair: age/next; top-right pair: rise/set).
+ * NULL-initialised; created lazily inside nina_image_display_create() and guarded
+ * before every access.  Only shown when source==1 AND overlay is visible. */
+static lv_obj_t *lbl_moon_age  = NULL;
+static lv_obj_t *lbl_moon_next = NULL;
+static lv_obj_t *lbl_moon_rise = NULL;
+static lv_obj_t *lbl_moon_set  = NULL;
 
 /* One persistent RGB565 descriptor per image slot. The slot whose image is
  * currently "front" owns the displayed buffer; the "back" slot owns the
@@ -253,6 +265,70 @@ static void moon_drag_released_cb(lv_event_t *e)
     if (goes_task_handle) xTaskNotifyGive(goes_task_handle);
 }
 
+/* Apply the "chip" style to a label: small translucent rounded background that
+ * keeps text legible when the main overlay bar is nearly transparent.
+ * bg_opa=120 (~47%), corner radius=8, horizontal pad=8, vertical pad=3.
+ * The label's own bg colour is set to black; text colour is always white so it
+ * is never inadvertently overridden by apply_theme() later. */
+static void apply_chip_style(lv_obj_t *lbl)
+{
+    lv_obj_set_style_bg_color(lbl,   lv_color_black(), 0);
+    lv_obj_set_style_bg_opa(lbl,     120,              0);
+    lv_obj_set_style_radius(lbl,     8,                0);
+    lv_obj_set_style_pad_left(lbl,   8,                0);
+    lv_obj_set_style_pad_right(lbl,  8,                0);
+    lv_obj_set_style_pad_top(lbl,    3,                0);
+    lv_obj_set_style_pad_bottom(lbl, 3,                0);
+    lv_obj_set_style_text_color(lbl, lv_color_white(), 0);
+}
+
+/* extern declaration for moon_overlay_info — owned by moon_ephemeris.c,
+ * parallel to the existing moon_caption() extern declarations scattered at each
+ * call site.  Placed here so all three call sites below can share one decl. */
+extern void moon_overlay_info(char *age,  size_t age_sz,
+                              char *next, size_t next_sz,
+                              char *rise, size_t rise_sz,
+                              char *set,  size_t set_sz);
+
+static void hide_moon_corner_labels(void);
+
+/* Show the four moon corner labels and populate them from moon_overlay_info().
+ * Called from every moon update path.  Guards against NULL in case the labels
+ * were not yet created or have already been cleaned up. */
+static void update_moon_corner_labels(void)
+{
+    if (!lbl_moon_age) return;
+    /* The corner labels track overlay visibility. overlay_bar's HIDDEN flag is the
+     * single source of truth (set by the initial config check and by
+     * nina_image_display_set_overlay_visible). Without this guard the live drag
+     * paths (show_scaled / show_borrowed) would re-show the labels on every frame
+     * even while the overlay is turned off. */
+    if (overlay_bar && lv_obj_has_flag(overlay_bar, LV_OBJ_FLAG_HIDDEN)) {
+        hide_moon_corner_labels();
+        return;
+    }
+    char age[20], next[20], rise[20], set[20];
+    moon_overlay_info(age, sizeof(age), next, sizeof(next),
+                      rise, sizeof(rise), set, sizeof(set));
+    lv_label_set_text(lbl_moon_age,  age);
+    lv_label_set_text(lbl_moon_next, next);
+    lv_label_set_text(lbl_moon_rise, rise);
+    lv_label_set_text(lbl_moon_set,  set);
+    lv_obj_clear_flag(lbl_moon_age,  LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_moon_next, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_moon_rise, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(lbl_moon_set,  LV_OBJ_FLAG_HIDDEN);
+}
+
+/* Hide the four moon corner labels (non-Moon sources and overlay-off state). */
+static void hide_moon_corner_labels(void)
+{
+    if (lbl_moon_age)  lv_obj_add_flag(lbl_moon_age,  LV_OBJ_FLAG_HIDDEN);
+    if (lbl_moon_next) lv_obj_add_flag(lbl_moon_next, LV_OBJ_FLAG_HIDDEN);
+    if (lbl_moon_rise) lv_obj_add_flag(lbl_moon_rise, LV_OBJ_FLAG_HIDDEN);
+    if (lbl_moon_set)  lv_obj_add_flag(lbl_moon_set,  LV_OBJ_FLAG_HIDDEN);
+}
+
 lv_obj_t *nina_image_display_create(lv_obj_t *parent)
 {
     page_container = lv_obj_create(parent);
@@ -329,26 +405,65 @@ lv_obj_t *nina_image_display_create(lv_obj_t *parent)
     lv_obj_remove_style_all(overlay_bar);
     lv_obj_set_size(overlay_bar, SCREEN_SIZE, 68);
     lv_obj_align(overlay_bar, LV_ALIGN_BOTTOM_MID, 0, 0);
-    lv_obj_set_style_bg_color(overlay_bar, lv_color_black(), 0);
-    lv_obj_set_style_bg_opa(overlay_bar, 210, 0);
-    lv_obj_set_style_pad_left(overlay_bar, 18, 0);
-    lv_obj_set_style_pad_right(overlay_bar, 18, 0);
+    /* No bar background: each bottom label carries its own translucent chip
+     * (apply_chip_style), so overlay_bar is just an invisible positioning
+     * container for lbl_region / lbl_timestamp. */
+    lv_obj_set_style_bg_opa(overlay_bar, LV_OPA_TRANSP, 0);
+    /* No edge padding — the bottom labels sit flush in the screen corners so they
+     * stay clear of the inscribed moon disc. */
+    lv_obj_set_style_pad_left(overlay_bar, 0, 0);
+    lv_obj_set_style_pad_right(overlay_bar, 0, 0);
     lv_obj_clear_flag(overlay_bar, LV_OBJ_FLAG_SCROLLABLE);
 
     lbl_region = lv_label_create(overlay_bar);
-    lv_obj_set_style_text_color(lbl_region, lv_color_white(), 0);
     lv_obj_set_style_text_font(lbl_region, &lv_font_overpass_27, 0);
-    lv_obj_align(lbl_region, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_obj_align(lbl_region, LV_ALIGN_BOTTOM_LEFT, 0, 0);
+    apply_chip_style(lbl_region);   /* white text + translucent chip bg */
     lv_label_set_text(lbl_region, "");
 
     lbl_timestamp = lv_label_create(overlay_bar);
-    lv_obj_set_style_text_color(lbl_timestamp, lv_color_hex(0xE8E8E8), 0);
     lv_obj_set_style_text_font(lbl_timestamp, &lv_font_overpass_27, 0);
-    lv_obj_align(lbl_timestamp, LV_ALIGN_RIGHT_MID, 0, 0);
+    lv_obj_align(lbl_timestamp, LV_ALIGN_BOTTOM_RIGHT, 0, 0);
+    apply_chip_style(lbl_timestamp);
     lv_label_set_text(lbl_timestamp, "");
+
+    /* Moon corner labels: children of page_container (NOT overlay_bar) so they
+     * sit at the TOP corners above the image.  Created after overlay_bar so their
+     * z-order keeps them on top.  Shown only for Moon source; start hidden. */
+    lbl_moon_age = lv_label_create(page_container);
+    lv_obj_set_style_text_font(lbl_moon_age, &lv_font_overpass_27, 0);
+    apply_chip_style(lbl_moon_age);
+    lv_obj_align(lbl_moon_age, LV_ALIGN_TOP_LEFT, 0, 0);
+    lv_label_set_text(lbl_moon_age, "");
+    lv_obj_add_flag(lbl_moon_age, LV_OBJ_FLAG_HIDDEN);
+
+    lbl_moon_next = lv_label_create(page_container);
+    lv_obj_set_style_text_font(lbl_moon_next, &lv_font_overpass_27, 0);
+    apply_chip_style(lbl_moon_next);
+    /* Stack flush below lbl_moon_age. At 27px the chip is line_height(39)+pad(6) =
+     * 45px tall, so the second row sits at y = 45 (chips touch, no gap). */
+    lv_obj_align(lbl_moon_next, LV_ALIGN_TOP_LEFT, 0, 45);
+    lv_label_set_text(lbl_moon_next, "");
+    lv_obj_add_flag(lbl_moon_next, LV_OBJ_FLAG_HIDDEN);
+
+    lbl_moon_rise = lv_label_create(page_container);
+    lv_obj_set_style_text_font(lbl_moon_rise, &lv_font_overpass_27, 0);
+    apply_chip_style(lbl_moon_rise);
+    lv_obj_align(lbl_moon_rise, LV_ALIGN_TOP_RIGHT, 0, 0);
+    lv_label_set_text(lbl_moon_rise, "");
+    lv_obj_add_flag(lbl_moon_rise, LV_OBJ_FLAG_HIDDEN);
+
+    lbl_moon_set = lv_label_create(page_container);
+    lv_obj_set_style_text_font(lbl_moon_set, &lv_font_overpass_27, 0);
+    apply_chip_style(lbl_moon_set);
+    lv_obj_align(lbl_moon_set, LV_ALIGN_TOP_RIGHT, 0, 45);
+    lv_label_set_text(lbl_moon_set, "");
+    lv_obj_add_flag(lbl_moon_set, LV_OBJ_FLAG_HIDDEN);
 
     if (!app_config_get()->image_display_show_overlay) {
         lv_obj_add_flag(overlay_bar, LV_OBJ_FLAG_HIDDEN);
+        /* Corner labels also start hidden when the overlay is off. */
+        hide_moon_corner_labels();
     }
     return page_container;
 }
@@ -565,17 +680,20 @@ void nina_image_display_update(goes_data_t *data)
         moon_caption(name, sizeof(name), pct, sizeof(pct));
         lv_label_set_text(lbl_region, name);
         lv_label_set_text(lbl_timestamp, pct);
+        update_moon_corner_labels();
     } else if (cfg->image_display_source == 2) {     /* Solar (SDO/AIA) */
         extern const char *solar_band_label(uint8_t idx);
         lv_label_set_text(lbl_region, solar_band_label(cfg->solar_band));
         time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);
         char ts[32]; strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
         lv_label_set_text(lbl_timestamp, ts);
+        hide_moon_corner_labels();
     } else {                                         /* GOES */
         lv_label_set_text(lbl_region, region_code_to_name(cfg->goes_region));
         time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);
         char ts[32]; strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
         lv_label_set_text(lbl_timestamp, ts);
+        hide_moon_corner_labels();
     }
 
     /* The new image is now committed (swap done, overlay labels updated). Hide
@@ -663,6 +781,7 @@ void nina_image_display_show_scaled(const uint16_t *buf, int w, int h)
     moon_caption(name, sizeof(name), pct, sizeof(pct));
     lv_label_set_text(lbl_region, name);
     lv_label_set_text(lbl_timestamp, pct);
+    update_moon_corner_labels();
 
     nina_wait_overlay_hide();
 }
@@ -727,6 +846,7 @@ void nina_image_display_show_borrowed(const uint16_t *buf, int w, int h)
     moon_caption(name, sizeof(name), pct, sizeof(pct));
     lv_label_set_text(lbl_region, name);
     lv_label_set_text(lbl_timestamp, pct);
+    update_moon_corner_labels();
 
     nina_wait_overlay_hide();
 }
@@ -789,13 +909,22 @@ void nina_image_display_set_overlay_visible(bool visible)
     if (!overlay_bar) return;
     if (visible) lv_obj_clear_flag(overlay_bar, LV_OBJ_FLAG_HIDDEN);
     else         lv_obj_add_flag(overlay_bar, LV_OBJ_FLAG_HIDDEN);
+
+    /* Corner labels follow the overlay visibility, but only ever show for Moon.
+     * When making visible, restore them only if we are actually on the Moon source;
+     * when hiding, always hide unconditionally. */
+    if (visible && app_config_get()->image_display_source == 1) {
+        update_moon_corner_labels();
+    } else {
+        hide_moon_corner_labels();
+    }
 }
 
 void nina_image_display_apply_theme(void)
 {
-    if (!overlay_bar || !current_theme) return;
-    int gb = app_config_get()->color_brightness;
-    lv_obj_set_style_text_color(
-        lbl_region,
-        lv_color_hex(app_config_apply_brightness(current_theme->text_color, gb)), 0);
+    /* lbl_region text colour is now enforced white by apply_chip_style() so the
+     * phase name remains legible regardless of theme.  The function is kept for
+     * future per-theme customisation of this page and for callers that invoke it
+     * unconditionally. */
+    (void)current_theme;
 }

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -169,6 +169,9 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     // Authentication
     cJSON_AddBoolToObject(obj, "auth_enabled", cfg->auth_enabled);
 
+    // Crash log
+    cJSON_AddNumberToObject(obj, "crash_log_retention_days", cfg->crash_log_retention_days);
+
     return obj;
 }
 
@@ -297,6 +300,7 @@ static const backup_field_t s_backup_fields[] = {
     {"deep_sleep_wake_timer_s","Deep Sleep Timer",   "System", false, false},
     {"deep_sleep_on_idle",   "Sleep on Idle",        "System", false, false},
     {"wifi_power_save",      "WiFi Power Save",      "System", false, false},
+    {"crash_log_retention_days","Crash Log Retention","System", false, false},
 
     /* AllSky */
     {"allsky_enabled",            "AllSky Enabled",       "AllSky", false, false},
@@ -980,6 +984,15 @@ static app_config_t *parse_config_from_json(cJSON *root)
 
     // Authentication toggle
     JSON_TO_BOOL(root, "auth_enabled", cfg->auth_enabled);
+
+    // Crash log retention (days; 0 = never, clamp to common preset range)
+    cJSON *clr_item = cJSON_GetObjectItem(root, "crash_log_retention_days");
+    if (cJSON_IsNumber(clr_item)) {
+        int v = clr_item->valueint;
+        if (v < 0) v = 0;
+        if (v > 255) v = 255;
+        cfg->crash_log_retention_days = (uint8_t)v;
+    }
 
     return cfg;
 }

--- a/main/web_handlers_logs.c
+++ b/main/web_handlers_logs.c
@@ -1,14 +1,19 @@
 /**
  * @file web_handlers_logs.c
- * @brief Web endpoints for the boot log capture buffer.
+ * @brief Web endpoints for the boot log capture buffer and persistent crash log.
  *
- * GET  /api/logs        -> streams the captured log oldest->newest as a
- *                          text/plain attachment, chunked from PSRAM.
- * POST /api/logs/clear  -> empties the capture buffer, returns {"ok":true}.
+ * GET  /api/logs            -> streams the captured log oldest->newest as a
+ *                              text/plain attachment, chunked from PSRAM.
+ * POST /api/logs/clear      -> empties the capture buffer, returns {"ok":true}.
+ * GET  /api/crashlog        -> streams the persistent crash-history JSONL file
+ *                              (text/plain attachment; the UI also fetches it
+ *                              inline). Empty body when no crashes recorded.
+ * POST /api/crashlog/clear  -> deletes the crash-history file, returns {"ok":true}.
  */
 
 #include "web_server_internal.h"
 #include "log_capture.h"
+#include "crash_log.h"
 #include "esp_heap_caps.h"
 #include <string.h>
 
@@ -67,6 +72,71 @@ esp_err_t logs_clear_post_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
     log_capture_clear();
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}
+
+// Handler for downloading / displaying the persistent crash-history file
+esp_err_t crashlog_get_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    /* Build the download filename from the configured hostname. */
+    const char *hostname = app_config_get()->hostname;
+    if (!hostname || hostname[0] == '\0') {
+        hostname = "ninadash";
+    }
+    char disp[96];
+    snprintf(disp, sizeof(disp),
+             "attachment; filename=\"%s-crashlog.jsonl\"", hostname);
+
+    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_set_hdr(req, "Content-Disposition", disp);
+
+    /* No crash history yet (or SPIFFS unmounted): respond 200 with empty body so
+     * the UI can render an "no crashes" state without treating it as an error. */
+    FILE *f = crash_log_open_read();
+    if (!f) {
+        httpd_resp_send(req, NULL, 0);
+        return ESP_OK;
+    }
+
+    char *chunk = heap_caps_malloc(LOG_CHUNK_SIZE, MALLOC_CAP_SPIRAM);
+    if (!chunk) {
+        fclose(f);
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    /* Stream the JSONL file start->end in PSRAM-sized chunks. */
+    for (;;) {
+        size_t got = fread(chunk, 1, LOG_CHUNK_SIZE, f);
+        if (got > 0) {
+            if (httpd_resp_send_chunk(req, chunk, got) != ESP_OK) {
+                heap_caps_free(chunk);
+                fclose(f);
+                return ESP_FAIL;  /* connection aborted; httpd cleans up */
+            }
+        }
+        if (got < LOG_CHUNK_SIZE) {
+            break;  /* EOF or short read */
+        }
+    }
+
+    heap_caps_free(chunk);
+    fclose(f);
+
+    /* Terminate the chunked response with a zero-length chunk. */
+    httpd_resp_send_chunk(req, NULL, 0);
+    return ESP_OK;
+}
+
+// Handler for clearing the persistent crash-history file
+esp_err_t crashlog_clear_post_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+    crash_log_clear();  /* idempotent, always ESP_OK */
     httpd_resp_set_type(req, "application/json");
     httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
     return ESP_OK;

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -607,6 +607,7 @@ static const char *reset_reason_to_str(uint32_t reason)
 // Handler for crash info
 esp_err_t crash_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     power_mgmt_crash_info_t info = power_mgmt_get_crash_info();
 
     cJSON *root = cJSON_CreateObject();

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -196,7 +196,7 @@ void start_web_server(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 16384;
-    config.max_uri_handlers = 49;
+    config.max_uri_handlers = 52;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -261,7 +261,15 @@ void start_web_server(void)
         { "/api/auth/status",        HTTP_GET,  auth_status_get_handler, NULL },
         { "/api/logs",               HTTP_GET,  logs_get_handler, NULL },
         { "/api/logs/clear",         HTTP_POST, logs_clear_post_handler, NULL },
+        { "/api/crashlog",           HTTP_GET,  crashlog_get_handler, NULL },
+        { "/api/crashlog/clear",     HTTP_POST, crashlog_clear_post_handler, NULL },
     };
+
+    /* Keep config.max_uri_handlers (set to 52 above) in sync with the route
+     * table; a route that overflows it would be silently dropped at
+     * registration. Bump both together when adding routes. */
+    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 52,
+                   "max_uri_handlers too small for route table");
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {
         httpd_register_uri_handler(server, &routes[i]);

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -112,4 +112,6 @@ esp_err_t wifi_status_get_handler(httpd_req_t *req);
 esp_err_t auth_status_get_handler(httpd_req_t *req);
 esp_err_t logs_get_handler(httpd_req_t *req);
 esp_err_t logs_clear_post_handler(httpd_req_t *req);
+esp_err_t crashlog_get_handler(httpd_req_t *req);
+esp_err_t crashlog_clear_post_handler(httpd_req_t *req);
 void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t *new_cfg);


### PR DESCRIPTION
### Summary
This PR improves the accuracy of moon orientation by adding ephemeris calculations for moon rise and set times. It also introduces a setting for crash log retention and redesigns the Logs tab user interface.

### Changes
*   Improve moon orientation accuracy by calculating moon rise and set ephemeris and tuning default settings.
*   Add a configurable setting for crash log retention, allowing users to specify how many crash logs to keep.
*   Redesign the Logs tab user interface with a unified Device/Crash log toggle, a horizontal toolbar, and viewport-constrained scrolling.
*   Update the application configuration to version 41, incorporating new settings.
*   Fix an issue where the last active tab was not restored correctly on page load.
*   Lower the default moon free-spin return delay from 10 seconds to 3 seconds.

---
<sub>Analyzed **6** commit(s) | Updated: 2026-06-04T13:26:08.967Z | Generated by GitHub Actions</sub>