### PR TITLE
ci: add workflow_dispatch for on-demand clean builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build Firmware
 on:
   push:
     branches: [main, dev]
+  workflow_dispatch:
 
 env:
   IDF_VERSION: v5.5.2
@@ -29,6 +30,13 @@ jobs:
       - name: Check if code files changed
         id: filter
         run: |
+          # A manual run (workflow_dispatch) always builds; github.event.before is
+          # unset there, so short-circuit before the diff to avoid an empty BASE.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
+            echo "Manual run requested, build will run"
+            exit 0
+          fi
           BASE=${{ github.event.before }}
           HEAD=${{ github.sha }}
           CODE_CHANGES=$(git diff --name-only "$BASE" "$HEAD" -- \
@@ -45,7 +53,7 @@ jobs:
 
   build:
     needs: check-changes
-    if: needs.check-changes.outputs.has_code_changes == 'true'
+    if: needs.check-changes.outputs.has_code_changes == 'true' || github.event_name == 'workflow_dispatch'
     runs-on: self-hosted
     steps:
       - name: Checkout code


### PR DESCRIPTION
Adds a manual 'Run workflow' trigger so a clean OTA build can be produced without faking a code change (e.g. to replace a stale binary). The check-changes filter short-circuits to has_code_changes=true on a manual run (github.event.before is unset there), and the build job also gates on github.event_name == 'workflow_dispatch'.