### PR TITLE
fix: accurate exposure arc display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,3 +168,6 @@ components/tgx/*
 .env.development.local
 .env.test.local
 .env.production.local
+
+# Local serial-console DSI underrun watcher (not part of the build)
+watch_underrun.ps1

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LV_DEMO_DIR ../managed_components/lvgl__lvgl/demos)
 file(GLOB_RECURSE LV_DEMOS_SOURCES ${LV_DEMO_DIR}/*.c)
 
 idf_component_register(
-    SRCS main.c tasks.c power_mgmt.c jpeg_utils.c stb_image.c perf_monitor.c ota_github.c
+    SRCS main.c tasks.c axi_qos.c power_mgmt.c jpeg_utils.c stb_image.c perf_monitor.c ota_github.c
          nina_connection.c nina_client.c nina_api_fetchers.c nina_sequence.c nina_websocket.c
          allsky_client.c goes_client.c weather_client.c moon_ephemeris.c moon_render.c moon_sphere.cpp moon_interaction.c spotify_auth.c spotify_client.c demo_data.c
          app_config.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_image_display.c web_handlers_auth.c web_handlers_wifi.c web_handlers_logs.c log_capture.c crash_log.c mqtt_ha.c

--- a/main/axi_qos.c
+++ b/main/axi_qos.c
@@ -1,0 +1,41 @@
+#include "axi_qos.h"
+
+/* axi_icm_ll.h is a PRIVATE HAL header, pinned to ESP-IDF v5.5.2. The QoS
+ * arbiter-priority register fields and the inline helper signatures used here
+ * are not part of the stable public API and may change on an IDF upgrade. If a
+ * future IDF drops or renames these helpers, this file is the single place to
+ * update. */
+#include "hal/axi_icm_ll.h"
+#include "esp_log.h"
+
+static const char *TAG = "axi_qos";
+
+/* The arbiter-priority register fields are 4 bits wide (bitpos [3:0] per
+ * master, default 0); higher value = higher priority. Verified against
+ * soc/esp32p4/.../icm_sys_struct.h (reg_*_arqos:4 / reg_*_awqos:4). */
+#define AXI_QOS_PRIO_MAX   0xF  /* top read priority for the DSI scanout DMA */
+#define AXI_QOS_PRIO_LOW   1    /* de-prioritized Cache/CPU reads             */
+#define AXI_QOS_PRIO_WRITE 0    /* keep writes low; the fix is read-side only */
+
+void board_boost_dsi_axi_qos(void)
+{
+    /* DW-GDMA has two master ports (0 -> gdma_mst1, 1 -> gdma_mst2); the DSI
+     * scanout reads come through these. Give both top read priority.
+     * Signature: axi_icm_ll_set_dw_gdma_qos_arbiter_prio(master_port,
+     *            write_prio, read_prio). */
+    axi_icm_ll_set_dw_gdma_qos_arbiter_prio(0, AXI_QOS_PRIO_WRITE, AXI_QOS_PRIO_MAX);
+    axi_icm_ll_set_dw_gdma_qos_arbiter_prio(1, AXI_QOS_PRIO_WRITE, AXI_QOS_PRIO_MAX);
+
+    /* Lower Cache and CPU read priority so LVGL/PPA/CPU PSRAM reads yield to
+     * the scanout DMA. Signature: (write_prio, read_prio). */
+    axi_icm_ll_set_cache_qos_arbiter_prio(AXI_QOS_PRIO_WRITE, AXI_QOS_PRIO_LOW);
+    axi_icm_ll_set_cpu_qos_arbiter_prio(AXI_QOS_PRIO_WRITE, AXI_QOS_PRIO_LOW);
+
+    /* Follow-up lever if priority alone is insufficient: the burstiness and
+     * peak/transaction-rate regulators (axi_icm_ll_set_qos_burstiness,
+     * axi_icm_ll_set_qos_peak_transaction_rate) can throttle the Cache/CPU
+     * masters harder. Intentionally not touched here. */
+
+    ESP_LOGI(TAG, "AXI ICM QoS boosted: DW-GDMA(DSI) read prio=%d, Cache/CPU read prio=%d (blue-flash/PSRAM-starvation fix)",
+             AXI_QOS_PRIO_MAX, AXI_QOS_PRIO_LOW);
+}

--- a/main/axi_qos.h
+++ b/main/axi_qos.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Boost AXI ICM read-arbitration priority for the MIPI-DSI scanout path.
+ *
+ * The 720x720 DPI panel scans out its framebuffer from PSRAM via DW-GDMA. That
+ * DMA shares the PSRAM bus with the Cache/CPU masters (LVGL widget allocs, PPA
+ * blits, general CPU reads). Under heavy LVGL/PPA traffic the DSI DMA can be
+ * starved of PSRAM read bandwidth, the scanout FIFO underruns, and the panel
+ * briefly shows the fill color (a blue-screen flash).
+ *
+ * This raises both DW-GDMA master ports to the maximum read priority on the AXI
+ * ICM and lowers the Cache and CPU master read priorities so they yield to the
+ * scanout. Write priorities are left low. Only register writes are performed;
+ * the call is idempotent and lock-free.
+ *
+ * Call once after the display/DPI panel is started (after
+ * bsp_display_start_with_config), so the DPI panel and its DW-GDMA channel
+ * already exist.
+ */
+void board_boost_dsi_axi_qos(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -21,6 +21,7 @@
 #include "ui/nina_safety.h"
 #include "ui/nina_session_stats.h"
 #include "app_config.h"
+#include "axi_qos.h"
 #include "log_capture.h"
 #include "web_server.h"
 #include "mqtt_ha.h"
@@ -634,6 +635,12 @@ void app_main(void)
     bsp_display_start_with_config(&cfg);
     bsp_display_backlight_on();
     bsp_display_brightness_set(app_config_get()->brightness);
+
+    /* Raise DW-GDMA (DSI scanout) PSRAM read priority above Cache/CPU so the
+     * MIPI-DSI framebuffer fetch is not starved by LVGL/PPA traffic. Fixes the
+     * brief blue-screen flashes (scanout FIFO underrun). Must run after the DPI
+     * panel + its DW-GDMA channel exist. */
+    board_boost_dsi_axi_qos();
 
     /* ── SW rotation setup ──
      * Allocate one temp PSRAM buffer for in-place rotation.  The flush

--- a/main/nina_client.c
+++ b/main/nina_client.c
@@ -552,6 +552,7 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
         state->static_fetched = false;
         state->cached_image_count = -1;
         nina_connection_set_static_data_ready(instance, false);
+        data->prev_target_container[0] = '\0';
         state->http_client = (void *)reuse_handle;
         http_poll_ctx_set(NULL);
         return;

--- a/main/nina_client.h
+++ b/main/nina_client.h
@@ -22,6 +22,7 @@ typedef struct {
     bool connected;
     char status[32];
     char target_name[64];
+    char prev_target_container[64];   // last RUNNING target container Name (stripped) — for new-target detection
     char profile_name[64];
     char telescope_name[64];
     char camera_name[64];

--- a/main/nina_sequence.c
+++ b/main/nina_sequence.c
@@ -271,7 +271,7 @@ void fetch_sequence_counts_optional(const char *base_url, nina_client_t *data) {
                 cJSON *target_container = find_active_target_container(item);
                 if (!target_container) target_container = cJSON_GetArrayItem(items, 0);
 
-                // Use container name as fallback target name
+                // Resolve target name from the active target container.
                 cJSON *target_name_json = cJSON_GetObjectItem(target_container, "Name");
                 if (target_name_json && target_name_json->valuestring) {
                     char temp_name[64];
@@ -280,9 +280,22 @@ void fetch_sequence_counts_optional(const char *base_url, nina_client_t *data) {
                     char *suffix = strstr(temp_name, "_Container");
                     if (suffix) *suffix = '\0';
 
-                    if (temp_name[0] != '\0' &&
-                        (data->target_name[0] == '\0' ||
-                         strcmp(data->target_name, "No Target") == 0)) {
+                    // Is the chosen container actually RUNNING? (find_active_target_container can
+                    // return a FINISHED container as fallback; only a RUNNING one is a real active target.)
+                    cJSON *tc_status = cJSON_GetObjectItem(target_container, "Status");
+                    bool tc_running = (tc_status && tc_status->valuestring &&
+                                       strcmp(tc_status->valuestring, "RUNNING") == 0);
+
+                    if (temp_name[0] != '\0' && tc_running &&
+                        strcmp(temp_name, data->prev_target_container) != 0) {
+                        // New RUNNING target container detected -> authoritative update at sequence/target start
+                        strlcpy(data->target_name, temp_name, sizeof(data->target_name));
+                        strlcpy(data->prev_target_container, temp_name, sizeof(data->prev_target_container));
+                        ESP_LOGI(TAG, "Target (new RUNNING container): %s", data->target_name);
+                    } else if (temp_name[0] != '\0' &&
+                               (data->target_name[0] == '\0' ||
+                                strcmp(data->target_name, "No Target") == 0)) {
+                        // Existing fallback: fill when we have no name yet (idle/CREATED/boot)
                         strlcpy(data->target_name, temp_name, sizeof(data->target_name));
                         ESP_LOGI(TAG, "Target (fallback from sequence): %s", data->target_name);
                     }

--- a/main/ui/nina_dashboard_internal.h
+++ b/main/ui/nina_dashboard_internal.h
@@ -106,6 +106,8 @@ typedef struct {
     float    cached_total;          // Last-known exposure_total from poll data
     lv_timer_t *arc_timer;          // 200ms LVGL timer for real-time arc progress
     int64_t  gap_start_epoch;       // When the inter-exposure gap began (0 = not in gap)
+    int64_t  exp_anchor_us;         // esp_timer_get_time() at exposure-start anchor (0 = no active anchor)
+    float    exp_anchor_elapsed;    // Elapsed seconds already done at the anchor moment (seed)
     bool     arc_completing;        // True during completion/transition animation
     bool     cached_is_exposing;    // Last-known is_exposing state from poll data
     char     prev_filter[32];       // Track previous filter for change detection

--- a/main/ui/nina_dashboard_update.c
+++ b/main/ui/nina_dashboard_update.c
@@ -99,42 +99,38 @@ static void arc_start_exposure_anim(dashboard_page_t *p);
 void arc_interp_timer_cb(lv_timer_t *timer) {
     dashboard_page_t *p = (dashboard_page_t *)lv_timer_get_user_data(timer);
     if (!p || !p->arc_exposure || p->arc_completing) return;
-    if (p->cached_end_epoch == 0 || p->cached_total <= 0) return;
+    if (p->exp_anchor_us == 0 || p->cached_total <= 0) return;
 
-    /* Compute the remaining time as an int64 millisecond difference first.
-     * Epoch seconds (~1.7e9) exceed float's 24-bit integer precision, so a
-     * direct (float)tv.tv_sec would lose ~100s of seconds. Differencing in
-     * int64 ms keeps full precision; the small result converts to float
-     * safely for the P4 single-precision FPU. */
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    int64_t now_ms = (int64_t)tv.tv_sec * 1000 + (int64_t)tv.tv_usec / 1000;
-    int64_t remaining_ms = p->cached_end_epoch * 1000 - now_ms;
+    /* Completion is handled on the IsExposing edge in update_exposure_arc.
+     * Do not delete the anim here; just stop driving it while not exposing. */
+    if (!p->cached_is_exposing) return;
 
-    if (remaining_ms <= 0) {
-        lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
-        if (p->cached_is_exposing && lv_arc_get_value(p->arc_exposure) != ARC_RANGE)
-            lv_arc_set_value(p->arc_exposure, ARC_RANGE);
+    /* Monotonic elapsed: esp_timer is microseconds since boot, never skews and
+     * never goes backward. This is the smooth source of truth. */
+    float elapsed = p->exp_anchor_elapsed +
+                    (float)(esp_timer_get_time() - p->exp_anchor_us) / 1e6f;
+
+    /* Backward-only wall correction. Epoch seconds (~1.7e9) exceed float's
+     * 24-bit integer precision, so difference in int64 first, then cast the
+     * small result to float for the P4 single-precision FPU. If NINA is
+     * genuinely slower than our anchor predicted (paused / dither / meridian
+     * flip extended the sub), the wall clock shows less elapsed than us — only
+     * then re-anchor backward. Never pull forward on wall drift. */
+    int64_t remaining_wall_ms = (p->cached_end_epoch - (int64_t)time(NULL)) * 1000;
+    float elapsed_wall = p->cached_total - (float)remaining_wall_ms / 1000.0f;
+
+    if (elapsed_wall < elapsed - 1.0f) {
+        p->exp_anchor_us = esp_timer_get_time();
+        p->exp_anchor_elapsed = (elapsed_wall > 0.0f) ? elapsed_wall : 0.0f;
+        arc_start_exposure_anim(p);
         return;
     }
 
-    if (!p->cached_is_exposing) {
-        lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
-        return;
-    }
-
-    float remaining = (float)remaining_ms / 1000.0f;
-    float elapsed = p->cached_total - remaining;
-    if (elapsed < 0) elapsed = 0;
-    int expected = (int)((elapsed * (float)ARC_RANGE) / p->cached_total);
-    if (expected > ARC_RANGE) expected = ARC_RANGE;
-    if (expected < 0) expected = 0;
-
-    int current = lv_arc_get_value(p->arc_exposure);
+    /* The long linear anim is the smooth source of truth; do NOT restart on
+     * small drift. Only restart if no anim is running (e.g. a prior shorter
+     * estimate ended the anim early) and we still have time left. */
     lv_anim_t *existing = lv_anim_get(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
-
-    int drift = abs(current - expected);
-    if (!existing || drift > 20) {
+    if (!existing && elapsed < p->cached_total) {
         arc_start_exposure_anim(p);
     }
 }
@@ -214,6 +210,16 @@ static void update_disconnected_state(dashboard_page_t *p, int instance_idx, int
     set_label_if_changed(p->lbl_exposure_total, "");
     set_label_if_changed(p->lbl_loop_count, "");
     set_label_if_changed(p->lbl_exposure_current, "--");
+    /* Drop any active exposure anchor so a stale anchor can't keep the 200ms
+     * timer driving the arc while this instance is disconnected. */
+    lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
+    p->exp_anchor_us = 0;
+    p->exp_anchor_elapsed = 0;
+    p->cached_is_exposing = false;
+    p->arc_completing = false;
+    p->cached_end_epoch = 0;
+    p->cached_total = 0;
+    p->gap_start_epoch = 0;
     lv_arc_set_value(p->arc_exposure, 0);
     lv_obj_add_flag(p->row_filter_total, LV_OBJ_FLAG_HIDDEN);
     lv_anim_delete(p->lbl_rms_value, arcsec_anim_exec);
@@ -262,22 +268,23 @@ static void update_sequence_info(dashboard_page_t *p, const nina_client_t *d) {
 }
 
 static void arc_start_exposure_anim(dashboard_page_t *p) {
-    if (p->cached_end_epoch == 0 || p->cached_total <= 0 || !p->cached_is_exposing) return;
+    if (p->exp_anchor_us == 0 || p->cached_total <= 0 || !p->cached_is_exposing) return;
 
-    /* int64 ms difference to preserve epoch precision (see arc_interp_timer_cb). */
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    int64_t now_ms = (int64_t)tv.tv_sec * 1000 + (int64_t)tv.tv_usec / 1000;
-    int64_t remaining_ms64 = p->cached_end_epoch * 1000 - now_ms;
-    if (remaining_ms64 <= 100) return;
+    /* Drive remaining time from the monotonic anchor (esp_timer), never wall
+     * clock. The device SNTP clock is skewed vs the NINA-PC clock that stamped
+     * ExposureEndTime, so wall-clock progress mistracks (worst near the end). */
+    float since_anchor_s = (float)(esp_timer_get_time() - p->exp_anchor_us) / 1e6f;
+    float remaining_s = p->cached_total - (p->exp_anchor_elapsed + since_anchor_s);
+    if (remaining_s <= 0.1f) return;   /* <=100ms: completion edge will fill it */
 
     int current = lv_arc_get_value(p->arc_exposure);
-    int remaining_ms = (int)remaining_ms64;
+    int remaining_ms = (int)(remaining_s * 1000.0f);
 
+    /* Never reach full while exposing; only the IsExposing edge fills the circle. */
     lv_anim_t a;
     lv_anim_init(&a);
     lv_anim_set_var(&a, p->arc_exposure);
-    lv_anim_set_values(&a, current, ARC_RANGE);
+    lv_anim_set_values(&a, current, ARC_RANGE - 1);
     lv_anim_set_time(&a, remaining_ms);
     lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t)lv_arc_set_value);
     lv_anim_set_path_cb(&a, lv_anim_path_linear);
@@ -300,12 +307,37 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
         p->cached_end_epoch = 0;
         p->cached_total = 0;
         p->gap_start_epoch = 0;
+        p->exp_anchor_us = 0;
+        p->exp_anchor_elapsed = 0;
         lv_arc_set_value(p->arc_exposure, 0);
         snprintf(p->prev_filter, sizeof(p->prev_filter), "%s", d->current_filter);
     }
 
     time_t now = time(NULL);
+
+    /* Detect the IsExposing true->false edge BEFORE updating cached_is_exposing.
+     * NINA flips IsExposing->false at sub end and the poll usually sees that
+     * before remaining hits zero, so this edge (not a wall-clock timeout) is
+     * what drives the satisfying snap-to-full completion. */
+    bool finished_edge = (p->cached_is_exposing && !d->is_exposing && p->exp_anchor_us != 0);
     p->cached_is_exposing = d->is_exposing;
+
+    if (finished_edge) {
+        /* Snap the arc to a full circle for a polished completion, then let the
+         * inter-exposure gap logic below hold/fade it before the next sub. */
+        lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
+        p->arc_completing = true;
+        p->exp_anchor_us = 0;
+        int current_fill = lv_arc_get_value(p->arc_exposure);
+        lv_anim_t a;
+        lv_anim_init(&a);
+        lv_anim_set_var(&a, p->arc_exposure);
+        lv_anim_set_values(&a, current_fill, ARC_RANGE);
+        lv_anim_set_time(&a, ARC_TRANSITION_MS);
+        lv_anim_set_exec_cb(&a, (lv_anim_exec_xcb_t)lv_arc_set_value);
+        lv_anim_set_path_cb(&a, lv_anim_path_ease_out);
+        lv_anim_start(&a);
+    }
 
     if (d->exposure_total > 0 && d->exposure_end_epoch > 0 && d->is_exposing) {
         // Camera is actively exposing
@@ -323,18 +355,41 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
             set_label_if_changed(p->lbl_exposure_total, "");
         }
 
-        // Detect new exposure by end_epoch change
+        // Detect new exposure by end_epoch change, or idle->exposing with no anchor
         bool new_exposure = (d->exposure_end_epoch != p->cached_end_epoch
-                             && d->exposure_end_epoch > (int64_t)now);
+                             && d->exposure_end_epoch > (int64_t)now)
+                            || (p->exp_anchor_us == 0);
 
         // Update cached values for the timer
         p->cached_end_epoch = d->exposure_end_epoch;
         p->cached_total = d->exposure_total;
 
         if (new_exposure) {
-            lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
+            /* Anchor the monotonic clock at this moment. Seed exp_anchor_elapsed
+             * with a ONE-TIME wall estimate of how far into the sub we already
+             * are (detection can land mid-sub on page switch / first connect).
+             * Difference the epochs in int64 first to preserve precision, then
+             * cast the small result to float for the P4 single-precision FPU. */
+            int64_t remaining_seed_ms = (d->exposure_end_epoch - (int64_t)now) * 1000;
+            float seed = d->exposure_total - (float)remaining_seed_ms / 1000.0f;
+            if (seed < 0.0f) seed = 0.0f;
+            if (seed > d->exposure_total) seed = d->exposure_total;
+
+            p->exp_anchor_us = esp_timer_get_time();
+            p->exp_anchor_elapsed = seed;
             p->arc_completing = false;
-            lv_arc_set_value(p->arc_exposure, 0);
+
+            lv_anim_delete(p->arc_exposure, (lv_anim_exec_xcb_t)lv_arc_set_value);
+            /* Seed the arc value from the elapsed estimate so a mid-sub detection
+             * does not snap back to zero. */
+            int seed_val = (int)((seed * (float)ARC_RANGE) / d->exposure_total);
+            if (seed_val < 0) seed_val = 0;
+            if (seed_val > ARC_RANGE - 1) seed_val = ARC_RANGE - 1;
+            lv_arc_set_value(p->arc_exposure, seed_val);
+
+            /* Start one long linear anim toward (ARC_RANGE-1) over the monotonic
+             * remaining time. arc_start_exposure_anim skips if <=100ms remain
+             * (the completion edge fills it). */
             arc_start_exposure_anim(p);
         }
         // Normal progress updates are handled by the 200ms timer (arc_interp_timer_cb)
@@ -382,6 +437,9 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
                 p->cached_end_epoch = 0;
                 p->cached_total = 0;
                 p->gap_start_epoch = 0;
+                p->exp_anchor_us = 0;
+                p->exp_anchor_elapsed = 0;
+                p->arc_completing = false;
                 set_label_if_changed(p->lbl_exposure_total, "");
                 set_label_if_changed(p->lbl_loop_count, "");
                 set_label_if_changed(p->lbl_exposure_current, "--");
@@ -402,6 +460,8 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
         } else {
             // Genuinely idle — no recent exposure data
             p->gap_start_epoch = 0;
+            p->exp_anchor_us = 0;
+            p->exp_anchor_elapsed = 0;
             set_label_if_changed(p->lbl_exposure_total, "");
             set_label_if_changed(p->lbl_loop_count, "");
             set_label_if_changed(p->lbl_exposure_current, "--");


### PR DESCRIPTION
### Summary
The exposure progress arc now displays more accurately and smoothly by using a monotonic timer instead of a wall-clock. The target name updates immediately when a new imaging sequence begins, improving responsiveness. UI operations are also prioritized to prevent screen flashes.

### Changes
*   Prioritized UI operations to prevent screen flashes by configuring AXI QoS.
*   The exposure progress arc now uses a monotonic timer, which provides accurate and smooth progress display by eliminating issues caused by clock skew.
*   The target name on the dashboard updates immediately when a new imaging sequence begins, instead of waiting for an image to be saved.
*   Added new internal fields to track the exposure anchor time and the previous target container for these updates.
*   Updated `.gitignore` to include new ignored files.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-06-24T16:48:32.856Z | Generated by GitHub Actions</sub>