### PR TITLE
feat: add custom image URL display source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,54 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "branch=$BRANCH" >> $GITHUB_OUTPUT
 
+      - name: Determine tag
+        if: steps.check_skip.outputs.skip != 'true'
+        id: tag
+        run: |
+          BRANCH=${GITHUB_REF_NAME}
+
+          if [ "$BRANCH" = "main" ]; then
+            VERSION=$(cat version.txt | tr -d '[:space:]')
+            TAG="v${VERSION}"
+          else
+            # Make the local tag set authoritative: pull every tag created by
+            # prior release runs (a shallow/persistent runner workspace otherwise
+            # lags the remote, which previously caused the number to collide and
+            # silently clobber an existing pre-release).
+            git fetch --force --tags origin
+
+            # Use latest main release version so pre-releases sort correctly
+            LATEST_MAIN_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v '-' | head -1)
+            if [ -n "$LATEST_MAIN_TAG" ]; then
+              BASE_VERSION=${LATEST_MAIN_TAG#v}
+            else
+              BASE_VERSION=$(cat version.txt | tr -d '[:space:]')
+            fi
+
+            # Next number = highest existing dev.N + 1 (use the max, not a count,
+            # so gaps from deleted/withdrawn tags never cause a reuse), then skip
+            # any number whose tag already exists as a final race/lag safeguard.
+            PREFIX="v${BASE_VERSION}-${BRANCH}."
+            LAST=$(git tag -l "${PREFIX}*" | sed "s|^${PREFIX}||" | grep -E '^[0-9]+$' | sort -n | tail -1)
+            NEXT=$(( ${LAST:-0} + 1 ))
+            TAG="${PREFIX}${NEXT}"
+            while git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; do
+              NEXT=$(( NEXT + 1 ))
+              TAG="${PREFIX}${NEXT}"
+            done
+          fi
+
+          # Force the build to embed THIS tag (build runs before the tag is
+          # created at release time, so git describe alone would lag by one).
+          echo "BUILD_GIT_TAG_OVERRIDE=$TAG" >> $GITHUB_ENV
+
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          if [ "$BRANCH" = "main" ]; then
+            echo "is_prerelease=false" >> $GITHUB_OUTPUT
+          else
+            echo "is_prerelease=true" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set ESP-IDF paths
         if: steps.check_skip.outputs.skip != 'true'
         run: |
@@ -340,50 +388,6 @@ jobs:
           name: firmware-${{ steps.version.outputs.branch }}-${{ steps.version.outputs.short_sha }}
           path: firmware/
           retention-days: 30
-
-      - name: Determine tag
-        if: steps.check_skip.outputs.skip != 'true'
-        id: tag
-        run: |
-          BRANCH=${GITHUB_REF_NAME}
-
-          if [ "$BRANCH" = "main" ]; then
-            VERSION=$(cat version.txt | tr -d '[:space:]')
-            TAG="v${VERSION}"
-          else
-            # Make the local tag set authoritative: pull every tag created by
-            # prior release runs (a shallow/persistent runner workspace otherwise
-            # lags the remote, which previously caused the number to collide and
-            # silently clobber an existing pre-release).
-            git fetch --force --tags origin
-
-            # Use latest main release version so pre-releases sort correctly
-            LATEST_MAIN_TAG=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | grep -v '-' | head -1)
-            if [ -n "$LATEST_MAIN_TAG" ]; then
-              BASE_VERSION=${LATEST_MAIN_TAG#v}
-            else
-              BASE_VERSION=$(cat version.txt | tr -d '[:space:]')
-            fi
-
-            # Next number = highest existing dev.N + 1 (use the max, not a count,
-            # so gaps from deleted/withdrawn tags never cause a reuse), then skip
-            # any number whose tag already exists as a final race/lag safeguard.
-            PREFIX="v${BASE_VERSION}-${BRANCH}."
-            LAST=$(git tag -l "${PREFIX}*" | sed "s|^${PREFIX}||" | grep -E '^[0-9]+$' | sort -n | tail -1)
-            NEXT=$(( ${LAST:-0} + 1 ))
-            TAG="${PREFIX}${NEXT}"
-            while git rev-parse -q --verify "refs/tags/${TAG}" >/dev/null 2>&1; do
-              NEXT=$(( NEXT + 1 ))
-              TAG="${PREFIX}${NEXT}"
-            done
-          fi
-
-          echo "tag=$TAG" >> $GITHUB_OUTPUT
-          if [ "$BRANCH" = "main" ]; then
-            echo "is_prerelease=false" >> $GITHUB_OUTPUT
-          else
-            echo "is_prerelease=true" >> $GITHUB_OUTPUT
-          fi
 
       - name: Generate changelog
         if: steps.check_skip.outputs.skip != 'true'

--- a/build_firmware.ps1
+++ b/build_firmware.ps1
@@ -7,6 +7,7 @@
 #   .\build_firmware.ps1 -FullClean   # Clean rebuild
 #   .\build_firmware.ps1 -OTA         # Build + OTA flash to both devices
 #   .\build_firmware.ps1 -OTA -Devices "NinaDash1.lan","NinaDash2.lan"
+#   .\build_firmware.ps1 -Release      # Enforce clean tree + tag matches version.txt, fail otherwise
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingPlainTextForPassword', 'Password',
     Justification='Dev tool: password sourced from env var or interactive prompt; not persisted.')]
@@ -14,6 +15,7 @@ param(
     [string]$IdfPath = "C:\Espressif\frameworks\esp-idf-v5.5.2",
     [switch]$FullClean,
     [switch]$OTA,
+    [switch]$Release,
     [string[]]$Devices = @("NinaDash2.lan"),
     [string]$Password = $(if ($env:NINADASH_PASSWORD) { $env:NINADASH_PASSWORD } else { "changeme123!" })
 )
@@ -89,6 +91,45 @@ Write-Host "Activating ESP-IDF environment from $IdfPath ..." -ForegroundColor C
 if ($LASTEXITCODE -and $LASTEXITCODE -ne 0) {
     Write-Error "Failed to activate ESP-IDF environment."
     exit 1
+}
+
+# Version integrity check
+Push-Location $ProjectDir
+try {
+    $gitDescribe = (git describe --tags --always --dirty 2>$null)
+    if ($gitDescribe) { $gitDescribe = $gitDescribe.Trim() } else { $gitDescribe = "" }
+} finally {
+    Pop-Location
+}
+
+$versionTxt = (Get-Content (Join-Path $ProjectDir 'version.txt') -Raw).Trim()
+$isDirty = $gitDescribe -match '-dirty$'
+
+# Parse base version from git describe: strip leading v/V, take substring before first '-'
+$tagBase = $gitDescribe -replace '^[vV]', ''
+$dashIdx = $tagBase.IndexOf('-')
+if ($dashIdx -ge 0) { $tagBase = $tagBase.Substring(0, $dashIdx) }
+
+if ($tagBase -match '^\d+\.\d+\.\d+') {
+    $tagMismatch = ($tagBase -ne $versionTxt)
+} else {
+    # Describe returned a bare commit sha (no usable tag) - treat as mismatch
+    $tagMismatch = $true
+}
+
+Write-Host "Version: version.txt=$versionTxt  git-describe=$gitDescribe" -ForegroundColor Cyan
+
+if ($isDirty -or $tagMismatch) {
+    $reasons = @()
+    if ($isDirty) { $reasons += "dirty tree" }
+    if ($tagMismatch) { $reasons += "git tag base '$tagBase' != version.txt '$versionTxt'" }
+    $msg = "version integrity check failed (" + ($reasons -join "; ") + ")."
+    if ($Release) {
+        Write-Error ("Release build blocked: " + $msg + " Commit/stash changes and create matching tag ``git tag v$versionTxt`` so git describe == v$versionTxt.")
+        exit 1
+    } else {
+        Write-Host ("WARNING: " + $msg) -ForegroundColor Yellow
+    }
 }
 
 # Full clean if requested or if build dir has a Python mismatch

--- a/generate_version.cmake
+++ b/generate_version.cmake
@@ -16,14 +16,24 @@ set(GIT_TAG "unknown")
 set(GIT_SHA "unknown")
 set(GIT_BRANCH "unknown")
 
+# CI sets BUILD_GIT_TAG_OVERRIDE to the exact release tag so the embedded
+# version matches the published release, even though the git tag is created
+# after the build and the tree may be dirty. Local/dev builds fall back to
+# git describe.
+if(DEFINED ENV{BUILD_GIT_TAG_OVERRIDE} AND NOT "$ENV{BUILD_GIT_TAG_OVERRIDE}" STREQUAL "")
+    set(GIT_TAG "$ENV{BUILD_GIT_TAG_OVERRIDE}")
+endif()
+
 if(GIT_FOUND)
-    execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
-        WORKING_DIRECTORY ${SRC_DIR}
-        OUTPUT_VARIABLE GIT_TAG
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-    )
+    if(GIT_TAG STREQUAL "unknown")
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+            WORKING_DIRECTORY ${SRC_DIR}
+            OUTPUT_VARIABLE GIT_TAG
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+    endif()
     execute_process(
         COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
         WORKING_DIRECTORY ${SRC_DIR}

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -808,6 +808,11 @@ static void set_defaults(app_config_t *cfg) {
     cfg->goes_orientation = 0;
     cfg->solar_orientation = 0;
 
+    // Custom Image URL source (Image Display source index 3)
+    strcpy(cfg->custom_image_url, "https://picsum.photos/720");
+    cfg->custom_orientation = 0;          // 0=0°,1=90°,2=180°,3=270° clockwise
+    cfg->custom_update_interval_s = 60;   // poll interval (10-7200s)
+
     // Auth is on by default — protects device from open-LAN access
     cfg->auth_enabled = true;
 }
@@ -1944,6 +1949,24 @@ static void migrate_from_v43(const void *raw, size_t raw_size, app_config_t *cfg
         (int)cfg->active_page_override, dn, (int)cfg->nav_grace_s);
 }
 
+/* --- v44 → v45 migration: add Custom Image URL source (Image Display source
+ *     index 3) — custom_image_url, custom_orientation, custom_update_interval_s. --- */
+static void migrate_from_v44(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v44_t) ? raw_size : sizeof(app_config_v44_t);
+    memcpy(cfg, raw, copy);
+
+    /* custom_image_url / custom_orientation / custom_update_interval_s: new in
+     * v45, appended past the v44 snapshot — apply the set_defaults() values. */
+    strlcpy(cfg->custom_image_url, "https://picsum.photos/720", sizeof(cfg->custom_image_url));
+    cfg->custom_orientation = 0;
+    cfg->custom_update_interval_s = 60;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v44 to v%d", APP_CONFIG_VERSION);
+}
+
 static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -2562,7 +2585,17 @@ static bool validate_config(app_config_t *cfg) {
         strcpy(cfg->goes_region, "umv");
         fixed = true;
     }
-    if (cfg->image_display_source > 2) {
+    /* Custom Image URL source (Image Display source index 3) */
+    cfg->custom_image_url[sizeof(cfg->custom_image_url) - 1] = '\0';
+    if (cfg->custom_orientation > 3) {
+        cfg->custom_orientation = 0;
+        fixed = true;
+    }
+    if (cfg->custom_update_interval_s < 10 || cfg->custom_update_interval_s > 7200) {
+        cfg->custom_update_interval_s = 60;
+        fixed = true;
+    }
+    if (cfg->image_display_source > 3) {   /* 0=GOES, 1=Moon, 2=Solar, 3=Custom URL */
         cfg->image_display_source = 0;
         fixed = true;
     }
@@ -2683,6 +2716,12 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 44) {
+        /* v44 → v45: added Custom Image URL source (custom_image_url, custom_orientation, custom_update_interval_s) */
+        migrate_from_v44(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 43) {
         /* v43 → v44: Home Page rename, single slideshow list, nav_grace_s, drop persistent */
         migrate_from_v43(raw, stored_size, &s_config);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -14,7 +14,7 @@ extern "C" {
 #define MAX_NINA_INSTANCES 3
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 44
+#define APP_CONFIG_VERSION 45
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -204,6 +204,12 @@ typedef struct {
     uint16_t nav_grace_s;   // USER manual-nav grace window in seconds (10-300, default 10).
                             // Replaces idle_page_persistent: the grace window now
                             // performs the "honor the user's page" job in both modes.
+
+    // Added after v44 — must stay at end to preserve NVS binary compatibility
+    // Image Display "Custom Image URL" source (source index 3).
+    char     custom_image_url[256];      // user-supplied JPEG image URL
+    uint8_t  custom_orientation;         // render rotation: 0=0°,1=90°,2=180°,3=270° CW (mirrors solar_orientation)
+    uint16_t custom_update_interval_s;   // poll interval in seconds (10-7200, default 60)
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -312,6 +318,120 @@ typedef struct {
 
 _Static_assert(offsetof(app_config_t, nav_grace_s) == sizeof(app_config_v43_t),
                "app_config_v43_t snapshot drifted from app_config_t layout");
+
+/* ── Version 44 config struct — used only for NVS migration to v45 ────── */
+/* Byte-identical to app_config_t minus the trailing custom_* fields.     */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+} app_config_v44_t;
+
+/* custom_image_url (char[], align 1) appends directly after nav_grace_s,
+ * reclaiming app_config_v44_t's 2-byte tail padding, so offsetof != sizeof here.
+ * Check against the end of the last v44 field instead: this still catches any
+ * field inserted/reordered ahead of the new block, without tripping on padding. */
+_Static_assert(offsetof(app_config_t, custom_image_url) ==
+                   offsetof(app_config_v44_t, nav_grace_s) +
+                       sizeof(((app_config_v44_t *)0)->nav_grace_s),
+               "app_config_v44_t snapshot drifted from app_config_t layout");
 
 // v17 snapshot — AllSky fields without allsky_enabled
 typedef struct {

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1135,8 +1135,12 @@
                 <input type="radio" name="imageSourceSel" id="imageSource2" value="2" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
                 <span class="pn-pill-visual">Solar (SDO)</span>
               </label>
+              <label class="pn-pill rotate-pill">
+                <input type="radio" name="imageSourceSel" id="imageSource3" value="3" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
+                <span class="pn-pill-visual">Custom URL</span>
+              </label>
             </div>
-            <div class="field-hint">Chooses GOES satellite, Moon phase, or Solar; the options below switch to match.</div>
+            <div class="field-hint">Chooses GOES satellite, Moon phase, Solar, or a custom image URL; the options below switch to match.</div>
           </div>
           <div class="toggle-row">
             <span class="toggle-label">Show Overlay</span>
@@ -1332,6 +1336,40 @@
               <option value="3">270&deg;</option>
             </select>
             <div class="field-hint">Rotate the solar image clockwise.</div>
+          </div>
+          </div>
+          <div id="customGroup" style="display:none">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Image URL</label>
+            <input class="input" id="customImageUrl" type="url" placeholder="https://picsum.photos/720" onchange="applyImageDisplay();checkDirty()">
+            <div class="field-hint">JPEG only. Max 1024x1024 pixels, max 1 MB. PNG and WebP are not supported.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Custom Rotation</label>
+            <select class="input" id="customOrientation" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">0&deg;</option>
+              <option value="1">90&deg;</option>
+              <option value="2">180&deg;</option>
+              <option value="3">270&deg;</option>
+            </select>
+            <div class="field-hint">Rotate the custom image clockwise.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Update Interval</label>
+            <select class="input" id="customInterval" onchange="applyImageDisplay();checkDirty()">
+              <option value="10">10 seconds</option>
+              <option value="30">30 seconds</option>
+              <option value="60" selected>1 minute</option>
+              <option value="300">5 minutes</option>
+              <option value="600">10 minutes</option>
+              <option value="1800">30 minutes</option>
+              <option value="3600">1 hour</option>
+              <option value="7200">2 hours</option>
+            </select>
+            <div class="field-hint">How often the custom image refreshes.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <button onclick="fetchCustomPreview()" class="btn btn-primary" id="customPreviewBtn" style="width:100%">Refresh on Device</button>
           </div>
           </div>
         </div>
@@ -2670,6 +2708,9 @@
         solar_band:parseInt($('solarBand').value,10)||0,
         goes_orientation:parseInt($('goesOrientation').value,10)||0,
         solar_orientation:parseInt($('solarOrientation').value,10)||0,
+        custom_image_url:$('customImageUrl')?$('customImageUrl').value.trim():'',
+        custom_orientation:$('customOrientation')?parseInt($('customOrientation').value,10)||0:0,
+        custom_update_interval_s:$('customInterval')?parseInt($('customInterval').value,10)||60:60,
         moon_lat:parseFloat($('moonLat').value)||0,
         moon_lon:parseFloat($('moonLon').value)||0,
         moon_north_up:$('moon_north_up').checked?1:0,
@@ -2844,6 +2885,10 @@
       if($('imageSource0')) $('imageSource0').checked=(imgSrc===0);
       if($('imageSource1')) $('imageSource1').checked=(imgSrc===1);
       if($('imageSource2')) $('imageSource2').checked=(imgSrc===2);
+      if($('imageSource3')) $('imageSource3').checked=(imgSrc===3);
+      if($('customImageUrl')) $('customImageUrl').value=data.custom_image_url||'';
+      if($('customOrientation')) $('customOrientation').value=String(data.custom_orientation||0);
+      if($('customInterval')) $('customInterval').value=String(data.custom_update_interval_s||60);
       if($('moonBg')) $('moonBg').value=String(data.moon_bg_style||0);
       if($('moonDragLight')) $('moonDragLight').value=String(data.moon_drag_light_mode||0);
       if($('solarBand')) $('solarBand').value=String(data.solar_band||0);
@@ -4107,14 +4152,18 @@
 
     function updateImageSourceUI(){
       var s=getImageSource();
-      if($('discOptions')) $('discOptions').style.display=(s===1)?'none':'';
+      // The shared disc options (GOES/Solar update interval + crop) do not apply
+      // to Moon (rendered locally) or Custom (its own interval, no crop).
+      if($('discOptions')) $('discOptions').style.display=(s===1||s===3)?'none':'';
       if($('goesGroup'))  $('goesGroup').style.display =(s===0)?'':'none';
       if($('moonGroup'))  $('moonGroup').style.display =(s===1)?'':'none';
       if($('solarGroup')) $('solarGroup').style.display=(s===2)?'':'none';
+      if($('customGroup')) $('customGroup').style.display=(s===3)?'':'none';
     }
 
-    function applyImageDisplay(){
-      postJson('/api/image-display-config', {
+    function applyImageDisplay(force){
+      return postJson('/api/image-display-config', {
+        force_fetch: !!force,
         image_display_enabled: !!$('image_display_enabled').checked,
         image_display_show_overlay: !!$('image_display_show_overlay').checked,
         image_display_crop: !!$('image_display_crop').checked,
@@ -4135,8 +4184,16 @@
         moon_spin_return_s: parseInt($('moon_spin_return_s').value,10)||3,
         solar_band: parseInt($('solarBand').value,10)||0,
         goes_orientation: parseInt($('goesOrientation').value,10)||0,
-        solar_orientation: parseInt($('solarOrientation').value,10)||0
-      });
+        solar_orientation: parseInt($('solarOrientation').value,10)||0,
+        custom_image_url: $('customImageUrl')?$('customImageUrl').value.trim():'',
+        custom_orientation: $('customOrientation')?parseInt($('customOrientation').value,10)||0:0,
+        custom_update_interval_s: $('customInterval')?parseInt($('customInterval').value,10)||60:60
+      }).then(function(r){
+        if(!r.ok){ showToast('Failed to save image settings','error'); return; }
+        return r.json().then(function(d){
+          if(d&&d.error_msg) showToast(d.error_msg,'error');
+        }).catch(function(){});
+      }).catch(function(){});
     }
 
     function updateMoonOrientReadout(which){
@@ -4195,6 +4252,21 @@
         showToast('Failed to load preview image','error');
       };
       img.src='https://cdn.star.nesdis.noaa.gov/GOES19/ABI/SECTOR/'+region+'/GEOCOLOR/'+psize+'.jpg?t='+Date.now();
+    }
+
+    function fetchCustomPreview(){
+      var url=$('customImageUrl')?$('customImageUrl').value.trim():'';
+      if(!url){ showToast('Enter an image URL first','error'); return; }
+      if(!/^https?:\/\//i.test(url)){ showToast('URL must start with http:// or https://','error'); return; }
+      var btn=$('customPreviewBtn');
+      btn.disabled=true; btn.textContent='Refreshing...';
+      // Push to the device and FORCE an immediate re-fetch so the screen
+      // refreshes now, even if the URL is unchanged since the last POST.
+      applyImageDisplay(true).then(function(){
+        btn.disabled=false; btn.textContent='Refresh on Device';
+      }).catch(function(){
+        btn.disabled=false; btn.textContent='Refresh on Device';
+      });
     }
 
     function updateAllSkyEnabledUI(){

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -12,6 +12,20 @@ static const char *TAG = "goes_client";
 #define GOES_JPEG_MAX_SIZE   (1024 * 1024)   /* 1MB: fits SOHO LASCO C3 1024 (~815KB) */
 #define GOES_HTTP_BUF_SIZE   4096
 #define GOES_HTTP_TIMEOUT_MS 30000
+#define GOES_IMG_MAX_DIM     1024            /* reject images wider/taller than this before decode */
+#define GOES_MAX_REDIRECTS   5               /* follow up to this many 30x Location hops */
+
+/* Set a human-readable failure reason under the goes lock and mark disconnected.
+ * Centralizes the lock boilerplate so every failure exit can record a reason. */
+static void set_error_msg(goes_data_t *d, const char *m)
+{
+    if (!d) return;
+    if (goes_data_lock(d, 1000)) {
+        strlcpy(d->error_msg, m ? m : "", sizeof(d->error_msg));
+        d->connected = false;
+        goes_data_unlock(d);
+    }
+}
 
 void goes_data_init(goes_data_t *data)
 {
@@ -201,10 +215,7 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, c
     esp_http_client_handle_t client = esp_http_client_init(&http_cfg);
     if (!client) {
         ESP_LOGE(TAG, "Failed to create HTTP client");
-        if (goes_data_lock(data, 1000)) {
-            data->connected = false;
-            goes_data_unlock(data);
-        }
+        set_error_msg(data, "Fetch failed");
         return ESP_FAIL;
     }
 
@@ -212,23 +223,47 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, c
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "HTTP open failed: %s", esp_err_to_name(err));
         esp_http_client_cleanup(client);
-        if (goes_data_lock(data, 1000)) {
-            data->connected = false;
-            goes_data_unlock(data);
-        }
+        set_error_msg(data, "Fetch failed");
         return err;
     }
 
     int content_length = esp_http_client_fetch_headers(client);
     int status = esp_http_client_get_status_code(client);
 
+    /* Follow Location redirects manually: the streaming open()/fetch_headers()
+     * path does NOT auto-follow. For each 30x, esp_http_client_set_redirection()
+     * adopts the captured Location URL; we then re-open + re-fetch_headers on the
+     * new URL. Cap the chain to avoid loops. crt_bundle already covers TLS hosts. */
+    int redirects = 0;
+    while ((status == 301 || status == 302 || status == 307 || status == 308) &&
+           redirects < GOES_MAX_REDIRECTS) {
+        ESP_LOGI(TAG, "HTTP %d redirect, following (hop %d)", status, redirects + 1);
+        err = esp_http_client_set_redirection(client);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "set_redirection failed: %s", esp_err_to_name(err));
+            break;
+        }
+        /* Close the prior response's socket before reconnecting to the redirect
+         * target. Without this, the previous connection leaks for the duration of
+         * the chain. cleanup() on the terminal path still closes exactly once. */
+        esp_http_client_close(client);
+        /* Re-issue the request against the new (redirected) URL. */
+        err = esp_http_client_open(client, 0);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "HTTP re-open failed: %s", esp_err_to_name(err));
+            esp_http_client_cleanup(client);
+            set_error_msg(data, "Fetch failed");
+            return err;
+        }
+        content_length = esp_http_client_fetch_headers(client);
+        status = esp_http_client_get_status_code(client);
+        redirects++;
+    }
+
     if (status != 200) {
         ESP_LOGW(TAG, "HTTP status %d", status);
         esp_http_client_cleanup(client);
-        if (goes_data_lock(data, 1000)) {
-            data->connected = false;
-            goes_data_unlock(data);
-        }
+        set_error_msg(data, "Fetch failed");
         return ESP_FAIL;
     }
 
@@ -243,10 +278,7 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, c
     if (!jpeg_buf) {
         ESP_LOGE(TAG, "PSRAM alloc failed for JPEG (%d bytes)", content_length);
         esp_http_client_cleanup(client);
-        if (goes_data_lock(data, 1000)) {
-            data->connected = false;
-            goes_data_unlock(data);
-        }
+        set_error_msg(data, "Out of memory");
         return ESP_ERR_NO_MEM;
     }
 
@@ -263,11 +295,31 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, c
     if (total_read < 1000) {
         ESP_LOGW(TAG, "JPEG too small (%d bytes), likely error page", total_read);
         heap_caps_free(jpeg_buf);
-        if (goes_data_lock(data, 1000)) {
-            data->connected = false;
-            goes_data_unlock(data);
-        }
+        set_error_msg(data, "Fetch failed");
         return ESP_FAIL;
+    }
+
+    /* JPEG magic gate: SOI marker is FF D8. Reject non-JPEG payloads (HTML error
+     * pages, PNG, etc.) before handing anything to the decoder. */
+    if (jpeg_buf[0] != 0xFF || jpeg_buf[1] != 0xD8) {
+        ESP_LOGW(TAG, "Not a JPEG (magic %02X %02X)", jpeg_buf[0], jpeg_buf[1]);
+        heap_caps_free(jpeg_buf);
+        set_error_msg(data, "Not a JPEG image");
+        return ESP_FAIL;
+    }
+
+    /* Pre-decode dimension cap: a small JPEG can decode to enormous dimensions,
+     * so probe width/height from the header and reject BEFORE the big decode
+     * allocation to avoid OOM. */
+    uint32_t probe_w = 0, probe_h = 0;
+    if (jpeg_probe_dimensions(jpeg_buf, total_read, &probe_w, &probe_h)) {
+        if (probe_w > GOES_IMG_MAX_DIM || probe_h > GOES_IMG_MAX_DIM) {
+            ESP_LOGW(TAG, "JPEG too large: %lux%lu (max %d)",
+                     (unsigned long)probe_w, (unsigned long)probe_h, GOES_IMG_MAX_DIM);
+            heap_caps_free(jpeg_buf);
+            set_error_msg(data, "Image too large (max 1024px)");
+            return ESP_FAIL;
+        }
     }
 
     ESP_LOGI(TAG, "Downloaded %d bytes JPEG, decoding...", total_read);
@@ -283,10 +335,7 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, c
     if (!decoded || !rgb565) {
         ESP_LOGE(TAG, "JPEG decode failed");
         if (rgb565) heap_caps_free(rgb565);
-        if (goes_data_lock(data, 1000)) {
-            data->connected = false;
-            goes_data_unlock(data);
-        }
+        set_error_msg(data, "Decode failed");
         return ESP_FAIL;
     }
 
@@ -300,6 +349,7 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, c
         data->vflip = vflip;
         if (label) { strlcpy(data->label, label, sizeof(data->label)); }
         else       { data->label[0] = '\0'; }
+        data->error_msg[0] = '\0';   /* clear: this fetch succeeded */
         data->connected = true;
         data->last_poll_ms = esp_timer_get_time() / 1000;
         goes_data_unlock(data);

--- a/main/goes_client.h
+++ b/main/goes_client.h
@@ -14,6 +14,7 @@ typedef struct {
     uint16_t          image_h;
     bool              vflip;        /* true: buffer is vertically flipped (sw JPEG) */
     char              label[48];    /* human-readable name of the source this buffer holds (region/band); rendered verbatim by the page so it can never desync from image_buf */
+    char              error_msg[48]; /* human-readable failure reason shown on-screen when a fetch fails; "" when last fetch succeeded */
     SemaphoreHandle_t mutex;
 } goes_data_t;
 

--- a/main/jpeg_utils.c
+++ b/main/jpeg_utils.c
@@ -142,6 +142,22 @@ bool fetch_and_show_thumbnail(const char *base_url) {
 // Software JPEG Decode Fallback (stb_image)
 // =============================================================================
 
+bool jpeg_probe_dimensions(const uint8_t *jpg_data, size_t jpg_size,
+                           uint32_t *out_w, uint32_t *out_h)
+{
+    if (!jpg_data || !out_w || !out_h || jpg_size == 0) return false;
+
+    int w = 0, h = 0, comp = 0;
+    /* Header-only probe: reads dimensions without decoding pixel data. */
+    if (!stbi_info_from_memory(jpg_data, (int)jpg_size, &w, &h, &comp) ||
+        w <= 0 || h <= 0) {
+        return false;
+    }
+    *out_w = (uint32_t)w;
+    *out_h = (uint32_t)h;
+    return true;
+}
+
 bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
                            uint8_t **out_buf, uint32_t *out_w, uint32_t *out_h,
                            size_t *out_size)

--- a/main/jpeg_utils.h
+++ b/main/jpeg_utils.h
@@ -29,6 +29,20 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
                            size_t *out_size);
 
 /**
+ * @brief Probe a JPEG's pixel dimensions from its header WITHOUT decoding it.
+ * Wraps stbi_info_from_memory(); reads only the header, allocates nothing for
+ * pixel data. Use to reject oversized images before the full decode allocation.
+ *
+ * @param jpg_data  JPEG compressed data
+ * @param jpg_size  Size in bytes
+ * @param out_w     Receives image width in pixels
+ * @param out_h     Receives image height in pixels
+ * @return true if dimensions were read successfully
+ */
+bool jpeg_probe_dimensions(const uint8_t *jpg_data, size_t jpg_size,
+                           uint32_t *out_w, uint32_t *out_h);
+
+/**
  * @brief Scale an RGB565 image buffer using the PPA hardware accelerator.
  * Allocates a new 128-byte-aligned output buffer in PSRAM.
  * Caller takes ownership of the returned buffer (free with free()).

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -1246,7 +1246,21 @@ void goes_poll_task(void *arg)
         }
 
         esp_err_t fetch_err = ESP_OK;
-        if (cfg->image_display_source == 2) {                       /* Solar (SDO/AIA) */
+        if (cfg->image_display_source == 3) {                       /* Custom image URL */
+            if (cfg->custom_image_url[0] == '\0') {
+                /* No URL configured: skip the fetch and surface the reason so the
+                 * page shows why nothing loads instead of a stuck overlay. */
+                if (goes_data_lock(&goes_data, 200)) {
+                    strlcpy(goes_data.error_msg, "No URL configured", sizeof(goes_data.error_msg));
+                    goes_data_unlock(&goes_data);
+                }
+                fetch_err = ESP_ERR_INVALID_ARG;
+            } else {
+                /* Custom uses the same software JPEG decode path as GOES/Solar,
+                 * which needs a vertical flip to display upright. */
+                fetch_err = goes_client_poll_url(cfg->custom_image_url, &goes_data, true, "Custom");
+            }
+        } else if (cfg->image_display_source == 2) {                /* Solar (SDO/AIA) */
             const char *url = solar_band_url(cfg->solar_band);
             /* All solar bands need a vertical flip to display upright (see solar_band_vflip). */
             if (url && url[0]) {
@@ -1274,11 +1288,19 @@ void goes_poll_task(void *arg)
             nina_toast_show(TOAST_WARNING, "Failed to load image");
         }
 
-        /* Sleep for the configured interval (clamped 5min-2h to respect the
-         * satellite image cadence and avoid hammering the source). */
-        uint32_t interval_ms = (uint32_t)cfg->goes_update_interval_s * 1000;
-        if (interval_ms < 300000) interval_ms = 300000;
-        if (interval_ms > 7200000) interval_ms = 7200000;
+        /* Sleep for the configured interval. The satellite sources (GOES/Solar)
+         * clamp to 5min-2h to respect the image cadence; the custom source uses
+         * its own interval (10s-2h) since the user controls the endpoint. */
+        uint32_t interval_ms;
+        if (cfg->image_display_source == 3) {
+            interval_ms = (uint32_t)cfg->custom_update_interval_s * 1000;
+            if (interval_ms < 10000) interval_ms = 10000;
+            if (interval_ms > 7200000) interval_ms = 7200000;
+        } else {
+            interval_ms = (uint32_t)cfg->goes_update_interval_s * 1000;
+            if (interval_ms < 300000) interval_ms = 300000;
+            if (interval_ms > 7200000) interval_ms = 7200000;
+        }
         ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(interval_ms));
     }
 }

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -461,6 +461,29 @@ void nina_image_display_update(goes_data_t *data)
      * crossfade between two crops of the same frame is pointless. */
     bool forced = force_redraw;
     force_redraw = false;
+
+    /* Custom Image URL (source 3) error overlay. A failed fetch sets
+     * goes_data.error_msg to a reason string and leaves no fresh frame
+     * (last_poll_ms not advanced), so the new-image gate below would return
+     * early and the page would show a blank or stale panel with no explanation.
+     * Read error_msg under the goes lock (like every other goes_data read here),
+     * and when the active source is Custom AND a reason is present, render it as
+     * the caption text and bail. A successful fetch clears error_msg, so the
+     * normal swap path below runs and overwrites the caption — no stale error.
+     * Scoped to source 3, so GOES/Solar/Moon are visually unchanged. */
+    if (app_config_get()->image_display_source == 3 && data->error_msg[0] != '\0') {
+        char err_copy[48];
+        strlcpy(err_copy, data->error_msg, sizeof(err_copy));
+        goes_data_unlock(data);
+        lv_label_set_text(lbl_region, err_copy);
+        lv_label_set_text(lbl_timestamp, "");
+        hide_moon_corner_labels();
+        /* Release any manual-fetch wait overlay so it cannot get stuck on the
+         * error path (mirrors the other early-exit overlay-hide sites). */
+        nina_wait_overlay_hide();
+        return;
+    }
+
     if (!data->image_buf || (!forced && data->last_poll_ms <= displayed_poll_ms)) {
         goes_data_unlock(data);
         return;
@@ -491,7 +514,10 @@ void nina_image_display_update(goes_data_t *data)
     uint8_t crop_pct = (cfg->image_display_source == 2)
                            ? solar_band_crop_pct(cfg->solar_band)
                            : 88;
-    if (cfg->image_display_crop && cfg->image_display_source != 1 && crop_pct < 100) {
+    /* Custom Image URL (source 3) is arbitrary user content: never center-crop
+     * it (treat like Moon source 1 — show the full image, width-fit). */
+    if (cfg->image_display_crop && cfg->image_display_source != 1 &&
+        cfg->image_display_source != 3 && crop_pct < 100) {
         w  = (uint16_t)((uint32_t)sw * crop_pct / 100);
         h  = (uint16_t)((uint32_t)sh * crop_pct / 100);
         ox = (uint16_t)((sw - w) / 2);
@@ -585,6 +611,7 @@ void nina_image_display_update(goes_data_t *data)
      * rotates. 90/270 swap width<->height. */
     uint8_t orient = (cfg->image_display_source == 0)   ? cfg->goes_orientation
                      : (cfg->image_display_source == 2) ? cfg->solar_orientation
+                     : (cfg->image_display_source == 3) ? cfg->custom_orientation
                                                         : 0;
     if (orient != 0) {
         uint16_t rw, rh;

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -142,6 +142,9 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     cJSON_AddStringToObject(obj, "goes_region", cfg->goes_region);
     cJSON_AddNumberToObject(obj, "goes_update_interval_s", cfg->goes_update_interval_s);
     cJSON_AddNumberToObject(obj, "image_display_source", cfg->image_display_source);
+    cJSON_AddStringToObject(obj, "custom_image_url", cfg->custom_image_url);
+    cJSON_AddNumberToObject(obj, "custom_orientation", cfg->custom_orientation);
+    cJSON_AddNumberToObject(obj, "custom_update_interval_s", cfg->custom_update_interval_s);
     cJSON_AddNumberToObject(obj, "moon_bg_style", cfg->moon_bg_style);
     cJSON_AddNumberToObject(obj, "moon_lat", (double)cfg->moon_lat);
     cJSON_AddNumberToObject(obj, "moon_lon", (double)cfg->moon_lon);
@@ -339,6 +342,9 @@ static const backup_field_t s_backup_fields[] = {
     {"goes_region",                "GOES Region",          "Image Display", false, false},
     {"goes_update_interval_s",     "GOES Update Interval", "Image Display", false, false},
     {"image_display_source",       "Image Source",         "Image Display", false, false},
+    {"custom_image_url",           "Custom Image URL",     "Image Display", false, false},
+    {"custom_orientation",         "Custom Orientation",   "Image Display", false, false},
+    {"custom_update_interval_s",   "Custom Update Interval","Image Display", false, false},
     {"moon_bg_style",              "Moon Background Style", "Image Display", false, false},
     {"moon_lat",                   "Moon Latitude",        "Image Display", false, false},
     {"moon_lon",                   "Moon Longitude",       "Image Display", false, false},
@@ -427,6 +433,7 @@ static const restore_strmax_t s_restore_strmax[] = {
     {"allsky_hostname",     128},
     {"allsky_field_config", 1536},
     {"allsky_thresholds",   1024},
+    {"custom_image_url",    256},
     /* goes_region max sourced from the struct field size at runtime below */
     {NULL, 0}
 };
@@ -451,7 +458,9 @@ static const restore_numrange_t s_restore_numrange[] = {
     {"allsky_update_interval_s",1,    300,   false},  /* app_config.c:2548 */
     {"allsky_dew_offset",       -50,  50,    true},   /* app_config.c:2552 */
     {"goes_update_interval_s",  300,  7200,  false},  /* app_config.c:2556 */
-    {"image_display_source",    0,    2,     false},  /* app_config.c:2565 */
+    {"image_display_source",    0,    3,     false},  /* app_config.c:2598 (0=GOES,1=Moon,2=Solar,3=Custom URL) */
+    {"custom_orientation",      0,    3,     false},  /* app_config.c:2590 */
+    {"custom_update_interval_s",10,   7200,  false},  /* app_config.c:2594 */
     {"moon_bg_style",           0,    3,     false},  /* app_config.c:2569 */
     {"solar_band",              0,    17,    false},  /* app_config.c:2573 */
     {"moon_drag_light_mode",    0,    2,     false},  /* app_config.c:2577 */
@@ -826,7 +835,8 @@ static bool validate_config_fields(cJSON *root, httpd_req_t *req)
         !validate_string_len(root, "allsky_hostname", 128) ||
         !validate_string_len(root, "allsky_field_config", 1536) ||
         !validate_string_len(root, "allsky_thresholds", 1024) ||
-        !validate_string_len(root, "goes_region", sizeof(((app_config_t *)0)->goes_region))) {
+        !validate_string_len(root, "goes_region", sizeof(((app_config_t *)0)->goes_region)) ||
+        !validate_string_len(root, "custom_image_url", sizeof(((app_config_t *)0)->custom_image_url))) {
         send_400(req, "String field exceeds maximum length");
         return false;
     }
@@ -1123,6 +1133,21 @@ static app_config_t *parse_config_from_json(cJSON *root)
     }
 
     JSON_TO_INT(root, "image_display_source", cfg->image_display_source);
+
+    JSON_TO_STRING(root, "custom_image_url", cfg->custom_image_url);
+    cJSON *custom_orient = cJSON_GetObjectItem(root, "custom_orientation");
+    if (cJSON_IsNumber(custom_orient)) {
+        int v = custom_orient->valueint;
+        cfg->custom_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0;
+    }
+    cJSON *custom_interval = cJSON_GetObjectItem(root, "custom_update_interval_s");
+    if (cJSON_IsNumber(custom_interval)) {
+        int v = custom_interval->valueint;
+        if (v < 10) v = 10;
+        if (v > 7200) v = 7200;
+        cfg->custom_update_interval_s = (uint16_t)v;
+    }
+
     JSON_TO_INT(root, "moon_bg_style",        cfg->moon_bg_style);
 
     cJSON *jmoonlat = cJSON_GetObjectItem(root, "moon_lat");

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -34,6 +34,9 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "solar_band", cfg->solar_band);
     cJSON_AddNumberToObject(root, "goes_orientation", cfg->goes_orientation);
     cJSON_AddNumberToObject(root, "solar_orientation", cfg->solar_orientation);
+    cJSON_AddStringToObject(root, "custom_image_url", cfg->custom_image_url);
+    cJSON_AddNumberToObject(root, "custom_orientation", cfg->custom_orientation);
+    cJSON_AddNumberToObject(root, "custom_update_interval_s", cfg->custom_update_interval_s);
     cJSON_AddNumberToObject(root, "moon_drag_light_mode", cfg->moon_drag_light_mode);
     cJSON_AddNumberToObject(root, "moon_flip_u", cfg->moon_flip_u);
     cJSON_AddNumberToObject(root, "moon_flip_v", cfg->moon_flip_v);
@@ -74,6 +77,22 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
         cJSON_Delete(root);
         return send_400(req, "goes_region too long");
     }
+    if (!validate_string_len(root, "custom_image_url", sizeof(((app_config_t *)0)->custom_image_url))) {
+        cJSON_Delete(root);
+        return send_400(req, "custom_image_url too long");
+    }
+    /* A custom URL, when present, must be an http(s) URL. validate_url_format
+     * also accepts mqtt(s) schemes, so additionally require http/https here.
+     * An empty string is allowed (clears the URL / "not configured" state). */
+    cJSON *custom_url_item = cJSON_GetObjectItem(root, "custom_image_url");
+    if (cJSON_IsString(custom_url_item) && custom_url_item->valuestring[0] != '\0') {
+        const char *u = custom_url_item->valuestring;
+        bool http_scheme = (strncmp(u, "http://", 7) == 0 || strncmp(u, "https://", 8) == 0);
+        if (!http_scheme || !validate_url_format(u)) {
+            cJSON_Delete(root);
+            return send_400(req, "custom_image_url must start with http:// or https://");
+        }
+    }
 
     /* Work on a mutex-protected snapshot copy; never field-write the live config. */
     app_config_t cfg = app_config_get_snapshot();
@@ -96,8 +115,11 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     uint8_t prev_spin_return = cfg.moon_spin_return_s;
     uint8_t prev_goes_orient  = cfg.goes_orientation;
     uint8_t prev_solar_orient = cfg.solar_orientation;
+    uint8_t prev_custom_orient = cfg.custom_orientation;
     char    prev_region[sizeof(cfg.goes_region)];
     strlcpy(prev_region, cfg.goes_region, sizeof(prev_region));
+    char    prev_custom_url[sizeof(cfg.custom_image_url)];
+    strlcpy(prev_custom_url, cfg.custom_image_url, sizeof(prev_custom_url));
 
     JSON_TO_BOOL(root, "image_display_enabled", cfg.image_display_enabled);
     JSON_TO_BOOL(root, "image_display_show_overlay", cfg.image_display_show_overlay);
@@ -113,7 +135,7 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     }
 
     cJSON *src = cJSON_GetObjectItem(root, "image_display_source");
-    if (cJSON_IsNumber(src)) { int v = src->valueint; cfg.image_display_source = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
+    if (cJSON_IsNumber(src)) { int v = src->valueint; cfg.image_display_source = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *bg = cJSON_GetObjectItem(root, "moon_bg_style");
     if (cJSON_IsNumber(bg)) { int v = bg->valueint; cfg.moon_bg_style = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *mlat = cJSON_GetObjectItem(root, "moon_lat");
@@ -126,6 +148,13 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     if (cJSON_IsNumber(go)) { int v = go->valueint; cfg.goes_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
     cJSON *so = cJSON_GetObjectItem(root, "solar_orientation");
     if (cJSON_IsNumber(so)) { int v = so->valueint; cfg.solar_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    /* Custom image URL: length + scheme already validated above; copy bounded
+     * into the 256-byte field. */
+    JSON_TO_STRING(root, "custom_image_url", cfg.custom_image_url);
+    cJSON *co = cJSON_GetObjectItem(root, "custom_orientation");
+    if (cJSON_IsNumber(co)) { int v = co->valueint; cfg.custom_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    cJSON *ci = cJSON_GetObjectItem(root, "custom_update_interval_s");
+    if (cJSON_IsNumber(ci)) { int v = ci->valueint; if (v < 10) v = 10; if (v > 7200) v = 7200; cfg.custom_update_interval_s = (uint16_t)v; }
     cJSON *dlm = cJSON_GetObjectItem(root, "moon_drag_light_mode");
     if (cJSON_IsNumber(dlm)) { int v = dlm->valueint; cfg.moon_drag_light_mode = (v >= 0 && v <= 2) ? (uint8_t)v : 0; }
     cJSON *fu = cJSON_GetObjectItem(root, "moon_flip_u");
@@ -145,6 +174,12 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     cJSON *msr = cJSON_GetObjectItem(root, "moon_spin_return_s");
     if (cJSON_IsNumber(msr)) { int v = msr->valueint; if (v < 3) v = 3; if (v > 60) v = 60; cfg.moon_spin_return_s = (uint8_t)v; }
 
+    /* Preview button: force an immediate re-fetch even when no field changed
+     * (re-clicking Preview with the same URL must still refresh the device). */
+    bool force_fetch = false;
+    cJSON *ff = cJSON_GetObjectItem(root, "force_fetch");
+    if (cJSON_IsBool(ff)) { force_fetch = cJSON_IsTrue(ff); }
+
     cJSON_Delete(root);
 
     /* Single atomic memcpy under mutex + NVS persist. */
@@ -162,10 +197,14 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
         bool source_band_region_changed =
             cfg.image_display_source != prev_source ||
             cfg.solar_band != prev_band ||
-            strcmp(cfg.goes_region, prev_region) != 0;
+            strcmp(cfg.goes_region, prev_region) != 0 ||
+            (cfg.image_display_source == 3 &&
+             strcmp(cfg.custom_image_url, prev_custom_url) != 0) ||
+            (force_fetch && cfg.image_display_source == 3);
         bool crop_changed = cfg.image_display_crop != prev_crop;
         bool orient_changed = (cfg.goes_orientation != prev_goes_orient) ||
-                              (cfg.solar_orientation != prev_solar_orient);
+                              (cfg.solar_orientation != prev_solar_orient) ||
+                              (cfg.custom_orientation != prev_custom_orient);
 
         if (source_band_region_changed) {
             /* Source/band/region needs a genuinely new image: flag the next
@@ -225,7 +264,33 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
         }
     }
 
+    /* Surface the last-known fetch failure reason (if any) so the web UI can
+     * toast it. error_msg reflects the most recent completed fetch; a refetch
+     * triggered above runs asynchronously on the poll task. */
+    char err_copy[sizeof(((goes_data_t *)0)->error_msg)] = {0};
+    if (goes_data_lock(&goes_data, 200)) {
+        strlcpy(err_copy, goes_data.error_msg, sizeof(err_copy));
+        goes_data_unlock(&goes_data);
+    }
+
+    cJSON *resp = cJSON_CreateObject();
+    if (resp == NULL) {
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+    cJSON_AddBoolToObject(resp, "success", true);
+    if (err_copy[0] != '\0') {
+        cJSON_AddStringToObject(resp, "error_msg", err_copy);
+    }
+    const char *resp_str = cJSON_PrintUnformatted(resp);
     httpd_resp_set_type(req, "application/json");
-    httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
+    if (resp_str != NULL) {
+        httpd_resp_send(req, resp_str, HTTPD_RESP_USE_STRLEN);
+        free((void *)resp_str);
+    } else {
+        httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
+    }
+    cJSON_Delete(resp);
     return ESP_OK;
 }


### PR DESCRIPTION
### Summary
Users can now display images from a custom URL on the device, with options for rotation and update frequency. This update also fixes an issue where the device incorrectly reported available updates due to an embedded version tag mismatch.

### Changes
*   Add a new "Custom Image URL" source to the Image Display page, allowing users to specify a URL for an image.
*   New configuration options store the custom image URL, orientation, and update interval.
*   The device fetches and displays JPEG images from the provided URL, supporting HTTP redirects.
*   Image fetching includes safety checks for download size (1MB cap) and dimensions (1024x1024 cap) to prevent out-of-memory errors.
*   Images can be rotated by 0, 90, 180, or 270 degrees clockwise.
*   A "Refresh on Device" button in the web UI triggers an immediate image re-fetch.
*   Firmware builds now embed the correct Git release tag, resolving an issue where devices showed a perpetual update banner.
*   The build process now fails if the Git tree is dirty or the tag base does not match `version.txt` during a release build.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-06-26T05:13:13.117Z | Generated by GitHub Actions</sub>