### PR TITLE
fix: only record OTA version after new image boots

### DIFF
--- a/main/main.c
+++ b/main/main.c
@@ -26,6 +26,7 @@
 #include "mqtt_ha.h"
 #include "tasks.h"
 #include "esp_ota_ops.h"
+#include "ota_github.h"
 #include "driver/jpeg_decode.h"
 #include "display/lv_display_private.h"
 #include "draw/sw/lv_draw_sw_utils.h"
@@ -845,5 +846,15 @@ void app_main(void)
     /* Mark this firmware as valid so the bootloader won't roll back.
      * This must come after successful init — if we crash before here,
      * the bootloader will revert to the previous OTA partition. */
+    /* Determine whether this is the first boot of a freshly-OTA'd image.
+     * Only then is a pending OTA version promoted to the confirmed installed
+     * version; a rollback/normal boot discards the stale pending stamp. */
+    const esp_partition_t *running = esp_ota_get_running_partition();
+    esp_ota_img_states_t ota_state;
+    bool first_boot_new_image =
+        (esp_ota_get_state_partition(running, &ota_state) == ESP_OK &&
+         ota_state == ESP_OTA_IMG_PENDING_VERIFY);
+    ota_github_reconcile_version(first_boot_new_image);
+
     esp_ota_mark_app_valid_cancel_rollback();
 }

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -598,32 +598,71 @@ esp_err_t ota_github_download(const char *url, void (*progress_cb)(int percent))
 }
 
 /* ── NVS-backed OTA version tracking ─────────────────────────────── */
+/* Three keys in the "ota_ver" namespace:
+ *   tag     — confirmed release tag of the image that is ACTUALLY running.
+ *   build   — BUILD_GIT_TAG that the stored `tag` belongs to (identity guard).
+ *   pending — release tag an in-flight OTA intends to install; promoted to
+ *             `tag` only after that image boots and is confirmed valid.
+ * The `tag` key is never written at OTA-apply time, so a downloaded-but-not-
+ * booted image (rollback / slot mismatch) cannot poison the version banner. */
+#define OTA_NVS_NAMESPACE   "ota_ver"
+#define OTA_NVS_KEY         "tag"
+#define OTA_NVS_KEY_BUILD   "build"
+#define OTA_NVS_KEY_PENDING "pending"
 
-#define OTA_NVS_NAMESPACE "ota_ver"
-#define OTA_NVS_KEY       "tag"
-
-void ota_github_save_installed_version(const char *tag) {
+void ota_github_save_pending_version(const char *tag) {
     if (!tag || !tag[0]) return;
     nvs_handle_t h;
     if (nvs_open(OTA_NVS_NAMESPACE, NVS_READWRITE, &h) == ESP_OK) {
-        nvs_set_str(h, OTA_NVS_KEY, tag);
+        nvs_set_str(h, OTA_NVS_KEY_PENDING, tag);
         nvs_commit(h);
         nvs_close(h);
-        ESP_LOGI(TAG, "Saved OTA installed version: %s", tag);
+        ESP_LOGI(TAG, "OTA pending version stamped: %s (confirmed on next boot)", tag);
     }
 }
 
+void ota_github_reconcile_version(bool first_boot_new_image) {
+    nvs_handle_t h;
+    if (nvs_open(OTA_NVS_NAMESPACE, NVS_READWRITE, &h) != ESP_OK) return;
+
+    char pending[64] = {0};
+    size_t len = sizeof(pending);
+    bool have_pending = (nvs_get_str(h, OTA_NVS_KEY_PENDING, pending, &len) == ESP_OK && pending[0]);
+
+    if (first_boot_new_image && have_pending) {
+        /* The OTA image actually booted — promote intent to confirmed state and
+         * bind it to the running build so the read path can validate it later. */
+        nvs_set_str(h, OTA_NVS_KEY, pending);
+        nvs_set_str(h, OTA_NVS_KEY_BUILD, BUILD_GIT_TAG);
+        nvs_erase_key(h, OTA_NVS_KEY_PENDING);
+        ESP_LOGI(TAG, "OTA confirmed booted: installed=%s build=%s", pending, BUILD_GIT_TAG);
+    } else if (have_pending) {
+        /* Normal boot or rollback to the old image — the pending stamp is stale. */
+        nvs_erase_key(h, OTA_NVS_KEY_PENDING);
+        ESP_LOGW(TAG, "Discarded stale pending OTA version %s (image did not take)", pending);
+    }
+
+    nvs_commit(h);
+    nvs_close(h);
+}
+
 const char *ota_github_get_current_version(void) {
-    static char stored[64];
+    static char tag[64];
     nvs_handle_t h;
     if (nvs_open(OTA_NVS_NAMESPACE, NVS_READONLY, &h) == ESP_OK) {
-        size_t len = sizeof(stored);
-        if (nvs_get_str(h, OTA_NVS_KEY, stored, &len) == ESP_OK && stored[0]) {
-            nvs_close(h);
-            ESP_LOGI(TAG, "Using OTA-installed version for comparison: %s", stored);
-            return stored;
-        }
+        char build[64];
+        size_t tl = sizeof(tag);
+        size_t bl = sizeof(build);
+        bool ok_tag   = (nvs_get_str(h, OTA_NVS_KEY,       tag,   &tl) == ESP_OK && tag[0]);
+        bool ok_build = (nvs_get_str(h, OTA_NVS_KEY_BUILD, build, &bl) == ESP_OK && build[0]);
         nvs_close(h);
+        /* Only trust the stored release tag if it belongs to the build that is
+         * actually running. A mismatch means the stored tag is stale (e.g. an OTA
+         * that never booted, or a manual flash) — fall back to the truth. */
+        if (ok_tag && ok_build && strcmp(build, BUILD_GIT_TAG) == 0) {
+            ESP_LOGI(TAG, "Using OTA-installed version for comparison: %s", tag);
+            return tag;
+        }
     }
     return BUILD_GIT_TAG;
 }

--- a/main/ota_github.h
+++ b/main/ota_github.h
@@ -34,14 +34,24 @@ bool ota_github_check(bool include_prereleases, const char *current_version, git
 esp_err_t ota_github_download(const char *url, void (*progress_cb)(int percent));
 
 /**
- * Save the version tag of a successfully installed OTA update to NVS.
- * Called after OTA download succeeds, before reboot.
+ * Record the release tag an OTA update intends to install (pending state).
+ * Stamped at apply time, before reboot. Promoted to the confirmed installed
+ * version only after that image actually boots (see ota_github_reconcile_version).
  */
-void ota_github_save_installed_version(const char *tag);
+void ota_github_save_pending_version(const char *tag);
+
+/**
+ * Reconcile OTA version state once at boot.
+ * If first_boot_new_image is true, promote the pending OTA tag to the confirmed
+ * installed version (bound to the running build); otherwise discard a stale
+ * pending stamp left by an OTA image that never booted (rollback/slot mismatch).
+ */
+void ota_github_reconcile_version(bool first_boot_new_image);
 
 /**
  * Get the effective current version for OTA comparison.
- * Returns the NVS-stored OTA version if present, otherwise BUILD_GIT_TAG.
+ * Returns the NVS-stored OTA version only if it belongs to the running build,
+ * otherwise BUILD_GIT_TAG.
  * The returned pointer is valid until the next call to this function.
  */
 const char *ota_github_get_current_version(void);

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -1995,7 +1995,7 @@ void data_update_task(void *arg) {
                     }
                     esp_err_t ota_err = ota_github_download(rel->ota_url, ota_progress_cb);
                     if (ota_err == ESP_OK) {
-                        ota_github_save_installed_version(rel->tag);
+                        ota_github_save_pending_version(rel->tag);
                         ESP_LOGI(TAG, "OTA download success, rebooting...");
                         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                             nina_ota_prompt_set_progress(100);
@@ -2403,7 +2403,7 @@ main_loop:
                         }
                         esp_err_t ota_err = ota_github_download(rel->ota_url, ota_progress_cb);
                         if (ota_err == ESP_OK) {
-                            ota_github_save_installed_version(rel->tag);
+                            ota_github_save_pending_version(rel->tag);
                             ESP_LOGI(TAG, "OTA download success, rebooting...");
                             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                                 nina_ota_prompt_set_progress(100);

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -449,7 +449,7 @@ esp_err_t ota_github_post_handler(httpd_req_t *req)
     /* Download and flash */
     esp_err_t err = ota_github_download(rel->ota_url, ota_update_progress);
     if (err == ESP_OK) {
-        ota_github_save_installed_version(rel->tag);
+        ota_github_save_pending_version(rel->tag);
         ESP_LOGI(TAG, "GitHub OTA success (%s), rebooting...", rel->tag);
         ota_update_progress(100);
         heap_caps_free(rel);


### PR DESCRIPTION
### Summary
The device now accurately reports its running software version after an Over-The-Air (OTA) update. Previously, the reported version could be incorrect if the new software failed to boot or was rolled back. Now, the version is only confirmed and displayed after the new software successfully starts.

### Changes
*   The OTA update process now saves a 'pending' version to storage instead of immediately marking it as 'installed'.
*   On first boot after an OTA, the device verifies the new software and promotes the 'pending' version to the confirmed 'installed' version.
*   The system now stores the build tag alongside the release tag for better version integrity.
*   The `get_current_version()` function now validates the stored version against the running build tag, falling back to the compiled-in version if they do not match.
*   Removed the `ota_github_save_installed_version` function.
*   Added `save_pending_version` and `reconcile_version` functions to manage the new version confirmation flow.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-23T22:09:37.434Z | Generated by GitHub Actions</sub>