### PR TITLE
feat: add surface-locked moon lighting mode

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -786,7 +786,7 @@ static void set_defaults(app_config_t *cfg) {
     cfg->moon_lon = 0.0f;
     cfg->solar_band = 0;             // SDO/AIA band index 0..9
     cfg->image_display_crop = false; // crop/zoom image to fill & hide baked-in labels
-    cfg->moon_drag_light_mode = 0;   // 0=true phase, 1=explore (moon drag-to-rotate lighting)
+    cfg->moon_drag_light_mode = 2;   // 0=true phase, 1=explore, 2=locked to surface (default) (moon drag-to-rotate lighting)
 
     // Moon sphere orientation tuning defaults (tuned baseline from a reference device)
     cfg->moon_flip_u = 0;            // mirror texture longitude E<->W
@@ -1896,7 +1896,7 @@ static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg
      * explicitly only for documentation. */
 
     /* moon_drag_light_mode field: new in v37 — defaults already set by set_defaults() */
-    cfg->moon_drag_light_mode = 0;
+    cfg->moon_drag_light_mode = 2;
 
     /* Moon orientation tuning fields: new in v38 — defaults already set by set_defaults() */
     cfg->moon_flip_u = 0;
@@ -2505,7 +2505,7 @@ static bool validate_config(app_config_t *cfg) {
         cfg->solar_band = 0;
         fixed = true;
     }
-    if (cfg->moon_drag_light_mode > 1) {
+    if (cfg->moon_drag_light_mode > 2) {
         cfg->moon_drag_light_mode = 0;
         fixed = true;
     }

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -158,7 +158,7 @@ typedef struct {
     bool     image_display_crop;     // crop/zoom image to fill & hide baked-in labels (default false)
 
     // Added after v36 — must stay at end to preserve NVS binary compatibility
-    uint8_t  moon_drag_light_mode;   // 0=true phase, 1=explore (moon drag-to-rotate lighting)
+    uint8_t  moon_drag_light_mode;   // 0=true phase, 1=explore, 2=locked to surface (moon drag-to-rotate lighting)
 
     // Added after v37 — must stay at end to preserve NVS binary compatibility
     // Moon sphere orientation tuning

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1161,6 +1161,7 @@
             <select class="input" id="moonDragLight" onchange="applyImageDisplay();checkDirty()">
               <option value="0">True phase</option>
               <option value="1">Explore (full-lit)</option>
+              <option value="2">Locked to surface</option>
             </select>
             <div class="field-hint">How the Moon is lit while you drag to rotate it. True phase keeps the real terminator; Explore lights the whole surface.</div>
           </div>

--- a/main/moon_sphere.cpp
+++ b/main/moon_sphere.cpp
@@ -681,6 +681,24 @@ static uint16_t *moon_sphere_render_core(int w, int h, const moon_state_t *st,
     float n = sqrtf(sun_w.x * sun_w.x + sun_w.y * sun_w.y + sun_w.z * sun_w.z);
     if (n > 1e-6f) { sun_w.x /= n; sun_w.y /= n; sun_w.z /= n; }
 
+    /* Surface-locked lighting: apply the SAME outermost user-drag rotation that
+     * the vertices receive (lines above: M_rot = R_sky then pitch about +X then
+     * yaw about +Y). R_sky is already in sun_w, so add ONLY the drag part here:
+     * pitch about X then yaw about Y, in the identical order/sign as the vertex
+     * M_rot. This rotates the sun vector together with the features, pinning the
+     * terminator to the lunar surface as the user swipes. Real diffuse/ambient
+     * and terminator are kept (mode 2 falls through the else branch below). */
+    if (light_mode == MOON_LIGHT_SURFACE_LOCKED) {
+        fMat4 R_drag;
+        R_drag.setIdentity();
+        R_drag.multRotate(pitch_deg, fVec3(1.0f, 0.0f, 0.0f)); /* drag: pitch (screen-horiz) */
+        R_drag.multRotate(yaw_deg,   fVec3(0.0f, 1.0f, 0.0f)); /* drag: yaw   (screen-vert)  */
+        fVec4 sun_d4 = R_drag.mult0(sun_w);
+        sun_w.x = sun_d4.x; sun_w.y = sun_d4.y; sun_w.z = sun_d4.z;
+        float nd = sqrtf(sun_w.x * sun_w.x + sun_w.y * sun_w.y + sun_w.z * sun_w.z);
+        if (nd > 1e-6f) { sun_w.x /= nd; sun_w.y /= nd; sun_w.z /= nd; }
+    }
+
     if (light_mode == MOON_LIGHT_EXPLORE) {
         /* Explore view: light the whole disc so the user can inspect the far
          * side while spinning. Raise ambient near full and drop diffuse to a

--- a/main/moon_sphere.h
+++ b/main/moon_sphere.h
@@ -12,7 +12,7 @@ bool moon_sphere_init(void);
 uint16_t *moon_sphere_render(int w, int h, const moon_state_t *st,
                              int nb_sectors, int nb_stacks, uint8_t bg_style);
 
-typedef enum { MOON_LIGHT_TRUE_PHASE = 0, MOON_LIGHT_EXPLORE = 1 } moon_light_mode_t;
+typedef enum { MOON_LIGHT_TRUE_PHASE = 0, MOON_LIGHT_EXPLORE = 1, MOON_LIGHT_SURFACE_LOCKED = 2 } moon_light_mode_t;
 
 /* Render with an additional user rotation (drag-to-rotate) on top of the sky
  * orientation in `st`. yaw_deg rotates the disc about the screen-vertical axis,

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -971,14 +971,25 @@ void goes_poll_task(void *arg)
                     }
 
                     /* 2. Lighting for this frame. Active frames use the explore/config
-                     * lighting for free exploration; settle frames force TRUE_PHASE so
-                     * the terminator shadow dissolves back in as the disc returns home
-                     * (matching the resting render). The render SIZE is the single
-                     * touch size (240) for the whole interaction — active and settle —
-                     * because 240->720 is an exact 3.0x PPA ratio. */
-                    moon_light_mode_t light = active
-                        ? (moon_light_mode_t)cfg->moon_drag_light_mode
-                        : MOON_LIGHT_TRUE_PHASE;
+                     * lighting for free exploration. On settle, true-phase/explore force
+                     * TRUE_PHASE so the terminator shadow dissolves back in as the disc
+                     * returns home (matching the resting render). SURFACE_LOCKED keeps its
+                     * mode through the ease-back: its sun = R_drag(yaw,pitch)*R_sky*sun_body,
+                     * which at yaw=pitch=0 equals true-phase exactly, so the terminator
+                     * stays pinned to the surface and converges with no pop (forcing
+                     * TRUE_PHASE here would flash full-bright/dark on the first large-yaw
+                     * settle frame). The render SIZE is the single touch size (240) for the
+                     * whole interaction — active and settle — because 240->720 is an exact
+                     * 3.0x PPA ratio. */
+                    moon_light_mode_t cfg_light = (moon_light_mode_t)cfg->moon_drag_light_mode;
+                    moon_light_mode_t light;
+                    if (active) {
+                        light = cfg_light;                 /* finger down: use configured mode */
+                    } else if (cfg_light == MOON_LIGHT_SURFACE_LOCKED) {
+                        light = MOON_LIGHT_SURFACE_LOCKED; /* settle: keep terminator pinned; converges to true phase at yaw=pitch=0 */
+                    } else {
+                        light = MOON_LIGHT_TRUE_PHASE;     /* settle for true-phase/explore: dissolve terminator back in */
+                    }
 
                     bool shown = false;
                     if (s_drag_color && s_drag_zbuf && s_ppa_out[0] && s_ppa_out[1]) {
@@ -1082,7 +1093,7 @@ void goes_poll_task(void *arg)
                     float hy, hp; moon_drag_get(&hy, &hp);
                     uint16_t *hold_img = moon_sphere_render_ex(SCREEN_SIZE, SCREEN_SIZE, &live,
                                                                96, 48, cfg->moon_bg_style,
-                                                               hy, hp, MOON_LIGHT_TRUE_PHASE);
+                                                               hy, hp, (moon_light_mode_t)cfg->moon_drag_light_mode);
                     if (hold_img && image_display_page_active && cfg->image_display_source == 1 &&
                         !moon_drag_active()) {
                         if (goes_data_lock(&goes_data, 1000)) {

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -384,6 +384,7 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     p->lbl_target_name = lv_label_create(p->header_box);
     lv_obj_add_style(p->lbl_target_name, &style_value_large, 0);
     lv_obj_set_width(p->lbl_target_name, LV_PCT(100));
+    lv_label_set_long_mode(p->lbl_target_name, LV_LABEL_LONG_CLIP);
     lv_obj_set_style_text_align(p->lbl_target_name, LV_TEXT_ALIGN_RIGHT, 0);
     lv_label_set_text(p->lbl_target_name, "----");
 

--- a/main/ui/nina_dashboard_update.c
+++ b/main/ui/nina_dashboard_update.c
@@ -70,6 +70,30 @@ static void auto_fit_value_font(lv_obj_t *label) {
         lv_obj_set_style_text_font(label, pick, 0);
 }
 
+/* Pick the largest font that fits the label's parent width (wider ladder for target names) */
+static void auto_fit_target_name_font(lv_obj_t *label) {
+    static const lv_font_t *fonts[] = {
+        &lv_font_montserrat_48, &lv_font_montserrat_36,
+        &lv_font_montserrat_32, &lv_font_montserrat_28,
+        &lv_font_montserrat_24, &lv_font_montserrat_20,
+        &lv_font_montserrat_16,
+    };
+    const char *text = lv_label_get_text(label);
+    int32_t letter_space = lv_obj_get_style_text_letter_space(label, 0);
+    int32_t avail = lv_obj_get_content_width(lv_obj_get_parent(label));
+    const lv_font_t *pick = fonts[sizeof(fonts) / sizeof(fonts[0]) - 1];
+    for (int i = 0; i < (int)(sizeof(fonts) / sizeof(fonts[0])); i++) {
+        lv_point_t size;
+        lv_text_get_size(&size, text, fonts[i], letter_space, 0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
+        if (size.x <= avail) {
+            pick = fonts[i];
+            break;
+        }
+    }
+    if (lv_obj_get_style_text_font(label, 0) != pick)
+        lv_obj_set_style_text_font(label, pick, 0);
+}
+
 static void arc_start_exposure_anim(dashboard_page_t *p);
 
 void arc_interp_timer_cb(lv_timer_t *timer) {
@@ -177,6 +201,7 @@ static void update_disconnected_state(dashboard_page_t *p, int instance_idx, int
         set_label_if_changed(p->lbl_instance_name, state_text);
     }
     set_label_if_changed(p->lbl_target_name, "----");
+    auto_fit_target_name_font(p->lbl_target_name);
     set_label_if_changed(p->lbl_seq_container, "----");
     set_label_if_changed(p->lbl_seq_step, "----");
     set_label_if_changed(p->lbl_exposure_total, "");
@@ -219,6 +244,7 @@ static void update_header(dashboard_page_t *p, const nina_client_t *d) {
     }
 
     set_label_if_changed(p->lbl_target_name, d->target_name[0] != '\0' ? d->target_name : "----");
+    auto_fit_target_name_font(p->lbl_target_name);
 }
 
 static void update_sequence_info(dashboard_page_t *p, const nina_client_t *d) {

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -133,7 +133,7 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     cJSON *so = cJSON_GetObjectItem(root, "solar_orientation");
     if (cJSON_IsNumber(so)) { int v = so->valueint; cfg->solar_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *dlm = cJSON_GetObjectItem(root, "moon_drag_light_mode");
-    if (cJSON_IsNumber(dlm)) { int v = dlm->valueint; cfg->moon_drag_light_mode = (v >= 0 && v <= 1) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(dlm)) { int v = dlm->valueint; cfg->moon_drag_light_mode = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
     cJSON *fu = cJSON_GetObjectItem(root, "moon_flip_u");
     if (cJSON_IsNumber(fu)) { cfg->moon_flip_u = (fu->valueint != 0) ? 1 : 0; }
     cJSON *fv = cJSON_GetObjectItem(root, "moon_flip_v");


### PR DESCRIPTION
### Summary
This PR introduces a new interactive moon lighting mode that keeps the sun's terminator fixed to the lunar surface while swiping. It also improves the display of long target names on NINA pages by automatically fitting them onto a single line.

### Changes
*   Add a "Locked to surface" moon lighting mode where the sun's terminator stays pinned to the lunar surface during user swipes.
*   Provide "Locked to surface" as a new option in the moon lighting mode dropdown on the configuration UI.
*   Make the new "Locked to surface" moon lighting mode the default firmware setting.
*   Maintain surface-locked lighting during the ease-back phase of moon sphere interaction.
*   Adjust the configuration range for moon lighting modes to include the new option.
*   Automatically shrink the font size of long DSO target names on NINA pages to fit them on a single line.
*   Configure target name labels to clip text instead of wrapping if names are excessively long.

---
<sub>Analyzed **3** commit(s) | Updated: 2026-06-21T00:33:49.418Z | Generated by GitHub Actions</sub>