### PR TITLE
fix: stop MQTT brightness reboot loop

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -713,7 +713,7 @@ static void set_defaults(app_config_t *cfg) {
     cfg->screen_sleep_timeout_s = 60;
     cfg->alert_flash_enabled = true;
     cfg->idle_poll_interval_s = 30;
-    cfg->wifi_power_save = true;
+    cfg->wifi_power_save = false;  /* mains-powered display: WIFI_PS_NONE cuts DTIM modem-sleep latency */
     cfg->widget_style = 0;
     cfg->auto_update_check = 1;
     cfg->update_channel = 0;

--- a/main/main.c
+++ b/main/main.c
@@ -7,6 +7,8 @@
 #include "esp_err.h"
 #include "esp_wifi.h"
 #include "esp_event.h"
+#include "esp_hosted.h"
+#include "esp_hosted_host_fw_ver.h"
 #include "esp_sntp.h"
 #include "esp_timer.h"
 #include "bsp/esp-bsp.h"
@@ -580,6 +582,22 @@ void app_main(void)
     ESP_LOGI(TAG, "Configured instances: %d", instance_count);
 
     wifi_init();
+
+    /* Log esp-hosted host + C6 coprocessor firmware versions (diagnostic; readable
+     * via /api/logs). A host/slave version mismatch is the top cause of SDIO
+     * transport instability on the P4+C6. */
+    ESP_LOGI(TAG, "esp-hosted host fw: %d.%d.%d",
+             ESP_HOSTED_VERSION_MAJOR_1, ESP_HOSTED_VERSION_MINOR_1, ESP_HOSTED_VERSION_PATCH_1);
+    {
+        esp_hosted_coprocessor_fwver_t cpver = {0};
+        if (esp_hosted_get_coprocessor_fwversion(&cpver) == ESP_OK) {
+            ESP_LOGI(TAG, "esp-hosted C6 coprocessor fw: %u.%u.%u (rev %d)",
+                     (unsigned)cpver.major1, (unsigned)cpver.minor1, (unsigned)cpver.patch1,
+                     (int)cpver.revision);
+        } else {
+            ESP_LOGW(TAG, "esp-hosted: failed to read C6 coprocessor fw version");
+        }
+    }
 
 
     // Enable Dynamic Frequency Scaling — CPU scales 360 MHz (active) to 40 MHz (idle)

--- a/main/mqtt_ha.c
+++ b/main/mqtt_ha.c
@@ -346,55 +346,57 @@ void mqtt_ha_process_pending(void)
 {
     if (!s_cmd_queue) return;
 
-    bool screen_changed = false;
-    bool text_changed = false;
+    bool brightness_applied = false;
     bool reboot_requested = false;
 
     mqtt_cmd_t cmd;
     while (xQueueReceive(s_cmd_queue, &cmd, 0) == pdTRUE) {
         switch (cmd.type) {
         case MQTT_CMD_SCREEN_BRIGHTNESS: {
-            /* Snapshot+save: never mutate live &s_config field-by-field. */
-            app_config_t cfg = app_config_get_snapshot();
+            /* LIVE-ONLY: never persist MQTT brightness. NVS writes run with the
+             * CPU cache disabled, which can starve the esp-hosted SDIO transport
+             * and trigger a host restart. An HA lux automation publishes these
+             * commands very frequently, so we apply live and never save. Manual
+             * UI / web changes still persist via their own handlers. */
             int newv = cmd.value;
             if (newv < 0) {  /* "ON" with no value: restore a sane default if off */
-                newv = (cfg.brightness == 0) ? 50 : cfg.brightness;
+                int cur = app_config_get()->brightness;  /* scalar read, no save */
+                newv = (cur == 0) ? 50 : cur;
             }
-            if (newv != cfg.brightness) {
-                cfg.brightness = newv;
-                app_config_save(&cfg);  /* only persist on change (flash wear) */
-                screen_changed = true;
-            }
-            /* Apply backlight live unless screen-sleep owns it. data_update_task
-             * (this task) restores the saved brightness on wake. */
+            /* Apply backlight live unless screen-sleep owns it. The backlight set
+             * is config-independent and works without any config write. */
             if (!screen_asleep) {
                 bsp_display_brightness_set(newv);
-                ESP_LOGI(TAG, "Screen brightness set to %d%% via MQTT", newv);
+                ESP_LOGI(TAG, "Screen brightness set to %d%% via MQTT (live, not saved)", newv);
             } else {
-                ESP_LOGI(TAG, "Screen brightness config updated to %d%% via MQTT (display sleeping)", newv);
+                ESP_LOGI(TAG, "Screen brightness %d%% via MQTT ignored (display sleeping, live-only)", newv);
             }
+            brightness_applied = true;
             break;
         }
         case MQTT_CMD_TEXT_BRIGHTNESS: {
-            app_config_t cfg = app_config_get_snapshot();
+            /* LIVE-ONLY: never persist. The rendered theme reads color_brightness
+             * from the live app_config (apply_theme_to_page() in nina_dashboard.c),
+             * so the live effect requires the in-memory value to be visible to the
+             * theme code. Replicate the web UI live-preview (color_brightness_post_handler
+             * in web_handlers_display.c): write the single scalar field on the live
+             * config, then re-apply the theme — but skip app_config_save(). A single
+             * aligned int store is the same mechanism the UI uses; no torn-write race. */
+            app_config_t *cfg = app_config_get();
             int newv = cmd.value;
             if (newv < 0) {  /* "ON" with no value */
-                newv = (cfg.color_brightness == 0) ? 100 : cfg.color_brightness;
+                newv = (cfg->color_brightness == 0) ? 100 : cfg->color_brightness;
             }
-            int theme_index = cfg.theme_index;
-            if (newv != cfg.color_brightness) {
-                cfg.color_brightness = newv;
-                app_config_save(&cfg);
-                text_changed = true;
-            }
+            cfg->color_brightness = newv;  /* live scalar write, NOT saved */
             /* Re-apply theme so the new color brightness takes effect live. */
             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                nina_dashboard_apply_theme(theme_index);
+                nina_dashboard_apply_theme(cfg->theme_index);
                 bsp_display_unlock();
             } else {
                 ESP_LOGW(TAG, "Display lock timeout (MQTT theme apply)");
             }
-            ESP_LOGI(TAG, "Text brightness set to %d%% via MQTT", newv);
+            ESP_LOGI(TAG, "Text brightness set to %d%% via MQTT (live, not saved)", newv);
+            brightness_applied = true;
             break;
         }
         case MQTT_CMD_REBOOT:
@@ -403,7 +405,9 @@ void mqtt_ha_process_pending(void)
         }
     }
 
-    if (screen_changed || text_changed) {
+    /* Publish current (live) state so HA optimistic state stays in sync. Nothing
+     * is persisted; this only reflects the value we just applied in memory. */
+    if (brightness_applied) {
         mqtt_ha_publish_state();
     }
 

--- a/main/mqtt_ha.c
+++ b/main/mqtt_ha.c
@@ -13,12 +13,36 @@
 #include "bsp/display.h"
 #include "tasks.h"
 #include "ui/nina_dashboard.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdbool.h>
 #include <inttypes.h>
 
 static const char *TAG = "mqtt_ha";
+
+/* ── Deferred command handoff (INTEG-2/3/4) ─────────────────────────────────
+ * The MQTT event callback runs in the esp-mqtt event task and must stay fast
+ * and non-blocking — it must not take the display lock, drive the backlight,
+ * mutate live config, or write NVS (all of which can block and stall the MQTT
+ * keepalive). The callback only PARSES a command and enqueues the requested
+ * change here. mqtt_ha_process_pending(), called from the UI-context
+ * data_update_task each cycle, applies the change under the display lock and
+ * persists config via the snapshot+save pattern. */
+typedef enum {
+    MQTT_CMD_SCREEN_BRIGHTNESS,  /* value = 0..100 backlight brightness */
+    MQTT_CMD_TEXT_BRIGHTNESS,    /* value = 0..100 color (text) brightness */
+    MQTT_CMD_REBOOT,             /* deferred restart */
+} mqtt_cmd_type_t;
+
+typedef struct {
+    mqtt_cmd_type_t type;
+    int value;  /* clamped 0..100 for brightness commands; unused for reboot */
+} mqtt_cmd_t;
+
+#define MQTT_CMD_QUEUE_LEN 8
+static QueueHandle_t s_cmd_queue = NULL;
 
 // Exponential backoff for MQTT reconnection
 #define MQTT_BACKOFF_INITIAL_MS  5000   // 5 seconds
@@ -245,40 +269,43 @@ void mqtt_ha_publish_state(void)
     cJSON_Delete(text_state);
 }
 
+/* Non-blocking enqueue from the MQTT event task. Drops the command if the
+ * queue is full rather than blocking the event loop. */
+static void enqueue_cmd(mqtt_cmd_type_t type, int value)
+{
+    if (!s_cmd_queue) return;
+    mqtt_cmd_t cmd = { .type = type, .value = value };
+    if (xQueueSend(s_cmd_queue, &cmd, 0) != pdTRUE) {
+        ESP_LOGW(TAG, "MQTT command queue full — dropping command %d", (int)type);
+    }
+}
+
+/* Parse-only: resolve the requested brightness from the JSON payload and hand
+ * it off. Runs in the MQTT event task — no config writes, no display lock. */
 static void handle_screen_command(const char *data, int len)
 {
     cJSON *root = cJSON_ParseWithLength(data, len);
     if (!root) return;
 
-    app_config_t *cfg = app_config_get();
-
     cJSON *state = cJSON_GetObjectItem(root, "state");
     cJSON *brightness = cJSON_GetObjectItem(root, "brightness");
 
+    int val = -1;  /* -1 = "ON with no explicit value" sentinel */
     if (cJSON_IsString(state) && strcmp(state->valuestring, "OFF") == 0) {
-        cfg->brightness = 0;
+        val = 0;
     } else if (cJSON_IsNumber(brightness)) {
-        int val = brightness->valueint;
+        val = brightness->valueint;
         if (val < 0) val = 0;
         if (val > 100) val = 100;
-        cfg->brightness = val;
     } else if (cJSON_IsString(state) && strcmp(state->valuestring, "ON") == 0) {
-        if (cfg->brightness == 0) cfg->brightness = 50;
-    }
-
-    /* Don't physically change backlight while screen-sleep is active —
-     * the sleep logic in data_update_task owns the backlight during sleep.
-     * The config value is still saved so the correct brightness is restored on wake. */
-    if (!screen_asleep) {
-        bsp_display_brightness_set(cfg->brightness);
-        ESP_LOGI(TAG, "Screen brightness set to %d%% via MQTT", cfg->brightness);
+        val = -1;  /* consumer turns a 0 brightness back on at a default */
     } else {
-        ESP_LOGI(TAG, "Screen brightness config updated to %d%% via MQTT (display sleeping)", cfg->brightness);
+        cJSON_Delete(root);
+        return;  /* nothing actionable */
     }
 
-    app_config_save(cfg);
+    enqueue_cmd(MQTT_CMD_SCREEN_BRIGHTNESS, val);
     cJSON_Delete(root);
-    mqtt_ha_publish_state();
 }
 
 static void handle_text_command(const char *data, int len)
@@ -286,40 +313,102 @@ static void handle_text_command(const char *data, int len)
     cJSON *root = cJSON_ParseWithLength(data, len);
     if (!root) return;
 
-    app_config_t *cfg = app_config_get();
-
     cJSON *state = cJSON_GetObjectItem(root, "state");
     cJSON *brightness = cJSON_GetObjectItem(root, "brightness");
 
+    int val = -1;  /* -1 = "ON with no explicit value" sentinel */
     if (cJSON_IsString(state) && strcmp(state->valuestring, "OFF") == 0) {
-        cfg->color_brightness = 0;
+        val = 0;
     } else if (cJSON_IsNumber(brightness)) {
-        int val = brightness->valueint;
+        val = brightness->valueint;
         if (val < 0) val = 0;
         if (val > 100) val = 100;
-        cfg->color_brightness = val;
     } else if (cJSON_IsString(state) && strcmp(state->valuestring, "ON") == 0) {
-        if (cfg->color_brightness == 0) cfg->color_brightness = 100;
-    }
-
-    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        nina_dashboard_apply_theme(cfg->theme_index);
-        bsp_display_unlock();
+        val = -1;
     } else {
-        ESP_LOGW(TAG, "Display lock timeout (MQTT theme apply)");
+        cJSON_Delete(root);
+        return;
     }
 
-    ESP_LOGI(TAG, "Text brightness set to %d%% via MQTT", cfg->color_brightness);
-
-    app_config_save(cfg);
+    enqueue_cmd(MQTT_CMD_TEXT_BRIGHTNESS, val);
     cJSON_Delete(root);
-    mqtt_ha_publish_state();
 }
 
 static void handle_reboot_command(const char *data, int len)
 {
     if (len >= 5 && strncmp(data, "PRESS", 5) == 0) {
-        ESP_LOGW(TAG, "Reboot requested via MQTT");
+        ESP_LOGW(TAG, "Reboot requested via MQTT (deferred)");
+        enqueue_cmd(MQTT_CMD_REBOOT, 0);
+    }
+}
+
+void mqtt_ha_process_pending(void)
+{
+    if (!s_cmd_queue) return;
+
+    bool screen_changed = false;
+    bool text_changed = false;
+    bool reboot_requested = false;
+
+    mqtt_cmd_t cmd;
+    while (xQueueReceive(s_cmd_queue, &cmd, 0) == pdTRUE) {
+        switch (cmd.type) {
+        case MQTT_CMD_SCREEN_BRIGHTNESS: {
+            /* Snapshot+save: never mutate live &s_config field-by-field. */
+            app_config_t cfg = app_config_get_snapshot();
+            int newv = cmd.value;
+            if (newv < 0) {  /* "ON" with no value: restore a sane default if off */
+                newv = (cfg.brightness == 0) ? 50 : cfg.brightness;
+            }
+            if (newv != cfg.brightness) {
+                cfg.brightness = newv;
+                app_config_save(&cfg);  /* only persist on change (flash wear) */
+                screen_changed = true;
+            }
+            /* Apply backlight live unless screen-sleep owns it. data_update_task
+             * (this task) restores the saved brightness on wake. */
+            if (!screen_asleep) {
+                bsp_display_brightness_set(newv);
+                ESP_LOGI(TAG, "Screen brightness set to %d%% via MQTT", newv);
+            } else {
+                ESP_LOGI(TAG, "Screen brightness config updated to %d%% via MQTT (display sleeping)", newv);
+            }
+            break;
+        }
+        case MQTT_CMD_TEXT_BRIGHTNESS: {
+            app_config_t cfg = app_config_get_snapshot();
+            int newv = cmd.value;
+            if (newv < 0) {  /* "ON" with no value */
+                newv = (cfg.color_brightness == 0) ? 100 : cfg.color_brightness;
+            }
+            int theme_index = cfg.theme_index;
+            if (newv != cfg.color_brightness) {
+                cfg.color_brightness = newv;
+                app_config_save(&cfg);
+                text_changed = true;
+            }
+            /* Re-apply theme so the new color brightness takes effect live. */
+            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                nina_dashboard_apply_theme(theme_index);
+                bsp_display_unlock();
+            } else {
+                ESP_LOGW(TAG, "Display lock timeout (MQTT theme apply)");
+            }
+            ESP_LOGI(TAG, "Text brightness set to %d%% via MQTT", newv);
+            break;
+        }
+        case MQTT_CMD_REBOOT:
+            reboot_requested = true;
+            break;
+        }
+    }
+
+    if (screen_changed || text_changed) {
+        mqtt_ha_publish_state();
+    }
+
+    if (reboot_requested) {
+        ESP_LOGW(TAG, "Rebooting now (MQTT request)");
         esp_restart();
     }
 }
@@ -421,6 +510,16 @@ void mqtt_ha_start(void)
 
     init_device_id();
     build_topics(cfg->mqtt_topic_prefix);
+
+    /* Command handoff queue: written by the MQTT event task, drained by the
+     * UI-context data_update_task via mqtt_ha_process_pending(). */
+    if (!s_cmd_queue) {
+        s_cmd_queue = xQueueCreate(MQTT_CMD_QUEUE_LEN, sizeof(mqtt_cmd_t));
+        if (!s_cmd_queue) {
+            ESP_LOGE(TAG, "Failed to create MQTT command queue");
+            return;
+        }
+    }
 
     // Create reconnect timer (one-shot, managed by backoff logic)
     if (!s_reconnect_timer) {

--- a/main/mqtt_ha.h
+++ b/main/mqtt_ha.h
@@ -28,6 +28,17 @@ void mqtt_ha_publish_state(void);
  */
 bool mqtt_ha_is_connected(void);
 
+/**
+ * @brief Apply any pending MQTT commands (brightness, text brightness, theme,
+ *        reboot) queued by the MQTT event callback.
+ *
+ * Must be called from a UI-context task that may take the display lock
+ * (e.g. data_update_task). The MQTT event callback only parses and enqueues;
+ * the actual apply and config persist happen here so the esp-mqtt event loop
+ * is never blocked. Safe to call when MQTT is disabled (no-op).
+ */
+void mqtt_ha_process_pending(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/nina_client.c
+++ b/main/nina_client.c
@@ -186,6 +186,52 @@ cJSON *http_get_json(const char *url) {
     bool poll_mode = tls_ctx ? tls_ctx->poll_mode : false;
     esp_http_client_handle_t *reuse_slot = tls_ctx ? tls_ctx->client_handle : NULL;
 
+    /* ── mDNS-bypass URL rewrite ──
+     * NINA hostnames are typically .lan (mDNS), and esp_http_client does a fresh
+     * getaddrinfo() on every connect — that DNS+connect is ~42% of avg HTTP latency
+     * and the multi-second tail. Resolve the host ONCE via the app DNS cache, rebuild
+     * the request URL with the numeric IP (so connect skips getaddrinfo), and send the
+     * ORIGINAL hostname in the Host header so NINA's HTTP routing is unaffected.
+     * On a resolve miss we fall through to the original hostname URL (current
+     * behavior) — a resolve miss never breaks a request. */
+    const char *req_url = url;          /* URL actually handed to esp_http_client */
+    const char *host_hdr = NULL;        /* original hostname for the Host header, or NULL */
+    char rewritten_url[288];
+    char host_buf[128];
+    {
+        const char *scheme_end = strstr(url, "://");
+        if (scheme_end) {
+            const char *hstart = scheme_end + 3;
+            const char *hend = hstart;
+            while (*hend && *hend != ':' && *hend != '/') hend++;
+            size_t hlen = (size_t)(hend - hstart);
+            /* Only rewrite non-numeric hosts (a numeric host is already DNS-free). */
+            if (hlen > 0 && hlen < sizeof(host_buf) &&
+                !(hstart[0] >= '0' && hstart[0] <= '9')) {
+                memcpy(host_buf, hstart, hlen);
+                host_buf[hlen] = '\0';
+                /* Always carry the original hostname in Host (even on resolve
+                 * miss): a reused handle may have an explicit Host set from a
+                 * prior request, so we must re-assert the correct one every time
+                 * rather than leave a stale value behind. */
+                host_hdr = host_buf;
+                char ip_str[16];  /* INET_ADDRSTRLEN for IPv4 */
+                if (nina_client_resolve_host(host_buf, ip_str, sizeof(ip_str)) &&
+                    ip_str[0] != '\0') {
+                    /* Rebuild: <scheme://><ip><:port/path...>  (hend points at ':' or '/') */
+                    int n = snprintf(rewritten_url, sizeof(rewritten_url),
+                                     "%.*s%s%s",
+                                     (int)(hstart - url), url, ip_str, hend);
+                    if (n > 0 && n < (int)sizeof(rewritten_url)) {
+                        req_url = rewritten_url;  /* connect to IP, skip getaddrinfo */
+                    }
+                    /* else: rebuild overflowed — fall back to hostname URL, Host
+                     * still set to the same hostname (harmless, self-consistent). */
+                }
+            }
+        }
+    }
+
     perf_timer_start(&g_perf.http_request);
     perf_counter_increment(&g_perf.http_request_count);
     bool ever_connected = false;
@@ -203,10 +249,10 @@ cJSON *http_get_json(const char *url) {
 
         if (reusing) {
             client = *reuse_slot;
-            esp_http_client_set_url(client, url);
+            esp_http_client_set_url(client, req_url);
         } else {
             esp_http_client_config_t cfg = {
-                .url = url,
+                .url = req_url,
                 .timeout_ms = 3000,
                 .keep_alive_enable = poll_mode,
             };
@@ -214,7 +260,19 @@ cJSON *http_get_json(const char *url) {
             if (!client) continue;
         }
 
+        /* When the URL carries a numeric IP (mDNS bypass), the Host header must
+         * always carry the original hostname so NINA routes correctly. Re-set it
+         * every request: a reused handle may have served a different host, and
+         * set_url() does not update an explicitly-set Host header. When no rewrite
+         * happened (host_hdr == NULL) leave esp_http_client to derive Host from the
+         * URL as usual. */
+        if (host_hdr) {
+            esp_http_client_set_header(client, "Host", host_hdr);
+        }
+
+        perf_timer_start(&g_perf.http_connect);
         esp_err_t err = esp_http_client_open(client, 0);
+        perf_timer_stop(&g_perf.http_connect);
         if (err != ESP_OK) {
             esp_http_client_cleanup(client);
             if (reusing && reuse_slot) *reuse_slot = NULL;
@@ -222,7 +280,9 @@ cJSON *http_get_json(const char *url) {
         }
         ever_connected = true;
 
+        perf_timer_start(&g_perf.http_ttfb);
         int content_length = esp_http_client_fetch_headers(client);
+        perf_timer_stop(&g_perf.http_ttfb);
         if (content_length < 0) {
             esp_http_client_cleanup(client);
             if (reusing && reuse_slot) *reuse_slot = NULL;
@@ -276,12 +336,14 @@ cJSON *http_get_json(const char *url) {
         }
 
         int total_read_len = 0, read_len;
+        perf_timer_start(&g_perf.http_body);
         while (total_read_len < content_length) {
             read_len = esp_http_client_read(client, buffer + total_read_len,
                                             content_length - total_read_len);
             if (read_len <= 0) break;
             total_read_len += read_len;
         }
+        perf_timer_stop(&g_perf.http_body);
         /* Check for partial read — truncated JSON could parse into
          * a valid but incomplete tree, causing silent data loss. */
         if (total_read_len < content_length) {
@@ -312,6 +374,7 @@ cJSON *http_get_json(const char *url) {
         perf_counter_increment(&g_perf.json_parse_count);
         free(buffer);
         perf_timer_stop(&g_perf.http_request);
+        if (attempt > 0) perf_counter_increment(&g_perf.http_attempt0_fail_count);
         return json;
     }
 
@@ -781,6 +844,103 @@ void nina_client_init(void) {
     }
 }
 
+/* Resolve a hostname to a dotted-quad IPv4 string via the app-level DNS cache.
+ * Returns true and fills ip_out on success (cache hit, fresh lookup, or stale
+ * fallback); false (ip_out left empty) only when resolution fails with no cache.
+ * Shared by nina_client_dns_check() (connectivity pre-check) and http_get_json()
+ * (per-request URL rewrite to skip per-connect getaddrinfo on .lan hosts). */
+bool nina_client_resolve_host(const char *host, char *ip_out, size_t ip_len) {
+    if (!host || !ip_out || ip_len == 0) return false;
+    ip_out[0] = '\0';
+
+    size_t host_len = strlen(host);
+    if (host_len == 0 || host_len >= 128) return false;
+
+    // Numeric IPv4 host — return verbatim, no DNS needed.
+    if (host[0] >= '0' && host[0] <= '9') {
+        if (host_len >= ip_len) return false;
+        memcpy(ip_out, host, host_len + 1);
+        return true;
+    }
+
+    int64_t now_ms = esp_timer_get_time() / 1000;
+
+    if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
+
+    // Check DNS cache for a valid (non-expired) entry
+    for (int i = 0; i < 3; i++) {
+        if (strcmp(s_dns_cache[i].hostname, host) == 0 &&
+            s_dns_cache[i].resolved_ip[0] != '\0') {
+            if (now_ms - s_dns_cache[i].resolve_time_ms < DNS_CACHE_TTL_MS) {
+                snprintf(ip_out, ip_len, "%s", s_dns_cache[i].resolved_ip);
+                ESP_LOGD(TAG, "DNS cache hit for %s -> %s", host, ip_out);
+                if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
+                return true;
+            }
+            break;  // Found entry but expired — do fresh lookup
+        }
+    }
+
+    if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
+
+    // Cache miss or expired — perform real DNS lookup (outside mutex — can block)
+    struct addrinfo hints = {0};
+    hints.ai_family = AF_INET;
+    struct addrinfo *result = NULL;
+    int err = getaddrinfo(host, NULL, &hints, &result);
+
+    if (err == 0 && result) {
+        // Lookup succeeded — update cache under mutex
+        char ip_str[46] = {0};
+        struct sockaddr_in *addr = (struct sockaddr_in *)result->ai_addr;
+        inet_ntoa_r(addr->sin_addr, ip_str, sizeof(ip_str));
+        freeaddrinfo(result);
+
+        if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
+
+        // Find existing slot or first empty slot
+        int slot = -1;
+        for (int i = 0; i < 3; i++) {
+            if (strcmp(s_dns_cache[i].hostname, host) == 0 ||
+                s_dns_cache[i].hostname[0] == '\0') {
+                slot = i;
+                break;
+            }
+        }
+        if (slot < 0) slot = 0;  // Evict first slot if all full
+
+        snprintf(s_dns_cache[slot].hostname, sizeof(s_dns_cache[slot].hostname), "%s", host);
+        snprintf(s_dns_cache[slot].resolved_ip, sizeof(s_dns_cache[slot].resolved_ip), "%s", ip_str);
+        s_dns_cache[slot].resolve_time_ms = now_ms;
+
+        snprintf(ip_out, ip_len, "%s", ip_str);
+
+        if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
+
+        ESP_LOGD(TAG, "DNS cached %s -> %s", host, ip_str);
+        return true;
+    }
+
+    if (result) freeaddrinfo(result);
+
+    // Lookup failed — try stale cache as fallback
+    if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
+    for (int i = 0; i < 3; i++) {
+        if (strcmp(s_dns_cache[i].hostname, host) == 0 &&
+            s_dns_cache[i].resolved_ip[0] != '\0') {
+            snprintf(ip_out, ip_len, "%s", s_dns_cache[i].resolved_ip);
+            ESP_LOGW(TAG, "DNS lookup failed for %s, using stale cache -> %s",
+                     host, ip_out);
+            if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
+            return true;
+        }
+    }
+    if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
+
+    ESP_LOGD(TAG, "DNS check failed for %s (err %d), no cache available", host, err);
+    return false;
+}
+
 bool nina_client_dns_check(const char *base_url) {
     if (!base_url) return false;
 
@@ -800,81 +960,8 @@ bool nina_client_dns_check(const char *base_url) {
     memcpy(hostname, host_start, host_len);
     hostname[host_len] = '\0';
 
-    // IP addresses don't need DNS resolution
-    if (hostname[0] >= '0' && hostname[0] <= '9') return true;
-
-    int64_t now_ms = esp_timer_get_time() / 1000;
-
-    if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
-
-    // Check DNS cache for a valid (non-expired) entry
-    for (int i = 0; i < 3; i++) {
-        if (strcmp(s_dns_cache[i].hostname, hostname) == 0 &&
-            s_dns_cache[i].resolved_ip[0] != '\0') {
-            if (now_ms - s_dns_cache[i].resolve_time_ms < DNS_CACHE_TTL_MS) {
-                ESP_LOGD(TAG, "DNS cache hit for %s -> %s", hostname, s_dns_cache[i].resolved_ip);
-                if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
-                return true;
-            }
-            break;  // Found entry but expired — do fresh lookup
-        }
-    }
-
-    if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
-
-    // Cache miss or expired — perform real DNS lookup (outside mutex — can block)
-    struct addrinfo hints = {0};
-    hints.ai_family = AF_INET;
-    struct addrinfo *result = NULL;
-    int err = getaddrinfo(hostname, NULL, &hints, &result);
-
-    if (err == 0 && result) {
-        // Lookup succeeded — update cache under mutex
-        char ip_str[46] = {0};
-        struct sockaddr_in *addr = (struct sockaddr_in *)result->ai_addr;
-        inet_ntoa_r(addr->sin_addr, ip_str, sizeof(ip_str));
-        freeaddrinfo(result);
-
-        if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
-
-        // Find existing slot or first empty slot
-        int slot = -1;
-        for (int i = 0; i < 3; i++) {
-            if (strcmp(s_dns_cache[i].hostname, hostname) == 0 ||
-                s_dns_cache[i].hostname[0] == '\0') {
-                slot = i;
-                break;
-            }
-        }
-        if (slot < 0) slot = 0;  // Evict first slot if all full
-
-        snprintf(s_dns_cache[slot].hostname, sizeof(s_dns_cache[slot].hostname), "%s", hostname);
-        snprintf(s_dns_cache[slot].resolved_ip, sizeof(s_dns_cache[slot].resolved_ip), "%s", ip_str);
-        s_dns_cache[slot].resolve_time_ms = now_ms;
-
-        if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
-
-        ESP_LOGD(TAG, "DNS cached %s -> %s", hostname, ip_str);
-        return true;
-    }
-
-    if (result) freeaddrinfo(result);
-
-    // Lookup failed — try stale cache as fallback
-    if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
-    for (int i = 0; i < 3; i++) {
-        if (strcmp(s_dns_cache[i].hostname, hostname) == 0 &&
-            s_dns_cache[i].resolved_ip[0] != '\0') {
-            ESP_LOGW(TAG, "DNS lookup failed for %s, using stale cache -> %s",
-                     hostname, s_dns_cache[i].resolved_ip);
-            if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
-            return true;
-        }
-    }
-    if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
-
-    ESP_LOGD(TAG, "DNS check failed for %s (err %d), no cache available", hostname, err);
-    return false;
+    char ip_str[46];
+    return nina_client_resolve_host(hostname, ip_str, sizeof(ip_str));
 }
 
 #define MAX_IMAGE_SIZE (4 * 1024 * 1024)  // 4 MB cap for image downloads

--- a/main/nina_client_internal.h
+++ b/main/nina_client_internal.h
@@ -46,6 +46,18 @@ http_poll_ctx_t *http_poll_ctx_get(void);
  * Uses per-task poll context for client reuse when available. */
 cJSON *http_get_json(const char *url);
 
+/* Resolve an IPv4 hostname to its dotted-quad string using the app-level
+ * DNS cache (60s TTL, stale fallback). On a hit, copies the cached IP into
+ * ip_out and returns true; on a miss, performs a fresh getaddrinfo(), caches
+ * the result, and returns true. Returns false (ip_out untouched/empty) only
+ * when resolution fails and no cached entry exists.
+ *
+ * A numeric-IP host is returned verbatim (no DNS). ip_out should be at least
+ * 16 bytes (INET_ADDRSTRLEN) for IPv4. This lets the request path replace a
+ * .lan mDNS hostname with a numeric IP so esp_http_client skips getaddrinfo()
+ * on the hot path, while the original hostname is still sent in the Host header. */
+bool nina_client_resolve_host(const char *host, char *ip_out, size_t ip_len);
+
 /* NINA Advanced API envelope helpers. The API wraps every response in
  * { "Response": ..., "Success": bool, ... }. These honor the application-level
  * Success flag so callers can treat Success!=true as "API unavailable" even when

--- a/main/nina_websocket.c
+++ b/main/nina_websocket.c
@@ -429,9 +429,6 @@ static void handle_websocket_message(int index, const char *payload, int len) {
             if (filter && filter->valuestring)
                 strncpy(img_stats.filter, filter->valuestring, sizeof(img_stats.filter) - 1);
 
-            if (new_target)
-                strncpy(img_stats.camera_name, "", sizeof(img_stats.camera_name) - 1);
-
             cJSON *camera_name = cJSON_GetObjectItem(stats, "CameraName");
             if (camera_name && camera_name->valuestring)
                 strncpy(img_stats.camera_name, camera_name->valuestring, sizeof(img_stats.camera_name) - 1);
@@ -449,6 +446,10 @@ static void handle_websocket_message(int index, const char *payload, int len) {
             cJSON *filename = cJSON_GetObjectItem(stats, "Filename");
             if (filename && filename->valuestring)
                 strncpy(img_stats.filename, filename->valuestring, sizeof(img_stats.filename) - 1);
+
+            // Snapshots for post-unlock logging (avoid racing reads of data->)
+            int log_exposure_count = 0;
+            char log_target_name[64] = {0};
 
             // Short critical section: write parsed values into the shared struct
             if (nina_client_lock(data, 50)) {
@@ -477,6 +478,9 @@ static void handle_websocket_message(int index, const char *payload, int len) {
                     data->hfr_ring.count++;
                 }
 
+                log_exposure_count = data->exposure_count;
+                snprintf(log_target_name, sizeof(log_target_name), "%s", data->target_name);
+
                 nina_client_unlock(data);
             } else {
                 ESP_LOGW(TAG, "WS[%d]: Could not acquire mutex for IMAGE-SAVE", index);
@@ -484,12 +488,12 @@ static void handle_websocket_message(int index, const char *payload, int len) {
 
             nina_event_log_add_fmt(EVENT_SEV_INFO, index,
                 "Image #%d: %s, HFR %.2f, %d stars",
-                data->exposure_count, img_stats.filter, new_hfr, new_stars);
+                log_exposure_count, img_stats.filter, new_hfr, new_stars);
             nina_session_stats_add_exposure(index, new_exp_total);
 
             ESP_LOGI(TAG, "WS[%d]: HFR=%.2f Stars=%d Filter=%s Target=%s",
                 index, new_hfr, new_stars,
-                img_stats.filter, data->target_name);
+                img_stats.filter, log_target_name);
         }
     }
     // FILTERWHEEL-CHANGED: Replaces fetch_filter_robust_ex for current filter
@@ -506,7 +510,7 @@ static void handle_websocket_message(int index, const char *payload, int len) {
                 }
                 nina_event_log_add_fmt(EVENT_SEV_INFO, index,
                     "Filter changed to %s", name->valuestring);
-                ESP_LOGI(TAG, "WS[%d]: Filter changed to %s", index, data->current_filter);
+                ESP_LOGI(TAG, "WS[%d]: Filter changed to %s", index, name->valuestring);
             }
         }
     }
@@ -588,11 +592,12 @@ static void handle_websocket_message(int index, const char *payload, int len) {
     }
     // AUTOFOCUS-FINISHED: Mark AF complete, find best point
     else if (strcmp(evt->valuestring, "AUTOFOCUS-FINISHED") == 0) {
+        float best_hfr = 999.0f;
+        int best_pos = 0;
+        int af_count = 0;
         if (nina_client_lock(data, 50)) {
             data->autofocus.af_running = false;
             // Find best (minimum HFR) point
-            float best_hfr = 999.0f;
-            int best_pos = 0;
             for (int i = 0; i < data->autofocus.count; i++) {
                 if (data->autofocus.points[i].hfr < best_hfr) {
                     best_hfr = data->autofocus.points[i].hfr;
@@ -601,6 +606,7 @@ static void handle_websocket_message(int index, const char *payload, int len) {
             }
             data->autofocus.best_hfr = best_hfr;
             data->autofocus.best_position = best_pos;
+            af_count = data->autofocus.count;
             data->ui_refresh_needed = true;
             nina_client_unlock(data);
         }
@@ -608,8 +614,8 @@ static void handle_websocket_message(int index, const char *payload, int len) {
             ws_toast(index, TOAST_SUCCESS, "Autofocus complete");
         nina_event_log_add_fmt(EVENT_SEV_SUCCESS, index,
             "Autofocus complete: pos %d, HFR %.2f",
-            data->autofocus.best_position, data->autofocus.best_hfr);
-        ESP_LOGI(TAG, "WS[%d]: Autofocus finished (%d points)", index, data->autofocus.count);
+            best_pos, best_hfr);
+        ESP_LOGI(TAG, "WS[%d]: Autofocus finished (%d points)", index, af_count);
     }
     // AUTOFOCUS-POINT-ADDED: Add V-curve data point {Position, HFR}
     else if (strcmp(evt->valuestring, "AUTOFOCUS-POINT-ADDED") == 0) {
@@ -619,6 +625,7 @@ static void handle_websocket_message(int index, const char *payload, int len) {
         if (position && af_hfr) {
             int pos = position->valueint;
             float hfr_val = (float)af_hfr->valuedouble;
+            int af_count = 0;
 
             if (nina_client_lock(data, 50)) {
                 if (data->autofocus.count < MAX_AF_POINTS) {
@@ -627,11 +634,12 @@ static void handle_websocket_message(int index, const char *payload, int len) {
                     data->autofocus.points[idx].hfr = hfr_val;
                     data->autofocus.count++;
                 }
+                af_count = data->autofocus.count;
                 data->ui_refresh_needed = true;
                 nina_client_unlock(data);
             }
             ESP_LOGI(TAG, "WS[%d]: AF point: pos=%d HFR=%.2f (%d/%d)",
-                     index, pos, hfr_val, data->autofocus.count, MAX_AF_POINTS);
+                     index, pos, hfr_val, af_count, MAX_AF_POINTS);
         }
     }
     // ROTATOR-MOVED / ROTATOR-MOVED-MECHANICAL: Update rotator angle from WS

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -513,7 +513,8 @@ static void ota_download_task(void *arg) {
             }
 
             received += len;
-            int pct = (received * 100) / total_size;
+            /* 64-bit math: received*100 overflows int32 above ~21MB */
+            int pct = (int)(((int64_t)received * 100) / total_size);
             if (pct > 100) pct = 100;
             if (pct != last_pct) {
                 last_pct = pct;

--- a/main/perf_monitor.c
+++ b/main/perf_monitor.c
@@ -293,6 +293,9 @@ void perf_monitor_capture_cpu(void)
 
         uint32_t runtime_delta = current_tasks[i].ulRunTimeCounter - prev_runtime;
         float pct = (float)runtime_delta / (float)total_delta * 100.0f;
+        // Clamp: runtime counter wrap can produce pct > 100 (or < 0)
+        if (pct < 0.0f) pct = 0.0f;
+        if (pct > 100.0f) pct = 100.0f;
 
         // Check if this is an idle task (per-core idle tracking)
         if (strncmp(current_tasks[i].pcTaskName, "IDLE", 4) == 0) {

--- a/main/perf_monitor.c
+++ b/main/perf_monitor.c
@@ -387,6 +387,9 @@ void perf_monitor_report(void)
 
     ESP_LOGI(TAG, "── Network ──");
     log_timer("http_request",    &g_perf.http_request);
+    log_timer("http_connect",    &g_perf.http_connect);
+    log_timer("http_ttfb",       &g_perf.http_ttfb);
+    log_timer("http_body",       &g_perf.http_body);
     ESP_LOGI(TAG, "  HTTP requests:  %"PRIu32" (interval) / %"PRIu32" (total)",
              g_perf.http_request_count.per_interval, g_perf.http_request_count.total);
     ESP_LOGI(TAG, "  HTTP retries:   %"PRIu32" (interval) / %"PRIu32" (total)",
@@ -395,6 +398,8 @@ void perf_monitor_report(void)
              g_perf.http_failure_count.per_interval, g_perf.http_failure_count.total);
     ESP_LOGI(TAG, "  HTTP unreachable:%"PRIu32" (interval) / %"PRIu32" (total)",
              g_perf.http_unreachable_count.per_interval, g_perf.http_unreachable_count.total);
+    ESP_LOGI(TAG, "  HTTP attempt0 fail:%"PRIu32" (interval) / %"PRIu32" (total)",
+             g_perf.http_attempt0_fail_count.per_interval, g_perf.http_attempt0_fail_count.total);
     ESP_LOGI(TAG, "  WS events:      %"PRIu32" (interval) / %"PRIu32" (total)",
              g_perf.ws_event_count.per_interval, g_perf.ws_event_count.total);
 
@@ -499,6 +504,7 @@ void perf_monitor_report(void)
     perf_counter_reset_interval(&g_perf.http_retry_count);
     perf_counter_reset_interval(&g_perf.http_failure_count);
     perf_counter_reset_interval(&g_perf.http_unreachable_count);
+    perf_counter_reset_interval(&g_perf.http_attempt0_fail_count);
     perf_counter_reset_interval(&g_perf.ws_event_count);
     perf_counter_reset_interval(&g_perf.json_parse_count);
     perf_counter_reset_interval(&g_perf.spotify_poll_count);
@@ -594,10 +600,14 @@ char *perf_monitor_report_json(void)
     // Network
     cJSON *network = cJSON_CreateObject();
     cJSON_AddItemToObject(network, "http_request",      timer_to_json(&g_perf.http_request));
+    cJSON_AddItemToObject(network, "http_connect",      timer_to_json(&g_perf.http_connect));
+    cJSON_AddItemToObject(network, "http_ttfb",         timer_to_json(&g_perf.http_ttfb));
+    cJSON_AddItemToObject(network, "http_body",         timer_to_json(&g_perf.http_body));
     cJSON_AddItemToObject(network, "http_request_count", counter_to_json(&g_perf.http_request_count));
     cJSON_AddItemToObject(network, "http_retry_count",   counter_to_json(&g_perf.http_retry_count));
     cJSON_AddItemToObject(network, "http_failure_count", counter_to_json(&g_perf.http_failure_count));
     cJSON_AddItemToObject(network, "http_unreachable_count", counter_to_json(&g_perf.http_unreachable_count));
+    cJSON_AddItemToObject(network, "http_attempt0_fail_count", counter_to_json(&g_perf.http_attempt0_fail_count));
     cJSON_AddItemToObject(network, "ws_event_count",     counter_to_json(&g_perf.ws_event_count));
     cJSON_AddItemToObject(root, "network", network);
 

--- a/main/perf_monitor.h
+++ b/main/perf_monitor.h
@@ -87,6 +87,11 @@ typedef struct {
     perf_counter_t http_failure_count;    // HTTP failures per interval (connected but failed)
     perf_counter_t http_unreachable_count;// Host unreachable (connection refused/timeout)
     perf_counter_t ws_event_count;        // WebSocket events received per interval
+    // Per-phase HTTP timing (for resolve-once / numeric-IP latency diagnosis)
+    perf_timer_t http_connect;            // esp_http_client_open: DNS + TCP connect
+    perf_timer_t http_ttfb;               // fetch_headers: request sent -> response headers
+    perf_timer_t http_body;               // body read loop
+    perf_counter_t http_attempt0_fail_count; // request succeeded only on a retry (first attempt failed though host reachable)
 
     // JSON parsing
     perf_timer_t json_parse;              // cJSON_Parse duration (per-parse)

--- a/main/spotify_auth.c
+++ b/main/spotify_auth.c
@@ -85,14 +85,14 @@ static void load_tokens_from_nvs(void) {
         s_access_token[0] = '\0';
     }
 
-    /* Expiry — stored as int64 but NVS only has i32/u64. Use blob. */
-    len = sizeof(s_token_expiry_ms);
-    err = nvs_get_blob(nvs, NVS_KEY_EXPIRY, &s_token_expiry_ms, &len);
-    if (err != ESP_OK) {
-        s_token_expiry_ms = 0;
-    }
-
     nvs_close(nvs);
+
+    /* INTEG-1: The access-token expiry is a boot-relative esp_timer ms value.
+     * After a reboot esp_timer restarts at ~0, so a persisted expiry would make
+     * a long-expired access token look valid. Never trust the monotonic expiry
+     * across boots — force it to 0 so the first get_access_token() refreshes.
+     * Only the refresh token is meaningfully persistent. */
+    s_token_expiry_ms = 0;
 
     if (s_refresh_token[0] != '\0') {
         s_state = SPOTIFY_AUTH_AUTHORIZED;

--- a/main/spotify_client.c
+++ b/main/spotify_client.c
@@ -20,6 +20,7 @@
 #include "freertos/queue.h"
 #include <string.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 static const char *TAG = "spotify_client";
 
@@ -494,6 +495,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
     }
 
     /* Stream response into buffer */
+    bool had_content_length = (content_length > 0);
     size_t total_read = 0;
     int read_len;
     while (total_read < buf_size) {
@@ -501,6 +503,22 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
                                          buf_size - total_read);
         if (read_len <= 0) break;
         total_read += read_len;
+    }
+
+    /* INTEG-7: With no Content-Length the buffer is sized to the cap. If it
+     * filled exactly, the image may be larger than the cap and silently
+     * truncated. Probe one more byte: if more data is available the source
+     * exceeded SPOTIFY_ART_MAX_SIZE — reject rather than decode a partial JPEG. */
+    if (!had_content_length && total_read == buf_size) {
+        char probe;
+        int extra = esp_http_client_read(client, &probe, 1);
+        if (extra > 0) {
+            ESP_LOGW(TAG, "Album art exceeds %d byte cap (no content-length) — rejecting",
+                     (int)SPOTIFY_ART_MAX_SIZE);
+            esp_http_client_cleanup(client);
+            free(buffer);
+            return ESP_FAIL;
+        }
     }
 
     esp_http_client_cleanup(client);

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -2187,6 +2187,11 @@ main_loop:
             }
         }
 
+        /* ── Apply any pending MQTT commands (brightness/text/theme/reboot) ──
+         * The MQTT event callback only parses+enqueues; the blocking apply
+         * (display lock, backlight, config save) happens here in UI context. */
+        mqtt_ha_process_pending();
+
         int current_active = nina_dashboard_get_active_page();  // Snapshot to avoid races
         bool on_allsky = nina_dashboard_is_allsky_page();
         bool on_sysinfo = nina_dashboard_is_sysinfo_page();

--- a/main/ui/nina_alerts.c
+++ b/main/ui/nina_alerts.c
@@ -153,17 +153,18 @@ void nina_alerts_init(lv_obj_t *screen) {
 void nina_alert_trigger(alert_type_t type, int instance, float value) {
     if (type < 0 || type > ALERT_SAFETY) return;
 
-    /* Cooldown check (read-only, minor race is acceptable) */
+    /* Cooldown read-modify-write of the 64-bit timestamp and the pending-slot
+     * write must be atomic together, else two tasks can both pass the cooldown
+     * gate or tear the 64-bit timestamp. esp_timer_get_time() is safe in a
+     * critical section. */
     int64_t t = now_ms();
+    portENTER_CRITICAL(&s_alert_lock);
     if (t - s_last_flash_ms[type] < ALERT_COOLDOWN_MS) {
+        portEXIT_CRITICAL(&s_alert_lock);
         return;
     }
-
-    /* Update cooldown timestamp */
     s_last_flash_ms[type] = t;
 
-    /* Write to pending slot under spinlock */
-    portENTER_CRITICAL(&s_alert_lock);
     s_pending_alert.type = type;
     s_pending_alert.instance = instance;
     s_pending_alert.value = value;

--- a/main/ui/nina_dashboard_update.c
+++ b/main/ui/nina_dashboard_update.c
@@ -101,12 +101,17 @@ void arc_interp_timer_cb(lv_timer_t *timer) {
     if (!p || !p->arc_exposure || p->arc_completing) return;
     if (p->cached_end_epoch == 0 || p->cached_total <= 0) return;
 
+    /* Compute the remaining time as an int64 millisecond difference first.
+     * Epoch seconds (~1.7e9) exceed float's 24-bit integer precision, so a
+     * direct (float)tv.tv_sec would lose ~100s of seconds. Differencing in
+     * int64 ms keeps full precision; the small result converts to float
+     * safely for the P4 single-precision FPU. */
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    double now = (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
-    double remaining = (double)p->cached_end_epoch - now;
+    int64_t now_ms = (int64_t)tv.tv_sec * 1000 + (int64_t)tv.tv_usec / 1000;
+    int64_t remaining_ms = p->cached_end_epoch * 1000 - now_ms;
 
-    if (remaining <= 0) {
+    if (remaining_ms <= 0) {
         lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
         if (p->cached_is_exposing && lv_arc_get_value(p->arc_exposure) != ARC_RANGE)
             lv_arc_set_value(p->arc_exposure, ARC_RANGE);
@@ -118,9 +123,10 @@ void arc_interp_timer_cb(lv_timer_t *timer) {
         return;
     }
 
-    double elapsed = (double)p->cached_total - remaining;
+    float remaining = (float)remaining_ms / 1000.0f;
+    float elapsed = p->cached_total - remaining;
     if (elapsed < 0) elapsed = 0;
-    int expected = (int)((elapsed * ARC_RANGE) / (double)p->cached_total);
+    int expected = (int)((elapsed * (float)ARC_RANGE) / p->cached_total);
     if (expected > ARC_RANGE) expected = ARC_RANGE;
     if (expected < 0) expected = 0;
 
@@ -258,14 +264,15 @@ static void update_sequence_info(dashboard_page_t *p, const nina_client_t *d) {
 static void arc_start_exposure_anim(dashboard_page_t *p) {
     if (p->cached_end_epoch == 0 || p->cached_total <= 0 || !p->cached_is_exposing) return;
 
+    /* int64 ms difference to preserve epoch precision (see arc_interp_timer_cb). */
     struct timeval tv;
     gettimeofday(&tv, NULL);
-    double now = (double)tv.tv_sec + (double)tv.tv_usec / 1000000.0;
-    double remaining = (double)p->cached_end_epoch - now;
-    if (remaining <= 0.1) return;
+    int64_t now_ms = (int64_t)tv.tv_sec * 1000 + (int64_t)tv.tv_usec / 1000;
+    int64_t remaining_ms64 = p->cached_end_epoch * 1000 - now_ms;
+    if (remaining_ms64 <= 100) return;
 
     int current = lv_arc_get_value(p->arc_exposure);
-    int remaining_ms = (int)(remaining * 1000);
+    int remaining_ms = (int)remaining_ms64;
 
     lv_anim_t a;
     lv_anim_init(&a);

--- a/main/ui/nina_graph_overlay.c
+++ b/main/ui/nina_graph_overlay.c
@@ -31,6 +31,12 @@
 /* -- History point options ----------------------------------------------- */
 const int point_options[] = {25, 50, 100, 200, 400};
 
+/* Max points actually drawn on the chart. The chart is ~720px wide, so more
+ * than this yields sub-pixel polyline segments with no visible difference.
+ * Decimating the displayed set (storage stays GRAPH_MAX_POINTS) roughly halves
+ * the per-point loop and polyline segment count for the heavy locked redraw. */
+#define GRAPH_MAX_DISPLAY_POINTS 360
+
 /* -- Y-scale options for RMS (arcseconds x 100) ------------------------- */
 const int rms_scale_values[] = {0, 100, 200, 400, 800, 1600};  /* 0 = auto */
 const char *rms_scale_labels[] = {"Auto", "1\"", "2\"", "4\"", "8\"", "16\""};
@@ -566,8 +572,18 @@ void nina_graph_set_rms_data(const graph_rms_data_t *data) {
     }
     if (count > GRAPH_MAX_POINTS) count = GRAPH_MAX_POINTS;
 
+    /* Decimate the displayed set to the chart's pixel width. When the source
+     * has more samples than the chart can resolve, subsample with an integer
+     * stride so the polyline draws far fewer segments under the display lock. */
+    int disp_count = count;
+    int stride = 1;
+    if (count > GRAPH_MAX_DISPLAY_POINTS) {
+        stride = (count + GRAPH_MAX_DISPLAY_POINTS - 1) / GRAPH_MAX_DISPLAY_POINTS;
+        disp_count = (count + stride - 1) / stride;
+    }
+
     /* Configure chart */
-    lv_chart_set_point_count(chart, count);
+    lv_chart_set_point_count(chart, disp_count);
 
     /* Hide HFR series, show RMS series (respecting legend toggle) */
     lv_chart_hide_series(chart, ser_hfr, true);
@@ -603,8 +619,9 @@ void nina_graph_set_rms_data(const graph_rms_data_t *data) {
     lv_chart_set_range(chart, LV_CHART_AXIS_PRIMARY_Y, -range, range);
     update_y_labels(-range, range);
 
-    /* Populate series data (values are x100 for int precision) */
-    for (int i = 0; i < count; i++) {
+    /* Populate series data (values are x100 for int precision).
+     * Stride through the source so exactly disp_count points are pushed. */
+    for (int i = 0; i < count; i += stride) {
         lv_chart_set_next_value(chart, ser_ra, (int32_t)(data->ra[i] * 100.0f));
         lv_chart_set_next_value(chart, ser_dec, (int32_t)(data->dec[i] * 100.0f));
         float total_i = sqrtf(data->ra[i] * data->ra[i] + data->dec[i] * data->dec[i]);
@@ -614,7 +631,8 @@ void nina_graph_set_rms_data(const graph_rms_data_t *data) {
     /* Show threshold lines at configured good/ok boundaries */
     update_threshold_lines(-range, range);
 
-    lv_chart_refresh(chart);
+    /* No explicit lv_chart_refresh: set_next_value already invalidated the
+     * chart; let the normal refresh timer coalesce the redraw. */
 
     /* Update summary */
     if (lbl_summary) {
@@ -641,8 +659,16 @@ void nina_graph_set_hfr_data(const graph_hfr_data_t *data) {
     }
     if (count > GRAPH_MAX_POINTS) count = GRAPH_MAX_POINTS;
 
+    /* Decimate the displayed set to the chart's pixel width (see RMS path). */
+    int disp_count = count;
+    int stride = 1;
+    if (count > GRAPH_MAX_DISPLAY_POINTS) {
+        stride = (count + GRAPH_MAX_DISPLAY_POINTS - 1) / GRAPH_MAX_DISPLAY_POINTS;
+        disp_count = (count + stride - 1) / stride;
+    }
+
     /* Configure chart */
-    lv_chart_set_point_count(chart, count);
+    lv_chart_set_point_count(chart, disp_count);
 
     /* Hide RMS series, show HFR series (respecting legend toggle) */
     lv_chart_hide_series(chart, ser_ra, true);
@@ -676,15 +702,17 @@ void nina_graph_set_hfr_data(const graph_hfr_data_t *data) {
     lv_chart_set_range(chart, LV_CHART_AXIS_PRIMARY_Y, 0, range);
     update_y_labels(0, range);
 
-    /* Populate series data (values are x100) */
-    for (int i = 0; i < count; i++) {
+    /* Populate series data (values are x100).
+     * Stride through the source so exactly disp_count points are pushed. */
+    for (int i = 0; i < count; i += stride) {
         lv_chart_set_next_value(chart, ser_hfr, (int32_t)(data->hfr[i] * 100.0f));
     }
 
     /* Show threshold lines at configured good/ok boundaries */
     update_threshold_lines(0, range);
 
-    lv_chart_refresh(chart);
+    /* No explicit lv_chart_refresh: set_next_value already invalidated the
+     * chart; let the normal refresh timer coalesce the redraw. */
 
     /* Update summary */
     if (lbl_summary) {

--- a/main/ui/nina_info_session_stats.c
+++ b/main/ui/nina_info_session_stats.c
@@ -277,7 +277,14 @@ void build_session_stats_content(lv_obj_t *content) {
 void populate_session_stats_data(int instance) {
     if (!content_root) return;
 
-    const session_stats_t *st = nina_session_stats_get(instance);
+    /* Copy stats under the collector's lock to avoid torn reads (the recorder
+     * mutates s_stats[] from other tasks). Only scalars are read below;
+     * stats_copy.points is the live pointer and is never dereferenced here. */
+    session_stats_t stats_copy;
+    const session_stats_t *st = NULL;
+    if (nina_session_stats_get_copy(instance, &stats_copy)) {
+        st = &stats_copy;
+    }
 
     if (!st || st->total_exposures == 0) {
         /* Show no-data, hide everything else */

--- a/main/ui/nina_session_stats.c
+++ b/main/ui/nina_session_stats.c
@@ -117,6 +117,14 @@ const session_stats_t *nina_session_stats_get(int instance) {
     return &s_stats[instance];
 }
 
+bool nina_session_stats_get_copy(int instance, session_stats_t *out) {
+    if (instance < 0 || instance >= MAX_NINA_INSTANCES || !out) return false;
+    portENTER_CRITICAL(&s_lock);
+    *out = s_stats[instance];   /* shallow copy of scalars; points not dereffed by consumer */
+    portEXIT_CRITICAL(&s_lock);
+    return true;
+}
+
 void nina_session_stats_add_exposure(int instance, float exposure_time_s) {
     if (instance < 0 || instance >= MAX_NINA_INSTANCES) return;
 

--- a/main/ui/nina_session_stats.h
+++ b/main/ui/nina_session_stats.h
@@ -57,6 +57,13 @@ void nina_session_stats_reset(int instance);
 /** Get read-only pointer to instance stats.  Caller should copy quickly. */
 const session_stats_t *nina_session_stats_get(int instance);
 
+/**
+ * Copy instance stats into @p out under the lock (torn-read safe).
+ * Copies scalars only; @c out->points is the live pointer and must not be
+ * dereferenced by the caller. Returns false on bad instance/null out.
+ */
+bool nina_session_stats_get_copy(int instance, session_stats_t *out);
+
 /** Add exposure time.  Thread-safe. */
 void nina_session_stats_add_exposure(int instance, float exposure_time_s);
 

--- a/main/ui/nina_summary.c
+++ b/main/ui/nina_summary.c
@@ -852,11 +852,18 @@ void summary_page_update(const nina_client_t *instances, int count) {
 
     int gb = app_config_get()->color_brightness;
 
-    /* Count connected instances (use centralized connection state) */
-    int connected_count = nina_connection_connected_count();
+    /* Count visible cards using the SAME predicate as the per-card show/hide
+     * loop below (slot-available AND within count AND connected). Using the
+     * raw nina_connection_connected_count() here would ignore slot
+     * availability and could desync the empty-state test and the layout tier
+     * from what the cards actually show. */
+    int visible = 0;
+    for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
+        if (nina_slot_available[i] && i < count && nina_connection_is_connected(i)) visible++;
+    }
 
-    /* Empty state: show message when nothing is connected */
-    if (connected_count == 0) {
+    /* Empty state: show message when nothing is visible */
+    if (visible == 0) {
         for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
             lv_obj_add_flag(cards[i].card, LV_OBJ_FLAG_HIDDEN);
         }
@@ -872,7 +879,7 @@ void summary_page_update(const nina_client_t *instances, int count) {
         lv_obj_add_flag(empty_cont, LV_OBJ_FLAG_HIDDEN);
     }
 
-    bool layout_changed = (connected_count != prev_visible_count);
+    bool layout_changed = (visible != prev_visible_count);
 
     if (layout_changed) {
         /* ── FLIP animation: First, Last, Invert, Play ───────────── */
@@ -893,7 +900,7 @@ void summary_page_update(const nina_client_t *instances, int count) {
         for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
             if (nina_slot_available[i] && i < count && nina_connection_is_connected(i)) {
                 lv_obj_clear_flag(cards[i].card, LV_OBJ_FLAG_HIDDEN);
-                update_card_layout(&cards[i], connected_count);
+                update_card_layout(&cards[i], visible);
             } else {
                 lv_obj_add_flag(cards[i].card, LV_OBJ_FLAG_HIDDEN);
             }
@@ -942,7 +949,7 @@ void summary_page_update(const nina_client_t *instances, int count) {
         }
     }
 
-    prev_visible_count = connected_count;
+    prev_visible_count = visible;
 
     /* ── Update card data ────────────────────────────────────────── */
     for (int i = 0; i < MAX_NINA_INSTANCES && i < count; i++) {
@@ -1099,7 +1106,7 @@ void summary_page_update(const nina_client_t *instances, int count) {
         }
 
         /* Sequence info (visible in 1-2 card mode) */
-        if (connected_count <= 2 && !lv_obj_has_flag(sc->seq_row, LV_OBJ_FLAG_HIDDEN)) {
+        if (visible <= 2 && !lv_obj_has_flag(sc->seq_row, LV_OBJ_FLAG_HIDDEN)) {
             if (d->container_name[0]) {
                 set_label_if_changed(sc->lbl_seq_name, d->container_name);
             } else {
@@ -1213,7 +1220,7 @@ void summary_page_update(const nina_client_t *instances, int count) {
         }
 
         /* Exposure detail line (1-card mode only) */
-        if (connected_count <= 1 &&
+        if (visible <= 1 &&
             !lv_obj_has_flag(sc->detail_row, LV_OBJ_FLAG_HIDDEN)) {
             char detail[128] = "";
             int len = 0;

--- a/main/ui/nina_toast.c
+++ b/main/ui/nina_toast.c
@@ -710,8 +710,12 @@ void nina_toast_show(toast_severity_t sev, const char *msg) {
         }
     }
     if (slot < 0) {
-        /* Queue full — overwrite oldest (slot 0) */
-        slot = 0;
+        /* Queue full — drop the new toast. The pending array is not a FIFO
+         * ring, so there is no reliable "oldest" slot to overwrite; clobbering
+         * slot 0 would destroy an arbitrary valid entry. Dropping under backlog
+         * is acceptable backpressure (the queue drains on the next tick). */
+        portEXIT_CRITICAL(&s_pending_lock);
+        return;
     }
 
     s_pending[slot].sev = sev;

--- a/main/ui/settings_tab_display.c
+++ b/main/ui/settings_tab_display.c
@@ -63,6 +63,102 @@ static void skip_offline_changed_cb(lv_event_t *e);
 static void page_checkbox_changed_cb(lv_event_t *e);
 static void update_mode_visibility(uint32_t mode);
 
+/* Home-page dropdown <-> absolute page index map.
+ * Dropdown rows: 0=Auto, 1=AllSky, 2=Spotify, 3=Clock, 4=Summary,
+ *                5=NINA1, 6=NINA2, 7=NINA3, 8=SysInfo.
+ * Absolute indices: AllSky=0, Spotify=1, Clock=2, Summary=4,
+ *                   NINA i = NINA_PAGE_OFFSET+i, SysInfo=SYSINFO_PAGE_IDX.
+ * Auto (row 0) maps to active_page_override = -1. */
+static int home_dd_sel_to_abs(uint32_t sel)
+{
+    switch (sel) {
+        case 0: return -1;                          /* Auto */
+        case 1: return PAGE_IDX_ALLSKY;             /* 0 */
+        case 2: return PAGE_IDX_SPOTIFY;            /* 1 */
+        case 3: return PAGE_IDX_CLOCK;             /* 2 */
+        case 4: return PAGE_IDX_SUMMARY;           /* 4 */
+        case 5: return NINA_PAGE_OFFSET + 0;       /* 5 */
+        case 6: return NINA_PAGE_OFFSET + 1;       /* 6 */
+        case 7: return NINA_PAGE_OFFSET + 2;       /* 7 */
+        case 8: return SYSINFO_PAGE_IDX(page_count);
+        default: return -1;
+    }
+}
+
+/* Inverse of home_dd_sel_to_abs: absolute page index -> dropdown row. */
+static uint32_t home_abs_to_dd_sel(int ov)
+{
+    if (ov < 0) return 0;                                  /* Auto */
+    if (ov == PAGE_IDX_ALLSKY) return 1;
+    if (ov == PAGE_IDX_SPOTIFY) return 2;
+    if (ov == PAGE_IDX_CLOCK) return 3;
+    if (ov == PAGE_IDX_SUMMARY) return 4;
+    if (ov == NINA_PAGE_OFFSET + 0) return 5;
+    if (ov == NINA_PAGE_OFFSET + 1) return 6;
+    if (ov == NINA_PAGE_OFFSET + 2) return 7;
+    if (ov == SYSINFO_PAGE_IDX(page_count)) return 8;
+    return 4;   /* PAGE_IDX_IMAGE_DISPLAY (3) and any stray value -> Summary */
+}
+
+/* ── Slideshow order-list helpers (canonical membership) ──
+ *
+ * The nav arbiter slideshow reads ONLY auto_rotate_order[0..7] +
+ * auto_rotate_order_ext (9 slots). Each slot holds a "bit code" page id:
+ *   0=Summary, 1=NINA1, 2=NINA2, 3=NINA3, 4=SysInfo,
+ *   5=AllSky, 6=Spotify, 7=Clock, 8=ImageDisplay; 0xFF = empty.
+ * The on-device checkbox table exposes only codes 0..5 (page_names below);
+ * codes 6/7/8 are preserved across edits since this UI cannot express them. */
+
+#define AR_ORDER_SLOTS  9   /* 8 in auto_rotate_order[] + 1 ext */
+
+/* Read slot i (0..8) of the canonical order list from cfg. */
+static uint8_t ar_order_get(const app_config_t *cfg, int i)
+{
+    return (i < 8) ? cfg->auto_rotate_order[i] : cfg->auto_rotate_order_ext;
+}
+
+/* Write slot i (0..8) of the canonical order list in cfg. */
+static void ar_order_set(app_config_t *cfg, int i, uint8_t v)
+{
+    if (i < 8) cfg->auto_rotate_order[i] = v;
+    else       cfg->auto_rotate_order_ext = v;
+}
+
+/* True if bit-code page is present anywhere in the order list. */
+static bool ar_order_contains(const app_config_t *cfg, uint8_t code)
+{
+    for (int i = 0; i < AR_ORDER_SLOTS; i++) {
+        if (ar_order_get(cfg, i) == code) return true;
+    }
+    return false;
+}
+
+/* Add a bit-code page to the order list (append into first empty slot),
+ * preserving existing order. No-op if already present or list is full. */
+static void ar_order_add(app_config_t *cfg, uint8_t code)
+{
+    if (ar_order_contains(cfg, code)) return;
+    for (int i = 0; i < AR_ORDER_SLOTS; i++) {
+        if (ar_order_get(cfg, i) == 0xFF) { ar_order_set(cfg, i, code); return; }
+    }
+}
+
+/* Remove a bit-code page from the order list and compact remaining entries
+ * forward so order is preserved and trailing slots become 0xFF. */
+static void ar_order_remove(app_config_t *cfg, uint8_t code)
+{
+    uint8_t kept[AR_ORDER_SLOTS];
+    int n = 0;
+    for (int i = 0; i < AR_ORDER_SLOTS; i++) {
+        uint8_t v = ar_order_get(cfg, i);
+        if (v == 0xFF || v == code) continue;
+        kept[n++] = v;
+    }
+    for (int i = 0; i < AR_ORDER_SLOTS; i++) {
+        ar_order_set(cfg, i, (i < n) ? kept[i] : 0xFF);
+    }
+}
+
 /* ═══════════════════════════════════════════════════════════════════════
  *  Appearance Card — Theme / Widget Style / Text Brightness
  * ═══════════════════════════════════════════════════════════════════════ */
@@ -343,21 +439,9 @@ static void create_page_nav_card(lv_obj_t *parent)
             lv_obj_set_style_border_width(dd_pinned_page, 1, 0);
         }
 
-        /* Set initial selection from config.
-         * Dropdown mapping: 0=Auto(-1), 1=AllSky(0), 2=Spotify(1), 3=Clock(2),
-         * 4=Summary(3), 5=NINA1(4), 6=NINA2(5), 7=NINA3(6), 8=SysInfo(total-1) */
-        {
-            int8_t ov = app_config_get()->active_page_override;
-            int total = nina_dashboard_get_total_page_count();
-            int sysinfo_ov = total > 0 ? total - 1 : 8;
-            if (ov < 0) {
-                lv_dropdown_set_selected(dd_pinned_page, 0);  /* Auto */
-            } else if (ov >= sysinfo_ov) {
-                lv_dropdown_set_selected(dd_pinned_page, 8);  /* SysInfo */
-            } else {
-                lv_dropdown_set_selected(dd_pinned_page, (uint32_t)(ov + 1));
-            }
-        }
+        /* Set initial selection from config (absolute page index -> row). */
+        lv_dropdown_set_selected(dd_pinned_page,
+                                 home_abs_to_dd_sel(app_config_get()->active_page_override));
 
         lv_obj_add_event_cb(dd_pinned_page, pinned_page_changed_cb, LV_EVENT_VALUE_CHANGED, NULL);
     }
@@ -461,11 +545,13 @@ static void create_page_nav_card(lv_obj_t *parent)
                 lv_color_hex(app_config_apply_brightness(current_theme->text_color, gb)), 0);
         }
 
+        /* Checkbox index i maps directly to canonical order-list bit code i:
+         * 0=Summary, 1=NINA1, 2=NINA2, 3=NINA3, 4=SysInfo, 5=AllSky. */
         static const char *page_names[] = {
             "Summary", "NINA 1", "NINA 2", "NINA 3", "SysInfo", "AllSky"
         };
 
-        uint8_t mask = app_config_get()->auto_rotate_pages;
+        const app_config_t *cfg_cb = app_config_get();
 
         /* Wrap container for checkboxes (2 columns) */
         lv_obj_t *cb_grid = lv_obj_create(cont_cycle);
@@ -482,7 +568,7 @@ static void create_page_nav_card(lv_obj_t *parent)
             lv_obj_set_style_text_font(cb_pages[i], &lv_font_montserrat_16, 0);
             lv_obj_set_style_min_width(cb_pages[i], 130, 0);
 
-            if (mask & (1 << i)) {
+            if (ar_order_contains(cfg_cb, (uint8_t)i)) {
                 lv_obj_add_state(cb_pages[i], LV_STATE_CHECKED);
             }
 
@@ -609,17 +695,10 @@ static void page_mode_changed_cb(lv_event_t *e)
     } else if (sel == 1) {
         /* Fixed */
         cfg->auto_rotate_enabled = false;
-        /* Set override to the currently selected pinned page */
+        /* Set override to the currently selected pinned page (absolute index) */
         if (dd_pinned_page) {
             uint32_t dd_sel = lv_dropdown_get_selected(dd_pinned_page);
-            if (dd_sel == 0) {
-                cfg->active_page_override = -1;
-            } else if (dd_sel == 8) {
-                int total = nina_dashboard_get_total_page_count();
-                cfg->active_page_override = (int8_t)(total > 0 ? total - 1 : 8);
-            } else {
-                cfg->active_page_override = (int8_t)(dd_sel - 1);
-            }
+            cfg->active_page_override = (int8_t)home_dd_sel_to_abs(dd_sel);
         }
     } else if (sel == 2) {
         /* Cycle */
@@ -639,16 +718,7 @@ static void pinned_page_changed_cb(lv_event_t *e)
 {
     LV_UNUSED(e);
     uint32_t sel = lv_dropdown_get_selected(dd_pinned_page);
-    /* Dropdown mapping: 0=Auto(-1), 1=AllSky(0), 2=Spotify(1), 3=Clock(2),
-     * 4=Summary(3), 5=NINA1(4), 6=NINA2(5), 7=NINA3(6), 8=SysInfo */
-    if (sel == 0) {
-        app_config_get()->active_page_override = -1;  /* Auto */
-    } else if (sel == 8) {
-        int total = nina_dashboard_get_total_page_count();
-        app_config_get()->active_page_override = (int8_t)(total > 0 ? total - 1 : 8);
-    } else {
-        app_config_get()->active_page_override = (int8_t)(sel - 1);
-    }
+    app_config_get()->active_page_override = (int8_t)home_dd_sel_to_abs(sel);
     settings_mark_dirty(false);
 }
 
@@ -694,15 +764,25 @@ static void skip_offline_changed_cb(lv_event_t *e)
 
 static void page_checkbox_changed_cb(lv_event_t *e)
 {
-    int bit = (int)(uintptr_t)lv_event_get_user_data(e);
+    int bit = (int)(uintptr_t)lv_event_get_user_data(e);   /* canonical order code */
     lv_obj_t *cb = lv_event_get_target(e);
-    app_config_t *cfg = app_config_get();
+    bool checked = lv_obj_has_state(cb, LV_STATE_CHECKED);
 
-    if (lv_obj_has_state(cb, LV_STATE_CHECKED)) {
-        cfg->auto_rotate_pages |= (1 << bit);
-    } else {
-        cfg->auto_rotate_pages &= ~(1 << bit);
-    }
+    /* Mutate the live config so the nav arbiter slideshow sees the new
+     * membership immediately, preserving existing order. Checked pages are
+     * appended; unchecked pages are removed and the list is compacted.
+     * Codes 6/7/8 (Spotify/Clock/ImageDisplay) are not in this checkbox set
+     * and are preserved untouched. */
+    app_config_t *cfg = app_config_get();
+    if (checked) ar_order_add(cfg, (uint8_t)bit);
+    else         ar_order_remove(cfg, (uint8_t)bit);
+
+    /* Persist the canonical list to NVS (snapshot pattern). */
+    app_config_t snap = app_config_get_snapshot();
+    memcpy(snap.auto_rotate_order, cfg->auto_rotate_order, sizeof(snap.auto_rotate_order));
+    snap.auto_rotate_order_ext = cfg->auto_rotate_order_ext;
+    app_config_save(&snap);
+
     settings_mark_dirty(false);
 }
 
@@ -793,18 +873,10 @@ void settings_tab_display_refresh(void)
     }
     update_mode_visibility(mode);
 
-    /* Fixed sub-section */
+    /* Fixed sub-section (absolute page index -> dropdown row) */
     if (dd_pinned_page) {
-        int8_t ov = cfg->active_page_override;
-        int total = nina_dashboard_get_total_page_count();
-        int sysinfo_ov = total > 0 ? total - 1 : 8;
-        if (ov < 0) {
-            lv_dropdown_set_selected(dd_pinned_page, 0);  /* Auto */
-        } else if (ov >= sysinfo_ov) {
-            lv_dropdown_set_selected(dd_pinned_page, 8);  /* SysInfo */
-        } else {
-            lv_dropdown_set_selected(dd_pinned_page, (uint32_t)(ov + 1));
-        }
+        lv_dropdown_set_selected(dd_pinned_page,
+                                 home_abs_to_dd_sel(cfg->active_page_override));
     }
 
     /* Cycle sub-section */
@@ -822,11 +894,11 @@ void settings_tab_display_refresh(void)
         }
     }
 
-    /* Page checkboxes */
-    uint8_t mask = cfg->auto_rotate_pages;
+    /* Page checkboxes — membership read from canonical order list.
+     * Checkbox index i maps directly to order-list bit code i. */
     for (int i = 0; i < 6; i++) {
         if (cb_pages[i]) {
-            if (mask & (1 << i)) {
+            if (ar_order_contains(cfg, (uint8_t)i)) {
                 lv_obj_add_state(cb_pages[i], LV_STATE_CHECKED);
             } else {
                 lv_obj_remove_state(cb_pages[i], LV_STATE_CHECKED);

--- a/main/web_handlers_allsky.c
+++ b/main/web_handlers_allsky.c
@@ -45,8 +45,10 @@ esp_err_t allsky_config_get_handler(httpd_req_t *req)
  */
 esp_err_t allsky_proxy_get_handler(httpd_req_t *req)
 {
-    app_config_t *cfg = app_config_get();
-    if (cfg->allsky_hostname[0] == '\0') {
+    /* Snapshot the hostname into a local under the config mutex so the live
+     * config is not read field-by-field during the (slow) outbound fetch. */
+    app_config_t cfg = app_config_get_snapshot();
+    if (cfg.allsky_hostname[0] == '\0') {
         httpd_resp_set_status(req, "400 Bad Request");
         httpd_resp_set_type(req, "application/json");
         httpd_resp_send(req, "{\"error\":\"AllSky hostname not configured\"}", HTTPD_RESP_USE_STRLEN);
@@ -55,11 +57,13 @@ esp_err_t allsky_proxy_get_handler(httpd_req_t *req)
 
     /* Build URL: http://<hostname>/all */
     char url[192];
-    snprintf(url, sizeof(url), "http://%s/all", cfg->allsky_hostname);
+    snprintf(url, sizeof(url), "http://%s/all", cfg.allsky_hostname);
 
     esp_http_client_config_t http_cfg = {
         .url = url,
-        .timeout_ms = 10000,
+        /* 3s outbound timeout: keep an httpd worker from blocking on a slow or
+         * unreachable AllSky host. */
+        .timeout_ms = 3000,
         .buffer_size = 2048,
     };
     esp_http_client_handle_t client = esp_http_client_init(&http_cfg);

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -1090,11 +1090,23 @@ static app_config_t *parse_config_from_json(cJSON *root)
         }
     }
     /* admin_password is never accepted via /api/config — use /api/admin-password. */
-    JSON_TO_INT   (root, "spotify_poll_interval_ms",   cfg->spotify_poll_interval_ms);
+    cJSON *spi_item = cJSON_GetObjectItem(root, "spotify_poll_interval_ms");
+    if (cJSON_IsNumber(spi_item)) {
+        int v = spi_item->valueint;
+        if (v < 1000) v = 1000;
+        if (v > 30000) v = 30000;
+        cfg->spotify_poll_interval_ms = (uint16_t)v;
+    }
     JSON_TO_BOOL  (root, "spotify_show_progress_bar",  cfg->spotify_show_progress_bar);
     JSON_TO_BOOL  (root, "spotify_minimal_mode",       cfg->spotify_minimal_mode);
     JSON_TO_BOOL  (root, "spotify_scroll_text",        cfg->spotify_scroll_text);
-    JSON_TO_INT   (root, "spotify_overlay_timeout_s",  cfg->spotify_overlay_timeout_s);
+    cJSON *sot_item = cJSON_GetObjectItem(root, "spotify_overlay_timeout_s");
+    if (cJSON_IsNumber(sot_item)) {
+        int v = sot_item->valueint;
+        if (v < 0) v = 0;
+        if (v > 255) v = 255;   /* uint8_t; 0 = never hide */
+        cfg->spotify_overlay_timeout_s = (uint8_t)v;
+    }
     JSON_TO_BOOL  (root, "spotify_overlay_visible",   cfg->spotify_overlay_visible);
 
     JSON_TO_BOOL  (root, "image_display_enabled",       cfg->image_display_enabled);
@@ -1168,7 +1180,11 @@ static app_config_t *parse_config_from_json(cJSON *root)
 
     cJSON *tnm_item = cJSON_GetObjectItem(root, "toast_notify_mask");
     if (cJSON_IsNumber(tnm_item)) {
-        cfg->toast_notify_mask = (uint32_t)tnm_item->valuedouble;
+        /* Bound to defined notification-category bits (highest used bit = 11).
+         * Mask to 20 bits for headroom; rejects garbage high-bit values. */
+        double d = tnm_item->valuedouble;
+        if (d < 0) d = 0;
+        cfg->toast_notify_mask = (uint32_t)d & 0xFFFFFu;
     }
 
     JSON_TO_BOOL(root, "toast_instance_muted_1", cfg->toast_instance_muted[0]);
@@ -1194,12 +1210,25 @@ static app_config_t *parse_config_from_json(cJSON *root)
         cfg->weather_poll_interval_s = (uint16_t)v;
     }
 
-    JSON_TO_INT(root, "weather_units", cfg->weather_units);
-    JSON_TO_INT(root, "weather_time_format", cfg->weather_time_format);
+    cJSON *wu_item = cJSON_GetObjectItem(root, "weather_units");
+    if (cJSON_IsNumber(wu_item)) {
+        cfg->weather_units = (wu_item->valueint != 0) ? 1 : 0;  /* 0=imperial, 1=metric */
+    }
+    cJSON *wtf_item = cJSON_GetObjectItem(root, "weather_time_format");
+    if (cJSON_IsNumber(wtf_item)) {
+        cfg->weather_time_format = (wtf_item->valueint != 0) ? 1 : 0;  /* 0=12h, 1=24h */
+    }
 
     // Idle override
     JSON_TO_BOOL(root, "idle_page_override_enabled", cfg->idle_page_override_enabled);
-    JSON_TO_INT(root, "idle_page_override_target", cfg->idle_page_override_target);
+    /* idle_page_override_target: idle_target_t enum, valid range -1 (Summary) .. 7 (NINA3) */
+    cJSON *ipt_item = cJSON_GetObjectItem(root, "idle_page_override_target");
+    if (cJSON_IsNumber(ipt_item)) {
+        int v = ipt_item->valueint;
+        if (v < IDLE_TARGET_SUMMARY) v = IDLE_TARGET_SUMMARY;
+        if (v > IDLE_TARGET_NINA3) v = IDLE_TARGET_NINA3;
+        cfg->idle_page_override_target = (int8_t)v;
+    }
     JSON_TO_BOOL(root, "idle_indicator_enabled", cfg->idle_indicator_enabled);
 
     // Manual navigation grace window (seconds). Clamp 10-300.
@@ -1228,7 +1257,8 @@ static app_config_t *parse_config_from_json(cJSON *root)
 
 // Receive and parse JSON body from a POST request.
 // Returns parsed cJSON root on success, NULL on failure (error response already sent).
-static cJSON *receive_json_body(httpd_req_t *req, int max_size)
+// Non-static: shared with other web_handlers_*.c via web_server_internal.h.
+cJSON *receive_json_body(httpd_req_t *req, int max_size)
 {
     int remaining = req->content_len;
     if (remaining >= max_size) {

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -64,16 +64,9 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
 esp_err_t image_display_config_post_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
-    char buf[CONFIG_MAX_PAYLOAD];
-    int received = httpd_req_recv(req, buf, sizeof(buf) - 1);
-    if (received <= 0) {
-        return send_400(req, "Empty request body");
-    }
-    buf[received] = '\0';
-
-    cJSON *root = cJSON_Parse(buf);
+    cJSON *root = receive_json_body(req, CONFIG_MAX_PAYLOAD);
     if (root == NULL) {
-        return send_400(req, "Invalid JSON");
+        return ESP_OK;  /* error response already sent */
     }
 
     /* Validate string lengths */
@@ -82,93 +75,97 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
         return send_400(req, "goes_region too long");
     }
 
-    app_config_t *cfg = app_config_get();
+    /* Work on a mutex-protected snapshot copy; never field-write the live config. */
+    app_config_t cfg = app_config_get_snapshot();
 
     /* Capture the current source/band/region/crop so we can tell, after saving,
      * whether the change needs a new image (source/band/region -> re-download +
      * wait overlay) or only a crop/full toggle (-> local re-render of the cached
      * frame, no download). */
-    uint8_t prev_source = cfg->image_display_source;
-    uint8_t prev_band   = cfg->solar_band;
-    bool    prev_crop   = cfg->image_display_crop;
-    uint8_t prev_bg     = cfg->moon_bg_style;
-    uint8_t prev_flip_u = cfg->moon_flip_u;
-    uint8_t prev_flip_v = cfg->moon_flip_v;
-    float   prev_roll   = cfg->moon_roll_offset;
-    float   prev_yaw    = cfg->moon_yaw_offset;
-    float   prev_pitch  = cfg->moon_pitch_offset;
-    uint8_t prev_north_up = cfg->moon_north_up;
-    uint8_t prev_spin_mode   = cfg->moon_spin_mode;
-    uint8_t prev_spin_return = cfg->moon_spin_return_s;
-    uint8_t prev_goes_orient  = cfg->goes_orientation;
-    uint8_t prev_solar_orient = cfg->solar_orientation;
-    char    prev_region[sizeof(cfg->goes_region)];
-    strlcpy(prev_region, cfg->goes_region, sizeof(prev_region));
+    uint8_t prev_source = cfg.image_display_source;
+    uint8_t prev_band   = cfg.solar_band;
+    bool    prev_crop   = cfg.image_display_crop;
+    uint8_t prev_bg     = cfg.moon_bg_style;
+    uint8_t prev_flip_u = cfg.moon_flip_u;
+    uint8_t prev_flip_v = cfg.moon_flip_v;
+    float   prev_roll   = cfg.moon_roll_offset;
+    float   prev_yaw    = cfg.moon_yaw_offset;
+    float   prev_pitch  = cfg.moon_pitch_offset;
+    uint8_t prev_north_up = cfg.moon_north_up;
+    uint8_t prev_spin_mode   = cfg.moon_spin_mode;
+    uint8_t prev_spin_return = cfg.moon_spin_return_s;
+    uint8_t prev_goes_orient  = cfg.goes_orientation;
+    uint8_t prev_solar_orient = cfg.solar_orientation;
+    char    prev_region[sizeof(cfg.goes_region)];
+    strlcpy(prev_region, cfg.goes_region, sizeof(prev_region));
 
-    JSON_TO_BOOL(root, "image_display_enabled", cfg->image_display_enabled);
-    JSON_TO_BOOL(root, "image_display_show_overlay", cfg->image_display_show_overlay);
-    JSON_TO_BOOL(root, "image_display_crop", cfg->image_display_crop);
-    JSON_TO_STRING(root, "goes_region", cfg->goes_region);
+    JSON_TO_BOOL(root, "image_display_enabled", cfg.image_display_enabled);
+    JSON_TO_BOOL(root, "image_display_show_overlay", cfg.image_display_show_overlay);
+    JSON_TO_BOOL(root, "image_display_crop", cfg.image_display_crop);
+    JSON_TO_STRING(root, "goes_region", cfg.goes_region);
 
     cJSON *interval = cJSON_GetObjectItem(root, "goes_update_interval_s");
     if (cJSON_IsNumber(interval)) {
         int v = interval->valueint;
         if (v < 300) v = 300;
         if (v > 7200) v = 7200;
-        cfg->goes_update_interval_s = (uint16_t)v;
+        cfg.goes_update_interval_s = (uint16_t)v;
     }
 
     cJSON *src = cJSON_GetObjectItem(root, "image_display_source");
-    if (cJSON_IsNumber(src)) { int v = src->valueint; cfg->image_display_source = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(src)) { int v = src->valueint; cfg.image_display_source = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
     cJSON *bg = cJSON_GetObjectItem(root, "moon_bg_style");
-    if (cJSON_IsNumber(bg)) { int v = bg->valueint; cfg->moon_bg_style = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(bg)) { int v = bg->valueint; cfg.moon_bg_style = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *mlat = cJSON_GetObjectItem(root, "moon_lat");
-    if (cJSON_IsNumber(mlat)) cfg->moon_lat = (float)mlat->valuedouble;
+    if (cJSON_IsNumber(mlat)) cfg.moon_lat = (float)mlat->valuedouble;
     cJSON *mlon = cJSON_GetObjectItem(root, "moon_lon");
-    if (cJSON_IsNumber(mlon)) cfg->moon_lon = (float)mlon->valuedouble;
+    if (cJSON_IsNumber(mlon)) cfg.moon_lon = (float)mlon->valuedouble;
     cJSON *sb = cJSON_GetObjectItem(root, "solar_band");
-    if (cJSON_IsNumber(sb)) { int v = sb->valueint; cfg->solar_band = (v >= 0 && v <= 17) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(sb)) { int v = sb->valueint; cfg.solar_band = (v >= 0 && v <= 17) ? (uint8_t)v : 0; }
     cJSON *go = cJSON_GetObjectItem(root, "goes_orientation");
-    if (cJSON_IsNumber(go)) { int v = go->valueint; cfg->goes_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(go)) { int v = go->valueint; cfg.goes_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *so = cJSON_GetObjectItem(root, "solar_orientation");
-    if (cJSON_IsNumber(so)) { int v = so->valueint; cfg->solar_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(so)) { int v = so->valueint; cfg.solar_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *dlm = cJSON_GetObjectItem(root, "moon_drag_light_mode");
-    if (cJSON_IsNumber(dlm)) { int v = dlm->valueint; cfg->moon_drag_light_mode = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(dlm)) { int v = dlm->valueint; cfg.moon_drag_light_mode = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
     cJSON *fu = cJSON_GetObjectItem(root, "moon_flip_u");
-    if (cJSON_IsNumber(fu)) { cfg->moon_flip_u = (fu->valueint != 0) ? 1 : 0; }
+    if (cJSON_IsNumber(fu)) { cfg.moon_flip_u = (fu->valueint != 0) ? 1 : 0; }
     cJSON *fv = cJSON_GetObjectItem(root, "moon_flip_v");
-    if (cJSON_IsNumber(fv)) { cfg->moon_flip_v = (fv->valueint != 0) ? 1 : 0; }
+    if (cJSON_IsNumber(fv)) { cfg.moon_flip_v = (fv->valueint != 0) ? 1 : 0; }
     cJSON *mro = cJSON_GetObjectItem(root, "moon_roll_offset");
-    if (cJSON_IsNumber(mro)) { float v = (float)mro->valuedouble; if (v < -180.0f) v = -180.0f; if (v > 180.0f) v = 180.0f; cfg->moon_roll_offset = v; }
+    if (cJSON_IsNumber(mro)) { float v = (float)mro->valuedouble; if (v < -180.0f) v = -180.0f; if (v > 180.0f) v = 180.0f; cfg.moon_roll_offset = v; }
     cJSON *myo = cJSON_GetObjectItem(root, "moon_yaw_offset");
-    if (cJSON_IsNumber(myo)) { float v = (float)myo->valuedouble; if (v < -180.0f) v = -180.0f; if (v > 180.0f) v = 180.0f; cfg->moon_yaw_offset = v; }
+    if (cJSON_IsNumber(myo)) { float v = (float)myo->valuedouble; if (v < -180.0f) v = -180.0f; if (v > 180.0f) v = 180.0f; cfg.moon_yaw_offset = v; }
     cJSON *mpo = cJSON_GetObjectItem(root, "moon_pitch_offset");
-    if (cJSON_IsNumber(mpo)) { float v = (float)mpo->valuedouble; if (v < -90.0f) v = -90.0f; if (v > 90.0f) v = 90.0f; cfg->moon_pitch_offset = v; }
+    if (cJSON_IsNumber(mpo)) { float v = (float)mpo->valuedouble; if (v < -90.0f) v = -90.0f; if (v > 90.0f) v = 90.0f; cfg.moon_pitch_offset = v; }
     cJSON *mnu = cJSON_GetObjectItem(root, "moon_north_up");
-    if (cJSON_IsNumber(mnu)) { cfg->moon_north_up = (mnu->valueint != 0) ? 1 : 0; }
+    if (cJSON_IsNumber(mnu)) { cfg.moon_north_up = (mnu->valueint != 0) ? 1 : 0; }
     cJSON *msm = cJSON_GetObjectItem(root, "moon_spin_mode");
-    if (cJSON_IsNumber(msm)) { cfg->moon_spin_mode = (msm->valueint != 0) ? 1 : 0; }
+    if (cJSON_IsNumber(msm)) { cfg.moon_spin_mode = (msm->valueint != 0) ? 1 : 0; }
     cJSON *msr = cJSON_GetObjectItem(root, "moon_spin_return_s");
-    if (cJSON_IsNumber(msr)) { int v = msr->valueint; if (v < 3) v = 3; if (v > 60) v = 60; cfg->moon_spin_return_s = (uint8_t)v; }
+    if (cJSON_IsNumber(msr)) { int v = msr->valueint; if (v < 3) v = 3; if (v > 60) v = 60; cfg.moon_spin_return_s = (uint8_t)v; }
 
     cJSON_Delete(root);
 
-    app_config_save(cfg);
+    /* Single atomic memcpy under mutex + NVS persist. */
+    app_config_save(&cfg);
 
+    /* Live apply (preview): push display/task state immediately from the saved
+     * snapshot so changes take effect without waiting for a reload. */
     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        nina_dashboard_set_image_display_enabled(cfg->image_display_enabled);
-        nina_image_display_set_overlay_visible(cfg->image_display_show_overlay);
+        nina_dashboard_set_image_display_enabled(cfg.image_display_enabled);
+        nina_image_display_set_overlay_visible(cfg.image_display_show_overlay);
         bsp_display_unlock();
     }
 
-    if (cfg->image_display_enabled) {
+    if (cfg.image_display_enabled) {
         bool source_band_region_changed =
-            cfg->image_display_source != prev_source ||
-            cfg->solar_band != prev_band ||
-            strcmp(cfg->goes_region, prev_region) != 0;
-        bool crop_changed = cfg->image_display_crop != prev_crop;
-        bool orient_changed = (cfg->goes_orientation != prev_goes_orient) ||
-                              (cfg->solar_orientation != prev_solar_orient);
+            cfg.image_display_source != prev_source ||
+            cfg.solar_band != prev_band ||
+            strcmp(cfg.goes_region, prev_region) != 0;
+        bool crop_changed = cfg.image_display_crop != prev_crop;
+        bool orient_changed = (cfg.goes_orientation != prev_goes_orient) ||
+                              (cfg.solar_orientation != prev_solar_orient);
 
         if (source_band_region_changed) {
             /* Source/band/region needs a genuinely new image: flag the next
@@ -181,16 +178,16 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
             if (goes_task_handle) {
                 xTaskNotifyGive(goes_task_handle);
             }
-        } else if (cfg->image_display_source == 1 &&
-                   (cfg->moon_bg_style != prev_bg ||
-                    cfg->moon_flip_u != prev_flip_u ||
-                    cfg->moon_flip_v != prev_flip_v ||
-                    cfg->moon_roll_offset != prev_roll ||
-                    cfg->moon_yaw_offset != prev_yaw ||
-                    cfg->moon_pitch_offset != prev_pitch ||
-                    cfg->moon_north_up != prev_north_up ||
-                    cfg->moon_spin_mode != prev_spin_mode ||
-                    cfg->moon_spin_return_s != prev_spin_return)) {
+        } else if (cfg.image_display_source == 1 &&
+                   (cfg.moon_bg_style != prev_bg ||
+                    cfg.moon_flip_u != prev_flip_u ||
+                    cfg.moon_flip_v != prev_flip_v ||
+                    cfg.moon_roll_offset != prev_roll ||
+                    cfg.moon_yaw_offset != prev_yaw ||
+                    cfg.moon_pitch_offset != prev_pitch ||
+                    cfg.moon_north_up != prev_north_up ||
+                    cfg.moon_spin_mode != prev_spin_mode ||
+                    cfg.moon_spin_return_s != prev_spin_return)) {
             /* Moon background style changed only (source unchanged, so the
              * source_band_region_changed branch above did not fire): wake the
              * image-display task so its Moon branch re-renders moon_render() with

--- a/main/web_handlers_spotify.c
+++ b/main/web_handlers_spotify.c
@@ -46,16 +46,9 @@ esp_err_t spotify_config_get_handler(httpd_req_t *req)
 esp_err_t spotify_config_post_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
-    char buf[CONFIG_MAX_PAYLOAD];
-    int received = httpd_req_recv(req, buf, sizeof(buf) - 1);
-    if (received <= 0) {
-        return send_400(req, "Empty request body");
-    }
-    buf[received] = '\0';
-
-    cJSON *root = cJSON_Parse(buf);
+    cJSON *root = receive_json_body(req, CONFIG_MAX_PAYLOAD);
     if (root == NULL) {
-        return send_400(req, "Invalid JSON");
+        return ESP_OK;  /* error response already sent */
     }
 
     /* Validate string lengths */
@@ -64,22 +57,38 @@ esp_err_t spotify_config_post_handler(httpd_req_t *req)
         return send_400(req, "spotify_client_id too long");
     }
 
-    app_config_t *cfg = app_config_get();
+    /* Work on a mutex-protected snapshot copy; never field-write the live config. */
+    app_config_t cfg = app_config_get_snapshot();
 
-    JSON_TO_BOOL(root, "spotify_enabled", cfg->spotify_enabled);
-    JSON_TO_STRING(root, "spotify_client_id", cfg->spotify_client_id);
-    JSON_TO_INT(root, "spotify_poll_interval_ms", cfg->spotify_poll_interval_ms);
-    JSON_TO_BOOL(root, "spotify_show_progress_bar", cfg->spotify_show_progress_bar);
-    JSON_TO_BOOL(root, "spotify_minimal_mode", cfg->spotify_minimal_mode);
-    JSON_TO_BOOL(root, "spotify_scroll_text", cfg->spotify_scroll_text);
-    JSON_TO_INT(root, "spotify_overlay_timeout_s", cfg->spotify_overlay_timeout_s);
-    JSON_TO_BOOL(root, "spotify_overlay_visible", cfg->spotify_overlay_visible);
+    JSON_TO_BOOL(root, "spotify_enabled", cfg.spotify_enabled);
+    JSON_TO_STRING(root, "spotify_client_id", cfg.spotify_client_id);
+    cJSON *spi_item = cJSON_GetObjectItem(root, "spotify_poll_interval_ms");
+    if (cJSON_IsNumber(spi_item)) {
+        int v = spi_item->valueint;
+        if (v < 1000) v = 1000;
+        if (v > 30000) v = 30000;
+        cfg.spotify_poll_interval_ms = (uint16_t)v;
+    }
+    JSON_TO_BOOL(root, "spotify_show_progress_bar", cfg.spotify_show_progress_bar);
+    JSON_TO_BOOL(root, "spotify_minimal_mode", cfg.spotify_minimal_mode);
+    JSON_TO_BOOL(root, "spotify_scroll_text", cfg.spotify_scroll_text);
+    cJSON *sot_item = cJSON_GetObjectItem(root, "spotify_overlay_timeout_s");
+    if (cJSON_IsNumber(sot_item)) {
+        int v = sot_item->valueint;
+        if (v < 0) v = 0;
+        if (v > 255) v = 255;   /* uint8_t; 0 = never hide */
+        cfg.spotify_overlay_timeout_s = (uint8_t)v;
+    }
+    JSON_TO_BOOL(root, "spotify_overlay_visible", cfg.spotify_overlay_visible);
 
     cJSON_Delete(root);
 
-    app_config_save(cfg);
+    /* Single atomic memcpy under mutex + NVS persist. */
+    app_config_save(&cfg);
 
-    if (cfg->spotify_enabled) {
+    /* Live apply: the poll task reads the live config (now updated by save) on
+     * its next cycle; ensure it is running when the feature is enabled. */
+    if (cfg.spotify_enabled) {
         spotify_ensure_task_running();
     }
 
@@ -147,16 +156,9 @@ esp_err_t spotify_callback_get_handler(httpd_req_t *req)
 esp_err_t spotify_token_exchange_post_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
-    char buf[CONFIG_MAX_PAYLOAD];
-    int received = httpd_req_recv(req, buf, sizeof(buf) - 1);
-    if (received <= 0) {
-        return send_400(req, "Empty request body");
-    }
-    buf[received] = '\0';
-
-    cJSON *root = cJSON_Parse(buf);
+    cJSON *root = receive_json_body(req, CONFIG_MAX_PAYLOAD);
     if (root == NULL) {
-        return send_400(req, "Invalid JSON");
+        return ESP_OK;  /* error response already sent */
     }
 
     cJSON *code_item = cJSON_GetObjectItem(root, "code");

--- a/main/web_handlers_wifi.c
+++ b/main/web_handlers_wifi.c
@@ -174,16 +174,18 @@ esp_err_t wifi_setup_post_handler(httpd_req_t *req)
         return send_400(req, "SSID is required");
     }
 
-    app_config_t *cfg = app_config_get();
-    strlcpy(cfg->wifi_networks[0].ssid, ssid_item->valuestring,
-            sizeof(cfg->wifi_networks[0].ssid));
+    /* Work on a mutex-protected snapshot copy; never field-write the live config. */
+    app_config_t cfg = app_config_get_snapshot();
+    strlcpy(cfg.wifi_networks[0].ssid, ssid_item->valuestring,
+            sizeof(cfg.wifi_networks[0].ssid));
     if (cJSON_IsString(pass_item)) {
-        strlcpy(cfg->wifi_networks[0].password, pass_item->valuestring,
-                sizeof(cfg->wifi_networks[0].password));
+        strlcpy(cfg.wifi_networks[0].password, pass_item->valuestring,
+                sizeof(cfg.wifi_networks[0].password));
     } else {
-        cfg->wifi_networks[0].password[0] = '\0';
+        cfg.wifi_networks[0].password[0] = '\0';
     }
-    app_config_save(cfg);
+    /* Single atomic memcpy under mutex + NVS persist. */
+    app_config_save(&cfg);
 
     cJSON_Delete(root);
 

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -45,6 +45,14 @@ esp_err_t send_400(httpd_req_t *req, const char *message);
 bool validate_string_len(cJSON *root, const char *key, size_t max_len);
 bool validate_url_format(const char *url);
 
+/* Receive and parse a JSON request body using a PSRAM-backed buffer.
+ * Loops httpd_req_recv() until content_len bytes are read (handles
+ * multi-segment bodies); rejects bodies >= max_size. On any error the
+ * appropriate HTTP response is already sent and NULL is returned.
+ * On success returns a cJSON root the caller must cJSON_Delete().
+ * Defined in web_handlers_config.c. */
+cJSON *receive_json_body(httpd_req_t *req, int max_size);
+
 /* ---- Session cookie auth (defined in web_server.c) ---- */
 bool check_session(httpd_req_t *req);
 esp_err_t send_auth_required(httpd_req_t *req);

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -62,7 +62,7 @@ CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
 
 # PPA requires full-screen DPI framebuffers (avoid_tearing mode)
 # Partial buffers (720*50*2=72000) are not cache-line aligned (72000%128!=0)
-CONFIG_BSP_LCD_DPI_BUFFER_NUMS=3
+CONFIG_BSP_LCD_DPI_BUFFER_NUMS=2
 CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR=y
 CONFIG_BSP_DISPLAY_LVGL_FULL_REFRESH=y
 

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -62,7 +62,7 @@ CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
 
 # PPA requires full-screen DPI framebuffers (avoid_tearing mode)
 # Partial buffers (720*50*2=72000) are not cache-line aligned (72000%128!=0)
-CONFIG_BSP_LCD_DPI_BUFFER_NUMS=2
+CONFIG_BSP_LCD_DPI_BUFFER_NUMS=3
 CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR=y
 CONFIG_BSP_DISPLAY_LVGL_FULL_REFRESH=y
 


### PR DESCRIPTION
### Summary
This PR addresses several stability, performance, and correctness issues across the system. It fixes a critical bug where frequent MQTT brightness updates caused the device to reboot repeatedly. The changes also include various concurrency and memory optimizations, display performance improvements, and enhanced network handling.

### Changes
*   Resolves a critical issue where frequent MQTT brightness updates caused the device to reboot by making brightness changes live-only.
*   Improves system stability by fixing concurrency issues in web configuration updates, session statistics, and alert handling.
*   Reduces memory usage by replacing large stack buffers with PSRAM for web request processing and reclaiming PSRAM from an unused display buffer.
*   Enhances network performance by optimizing mDNS lookups and disabling Wi-Fi power save by default on mains-powered devices.
*   Adds detailed HTTP performance metrics and logs firmware versions at boot for better diagnostics.
*   Optimizes display rendering for graph overlays and corrects UI settings for page rotation and Home page selection.
*   Adds input validation for various configuration settings to prevent invalid values.
*   Improves Spotify integration by making token expiry more reliable and detecting album art truncation.

---
<sub>Analyzed **4** commit(s) | Updated: 2026-06-22T23:36:35.067Z | Generated by GitHub Actions</sub>