### PR TITLE
fix: split soundtrack parentheticals to subtitle

### DIFF
--- a/main/ui/nina_spotify.c
+++ b/main/ui/nina_spotify.c
@@ -171,7 +171,7 @@ static void spotify_status_refresh(void)
         case SPOTIFY_AUTH_AUTHORIZED:
         default:
             if (!has_received_data) {
-                spotify_status_set("Connecting to Spotify\xE2\x80\xA6", "");
+                spotify_status_set("Connecting to Spotify...", "");
                 return;
             }
             /* Authorized and data has arrived (nothing-playing handled by the
@@ -197,7 +197,7 @@ static bool is_version_keyword(const char *start, size_t len)
         "remaster", "remix", "live", "edit", "version", "deluxe", "mix",
         "acoustic", "demo", "mono", "stereo", "anniversary", "bonus",
         "extended", "radio", "single", "original", "alternate", "session",
-        "stripped", "instrumental", "explicit", "clean", "feat", NULL
+        "stripped", "instrumental", "explicit", "clean", "feat", "from", NULL
     };
     /* Build a lowercase copy for case-insensitive search */
     char lower[128];


### PR DESCRIPTION
### Summary
This PR addresses two display issues in the UI. It improves how soundtrack titles are presented by moving parenthetical information to a separate line, and it fixes a visual glitch where an ellipsis character appeared as a blank box in the connecting status.

### Changes
*   Adjusted soundtrack title parsing to move parenthetical information like "(From "Movie")" to a subtitle line. This improves readability of long titles.
*   Replaced the U+2026 ellipsis character with ASCII '...' in the connecting status message. This resolves an issue where the original character was not displayed correctly by the UI font.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-24T22:07:23.842Z | Generated by GitHub Actions</sub>