### PR TITLE
feat: add per-source image rotation

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -803,6 +803,10 @@ static void set_defaults(app_config_t *cfg) {
     // Crash log defaults
     cfg->crash_log_retention_days = 30;  // auto-purge crash records older than 30 days (0 = never)
 
+    // Per-source Image Display render rotation (0=0°,1=90°,2=180°,3=270° clockwise)
+    cfg->goes_orientation = 0;
+    cfg->solar_orientation = 0;
+
     // Auth is on by default — protects device from open-LAN access
     cfg->auth_enabled = true;
 }
@@ -1862,6 +1866,21 @@ static void migrate_from_v41(const void *raw, size_t raw_size, app_config_t *cfg
     ESP_LOGI(TAG, "Migrated config from v41 to v%d", APP_CONFIG_VERSION);
 }
 
+static void migrate_from_v42(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v42_t) ? raw_size : sizeof(app_config_v42_t);
+    memcpy(cfg, raw, copy);
+
+    /* goes_orientation / solar_orientation: new in v43, appended past the v42
+     * snapshot — keep the set_defaults() values (both 0 = 0° rotation). */
+    cfg->goes_orientation = 0;
+    cfg->solar_orientation = 0;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v42 to v%d", APP_CONFIG_VERSION);
+}
+
 static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -2593,6 +2612,12 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 42) {
+        /* v42 → v43: added goes_orientation + solar_orientation (per-source Image Display rotation) */
+        migrate_from_v42(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 41) {
         /* v41 → v42: added auto_rotate_pages_hi + auto_rotate_order_ext (Image Display in rotation) */
         migrate_from_v41(raw, stored_size, &s_config);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,7 +13,7 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 42
+#define APP_CONFIG_VERSION 43
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -188,6 +188,11 @@ typedef struct {
     // is auto_rotate_order_ext.
     uint8_t  auto_rotate_pages_hi;     // rotation bitmask bits 8-15 (bit8=Image Display)
     uint8_t  auto_rotate_order_ext;    // 9th rotation-order slot (0xFF = unused/terminator)
+
+    // Added after v42 — must stay at end to preserve NVS binary compatibility
+    // Per-source Image Display render rotation: 0=0°,1=90°,2=180°,3=270° clockwise. GOES=source 0, Solar=source 2. Default 0.
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
 } app_config_t;
 
 // v17 snapshot — AllSky fields without allsky_enabled
@@ -1835,6 +1840,109 @@ typedef struct {
     uint8_t  moon_spin_return_s;
     uint8_t  crash_log_retention_days;
 } app_config_v41_t;
+
+// v42 snapshot — v41 layout plus auto_rotate_pages_hi / auto_rotate_order_ext.
+// This is the on-NVS layout before goes_orientation / solar_orientation were
+// appended in v43.
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+} app_config_v42_t;
 
 // WiFi credentials are stored in app_config_t.wifi_networks[3] (up to 3
 // priority-ordered networks). The AP provides headless access for initial

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1121,6 +1121,16 @@
             <div class="field-hint">GOES-19 GEOCOLOR sector for satellite imagery</div>
           </div>
           <div class="field" style="margin-top:16px">
+            <label class="field-label">GOES Rotation</label>
+            <select class="input" id="goesOrientation" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">0&deg;</option>
+              <option value="1">90&deg;</option>
+              <option value="2">180&deg;</option>
+              <option value="3">270&deg;</option>
+            </select>
+            <div class="field-hint">Rotate the satellite image clockwise.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
             <button onclick="fetchGoesPreview()" class="btn btn-primary" id="goesPreviewBtn" style="width:100%">Fetch Preview</button>
           </div>
           <div id="goesPreviewContainer" style="display:none;margin-top:12px;text-align:center">
@@ -1234,6 +1244,16 @@
               <option value="17">SDO/HMI Magnetogram</option>
             </select>
             <div class="field-hint">NASA SDO/AIA and SOHO realtime (LASCO, EIT, HMI)</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Solar Rotation</label>
+            <select class="input" id="solarOrientation" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">0&deg;</option>
+              <option value="1">90&deg;</option>
+              <option value="2">180&deg;</option>
+              <option value="3">270&deg;</option>
+            </select>
+            <div class="field-hint">Rotate the solar image clockwise.</div>
           </div>
           </div>
         </div>
@@ -2511,6 +2531,8 @@
         moon_bg_style:parseInt($('moonBg').value,10)||0,
         moon_drag_light_mode:parseInt($('moonDragLight').value,10)||0,
         solar_band:parseInt($('solarBand').value,10)||0,
+        goes_orientation:parseInt($('goesOrientation').value,10)||0,
+        solar_orientation:parseInt($('solarOrientation').value,10)||0,
         moon_lat:parseFloat($('moonLat').value)||0,
         moon_lon:parseFloat($('moonLon').value)||0,
         moon_north_up:$('moon_north_up').checked?1:0,
@@ -2689,6 +2711,8 @@
       if($('moonBg')) $('moonBg').value=String(data.moon_bg_style||0);
       if($('moonDragLight')) $('moonDragLight').value=String(data.moon_drag_light_mode||0);
       if($('solarBand')) $('solarBand').value=String(data.solar_band||0);
+      if($('goesOrientation')) $('goesOrientation').value=String(data.goes_orientation||0);
+      if($('solarOrientation')) $('solarOrientation').value=String(data.solar_orientation||0);
       var mlat=data.moon_lat, mlon=data.moon_lon;
       // Prefill from weather location when moon coords are unset
       if((!mlat && !mlon) && (data.weather_lat || data.weather_lon)){ mlat=data.weather_lat; mlon=data.weather_lon; }
@@ -3928,7 +3952,9 @@
         moon_pitch_offset: parseFloat($('moon_pitch_offset').value)||0,
         moon_spin_mode: $('moon_spin_mode').checked?1:0,
         moon_spin_return_s: parseInt($('moon_spin_return_s').value,10)||3,
-        solar_band: parseInt($('solarBand').value,10)||0
+        solar_band: parseInt($('solarBand').value,10)||0,
+        goes_orientation: parseInt($('goesOrientation').value,10)||0,
+        solar_orientation: parseInt($('solarOrientation').value,10)||0
       });
     }
 
@@ -3951,6 +3977,8 @@
     }
 
     function resetMoonOrientation(){
+      if($('goesOrientation')) $('goesOrientation').value='0';
+      if($('solarOrientation')) $('solarOrientation').value='0';
       if($('moon_flip_u')) $('moon_flip_u').checked=false;
       if($('moon_flip_v')) $('moon_flip_v').checked=false;
       if($('moon_roll_offset')) $('moon_roll_offset').value=0;

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -578,6 +578,68 @@ void nina_image_display_update(goes_data_t *data)
     strlcpy(label_copy, data->label, sizeof(label_copy));
     goes_data_unlock(data);
 
+    /* Per-source logical rotation pass. Rotates the decoded RGB565 pixel buffer
+     * (NOT via an LVGL transform) so it is independent of display rotation and
+     * runs on the upright `copy` produced above (after vflip + caption mask).
+     * orient: 0/1/2/3 = 0/90/180/270 degrees CLOCKWISE. Moon (source 1) never
+     * rotates. 90/270 swap width<->height. */
+    uint8_t orient = (cfg->image_display_source == 0)   ? cfg->goes_orientation
+                     : (cfg->image_display_source == 2) ? cfg->solar_orientation
+                                                        : 0;
+    if (orient != 0) {
+        uint16_t rw, rh;
+        if (orient == 2) {            /* 180deg: same dims */
+            rw = w;  rh = h;
+        } else {                       /* 90/270: dims swap */
+            rw = h;  rh = w;
+        }
+        size_t   rot_size = (size_t)rw * rh * 2;
+        uint8_t *rot = heap_caps_malloc(rot_size, MALLOC_CAP_SPIRAM);
+        if (!rot) {
+            ESP_LOGE(TAG, "PSRAM alloc failed for rotation buffer (%u bytes)",
+                     (unsigned)rot_size);
+            heap_caps_free(copy);
+            /* goes lock already released above; just retire the wait overlay. */
+            nina_wait_overlay_hide();
+            return;
+        }
+        const uint16_t *src = (const uint16_t *)copy;
+        uint16_t       *dst = (uint16_t *)rot;
+        if (orient == 2) {
+            /* rot[x,y] = copy[w-1-x, h-1-y] */
+            for (uint32_t Y = 0; Y < rh; Y++) {
+                for (uint32_t X = 0; X < rw; X++) {
+                    uint32_t sx = (uint32_t)w - 1 - X;
+                    uint32_t sy = (uint32_t)h - 1 - Y;
+                    dst[(size_t)Y * rw + X] = src[(size_t)sy * w + sx];
+                }
+            }
+        } else if (orient == 1) {
+            /* 90deg CW: rot[X,Y] = copy[Y, h-1-X], dims rw=h, rh=w */
+            for (uint32_t Y = 0; Y < rh; Y++) {           /* Y in [0,w) */
+                for (uint32_t X = 0; X < rw; X++) {       /* X in [0,h) */
+                    uint32_t sx = Y;
+                    uint32_t sy = (uint32_t)h - 1 - X;
+                    dst[(size_t)Y * rw + X] = src[(size_t)sy * w + sx];
+                }
+            }
+        } else {  /* orient == 3 */
+            /* 270deg CW: rot[X,Y] = copy[w-1-Y, X], dims rw=h, rh=w */
+            for (uint32_t Y = 0; Y < rh; Y++) {           /* Y in [0,w) */
+                for (uint32_t X = 0; X < rw; X++) {       /* X in [0,h) */
+                    uint32_t sx = (uint32_t)w - 1 - Y;
+                    uint32_t sy = X;
+                    dst[(size_t)Y * rw + X] = src[(size_t)sy * w + sx];
+                }
+            }
+        }
+        heap_caps_free(copy);
+        copy     = rot;
+        w        = rw;
+        h        = rh;
+        buf_size = rot_size;
+    }
+
     /* Point the BACK slot's descriptor at the new copy. release_dsc() frees the
      * previous buffer unless it was borrowed (moon-drag), and clears that flag —
      * this owned copy is not borrowed. */

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -32,6 +32,8 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "moon_lat", cfg->moon_lat);
     cJSON_AddNumberToObject(root, "moon_lon", cfg->moon_lon);
     cJSON_AddNumberToObject(root, "solar_band", cfg->solar_band);
+    cJSON_AddNumberToObject(root, "goes_orientation", cfg->goes_orientation);
+    cJSON_AddNumberToObject(root, "solar_orientation", cfg->solar_orientation);
     cJSON_AddNumberToObject(root, "moon_drag_light_mode", cfg->moon_drag_light_mode);
     cJSON_AddNumberToObject(root, "moon_flip_u", cfg->moon_flip_u);
     cJSON_AddNumberToObject(root, "moon_flip_v", cfg->moon_flip_v);
@@ -98,6 +100,8 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     uint8_t prev_north_up = cfg->moon_north_up;
     uint8_t prev_spin_mode   = cfg->moon_spin_mode;
     uint8_t prev_spin_return = cfg->moon_spin_return_s;
+    uint8_t prev_goes_orient  = cfg->goes_orientation;
+    uint8_t prev_solar_orient = cfg->solar_orientation;
     char    prev_region[sizeof(cfg->goes_region)];
     strlcpy(prev_region, cfg->goes_region, sizeof(prev_region));
 
@@ -124,6 +128,10 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     if (cJSON_IsNumber(mlon)) cfg->moon_lon = (float)mlon->valuedouble;
     cJSON *sb = cJSON_GetObjectItem(root, "solar_band");
     if (cJSON_IsNumber(sb)) { int v = sb->valueint; cfg->solar_band = (v >= 0 && v <= 17) ? (uint8_t)v : 0; }
+    cJSON *go = cJSON_GetObjectItem(root, "goes_orientation");
+    if (cJSON_IsNumber(go)) { int v = go->valueint; cfg->goes_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    cJSON *so = cJSON_GetObjectItem(root, "solar_orientation");
+    if (cJSON_IsNumber(so)) { int v = so->valueint; cfg->solar_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *dlm = cJSON_GetObjectItem(root, "moon_drag_light_mode");
     if (cJSON_IsNumber(dlm)) { int v = dlm->valueint; cfg->moon_drag_light_mode = (v >= 0 && v <= 1) ? (uint8_t)v : 0; }
     cJSON *fu = cJSON_GetObjectItem(root, "moon_flip_u");
@@ -159,6 +167,8 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
             cfg->solar_band != prev_band ||
             strcmp(cfg->goes_region, prev_region) != 0;
         bool crop_changed = cfg->image_display_crop != prev_crop;
+        bool orient_changed = (cfg->goes_orientation != prev_goes_orient) ||
+                              (cfg->solar_orientation != prev_solar_orient);
 
         if (source_band_region_changed) {
             /* Source/band/region needs a genuinely new image: flag the next
@@ -202,8 +212,9 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
             if (goes_task_handle) {
                 xTaskNotifyGive(goes_task_handle);
             }
-        } else if (crop_changed) {
-            /* Crop/full toggle only: re-render the already-decoded frame locally
+        } else if (crop_changed || orient_changed) {
+            /* Crop/full toggle or orientation change only: re-render the
+             * already-decoded frame locally
              * instead of re-downloading. nina_image_display_update() locks
              * goes_data internally but REQUIRES the display lock held by the
              * caller (see tasks.c), so wrap both calls in bsp_display_lock. The


### PR DESCRIPTION
### Summary
Adds user-configurable rotation options for GOES and solar images to resolve orientation inconsistencies that varied between build environments. Users can now set a specific rotation (0, 90, 180, 270 degrees) for each image source directly from the web UI. This ensures images display correctly regardless of the build environment.

### Changes
*   `app_config` updates to v43, adding `goes_orientation` and `solar_orientation` settings to control image rotation.
*   Image display logic now rotates GOES and Solar images based on their configured orientation, ensuring consistent display.
*   Rotating images by 90 or 270 degrees swaps their width and height, and the display scaling adjusts accordingly.
*   The web UI's Image Display tab now provides dropdowns to select rotation (0, 90, 180, 270 degrees) for GOES and Solar images.
*   Applying an orientation change in the web UI immediately re-renders the locally cached image without requiring a new download.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-16T01:33:47.111Z | Generated by GitHub Actions</sub>