### PR TITLE
feat: add Image Display to auto-rotate pages

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -697,8 +697,10 @@ static void set_defaults(app_config_t *cfg) {
     cfg->auto_rotate_effect = 0;
     cfg->auto_rotate_skip_disconnected = true;
     cfg->auto_rotate_pages = 0x0E;  // Default: all NINA instances (bits 1-3)
+    cfg->auto_rotate_pages_hi = 0;  // bits 8-15 off by default (Image Display opt-in, like AllSky/Spotify/Clock)
     /* Default rotation order: Summary, AllSky, Spotify, Clock, NINA1, NINA2, NINA3, SysInfo */
     for (int i = 0; i < 8; i++) cfg->auto_rotate_order[i] = (uint8_t)i;
+    cfg->auto_rotate_order_ext = 8;  // 9th slot = bit index 8 (Image Display)
     cfg->update_rate_s = 5;
     cfg->graph_update_interval_s = 10;
     cfg->connection_timeout_s = 6;
@@ -1844,6 +1846,22 @@ static void migrate_from_v40(const void *raw, size_t raw_size, app_config_t *cfg
     ESP_LOGI(TAG, "Migrated config from v40 to v%d", APP_CONFIG_VERSION);
 }
 
+static void migrate_from_v41(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v41_t) ? raw_size : sizeof(app_config_v41_t);
+    memcpy(cfg, raw, copy);
+
+    /* auto_rotate_pages_hi / auto_rotate_order_ext: new in v42, appended past the
+     * v41 snapshot — keep the set_defaults() values (Image Display bit off, 9th
+     * order slot = bit 8). */
+    cfg->auto_rotate_pages_hi = 0;
+    cfg->auto_rotate_order_ext = 8;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v41 to v%d", APP_CONFIG_VERSION);
+}
+
 static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -2404,6 +2422,7 @@ static bool validate_config(app_config_t *cfg) {
     /* Validate rotation order — reset to default if first entry is 0xFF (uninitialised) */
     if (cfg->auto_rotate_order[0] == 0xFF) {
         for (int i = 0; i < 8; i++) cfg->auto_rotate_order[i] = (uint8_t)i;
+        cfg->auto_rotate_order_ext = 8;  // 9th slot = Image Display bit index
         fixed = true;
     }
     if (cfg->update_rate_s < 1 || cfg->update_rate_s > 10) {
@@ -2574,8 +2593,14 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 41) {
+        /* v41 → v42: added auto_rotate_pages_hi + auto_rotate_order_ext (Image Display in rotation) */
+        migrate_from_v41(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 40) {
-        /* v40 → v41: added crash_log_retention_days */
+        /* v40 → v42: added crash_log_retention_days, then Image Display rotation fields */
         migrate_from_v40(raw, stored_size, &s_config);
         validate_config(&s_config);
         nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,7 +13,7 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 41
+#define APP_CONFIG_VERSION 42
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -56,7 +56,10 @@ typedef struct {
     uint16_t auto_rotate_interval_s;        // seconds between automatic page rotations
     uint8_t  auto_rotate_effect;            // 0 = instant, 1 = fade, 2 = slide-left, 3 = slide-right
     bool     auto_rotate_skip_disconnected; // skip pages where NINA is not connected during auto-rotate
-    uint8_t  auto_rotate_pages;            // bitmask: bit0=summary, bit1-3=NINA 1-3, bit4=sysinfo, bit5=allsky
+    uint8_t  auto_rotate_pages;            // rotation page bitmask, low byte (bits 0-7). High bits (8+) live in
+                                           // auto_rotate_pages_hi at end of struct. Full mask layout:
+                                           //   bit0=Summary, bit1-3=NINA 1-3, bit4=System Info, bit5=AllSky,
+                                           //   bit6=Spotify, bit7=Clock, bit8=Image Display
     uint8_t  update_rate_s;                // UI/data update interval in seconds (1-10, default 2)
     uint8_t  graph_update_interval_s;     // Graph overlay auto-refresh interval in seconds (2-30, default 5)
     uint8_t  connection_timeout_s;        // Seconds without successful poll before marking offline (2-30, default 6)
@@ -175,6 +178,16 @@ typedef struct {
 
     // Added after v40 — must stay at end to preserve NVS binary compatibility
     uint8_t  crash_log_retention_days; // Auto-purge crash records older than N days (0 = never, default 30)
+
+    // Added after v41 — must stay at end to preserve NVS binary compatibility
+    // Rotation bitmask high byte + 9th rotation-order slot. The in-place
+    // auto_rotate_pages / auto_rotate_order[8] fields could not be widened
+    // without shifting every trailing field's NVS offset, so the extra bits
+    // are appended here instead. Effective mask = auto_rotate_pages |
+    // (auto_rotate_pages_hi << 8); effective order has 9 slots where the last
+    // is auto_rotate_order_ext.
+    uint8_t  auto_rotate_pages_hi;     // rotation bitmask bits 8-15 (bit8=Image Display)
+    uint8_t  auto_rotate_order_ext;    // 9th rotation-order slot (0xFF = unused/terminator)
 } app_config_t;
 
 // v17 snapshot — AllSky fields without allsky_enabled
@@ -1722,6 +1735,106 @@ typedef struct {
     uint8_t  moon_spin_mode;
     uint8_t  moon_spin_return_s;
 } app_config_v40_t;
+
+// v41 snapshot — v40 layout plus crash_log_retention_days. This is the on-NVS
+// layout before auto_rotate_pages_hi / auto_rotate_order_ext were appended in v42.
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+} app_config_v41_t;
 
 // WiFi credentials are stored in app_config_t.wifi_networks[3] (up to 3
 // priority-ordered networks). The AP provides headless access for initial

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -547,7 +547,10 @@
     /* Drag-to-reorder */
     .pn-pill.dragging { opacity: 0.4; }
     .pn-pill.drag-over { border-left: 2px solid var(--accent); margin-left: -2px; }
-    .pn-pill-grid.reorderable .pn-pill { cursor: grab; }
+    .pn-pill-grid.reorderable { justify-content: flex-start; }
+    /* Wrapped reorder pills keep natural width and left-align instead of stretching */
+    .pn-pill-grid.reorderable .pn-pill { flex: 0 0 auto; cursor: grab; }
+    .pn-pill-grid.reorderable .pn-pill-visual { width: auto; }
     .pn-pill-grid.reorderable .pn-pill:active { cursor: grabbing; }
     .pn-pill-grip {
       display: flex; justify-content: center; width: 100%;
@@ -1992,7 +1995,8 @@
         ['arp_sysinfo','System Info'],
         ['arp_allsky','AllSky'],
         ['arp_spotify','Spotify'],
-        ['arp_clock','Clock']
+        ['arp_clock','Clock'],
+        ['arp_image_display','Image Display']
       ];
       var c=$('arp-container');
       if(!c) return;
@@ -2382,8 +2386,8 @@
     }
 
     /* === Rotation Bitmask === */
-    const arpIds=['arp_summary','arp_nina1','arp_nina2','arp_nina3','arp_sysinfo','arp_allsky','arp_spotify','arp_clock'];
-    const arpBits=[0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80];
+    const arpIds=['arp_summary','arp_nina1','arp_nina2','arp_nina3','arp_sysinfo','arp_allsky','arp_spotify','arp_clock','arp_image_display'];
+    const arpBits=[0x01,0x02,0x04,0x08,0x10,0x20,0x40,0x80,0x100];
 
     function getRotatePages(){
       var mask=0;

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -2493,9 +2493,13 @@ main_loop:
         }
 
         /* If auto-rotate is active and we're on a NINA instance page but no instances
-         * are connected, fall back to the summary page automatically. */
+         * are connected, fall back to the summary page automatically.
+         * Gate positively on "parked on a real NINA instance page" (active_nina_idx >= 0)
+         * so non-NINA pages (clock/allsky/spotify/image display/etc.) are never force-
+         * navigated away — enumerating non-NINA pages with negations silently broke when
+         * the Image Display page was added (on_image_display was missing from the list). */
         if (app_config_get()->auto_rotate_enabled && !app_config_get()->idle_page_override_enabled
-            && !on_summary && !on_sysinfo && !on_settings && !on_allsky && !on_spotify && !on_clock) {
+            && active_nina_idx >= 0) {
             bool any_connected = false;
             for (int i = 0; i < instance_count; i++) {
                 if (nina_connection_is_connected(i)) { any_connected = true; break; }
@@ -2521,6 +2525,11 @@ main_loop:
          *   bit 5  = AllSky page (PAGE_IDX_ALLSKY)
          *   bit 6  = Spotify page (PAGE_IDX_SPOTIFY)
          *   bit 7  = Clock page (PAGE_IDX_CLOCK)
+         *   bit 8  = Image Display page (PAGE_IDX_IMAGE_DISPLAY)
+         *
+         * Bits 0-7 live in cfg->auto_rotate_pages; bit 8 lives in
+         * cfg->auto_rotate_pages_hi. The custom order has 9 slots: the
+         * 8-element auto_rotate_order[] array plus auto_rotate_order_ext.
          */
         {
             app_config_t *r_cfg = app_config_get();
@@ -2529,17 +2538,24 @@ main_loop:
             if (r_cfg->auto_rotate_enabled && r_cfg->auto_rotate_interval_s > 0 && !idle_override_active) {
                 if (last_rotate_ms == 0) last_rotate_ms = now_ms;
                 if (now_ms - last_rotate_ms >= (int64_t)r_cfg->auto_rotate_interval_s * 1000) {
-                    uint8_t page_mask = r_cfg->auto_rotate_pages;
+                    uint16_t page_mask = (uint16_t)r_cfg->auto_rotate_pages
+                                       | ((uint16_t)r_cfg->auto_rotate_pages_hi << 8);
                     int total = nina_dashboard_get_total_page_count();
 
                     int ena_page_count = total - EXTRA_PAGES;  /* enabled NINA pages only */
 
-                    /* Build ordered candidate list from custom rotation order */
-                    int ordered[8];
+                    /* Build ordered candidate list from custom rotation order. The
+                     * order has 9 slots: auto_rotate_order[0..7] + auto_rotate_order_ext. */
+                    int ordered[9];
                     int ordered_count = 0;
-                    for (int i = 0; i < 8 && r_cfg->auto_rotate_order[i] != 0xFF; i++) {
-                        int bit_idx = r_cfg->auto_rotate_order[i];
-                        if (bit_idx > 7) continue;
+                    for (int i = 0; i < 9; i++) {
+                        int bit_idx = (i < 8) ? r_cfg->auto_rotate_order[i]
+                                              : r_cfg->auto_rotate_order_ext;
+                        if (bit_idx == 0xFF) {
+                            if (i < 8) break;   /* terminator in the main array */
+                            else continue;      /* ext slot unused */
+                        }
+                        if (bit_idx > 8) continue;
                         /* Check if this page is enabled in bitmask */
                         if (!(page_mask & (1 << bit_idx))) continue;
 
@@ -2558,6 +2574,9 @@ main_loop:
                                 if (app_config_get()->spotify_enabled) page_idx = PAGE_IDX_SPOTIFY;
                                 break;
                             case 7: page_idx = PAGE_IDX_CLOCK; break;
+                            case 8:
+                                if (app_config_get()->image_display_enabled) page_idx = PAGE_IDX_IMAGE_DISPLAY;
+                                break;
                         }
                         if (page_idx < 0) continue;
 

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -83,11 +83,18 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     cJSON_AddNumberToObject(obj, "auto_rotate_interval_s", cfg->auto_rotate_interval_s);
     cJSON_AddNumberToObject(obj, "auto_rotate_effect", cfg->auto_rotate_effect);
     cJSON_AddBoolToObject(obj, "auto_rotate_skip_disconnected", cfg->auto_rotate_skip_disconnected);
-    cJSON_AddNumberToObject(obj, "auto_rotate_pages", cfg->auto_rotate_pages);
+    cJSON_AddNumberToObject(obj, "auto_rotate_pages",
+        (int)cfg->auto_rotate_pages | ((int)cfg->auto_rotate_pages_hi << 8));
     {
         cJSON *order_arr = cJSON_CreateArray();
-        for (int i = 0; i < 8 && cfg->auto_rotate_order[i] != 0xFF; i++) {
-            cJSON_AddItemToArray(order_arr, cJSON_CreateNumber(cfg->auto_rotate_order[i]));
+        /* 9 rotation-order slots: the 8-element array plus auto_rotate_order_ext. */
+        for (int i = 0; i < 9; i++) {
+            uint8_t v = (i < 8) ? cfg->auto_rotate_order[i] : cfg->auto_rotate_order_ext;
+            if (v == 0xFF) {
+                if (i < 8) break;   /* terminator in the main array */
+                else continue;      /* ext slot unused */
+            }
+            cJSON_AddItemToArray(order_arr, cJSON_CreateNumber(v));
         }
         cJSON_AddItemToObject(obj, "auto_rotate_order", order_arr);
     }
@@ -732,23 +739,26 @@ static app_config_t *parse_config_from_json(cJSON *root)
     if (cJSON_IsNumber(arp_item)) {
         int v = arp_item->valueint;
         if (v < 0) v = 0;
-        if (v > 0xFF) v = 0xFF;
-        cfg->auto_rotate_pages = (uint8_t)v;
+        if (v > 0x1FF) v = 0x1FF;   /* bits 0-8 valid (bit8 = Image Display) */
+        cfg->auto_rotate_pages = (uint8_t)(v & 0xFF);
+        cfg->auto_rotate_pages_hi = (uint8_t)((v >> 8) & 0xFF);
     }
 
     cJSON *order_arr = cJSON_GetObjectItem(root, "auto_rotate_order");
     if (cJSON_IsArray(order_arr)) {
         int count = cJSON_GetArraySize(order_arr);
-        if (count > 8) count = 8;
+        if (count > 9) count = 9;   /* 9 rotation-order slots (8 array + ext) */
         for (int i = 0; i < count; i++) {
             cJSON *item = cJSON_GetArrayItem(order_arr, i);
-            if (cJSON_IsNumber(item) && item->valueint >= 0 && item->valueint <= 7) {
-                cfg->auto_rotate_order[i] = (uint8_t)item->valueint;
+            if (cJSON_IsNumber(item) && item->valueint >= 0 && item->valueint <= 8) {
+                if (i < 8) cfg->auto_rotate_order[i] = (uint8_t)item->valueint;
+                else       cfg->auto_rotate_order_ext = (uint8_t)item->valueint;
             }
         }
         for (int i = count; i < 8; i++) {
             cfg->auto_rotate_order[i] = 0xFF;
         }
+        if (count < 9) cfg->auto_rotate_order_ext = 0xFF;
     }
 
     cJSON *ur_item = cJSON_GetObjectItem(root, "update_rate_s");


### PR DESCRIPTION
### Summary
Users can now include the Image Display page in the set of pages that automatically rotate, allowing for more customization of the timed page rotation. This update also fixes an issue where the auto-rotation would incorrectly skip the Image Display page when there was no internet connection, and improves the visual layout of the page selection pills.

### Changes
*   Users can now select the Image Display page to be included in the automatic page rotation sequence.
*   The internal configuration for auto-rotating pages was updated to support more selectable pages, including Image Display, by adding new fields and incrementing the configuration version.
*   Fixed an issue in the auto-rotate loop that would incorrectly navigate away from the Image Display page when no network connections were active.
*   Corrected the display of the "Pages in Rotation" selection pills so they maintain their natural width and left-align when wrapping to multiple lines.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-15T01:41:18.219Z | Generated by GitHub Actions</sub>