### PR TITLE
ci: always clean build/ and sdkconfig before building

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,30 +134,39 @@ jobs:
           ccache --zero-stats
           ccache --show-config | grep -E "max_size|cache_dir|compression"
 
-      - name: Clean stale build if config changed
+      - name: Clean build state (always rebuild config)
         if: steps.check_skip.outputs.skip != 'true'
         run: |
-          NEEDS_CLEAN=false
-
-          # Detect changes in build-critical files since last successful build
-          # Hash is only saved after a successful build, so missing hash = no prior success
+          # Decide whether managed_components also needs purging BEFORE removing
+          # build/, since the comparison hash lives in build/.build_config_hash.
+          NEEDS_DEPS_CLEAN=false
           if [ -f build/.build_config_hash ]; then
             OLD_HASH=$(cat build/.build_config_hash)
             NEW_HASH=$(cat sdkconfig.defaults main/idf_component.yml main/CMakeLists.txt CMakeLists.txt dependencies.lock 2>/dev/null | sha256sum | cut -d' ' -f1)
             if [ "$OLD_HASH" != "$NEW_HASH" ]; then
-              echo "Build config changed, cleaning"
-              NEEDS_CLEAN=true
+              echo "Build config changed, will also purge managed_components"
+              NEEDS_DEPS_CLEAN=true
             fi
           else
-            echo "No previous successful build hash found, cleaning"
-            NEEDS_CLEAN=true
+            echo "No previous successful build hash found, will also purge managed_components"
+            NEEDS_DEPS_CLEAN=true
           fi
 
-          if [ "$NEEDS_CLEAN" = "true" ]; then
-            rm -rf build managed_components sdkconfig
-            echo "Clean complete"
+          # Always purge build/ and sdkconfig: a stale sdkconfig selects the wrong
+          # display pipeline and a stale build/ keeps a stale build_version.h and
+          # object files. ccache (separate CCACHE_DIR) is untouched, so recompiles
+          # stay fast.
+          rm -rf build sdkconfig
+          echo "Removed build and sdkconfig"
+
+          # Only re-download managed_components when the dependency/config hash
+          # changed: it is pinned by dependencies.lock, and re-fetching from the
+          # component registry every run adds a network failure point.
+          if [ "$NEEDS_DEPS_CLEAN" = "true" ]; then
+            rm -rf managed_components
+            echo "Removed managed_components"
           else
-            echo "Config unchanged, using incremental build"
+            echo "Config unchanged, reusing managed_components"
           fi
 
       - name: Build project


### PR DESCRIPTION
The self-hosted runner kept build/ and sdkconfig across runs (checkout clean: false). The old step only purged them when a hash of the build-config files changed, so a code-only change reused a stale sdkconfig (wrong display pipeline) and a stale build_version.h. That produced binaries that differed from a clean build of the same source, which is what made identical-source firmware render image orientation differently across devices.

Now build/ and sdkconfig are removed unconditionally every build so config and build_version.h regenerate from scratch. managed_components stays on the existing config-hash condition (pinned by dependencies.lock; avoids re-fetching from the registry each run). ccache is untouched, so recompiles stay fast.