### PR TITLE
fix: ignore retained MQTT commands to prevent reboot loop

### DIFF
--- a/main/mqtt_ha.c
+++ b/main/mqtt_ha.c
@@ -475,6 +475,15 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base,
         break;
 
     case MQTT_EVENT_DATA:
+        /* Ignore retained command messages. The screen/text/reboot topics are
+         * Home Assistant command topics (momentary light-set / button-press); a
+         * retained payload is a stale command the broker redelivers on every
+         * (re)connect. Acting on a retained reboot boot-loops the device (one
+         * reboot per MQTT connect). Only live commands represent real intent. */
+        if (event->retain) {
+            ESP_LOGW(TAG, "Ignoring retained MQTT command on subscribed topic");
+            break;
+        }
         if (event->topic && event->topic_len > 0) {
             if (event->topic_len == (int)strlen(s_topic_screen_cmd) &&
                 strncmp(event->topic, s_topic_screen_cmd, event->topic_len) == 0) {


### PR DESCRIPTION
### Summary
Devices could enter a continuous reboot loop if an MQTT command topic had a retained message, as the command would be replayed on every reconnect. This change prevents the device from processing retained MQTT command messages, stopping unintended reboots.

### Changes
- MQTT_EVENT_DATA messages are now checked for the retain flag before being processed.
- Retained MQTT command messages are ignored to prevent them from being replayed on every broker reconnect.
- This stops devices from entering a reboot loop caused by stale retained commands on topics like `/reboot/set`.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-23T23:21:18.408Z | Generated by GitHub Actions</sub>