### PR TITLE
fix: image display region label desync

### DIFF
--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -142,6 +142,31 @@ bool solar_band_text_mask(uint8_t idx, float *x0, float *y0, float *x1, float *y
     return true;
 }
 
+/* NESDIS sector code -> human-readable region name. Single source of truth
+ * (moved out of nina_image_display.c). Returns the code itself if no match. */
+const char *goes_region_name(const char *code)
+{
+    static const struct { const char *code; const char *name; } region_labels[] = {
+        {"umv","Upper Mississippi Valley"}, {"cgl","Great Lakes"},
+        {"ne","Northeast"},                 {"se","Southeast"},
+        {"smv","Southern Mississippi Valley"},{"sp","Southern Plains"},
+        {"nr","Northern Rockies"},          {"sr","Southern Rockies"},
+        {"pnw","Pacific Northwest"},        {"psw","Pacific Southwest"},
+        {"pr","Puerto Rico"},               {"eus","U.S. Atlantic Coast"},
+        {"cam","Central America"},          {"car","Caribbean"},
+        {"mex","Mexico"},                   {"ga","Gulf of America"},
+        {"na","Northern Atlantic"},         {"ssa","South America (South)"},
+        {"eep","Eastern Pacific"},          {"taw","Tropical Atlantic"},
+        {"nsa","South America (North)"},    {"can","Canada"},
+        {NULL,NULL}
+    };
+    if (!code) return "";
+    for (int i = 0; region_labels[i].code; i++) {
+        if (!strcmp(region_labels[i].code, code)) return region_labels[i].name;
+    }
+    return code;
+}
+
 esp_err_t goes_client_poll(const char *region, goes_data_t *data)
 {
     if (!region || !data) return ESP_ERR_INVALID_ARG;
@@ -152,11 +177,14 @@ esp_err_t goes_client_poll(const char *region, goes_data_t *data)
              "https://cdn.star.nesdis.noaa.gov/GOES19/ABI/SECTOR/%s/GEOCOLOR/%s.jpg",
              region, size);
 
-    /* NESDIS GOES JPEGs decode upside-down on this panel; flip them. */
-    return goes_client_poll_url(url, data, true);
+    /* The decode+render pipeline on this panel applies a net vertical flip, so the
+     * NESDIS GOES JPEG must be flipped (vflip=true) to display north-up. This matches
+     * the Solar path, which also uses vflip=true. Verified on-device: vflip=false
+     * renders the image upside-down (issue #166 regression). */
+    return goes_client_poll_url(url, data, true, goes_region_name(region));
 }
 
-esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip)
+esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, const char *label)
 {
     if (!url || !data) return ESP_ERR_INVALID_ARG;
 
@@ -270,6 +298,8 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip)
         data->image_w = (uint16_t)out_w;
         data->image_h = (uint16_t)out_h;
         data->vflip = vflip;
+        if (label) { strlcpy(data->label, label, sizeof(data->label)); }
+        else       { data->label[0] = '\0'; }
         data->connected = true;
         data->last_poll_ms = esp_timer_get_time() / 1000;
         goes_data_unlock(data);

--- a/main/goes_client.h
+++ b/main/goes_client.h
@@ -13,6 +13,7 @@ typedef struct {
     uint16_t          image_w;
     uint16_t          image_h;
     bool              vflip;        /* true: buffer is vertically flipped (sw JPEG) */
+    char              label[48];    /* human-readable name of the source this buffer holds (region/band); rendered verbatim by the page so it can never desync from image_buf */
     SemaphoreHandle_t mutex;
 } goes_data_t;
 
@@ -20,8 +21,12 @@ void      goes_data_init(goes_data_t *data);
 bool      goes_data_lock(goes_data_t *data, int timeout_ms);
 void      goes_data_unlock(goes_data_t *data);
 esp_err_t goes_client_poll(const char *region, goes_data_t *data);
-esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip);
+esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, const char *label);
 void      goes_client_cleanup(goes_data_t *data);
+
+/* NESDIS sector code -> human-readable region name. Returns the code itself
+ * when no match is found. Single source of truth for region labels. */
+const char *goes_region_name(const char *code);
 
 const char *solar_band_url(uint8_t idx);
 const char *solar_band_label(uint8_t idx);

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -1040,6 +1040,7 @@ void goes_poll_task(void *arg)
                                 goes_data.image_w = MOON_DRAG_SZ_TOUCH;
                                 goes_data.image_h = MOON_DRAG_SZ_TOUCH;
                                 goes_data.vflip = false;
+                                goes_data.label[0] = '\0';
                                 goes_data.connected = true;
                                 goes_data.last_poll_ms = esp_timer_get_time() / 1000;
                                 goes_data_unlock(&goes_data);
@@ -1090,6 +1091,7 @@ void goes_poll_task(void *arg)
                             goes_data.image_w = SCREEN_SIZE;
                             goes_data.image_h = SCREEN_SIZE;
                             goes_data.vflip = false;
+                            goes_data.label[0] = '\0';
                             goes_data.connected = true;
                             goes_data.last_poll_ms = esp_timer_get_time() / 1000;
                             goes_data_unlock(&goes_data);
@@ -1204,6 +1206,7 @@ void goes_poll_task(void *arg)
                         goes_data.image_w = MOON_SZ;
                         goes_data.image_h = MOON_SZ;
                         goes_data.vflip = false;
+                        goes_data.label[0] = '\0';
                         goes_data.connected = true;
                         goes_data.last_poll_ms = esp_timer_get_time() / 1000;
                         goes_data_unlock(&goes_data);
@@ -1275,7 +1278,7 @@ void goes_poll_task(void *arg)
             const char *url = solar_band_url(cfg->solar_band);
             /* All solar bands need a vertical flip to display upright (see solar_band_vflip). */
             if (url && url[0]) {
-                fetch_err = goes_client_poll_url(url, &goes_data, solar_band_vflip(cfg->solar_band));
+                fetch_err = goes_client_poll_url(url, &goes_data, solar_band_vflip(cfg->solar_band), solar_band_label(cfg->solar_band));
             } else {
                 fetch_err = ESP_ERR_INVALID_ARG;
             }

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -93,29 +93,9 @@ static size_t    moon_copy_cap[2] = { 0, 0 };
  * locally instead of forcing an HTTP re-download. */
 static bool force_redraw = false;
 
-/* NESDIS sector code -> human-readable region name. */
-static const struct { const char *code; const char *name; } region_labels[] = {
-    {"umv","Upper Mississippi Valley"}, {"cgl","Great Lakes"},
-    {"ne","Northeast"},                 {"se","Southeast"},
-    {"smv","Southern Mississippi Valley"},{"sp","Southern Plains"},
-    {"nr","Northern Rockies"},          {"sr","Southern Rockies"},
-    {"pnw","Pacific Northwest"},        {"psw","Pacific Southwest"},
-    {"pr","Puerto Rico"},               {"eus","U.S. Atlantic Coast"},
-    {"cam","Central America"},          {"car","Caribbean"},
-    {"mex","Mexico"},                   {"ga","Gulf of America"},
-    {"na","Northern Atlantic"},         {"ssa","South America (South)"},
-    {"eep","Eastern Pacific"},          {"taw","Tropical Atlantic"},
-    {"nsa","South America (North)"},    {"can","Canada"},
-    {NULL,NULL}
-};
-
-static const char *region_code_to_name(const char *code)
-{
-    for (int i = 0; region_labels[i].code; i++) {
-        if (!strcmp(region_labels[i].code, code)) return region_labels[i].name;
-    }
-    return code;
-}
+/* Region-code -> human-readable name lookup now lives in goes_client.c
+ * (goes_region_name); the page reads the label captured into goes_data at
+ * fetch time so the on-screen text can never desync from image_buf. */
 
 static void init_image_dsc(lv_image_dsc_t *dsc)
 {
@@ -591,6 +571,11 @@ void nina_image_display_update(goes_data_t *data)
         }
     }
     int64_t poll_ms = data->last_poll_ms;
+    /* Capture the label this buffer was fetched for UNDER the same lock so the
+     * on-screen text is coupled to image_buf and cannot desync if a config
+     * change lands between fetches (issue #166). */
+    char label_copy[48];
+    strlcpy(label_copy, data->label, sizeof(label_copy));
     goes_data_unlock(data);
 
     /* Point the BACK slot's descriptor at the new copy. release_dsc() frees the
@@ -682,14 +667,13 @@ void nina_image_display_update(goes_data_t *data)
         lv_label_set_text(lbl_timestamp, pct);
         update_moon_corner_labels();
     } else if (cfg->image_display_source == 2) {     /* Solar (SDO/AIA) */
-        extern const char *solar_band_label(uint8_t idx);
-        lv_label_set_text(lbl_region, solar_band_label(cfg->solar_band));
+        lv_label_set_text(lbl_region, label_copy);
         time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);
         char ts[32]; strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
         lv_label_set_text(lbl_timestamp, ts);
         hide_moon_corner_labels();
     } else {                                         /* GOES */
-        lv_label_set_text(lbl_region, region_code_to_name(cfg->goes_region));
+        lv_label_set_text(lbl_region, label_copy);
         time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);
         char ts[32]; strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
         lv_label_set_text(lbl_timestamp, ts);


### PR DESCRIPTION
### Summary
This PR fixes an issue where the on-screen label for GOES images could show the wrong region or band if image fetching was delayed. It ensures the displayed label always matches the image data currently shown. Additionally, it clarifies a comment about GOES image vertical flipping to ensure correct north-up display.

### Changes
*   The GOES image display now shows the correct region or band label for the image currently on screen, even if image fetching is slow.
*   The region and band labels are now stored with the fetched image data, ensuring they always match the displayed image.
*   The table mapping GOES region codes to names is moved to `goes_client.c` to centralize this information.
*   A comment explaining the GOES vertical flip setting is updated to clarify why `vflip=true` is required for north-up display.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-15T16:19:03.333Z | Generated by GitHub Actions</sub>