### PR TITLE
fix: route LVGL allocs to PSRAM to stop OOM reboots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -222,9 +222,11 @@ jobs:
           # Copy app binary as OTA file
           cp "$APP_BIN" firmware/nina-display-ota.bin
 
-          # Stage bootloader + partition table as standalone assets. The release
-          # uploads these so the next build can hash them against this baseline to
-          # decide OTA-safe vs full-erase (see "Check full erase requirement").
+          # Keep bootloader + partition table on disk (build/ tree) so the erase
+          # check can hash them. They are NOT uploaded as release assets anymore:
+          # the OTA-safe vs full-erase baseline is carried as SHA256 markers in the
+          # release body (see "Check full erase requirement" / "Generate release
+          # notes"). Staging copies kept for local inspection only.
           cp build/bootloader/bootloader.bin firmware/bootloader.bin
           cp build/partition_table/partition-table.bin firmware/partition-table.bin
 
@@ -508,52 +510,49 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Detection is artifact-primary: hash the freshly built partition table
-          # and bootloader against the previous release's uploaded baseline. The
-          # source-diff rules below are SECONDARY corroboration. Bias toward
-          # false-positive (require erase) over false-negative (silent OTA-break).
+          # and bootloader, then compare against the previous same-lineage
+          # release's SHA256 markers carried in its release body (no bin assets
+          # are downloaded). The source-diff rules below are SECONDARY
+          # corroboration. Bias toward false-positive (require erase) over
+          # false-negative (silent OTA-break).
           REASONS=""
           REQUIRED=false
 
           # Find previous release tag to diff/compare against.
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
 
-          # --- PRIMARY: built-artifact hash comparison vs previous release ----
+          # --- PRIMARY: built-artifact hash vs previous release body markers ---
+          # Freshly built hashes (also re-emitted into THIS release's body by the
+          # release-notes step so the next run can read them).
           NEW_PT="build/partition_table/partition-table.bin"
           NEW_BL="build/bootloader/bootloader.bin"
+          PT_SHA=$(sha256sum "$NEW_PT" | cut -d' ' -f1)
+          BL_SHA=$(sha256sum "$NEW_BL" | cut -d' ' -f1)
 
           if [ -z "$PREV_TAG" ]; then
             # First release ever: no baseline to compare. Cannot prove OTA-safe.
             REASONS="${REASONS}No previous release baseline to compare; flash factory binary.\n"
             REQUIRED=true
           else
-            BASE_DIR=$(mktemp -d)
-            # Tolerate absence: previous release may predate asset upload.
-            gh release download "$PREV_TAG" \
-              -p partition-table.bin -p bootloader.bin \
-              -D "$BASE_DIR" 2>/dev/null || true
+            # Read the previous release body and pull out its hash markers.
+            # Tolerate failure: prev release may be missing or predate this scheme.
+            PREV_BODY=$(gh release view "$PREV_TAG" --json body -q .body 2>/dev/null || true)
+            OLD_PT_SHA=$(echo "$PREV_BODY" | grep -oE 'nina:pt_sha=[0-9a-f]+' | head -1 | sed 's/.*nina:pt_sha=//')
+            OLD_BL_SHA=$(echo "$PREV_BODY" | grep -oE 'nina:bl_sha=[0-9a-f]+' | head -1 | sed 's/.*nina:bl_sha=//')
 
-            OLD_PT="$BASE_DIR/partition-table.bin"
-            OLD_BL="$BASE_DIR/bootloader.bin"
-
-            if [ ! -f "$OLD_PT" ] || [ ! -f "$OLD_BL" ]; then
-              # Previous release predates baseline asset upload, or partial upload.
+            if [ -z "$OLD_PT_SHA" ]; then
+              # Previous release predates this marker scheme (or body unreadable).
               REASONS="${REASONS}No previous release baseline to compare; flash factory binary.\n"
               REQUIRED=true
             else
-              NEW_PT_HASH=$(sha256sum "$NEW_PT" | cut -d' ' -f1)
-              OLD_PT_HASH=$(sha256sum "$OLD_PT" | cut -d' ' -f1)
-              if [ "$NEW_PT_HASH" != "$OLD_PT_HASH" ]; then
+              if [ "$PT_SHA" != "$OLD_PT_SHA" ]; then
                 REASONS="${REASONS}Partition table changed since ${PREV_TAG}.\n"
                 REQUIRED=true
               fi
 
-              NEW_BL_HASH=$(sha256sum "$NEW_BL" | cut -d' ' -f1)
-              OLD_BL_HASH=$(sha256sum "$OLD_BL" | cut -d' ' -f1)
-              if [ "$NEW_BL_HASH" != "$OLD_BL_HASH" ]; then
-                # A bootloader.bin hash change is flagged. Confirming MANDATORY
-                # would require diffing the previous release's resolved sdkconfig
-                # for security/target/MMU keys, which we cannot fetch reliably
-                # from the release. Prefer safety: treat as required.
+              if [ "$BL_SHA" != "$OLD_BL_SHA" ]; then
+                # A bootloader hash change is flagged. Prefer safety: treat as
+                # required and recommend a manual factory flash.
                 REASONS="${REASONS}Bootloader changed since ${PREV_TAG} (manual flash recommended).\n"
                 REQUIRED=true
               fi
@@ -616,6 +615,12 @@ jobs:
             REQUIRED=true
           fi
 
+          # Hashes of the freshly built baseline. The release-notes step emits
+          # these into THIS release's body as nina:pt_sha / nina:bl_sha markers
+          # so the next run can read them back (always present, both verdicts).
+          echo "pt_sha=$PT_SHA" >> $GITHUB_OUTPUT
+          echo "bl_sha=$BL_SHA" >> $GITHUB_OUTPUT
+
           if [ "$REQUIRED" = "true" ]; then
             echo "required=true" >> $GITHUB_OUTPUT
             echo "reason<<EOFR" >> $GITHUB_OUTPUT
@@ -637,6 +642,8 @@ jobs:
           OTA_MB="${{ steps.metrics.outputs.ota_mb }}"
           FULL_ERASE="${{ steps.erase_check.outputs.required }}"
           ERASE_REASON="${{ steps.erase_check.outputs.reason }}"
+          PT_SHA="${{ steps.erase_check.outputs.pt_sha }}"
+          BL_SHA="${{ steps.erase_check.outputs.bl_sha }}"
 
           if [ -n "$PREV_TAG" ]; then
             COMPARE_URL="https://github.com/chvvkumar/ESP32-P4-NINA-Display/compare/${PREV_TAG}...${TAG}"
@@ -645,7 +652,7 @@ jobs:
           fi
 
           AI_AVAILABLE="${{ steps.release_summary.outputs.ai_available }}"
-          export TAG PREV_TAG VERSION BRANCH COMPARE_URL FACTORY_MB OTA_MB AI_AVAILABLE FULL_ERASE ERASE_REASON
+          export TAG PREV_TAG VERSION BRANCH COMPARE_URL FACTORY_MB OTA_MB AI_AVAILABLE FULL_ERASE ERASE_REASON PT_SHA BL_SHA
           python3 << 'PYEOF'
           import os, json
           tag = os.environ['TAG']
@@ -658,6 +665,8 @@ jobs:
           ai_available = os.environ.get('AI_AVAILABLE', 'false') == 'true'
           full_erase = os.environ.get('FULL_ERASE', 'false') == 'true'
           erase_reason = os.environ.get('ERASE_REASON', '').strip()
+          pt_sha = os.environ.get('PT_SHA', '').strip()
+          bl_sha = os.environ.get('BL_SHA', '').strip()
 
           # Load metrics if available
           try:
@@ -687,8 +696,15 @@ jobs:
           # factory flash; "nina:full_erase=0" means OTA-safe. Emitted from the
           # same final verdict that drives the caution/OTA-safe block below.
           erase_marker = '<!-- nina:full_erase=1 -->' if full_erase else '<!-- nina:full_erase=0 -->'
+          # Hidden baseline markers, always present (both verdicts). The NEXT
+          # run reads these from this release's body to decide OTA-safe vs
+          # full-erase by comparing freshly built hashes against them.
+          pt_marker = f'<!-- nina:pt_sha={pt_sha} -->'
+          bl_marker = f'<!-- nina:bl_sha={bl_sha} -->'
           lines = [
               erase_marker,
+              pt_marker,
+              bl_marker,
               f'## NINA Display {tag}',
               '',
               f'**Branch:** {branch}',
@@ -734,6 +750,7 @@ jobs:
               '|------|-------------|',
               '| `nina-display-factory.bin` | Full factory image (flash at 0x0000) |',
               '| `nina-display-ota.bin` | OTA update binary (upload via web UI) |',
+              '| `nina-display.elf` | Firmware ELF (for decoding core dumps) |',
               '',
               '### Flashing',
               '- **Factory:** Use [ESP Web Flasher](https://espressif.github.io/esptool-js/) — flash at address `0x0000`',
@@ -766,8 +783,7 @@ jobs:
           gh release create "$TAG" \
             firmware/nina-display-factory.bin \
             firmware/nina-display-ota.bin \
-            firmware/bootloader.bin \
-            firmware/partition-table.bin \
+            firmware/nina-display.elf \
             --title "$TAG" \
             --notes-file /tmp/release-notes.md \
             $PRERELEASE_FLAG

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -27,6 +27,13 @@ target_compile_options(
         -Wno-unused-function  # unused atomic.h inlines in lv_freertos.c (upstream ESP-IDF issue)
 )
 
+# Custom LVGL malloc backend (routes lv_malloc -> PSRAM). Must be compiled INTO the
+# LVGL library, not main: lv_mem.c (inside liblvgl) references lv_*_core, and liblvgl
+# is linked after libmain. A single-pass linker would not extract these symbols from
+# libmain.a (nothing needs them yet when main is processed), leaving them undefined.
+# Building it into liblvgl resolves the reference within the same archive.
+target_sources(${LVGL_LIB} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lv_mem_psram.c)
+
 # Add hardware JPEG decoder for thumbnail feature
 idf_component_get_property(JPEG_LIB esp_driver_jpeg COMPONENT_LIB)
 target_link_libraries(${COMPONENT_LIB} PRIVATE ${JPEG_LIB})

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1964,6 +1964,13 @@
 
         <pre id="logsView" class="logs-view"></pre>
         <div id="crashlogView" class="logs-view hidden"></div>
+
+        <!-- Core dump diagnostics: hidden unless a crash dump is saved in flash -->
+        <div id="coredumpCard" class="logs-meta" style="display:none;margin-top:12px;align-items:center;gap:12px">
+          <span class="field-hint" id="coredumpInfo" style="margin:0">Crash dump present.</span>
+          <a class="btn btn-outline" id="coredumpDownloadLink" href="/api/coredump" style="text-align:center">Download dump</a>
+          <button type="button" class="btn btn-outline" id="coredumpClearBtn" onclick="clearCoredump()">Clear dump</button>
+        </div>
       </div>
     </div>
 
@@ -4357,9 +4364,13 @@
       var dl=$('logsDownloadLink');
       if(dl) dl.href=dev?'/api/logs':'/api/crashlog';
 
+      /* Core dump card is only relevant alongside crash history. */
+      var cd=$('coredumpCard');
+      if(cd) cd.style.display='none';
+
       /* Auto-refresh only applies to the device source. */
       if(dev){ syncLogsAutoRefresh(); refreshLogs(); }
-      else { stopLogsAutoRefresh(); refreshCrashlog(); }
+      else { stopLogsAutoRefresh(); refreshCrashlog(); if(typeof refreshCoredumpInfo==='function') refreshCoredumpInfo(); }
     }
 
     /* Shared toolbar buttons route to the active source. */
@@ -4571,6 +4582,44 @@
           refreshCrashlog();
         })
         .catch(function(e){ showToast('Clear crash logs failed: '+e.message,'error'); })
+        .finally(function(){ btn.disabled=false; btn.textContent=prev; });
+    }
+
+    /* ---- Core dump ---- */
+
+    /* Query /api/coredump/info and show the dump card only when a dump is saved. */
+    function refreshCoredumpInfo(){
+      var card=$('coredumpCard');
+      if(!card) return;
+      fetch('/api/coredump/info')
+        .then(function(r){
+          if(!r.ok) throw new Error('HTTP '+r.status);
+          return r.json();
+        })
+        .then(function(d){
+          if(d && d.present){
+            var kb=Math.round((d.size||0)/1024);
+            var info=$('coredumpInfo');
+            if(info) info.textContent='Crash dump present ('+kb+' KB)';
+            card.style.display='flex';
+          } else {
+            card.style.display='none';
+          }
+        })
+        .catch(function(){ card.style.display='none'; });
+    }
+
+    function clearCoredump(){
+      if(!confirm('Clear the saved crash dump? This cannot be undone.')) return;
+      var btn=$('coredumpClearBtn');
+      btn.disabled=true; var prev=btn.textContent; btn.textContent='Clearing...';
+      fetch('/api/coredump/clear',{method:'POST'})
+        .then(function(r){
+          if(!r.ok) throw new Error('Clear failed');
+          showToast('Crash dump cleared','success');
+          refreshCoredumpInfo();
+        })
+        .catch(function(e){ showToast('Clear crash dump failed: '+e.message,'error'); })
         .finally(function(){ btn.disabled=false; btn.textContent=prev; });
     }
 

--- a/main/crash_log.c
+++ b/main/crash_log.c
@@ -28,6 +28,7 @@
 #include "esp_spiffs.h"
 #include "esp_heap_caps.h"
 #include "esp_attr.h"
+#include "esp_core_dump.h"
 #include "cJSON.h"
 
 #include <string.h>
@@ -134,10 +135,11 @@ static bool ensure_mounted(void)
         return true;
     }
 
-    /* The "storage" partition ships unformatted; format on first mount. */
+    /* The "crashlog" partition (128KB) ships unformatted; format on first mount.
+     * It is small, so the format completes quickly. */
     esp_vfs_spiffs_conf_t conf = {
         .base_path              = CRASH_LOG_MOUNT_POINT,
-        .partition_label        = "storage",
+        .partition_label        = "crashlog",
         .max_files              = 4,
         .format_if_mount_failed = true,
     };
@@ -146,7 +148,7 @@ static bool ensure_mounted(void)
     if (err == ESP_OK) {
         s_mounted = true;
         size_t total = 0, used = 0;
-        if (esp_spiffs_info("storage", &total, &used) == ESP_OK) {
+        if (esp_spiffs_info("crashlog", &total, &used) == ESP_OK) {
             ESP_LOGI(TAG, "SPIFFS mounted: %u/%u bytes used", (unsigned)used, (unsigned)total);
         }
         return true;
@@ -329,6 +331,13 @@ static void append_crash_record(uint32_t reason, const char *panic_text)
     cJSON_AddNumberToObject(o, "crash_count", (double)info.crash_count);
     cJSON_AddNumberToObject(o, "boot_count", (double)info.boot_count);
     cJSON_AddStringToObject(o, "panic", panic_text ? panic_text : "");
+
+    /* Whether an ELF core dump was saved to the coredump partition for this
+     * crash. esp_core_dump_image_get() returns ESP_OK only when a valid image
+     * is present in flash. */
+    size_t cd_addr = 0, cd_size = 0;
+    bool coredump_present = (esp_core_dump_image_get(&cd_addr, &cd_size) == ESP_OK);
+    cJSON_AddBoolToObject(o, "coredump_present", coredump_present);
 
     char *line = cJSON_PrintUnformatted(o);
     cJSON_Delete(o);

--- a/main/lv_mem_psram.c
+++ b/main/lv_mem_psram.c
@@ -1,0 +1,87 @@
+/**
+ * @file lv_mem_psram.c
+ * @brief LVGL 9.5 custom memory backend — routes all lv_malloc() allocations to PSRAM.
+ *
+ * Root-cause fix for internal-SRAM exhaustion reboots. The esp-hosted SDIO WiFi
+ * RX path allocates a ~4608-byte buffer from internal DMA-capable SRAM
+ * (MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT). LVGL widget/object/
+ * style metadata previously came from that same internal pool (via
+ * CONFIG_LV_USE_CLIB_MALLOC=y system malloc, forced internal by
+ * CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096). Thousands of tiny LVGL allocations
+ * fragmented the internal pool until the largest contiguous free block dropped
+ * below 4608 bytes, the RX alloc returned NULL, and an assert rebooted the device.
+ *
+ * Selecting CONFIG_LV_USE_CUSTOM_MALLOC=y makes LVGL leave the *_core functions
+ * undefined (the clib/builtin core files self-exclude on LV_USE_STDLIB_MALLOC),
+ * so this translation unit supplies them. Every lv_malloc()/lv_realloc()/lv_free()
+ * now lands in PSRAM (MALLOC_CAP_SPIRAM), freeing the internal/DMA pool for the
+ * WiFi RX path.
+ *
+ * This does NOT touch the LCD/DPI framebuffers or the LVGL draw buffers: in
+ * avoid-tearing mode those are the LCD driver's DPI framebuffers obtained via
+ * esp_lcd_dpi_panel_get_frame_buffer() (esp_lvgl_port), never lv_malloc.
+ */
+
+#include "lvgl.h"
+
+#include "esp_heap_caps.h"
+
+/* Only compile the hooks when LVGL is configured for the custom backend.
+ * If the malloc choice is ever switched back to CLIB/BUILTIN, these symbols
+ * would otherwise multiply-define against LVGL's own core file. */
+#if LV_USE_STDLIB_MALLOC == LV_STDLIB_CUSTOM
+
+void lv_mem_init(void)
+{
+    /* PSRAM heap is initialized by ESP-IDF before app_main(); nothing to do. */
+}
+
+void lv_mem_deinit(void)
+{
+    /* Heap teardown is owned by ESP-IDF; nothing to do. */
+}
+
+lv_mem_pool_t lv_mem_add_pool(void *mem, size_t bytes)
+{
+    /* Custom backend uses the ESP-IDF PSRAM heap directly; pools unsupported. */
+    LV_UNUSED(mem);
+    LV_UNUSED(bytes);
+    return NULL;
+}
+
+void lv_mem_remove_pool(lv_mem_pool_t pool)
+{
+    LV_UNUSED(pool);
+}
+
+void *lv_malloc_core(size_t size)
+{
+    /* Returns NULL on failure; LVGL callers handle NULL gracefully. */
+    return heap_caps_malloc(size, MALLOC_CAP_SPIRAM);
+}
+
+void *lv_realloc_core(void *p, size_t new_size)
+{
+    return heap_caps_realloc(p, new_size, MALLOC_CAP_SPIRAM);
+}
+
+void lv_free_core(void *p)
+{
+    heap_caps_free(p);
+}
+
+void lv_mem_monitor_core(lv_mem_monitor_t *mon_p)
+{
+    /* Per-heap accounting comes from ESP-IDF heap_caps APIs, not LVGL. */
+    if (mon_p != NULL) {
+        lv_memzero(mon_p, sizeof(lv_mem_monitor_t));
+    }
+}
+
+lv_result_t lv_mem_test_core(void)
+{
+    /* ESP-IDF owns heap integrity checking; report OK. */
+    return LV_RESULT_OK;
+}
+
+#endif /* LV_USE_STDLIB_MALLOC == LV_STDLIB_CUSTOM */

--- a/main/main.c
+++ b/main/main.c
@@ -573,6 +573,11 @@ void app_main(void)
 
     perf_monitor_init(30);
     perf_monitor_set_enabled(app_config_get()->debug_mode);
+    // Deterministic OOM catcher: fires on EVERY failed heap allocation,
+    // including the sub-second transient SDIO RX DMA-SRAM exhaustion that the
+    // 30s perf sampling misses. Lock-free / allocation-free hook. Registered
+    // before tasks spawn so it is armed for all subsequent allocations.
+    perf_monitor_register_alloc_fail_hook();
 
     instance_count = app_config_get_instance_count();
     if (app_config_get()->demo_mode) {

--- a/main/perf_monitor.c
+++ b/main/perf_monitor.c
@@ -5,6 +5,7 @@
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "esp_heap_caps.h"
+#include "esp_rom_sys.h"   // esp_rom_printf — lock-free, allocation-free console output
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "cJSON.h"
@@ -13,6 +14,40 @@ static const char *TAG = "perf";
 
 // Global singleton
 perf_state_t g_perf;
+
+// ── Failed-allocation catcher ───────────────────────────────────────
+//
+// Counter is incremented inside the failed-alloc hook, which runs in the
+// context of the failing allocation (possibly the SDIO RX task with the heap
+// lock held, possibly high-IRQ context). The hook MUST stay lock-free and
+// allocation-free: it only does a plain volatile increment and one
+// esp_rom_printf (which writes directly to the ROM UART and takes no heap
+// lock). No heap_caps_* queries, no malloc, no ESP_LOGx here.
+static volatile uint32_t s_alloc_fail_count = 0;
+
+static void perf_alloc_failed_hook(size_t size, uint32_t caps, const char *function_name)
+{
+    s_alloc_fail_count++;  // plain increment, no lock
+    esp_rom_printf("[ALLOC-FAIL] size=%u caps=0x%x fn=%s dma_capable=%d\n",
+                   (unsigned)size, (unsigned)caps,
+                   function_name ? function_name : "?",
+                   (caps & MALLOC_CAP_DMA) ? 1 : 0);
+}
+
+void perf_monitor_register_alloc_fail_hook(void)
+{
+    esp_err_t err = heap_caps_register_failed_alloc_callback(perf_alloc_failed_hook);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "failed-alloc hook registration failed: %s", esp_err_to_name(err));
+    } else {
+        ESP_LOGI(TAG, "failed-alloc catcher registered");
+    }
+}
+
+uint32_t perf_get_alloc_fail_count(void)
+{
+    return s_alloc_fail_count;
+}
 
 // ── Start-time storage ──────────────────────────────────────────────
 // Simple hash table to store start times, indexed by pointer hash.
@@ -190,6 +225,14 @@ void perf_monitor_capture_memory(void)
         ? (float)g_perf.heap_largest_free_block / (float)g_perf.heap_free_bytes
         : 0.0f;
 
+    // DMA-capable internal heap subset — the pool the esp-hosted SDIO RX path
+    // allocates from. These heap_caps queries allocate nothing.
+    const uint32_t dma_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT;
+    g_perf.dma_free_bytes          = heap_caps_get_free_size(dma_caps);
+    g_perf.dma_min_free_bytes      = heap_caps_get_minimum_free_size(dma_caps);
+    g_perf.dma_largest_free_block  = heap_caps_get_largest_free_block(dma_caps);
+    g_perf.internal8_free_bytes    = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+
     // PSRAM
     g_perf.psram_free_bytes         = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
     g_perf.psram_min_free_bytes     = heap_caps_get_minimum_free_size(MALLOC_CAP_SPIRAM);
@@ -345,6 +388,87 @@ void perf_monitor_capture_cpu(void)
     s_prev_task_count = (uint8_t)filled;
 }
 
+// ── Low-DMA-heap watchdog ───────────────────────────────────────────
+//
+// Catches transient exhaustion of the DMA-capable internal heap (the pool
+// that esp-hosted's sdio_rx_get_buffer allocates from). Fires regardless of
+// g_perf.enabled because it is a safety diagnostic, not a profiling metric.
+// Allocates nothing from the internal heap: all heap_caps_* queries and
+// heap_caps_print_heap_info() are read-only / print directly to the console,
+// and the stack-HWM dump reads the already-captured cpu_stats snapshot.
+
+bool perf_monitor_dma_heap_watchdog(void)
+{
+    const uint32_t dma_caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT;
+
+    uint32_t dma_largest = heap_caps_get_largest_free_block(dma_caps);
+    if (dma_largest >= PERF_DMA_HEAP_WARN_THRESHOLD) {
+        return false;  // healthy — fast path, no logging
+    }
+
+    // Threshold crossed: count every crossing (cheap, for trend frequency).
+    g_perf.dma_heap_warn_count++;
+
+    // Rate-limit the verbose WARN block so a sustained low condition does not
+    // spam the log. Static timestamp survives across calls; no heap use.
+    static int64_t s_last_warn_us = 0;
+    int64_t now = esp_timer_get_time();
+    if (s_last_warn_us != 0 &&
+        (now - s_last_warn_us) < (int64_t)PERF_DMA_HEAP_WARN_MIN_INTERVAL_S * 1000000) {
+        return true;  // counted, but suppress the noisy block
+    }
+    s_last_warn_us = now;
+
+    uint32_t dma_free      = heap_caps_get_free_size(dma_caps);
+    uint32_t dma_min_free  = heap_caps_get_minimum_free_size(dma_caps);
+    uint32_t int_free      = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
+    uint32_t int_largest   = heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL);
+    uint32_t int8_free     = heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+    uint32_t psram_free    = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+
+    ESP_LOGW(TAG, "╔═══════════ LOW DMA-CAPABLE HEAP WARNING ═══════════╗");
+    ESP_LOGW(TAG, "  DMA-capable internal pool near exhaustion "
+                  "(SDIO RX alloc at risk)");
+    ESP_LOGW(TAG, "  dma_largest=%"PRIu32" B  < threshold=%d B",
+             dma_largest, PERF_DMA_HEAP_WARN_THRESHOLD);
+    ESP_LOGW(TAG, "  dma_free=%"PRIu32"  dma_min_free=%"PRIu32"  dma_largest=%"PRIu32,
+             dma_free, dma_min_free, dma_largest);
+    ESP_LOGW(TAG, "  internal_free=%"PRIu32"  internal_largest=%"PRIu32"  internal8_free=%"PRIu32,
+             int_free, int_largest, int8_free);
+    ESP_LOGW(TAG, "  psram_free=%"PRIu32"  warn_count=%"PRIu32,
+             psram_free, g_perf.dma_heap_warn_count);
+
+    // Per-capability heap dumps (print to console, allocate nothing).
+    ESP_LOGW(TAG, "  -- heap_caps_print_heap_info(INTERNAL|DMA|8BIT) --");
+    heap_caps_print_heap_info(dma_caps);
+    ESP_LOGW(TAG, "  -- heap_caps_print_heap_info(INTERNAL) --");
+    heap_caps_print_heap_info(MALLOC_CAP_INTERNAL);
+
+    // All-task stack HWM list from the existing cpu_stats snapshot — shows
+    // which task is closest to overflow. No uxTaskGetSystemState call here
+    // (that would allocate); we read what perf_monitor_capture_cpu() captured.
+    const cpu_stats_t *cpu = &g_perf.cpu;
+    if (cpu->task_info_count > 0) {
+        ESP_LOGW(TAG, "  -- task stack HWM (free bytes, from last snapshot) --");
+        for (uint8_t i = 0; i < cpu->task_info_count; i++) {
+            const cpu_task_info_t *t = &cpu->tasks[i];
+            const char *core_str = "any";
+            char core_buf[4];
+            if (t->core_id < 2) {
+                snprintf(core_buf, sizeof(core_buf), "%d", t->core_id);
+                core_str = core_buf;
+            }
+            ESP_LOGW(TAG, "    %-16s core=%-3s stack_hwm=%"PRIu32" B",
+                     t->name, core_str, t->stack_hwm_bytes);
+        }
+    } else {
+        ESP_LOGW(TAG, "  (no cpu_stats snapshot yet — stack HWM list unavailable)");
+    }
+    ESP_LOGW(TAG, "╚════════════════════════════════════════════════════╝");
+
+    return true;
+}
+
 // ── Serial log report ───────────────────────────────────────────────
 
 static void log_timer(const char *name, const perf_timer_t *t)
@@ -457,6 +581,9 @@ void perf_monitor_report(void)
     ESP_LOGI(TAG, "  Internal heap:  free=%"PRIu32"  min_ever=%"PRIu32"  largest_block=%"PRIu32"  frag_ratio=%.3f",
              g_perf.heap_free_bytes, g_perf.heap_min_free_bytes, g_perf.heap_largest_free_block,
              g_perf.heap_frag_ratio);
+    ESP_LOGI(TAG, "  DMA-capable:    free=%"PRIu32"  min_ever=%"PRIu32"  largest_block=%"PRIu32"  internal8_free=%"PRIu32"  warn_count=%"PRIu32,
+             g_perf.dma_free_bytes, g_perf.dma_min_free_bytes, g_perf.dma_largest_free_block,
+             g_perf.internal8_free_bytes, g_perf.dma_heap_warn_count);
     ESP_LOGI(TAG, "  PSRAM:          free=%"PRIu32"  min_ever=%"PRIu32"  largest_block=%"PRIu32"  frag_ratio=%.3f",
              g_perf.psram_free_bytes, g_perf.psram_min_free_bytes, g_perf.psram_largest_free_block,
              g_perf.psram_frag_ratio);
@@ -498,6 +625,11 @@ void perf_monitor_report(void)
                      t->name, t->cpu_percent, core_str, t->stack_hwm_bytes);
         }
     }
+
+    // Low-DMA-heap watchdog: check after capture_memory()/capture_cpu() so the
+    // metrics and stack-HWM snapshot it reports are fresh. Runs every report
+    // cycle; the WARN block itself is rate-limited inside the function.
+    perf_monitor_dma_heap_watchdog();
 
     // Reset per-interval counters
     perf_counter_reset_interval(&g_perf.http_request_count);
@@ -563,6 +695,104 @@ static cJSON *counter_to_json(const perf_counter_t *c)
     cJSON_AddNumberToObject(obj, "total", c->total);
     cJSON_AddNumberToObject(obj, "per_interval", c->per_interval);
     return obj;
+}
+
+static const char *task_state_str(eTaskState state)
+{
+    switch (state) {
+        case eRunning:   return "running";
+        case eReady:     return "ready";
+        case eBlocked:   return "blocked";
+        case eSuspended: return "suspended";
+        case eDeleted:   return "deleted";
+        default:         return "unknown";
+    }
+}
+
+// Build the "tasks_detail" array plus min_stack_hwm_bytes / min_stack_task on
+// the supplied `tasks` object.
+//
+// Stack high-water mark is a point-in-time value: it needs no CPU-delta cycle,
+// unlike cpu_percent. The g_perf.cpu snapshot is only refreshed every
+// report_interval_s (30s) by the data task, and is empty (task_info_count==0,
+// valid==false) until two capture_cpu() passes have run — which is why this
+// previously returned min_stack_hwm_bytes=0 and an empty tasks_detail on the
+// /api/perf request path. Run a FRESH uxTaskGetSystemState pass here instead so
+// the values always reflect the real current smallest stack headroom.
+//
+// The required TaskStatus_t array is allocated from PSRAM (MALLOC_CAP_SPIRAM)
+// to avoid internal-heap pressure. This runs only on the /api/perf request
+// path, never in the failed-alloc hook. usStackHighWaterMark is in words on
+// this port, so multiply by sizeof(StackType_t) to get BYTES — matching how
+// cpu_task_info_t.stack_hwm_bytes is computed in perf_monitor_capture_cpu().
+static void build_tasks_detail(cJSON *tasks)
+{
+    cJSON *tasks_detail = cJSON_CreateArray();
+    if (!tasks_detail) return;
+
+    uint32_t min_stack_hwm = 0;
+    bool min_stack_seen = false;
+    char min_stack_task[16] = "";
+
+    UBaseType_t n = uxTaskGetNumberOfTasks();
+    TaskStatus_t *snap = NULL;
+    UBaseType_t filled = 0;
+    if (n > 0) {
+        snap = heap_caps_malloc(n * sizeof(TaskStatus_t), MALLOC_CAP_SPIRAM);
+        if (snap) {
+            filled = uxTaskGetSystemState(snap, n, NULL);
+        }
+    }
+
+    if (snap && filled > 0) {
+        // Fresh pass succeeded — authoritative current stack HWM for every task.
+        for (UBaseType_t i = 0; i < filled; i++) {
+            uint32_t hwm_bytes = (uint32_t)snap[i].usStackHighWaterMark * sizeof(StackType_t);
+            cJSON *tobj = cJSON_CreateObject();
+            if (tobj) {
+                cJSON_AddStringToObject(tobj, "name", snap[i].pcTaskName);
+                cJSON_AddNumberToObject(tobj, "stack_hwm_bytes", hwm_bytes);
+                cJSON_AddStringToObject(tobj, "state", task_state_str(snap[i].eCurrentState));
+                cJSON_AddNumberToObject(tobj, "core",
+                    snap[i].xCoreID == (BaseType_t)tskNO_AFFINITY ? -1 : (int)snap[i].xCoreID);
+                cJSON_AddItemToArray(tasks_detail, tobj);
+            }
+            if (!min_stack_seen || hwm_bytes < min_stack_hwm) {
+                min_stack_hwm = hwm_bytes;
+                min_stack_seen = true;
+                strncpy(min_stack_task, snap[i].pcTaskName, sizeof(min_stack_task) - 1);
+                min_stack_task[sizeof(min_stack_task) - 1] = '\0';
+            }
+        }
+    } else {
+        // Fallback: PSRAM alloc or uxTaskGetSystemState failed — use whatever the
+        // last cpu snapshot captured (may be empty on a very early request).
+        for (uint8_t i = 0; i < g_perf.cpu.task_info_count; i++) {
+            const cpu_task_info_t *t = &g_perf.cpu.tasks[i];
+            cJSON *tobj = cJSON_CreateObject();
+            if (tobj) {
+                cJSON_AddStringToObject(tobj, "name", t->name);
+                cJSON_AddNumberToObject(tobj, "stack_hwm_bytes", t->stack_hwm_bytes);
+                cJSON_AddStringToObject(tobj, "state", task_state_str(t->state));
+                cJSON_AddNumberToObject(tobj, "core", t->core_id == 0xFF ? -1 : (int)t->core_id);
+                cJSON_AddItemToArray(tasks_detail, tobj);
+            }
+            if (!min_stack_seen || t->stack_hwm_bytes < min_stack_hwm) {
+                min_stack_hwm = t->stack_hwm_bytes;
+                min_stack_seen = true;
+                strncpy(min_stack_task, t->name, sizeof(min_stack_task) - 1);
+                min_stack_task[sizeof(min_stack_task) - 1] = '\0';
+            }
+        }
+    }
+
+    if (snap) {
+        heap_caps_free(snap);
+    }
+
+    cJSON_AddItemToObject(tasks, "tasks_detail", tasks_detail);
+    cJSON_AddNumberToObject(tasks, "min_stack_hwm_bytes", min_stack_hwm);
+    cJSON_AddStringToObject(tasks, "min_stack_task", min_stack_task);
 }
 
 char *perf_monitor_report_json(void)
@@ -653,6 +883,16 @@ char *perf_monitor_report_json(void)
     cJSON_AddNumberToObject(memory, "heap_min_free_bytes",     g_perf.heap_min_free_bytes);
     cJSON_AddNumberToObject(memory, "heap_largest_free_block", g_perf.heap_largest_free_block);
     cJSON_AddNumberToObject(memory, "heap_frag_ratio",        g_perf.heap_frag_ratio);
+    // DMA-capable internal heap subset (the SDIO RX pool that actually fails)
+    cJSON_AddNumberToObject(memory, "dma_free_bytes",          g_perf.dma_free_bytes);
+    cJSON_AddNumberToObject(memory, "dma_min_free_bytes",      g_perf.dma_min_free_bytes);
+    cJSON_AddNumberToObject(memory, "dma_largest_free_block",  g_perf.dma_largest_free_block);
+    cJSON_AddNumberToObject(memory, "internal8_free_bytes",    g_perf.internal8_free_bytes);
+    cJSON_AddNumberToObject(memory, "dma_heap_warn_count",     g_perf.dma_heap_warn_count);
+    // Cumulative failed-allocation count from the heap failed-alloc hook (the
+    // deterministic OOM catcher; nonzero means at least one heap_caps_* alloc
+    // returned NULL since boot — see the [ALLOC-FAIL] serial lines).
+    cJSON_AddNumberToObject(memory, "alloc_fail_count",        perf_get_alloc_fail_count());
     cJSON_AddNumberToObject(memory, "psram_free_bytes",         g_perf.psram_free_bytes);
     cJSON_AddNumberToObject(memory, "psram_min_free_bytes",     g_perf.psram_min_free_bytes);
     cJSON_AddNumberToObject(memory, "psram_largest_free_block", g_perf.psram_largest_free_block);
@@ -664,6 +904,11 @@ char *perf_monitor_report_json(void)
     cJSON_AddNumberToObject(tasks, "data_task_stack_hwm",  g_perf.data_task_stack_hwm);
     cJSON_AddNumberToObject(tasks, "input_task_stack_hwm", g_perf.input_task_stack_hwm);
     cJSON_AddNumberToObject(tasks, "spotify_task_stack_hwm", g_perf.spotify_task_stack_hwm);
+
+    // All-task stack HWM detail + worst (smallest headroom) task. Built from a
+    // FRESH uxTaskGetSystemState pass (PSRAM-backed) so it is valid even on the
+    // very first /api/perf request, before the periodic cpu snapshot populates.
+    build_tasks_detail(tasks);
     cJSON_AddItemToObject(root, "tasks", tasks);
 
     // JPEG

--- a/main/perf_monitor.h
+++ b/main/perf_monitor.h
@@ -25,6 +25,15 @@ void     perf_timer_reset(perf_timer_t *t);
 
 #define CPU_MAX_TRACKED_TASKS 24
 
+// Low-DMA-heap watchdog: when the largest contiguous DMA-capable internal
+// block (MALLOC_CAP_INTERNAL|MALLOC_CAP_DMA|MALLOC_CAP_8BIT) drops below this,
+// the esp-hosted SDIO RX allocation is at risk of failing. Emit a WARN block.
+#define PERF_DMA_HEAP_WARN_THRESHOLD 8192
+
+// Minimum seconds between low-DMA-heap WARN blocks (rate-limit so a sustained
+// low-heap condition does not spam the log).
+#define PERF_DMA_HEAP_WARN_MIN_INTERVAL_S 10
+
 typedef struct {
     char       name[16];          // Task name (configMAX_TASK_NAME_LEN)
     uint8_t    core_id;           // 0, 1, or 0xFF (no affinity)
@@ -104,6 +113,15 @@ typedef struct {
     uint32_t heap_min_free_bytes;         // Minimum ever (highwater mark)
     uint32_t heap_largest_free_block;     // Largest contiguous free block (fragmentation)
     float    heap_frag_ratio;             // largest_free_block / total_free (1.0 = no fragmentation)
+    // DMA-capable internal heap subset (the pool that the esp-hosted SDIO RX
+    // path allocates from; OOM here crashes sdio_rx_get_buffer). This is a
+    // subset of MALLOC_CAP_INTERNAL and is what actually fails, so track it
+    // separately from the generic internal-heap numbers above.
+    uint32_t dma_free_bytes;              // free(MALLOC_CAP_INTERNAL|DMA|8BIT)
+    uint32_t dma_min_free_bytes;          // min-ever free of the DMA-capable pool
+    uint32_t dma_largest_free_block;      // largest contiguous DMA-capable block
+    uint32_t internal8_free_bytes;        // free(MALLOC_CAP_INTERNAL|8BIT)
+    uint32_t dma_heap_warn_count;         // times the low-DMA-heap threshold was crossed
     uint32_t psram_free_bytes;
     uint32_t psram_min_free_bytes;
     uint32_t psram_largest_free_block;
@@ -180,6 +198,15 @@ void perf_monitor_record_wifi(const wifi_ap_record_t *ap_info);
 // Print a formatted report to serial log. Called automatically at interval.
 void perf_monitor_report(void);
 
+// Low-DMA-heap watchdog. Checks the largest contiguous DMA-capable internal
+// block; if it is below PERF_DMA_HEAP_WARN_THRESHOLD, increments
+// dma_heap_warn_count and (rate-limited) emits an ungated WARN diagnostic
+// block: DMA/internal/psram heap summary, per-capability heap dumps, and the
+// all-task stack HWM list from the existing cpu_stats snapshot. Allocates
+// nothing from the internal heap. Safe to call regardless of g_perf.enabled.
+// Returns true if the threshold was crossed on this call.
+bool perf_monitor_dma_heap_watchdog(void);
+
 // Reset all metrics (call between profiling runs to get clean data).
 void perf_monitor_reset_all(void);
 
@@ -188,3 +215,15 @@ char *perf_monitor_report_json(void);
 
 // Helper to manually record a duration (for intervals measured externally)
 void perf_timer_record(perf_timer_t *t, int64_t duration_us);
+
+// ── Failed-allocation catcher ───────────────────────────────────────
+//
+// Registers an ESP-IDF heap failed-alloc hook that prints one compact,
+// lock-free / allocation-free line on EVERY failed heap_caps_* allocation
+// (the deterministic catcher for the transient internal DMA-SRAM exhaustion
+// that crashes sdio_rx_get_buffer). Call once at startup, after log init and
+// before tasks spawn. Safe to call regardless of g_perf.enabled.
+void perf_monitor_register_alloc_fail_hook(void);
+
+// Cumulative count of failed allocations seen by the hook since boot.
+uint32_t perf_get_alloc_fail_count(void);

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -3046,7 +3046,19 @@ main_loop:
             if (esp_timer_get_time() - g_perf.last_report_time_us >=
                 (int64_t)g_perf.report_interval_s * 1000000) {
                 perf_monitor_capture_cpu();
-                perf_monitor_report();
+                perf_monitor_report();  // report() also runs the DMA-heap watchdog
+            }
+        } else {
+            // Perf profiling disabled, but the low-DMA-heap watchdog is a safety
+            // diagnostic that must fire regardless of debug_mode/perf state. Run
+            // it on the same ~report cadence. Allocates nothing from any heap.
+            static int64_t s_last_wd_us = 0;
+            uint32_t wd_interval_s = g_perf.report_interval_s ? g_perf.report_interval_s : 30;
+            int64_t now_wd = esp_timer_get_time();
+            if (s_last_wd_us == 0 ||
+                (now_wd - s_last_wd_us) >= (int64_t)wd_interval_s * 1000000) {
+                s_last_wd_us = now_wd;
+                perf_monitor_dma_heap_watchdog();
             }
         }
 

--- a/main/web_handlers_logs.c
+++ b/main/web_handlers_logs.c
@@ -9,12 +9,20 @@
  *                              (text/plain attachment; the UI also fetches it
  *                              inline). Empty body when no crashes recorded.
  * POST /api/crashlog/clear  -> deletes the crash-history file, returns {"ok":true}.
+ * GET  /api/coredump/info   -> JSON {present,size,git_sha,version} for the saved
+ *                              ELF core dump in the coredump partition.
+ * GET  /api/coredump        -> streams the raw core dump ELF as an octet-stream
+ *                              attachment (404 when no dump is present).
+ * POST /api/coredump/clear  -> erases the saved core dump, returns {"ok":true}.
  */
 
 #include "web_server_internal.h"
 #include "log_capture.h"
 #include "crash_log.h"
+#include "build_version.h"
 #include "esp_heap_caps.h"
+#include "esp_core_dump.h"
+#include "esp_partition.h"
 #include <string.h>
 
 /* PSRAM-backed chunk size for streaming the download. Keeps the send path off
@@ -137,6 +145,118 @@ esp_err_t crashlog_clear_post_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
     crash_log_clear();  /* idempotent, always ESP_OK */
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}
+
+// Handler reporting whether a saved core dump is present (+ its size and build info)
+esp_err_t coredump_info_get_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    /* esp_core_dump_image_get() returns ESP_OK only when a valid ELF image is
+     * present in the coredump partition; out_size is the image length. */
+    size_t out_addr = 0, out_size = 0;
+    bool present = (esp_core_dump_image_get(&out_addr, &out_size) == ESP_OK);
+
+    cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    cJSON_AddBoolToObject(root, "present", present);
+    cJSON_AddNumberToObject(root, "size", present ? (double)out_size : 0.0);
+    cJSON_AddStringToObject(root, "git_sha", BUILD_GIT_SHA);
+    cJSON_AddStringToObject(root, "version", BUILD_VERSION);
+
+    const char *json_str = cJSON_PrintUnformatted(root);
+    if (!json_str) {
+        cJSON_Delete(root);
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, json_str, HTTPD_RESP_USE_STRLEN);
+    free((void *)json_str);
+    cJSON_Delete(root);
+    return ESP_OK;
+}
+
+// Handler for downloading the raw core dump ELF from the coredump partition
+esp_err_t coredump_get_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    /* No core dump saved: 404 so the UI can distinguish "nothing to download". */
+    size_t out_addr = 0, out_size = 0;
+    if (esp_core_dump_image_get(&out_addr, &out_size) != ESP_OK || out_size == 0) {
+        httpd_resp_set_status(req, "404 Not Found");
+        httpd_resp_set_type(req, "text/plain");
+        httpd_resp_send(req, "No core dump present", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    const esp_partition_t *part =
+        esp_partition_find_first(ESP_PARTITION_TYPE_DATA,
+                                 ESP_PARTITION_SUBTYPE_DATA_COREDUMP, NULL);
+    if (!part) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    /* Build the download filename from the configured hostname + build SHA. */
+    const char *hostname = app_config_get()->hostname;
+    if (!hostname || hostname[0] == '\0') {
+        hostname = "ninadash";
+    }
+    char disp[160];
+    snprintf(disp, sizeof(disp),
+             "attachment; filename=\"%s-%s-coredump.elf\"", hostname, BUILD_GIT_SHA);
+
+    httpd_resp_set_type(req, "application/octet-stream");
+    httpd_resp_set_hdr(req, "Content-Disposition", disp);
+
+    char *chunk = heap_caps_malloc(LOG_CHUNK_SIZE, MALLOC_CAP_SPIRAM);
+    if (!chunk) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    /* Stream exactly out_size bytes from the partition in PSRAM-sized chunks. */
+    size_t remaining = out_size;
+    size_t offset = 0;
+    while (remaining > 0) {
+        size_t to_read = remaining < LOG_CHUNK_SIZE ? remaining : (size_t)LOG_CHUNK_SIZE;
+        esp_err_t rerr = esp_partition_read(part, offset, chunk, to_read);
+        if (rerr != ESP_OK) {
+            heap_caps_free(chunk);
+            return ESP_FAIL;  /* partial response; httpd aborts the connection */
+        }
+        if (httpd_resp_send_chunk(req, chunk, to_read) != ESP_OK) {
+            heap_caps_free(chunk);
+            return ESP_FAIL;  /* connection aborted; httpd cleans up */
+        }
+        offset    += to_read;
+        remaining -= to_read;
+    }
+
+    heap_caps_free(chunk);
+
+    /* Terminate the chunked response with a zero-length chunk. */
+    httpd_resp_send_chunk(req, NULL, 0);
+    return ESP_OK;
+}
+
+// Handler for erasing the saved core dump
+esp_err_t coredump_clear_post_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+    esp_err_t err = esp_core_dump_image_erase();
+    if (err != ESP_OK) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
     httpd_resp_set_type(req, "application/json");
     httpd_resp_send(req, "{\"ok\":true}", HTTPD_RESP_USE_STRLEN);
     return ESP_OK;

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -196,7 +196,7 @@ void start_web_server(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 16384;
-    config.max_uri_handlers = 52;
+    config.max_uri_handlers = 56;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -263,12 +263,15 @@ void start_web_server(void)
         { "/api/logs/clear",         HTTP_POST, logs_clear_post_handler, NULL },
         { "/api/crashlog",           HTTP_GET,  crashlog_get_handler, NULL },
         { "/api/crashlog/clear",     HTTP_POST, crashlog_clear_post_handler, NULL },
+        { "/api/coredump",           HTTP_GET,  coredump_get_handler,        NULL },
+        { "/api/coredump/info",      HTTP_GET,  coredump_info_get_handler,   NULL },
+        { "/api/coredump/clear",     HTTP_POST, coredump_clear_post_handler, NULL },
     };
 
-    /* Keep config.max_uri_handlers (set to 52 above) in sync with the route
+    /* Keep config.max_uri_handlers (set to 56 above) in sync with the route
      * table; a route that overflows it would be silently dropped at
      * registration. Bump both together when adding routes. */
-    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 52,
+    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 56,
                    "max_uri_handlers too small for route table");
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -122,4 +122,7 @@ esp_err_t logs_get_handler(httpd_req_t *req);
 esp_err_t logs_clear_post_handler(httpd_req_t *req);
 esp_err_t crashlog_get_handler(httpd_req_t *req);
 esp_err_t crashlog_clear_post_handler(httpd_req_t *req);
+esp_err_t coredump_info_get_handler(httpd_req_t *req);
+esp_err_t coredump_get_handler(httpd_req_t *req);
+esp_err_t coredump_clear_post_handler(httpd_req_t *req);
 void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t *new_cfg);

--- a/partitions.csv
+++ b/partitions.csv
@@ -1,7 +1,9 @@
 # Name,   Type, SubType,  Offset,    Size,    Flags
-nvs,      data, nvs,      0x9000,    0x6000,
-otadata,  data, ota,      0xf000,    0x2000,
-phy_init, data, phy,      0x11000,   0x1000,
+nvs,      data, nvs,      0x9000,    0x10000,
+otadata,  data, ota,      0x19000,   0x2000,
+phy_init, data, phy,      0x1B000,   0x1000,
 ota_0,    app,  ota_0,    0x20000,   0x800000,
 ota_1,    app,  ota_1,    0x820000,  0x800000,
-storage,  data, spiffs,   0x1020000, 0xFE0000,
+storage,  data, spiffs,   0x1020000, 0xF40000,
+coredump, data, coredump, 0x1F60000, 0x80000,
+crashlog, data, spiffs,   0x1FE0000, 0x20000,

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -24,7 +24,10 @@ CONFIG_ESP_MAIN_TASK_STACK_SIZE=10240
 CONFIG_FREERTOS_HZ=1000
 CONFIG_FREERTOS_VTASKLIST_INCLUDE_COREID=y
 CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS=y
-CONFIG_LV_USE_CLIB_MALLOC=y
+# LVGL widget/object/style metadata is allocated from PSRAM via a custom backend
+# (main/lv_mem_psram.c) to keep the internal/DMA SRAM pool free for the esp-hosted
+# WiFi RX path. Do not switch back to CLIB/BUILTIN without removing that file's hooks.
+CONFIG_LV_USE_CUSTOM_MALLOC=y
 CONFIG_LV_USE_CLIB_STRING=y
 CONFIG_LV_USE_CLIB_SPRINTF=y
 CONFIG_LV_DEF_REFR_PERIOD=25
@@ -98,3 +101,15 @@ CONFIG_LV_USE_DEMO_MUSIC=n
 CONFIG_LV_DEMO_MUSIC_AUTO_PLAY=n
 CONFIG_LV_USE_DEMO_FLEX_LAYOUT=n
 CONFIG_LV_USE_DEMO_MULTILANG=n
+
+# Crash core dump to dedicated flash partition (ELF + SHA256), own stack, boot check
+CONFIG_ESP_COREDUMP_ENABLE_TO_FLASH=y
+CONFIG_ESP_COREDUMP_DATA_FORMAT_ELF=y
+CONFIG_ESP_COREDUMP_CHECKSUM_SHA256=y
+CONFIG_ESP_COREDUMP_STACK_SIZE=1536
+CONFIG_ESP_COREDUMP_CHECK_BOOT=y
+
+# Heap tracing left off (default). Internal-heap fragmentation was root-caused
+# (LVGL routed to PSRAM via CONFIG_LV_USE_CUSTOM_MALLOC + main/lv_mem_psram.c);
+# RISC-V PC attribution was unreliable so the trace tooling was removed.
+CONFIG_HEAP_TRACING_OFF=y


### PR DESCRIPTION
### Summary
This PR resolves device reboots caused by memory fragmentation by moving LVGL memory allocations to PSRAM. It also adds permanent performance monitoring and crash diagnostic tools, including dedicated coredump partitions.

### Changes
*   LVGL memory allocations now use PSRAM instead of internal DMA-capable SRAM, preventing fragmentation that caused SDIO RX out-of-memory reboots.
*   A new performance monitor tracks DMA-capable heap metrics (free, min, largest block) and task stack high-water marks, accessible via the `/api/perf` endpoint.
*   Dedicated coredump (512 KB) and crashlog (128 KB) partitions are added to store crash data on flash, with new API endpoints to manage this data.
*   The web UI and device now display a warning that the next update requires a manual USB erase and flash due to partition layout changes.
*   The unreliable heap_trace_diag scaffold is removed, as its RISC-V PC attribution provided no usable signal.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-23T21:34:18.677Z | Generated by GitHub Actions</sub>