### PR TITLE
feat: individual image sources in auto-rotate

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -701,6 +701,12 @@ static void set_defaults(app_config_t *cfg) {
     /* Default rotation order: Summary, AllSky, Spotify, Clock, NINA1, NINA2, NINA3, SysInfo */
     for (int i = 0; i < 8; i++) cfg->auto_rotate_order[i] = (uint8_t)i;
     cfg->auto_rotate_order_ext = 8;  // 9th slot = bit index 8 (Image Display)
+    /* Default flat slideshow order (auto_rotate_order2): ARP_IDX_* values 0..7
+     * only. Image Display (ARP_IDX_IMG_GOES, index 8) stays OPT-IN, excluded from
+     * the fresh-install default rotation. memset() above already cleared the
+     * array, so set the explicit defaults and pad the tail (8..15) with 0xFF. */
+    for (int i = 0; i < 8; i++) cfg->auto_rotate_order2[i] = (uint8_t)i;   // 0..7 (Clock is last)
+    for (int i = 8; i < ARP_ORDER_CAPACITY; i++) cfg->auto_rotate_order2[i] = 0xFF;
     cfg->update_rate_s = 5;
     cfg->graph_update_interval_s = 10;
     cfg->connection_timeout_s = 6;
@@ -1890,6 +1896,38 @@ static void migrate_from_v42(const void *raw, size_t raw_size, app_config_t *cfg
 /* --- v43 → v44 migration: rename active_page_override semantics to "Home Page";
  *     collapse slideshow mask+order into one ordered list; add nav_grace_s;
  *     drop idle_page_persistent; normalize mode exclusivity. --- */
+/* Build the flat auto_rotate_order2[] list from the legacy 9-slot order
+ * already present in cfg (auto_rotate_order[0..7] + auto_rotate_order_ext).
+ * Bit-indices 0-7 copy through unchanged; the single legacy Image Display
+ * stop (bit-index 8) maps to the per-source ARP_IDX_IMG_* matching
+ * cfg->image_display_source (0->GOES,1->Moon,2->Solar,3->Custom). 0xFF
+ * terminators are skipped; order is preserved; the result is 0xFF-padded. */
+static void build_order2_from_legacy(app_config_t *cfg)
+{
+    for (int i = 0; i < ARP_ORDER_CAPACITY; i++) cfg->auto_rotate_order2[i] = 0xFF;
+
+    int dn = 0;
+    for (int i = 0; i < 9 && dn < ARP_ORDER_CAPACITY; i++) {
+        uint8_t v = (i < 8) ? cfg->auto_rotate_order[i] : cfg->auto_rotate_order_ext;
+        if (v == 0xFF) continue;
+        uint8_t mapped;
+        if (v == 8) {
+            /* Legacy single Image Display stop -> per-source stop. */
+            switch (cfg->image_display_source) {
+                case 1:  mapped = ARP_IDX_IMG_MOON;   break;
+                case 2:  mapped = ARP_IDX_IMG_SOLAR;  break;
+                case 3:  mapped = ARP_IDX_IMG_CUSTOM; break;
+                default: mapped = ARP_IDX_IMG_GOES;   break;
+            }
+        } else if (v <= 7) {
+            mapped = v;   /* indices 0-7 are identical across schemes */
+        } else {
+            continue;     /* skip invalid legacy index (9-254) */
+        }
+        cfg->auto_rotate_order2[dn++] = mapped;
+    }
+}
+
 static void migrate_from_v43(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -1930,6 +1968,12 @@ static void migrate_from_v43(const void *raw, size_t raw_size, app_config_t *cfg
     for (int i = 0; i < 8; i++) cfg->auto_rotate_order[i] = (i < dn) ? derived[i] : 0xFF;
     cfg->auto_rotate_order_ext = (dn > 8) ? derived[8] : 0xFF;
 
+    /* Translate the derived legacy 9-slot order into the flat auto_rotate_order2[]
+     * list so v43 users keep their saved slideshow order (consistent with
+     * v44/v45). build_order2_from_legacy() splits the single Image Display stop
+     * into the per-source ARP_IDX_IMG_* matching this device's image_display_source. */
+    build_order2_from_legacy(cfg);
+
     /* nav_grace_s default. */
     cfg->nav_grace_s = 10;
 
@@ -1949,7 +1993,7 @@ static void migrate_from_v43(const void *raw, size_t raw_size, app_config_t *cfg
         (int)cfg->active_page_override, dn, (int)cfg->nav_grace_s);
 }
 
-/* --- v44 → v45 migration: add Custom Image URL source (Image Display source
+/* --- v44 → v46 migration: add Custom Image URL source (Image Display source
  *     index 3) — custom_image_url, custom_orientation, custom_update_interval_s. --- */
 static void migrate_from_v44(const void *raw, size_t raw_size, app_config_t *cfg)
 {
@@ -1963,8 +2007,34 @@ static void migrate_from_v44(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->custom_orientation = 0;
     cfg->custom_update_interval_s = 60;
 
+    /* The legacy 9-slot order (auto_rotate_order[0..7] + auto_rotate_order_ext)
+     * lives at this struct offset and was already copied above. Translate it
+     * into the new flat auto_rotate_order2[] list, splitting the single
+     * Image Display stop into the per-source ARP_IDX_IMG_* matching this
+     * device's saved image_display_source. */
+    build_order2_from_legacy(cfg);
+
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v44 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v45 → v46 migration: append auto_rotate_order2[16] (each image source is
+ *     now its own distinct slideshow stop). The legacy auto_rotate_order[8] +
+ *     auto_rotate_order_ext encoding is preserved for binary stability but no
+ *     longer drives the slideshow. --- */
+static void migrate_from_v45(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v45_t) ? raw_size : sizeof(app_config_v45_t);
+    memcpy(cfg, raw, copy);
+
+    /* Translate the old 9-slot order into the new flat auto_rotate_order2[],
+     * mapping the single old Image Display stop (bit-index 8) to the matching
+     * per-source ARP_IDX_IMG_* based on cfg->image_display_source. */
+    build_order2_from_legacy(cfg);
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v45 to v%d", APP_CONFIG_VERSION);
 }
 
 static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg)
@@ -2536,6 +2606,15 @@ static bool validate_config(app_config_t *cfg) {
         cfg->auto_rotate_order_ext = 8;  // 9th slot = Image Display bit index
         fixed = true;
     }
+    /* Validate the flat slideshow order: any entry that is not the 0xFF
+     * terminator and out of ARP_IDX_* range is dropped to 0xFF. */
+    for (int i = 0; i < ARP_ORDER_CAPACITY; i++) {
+        if (cfg->auto_rotate_order2[i] != 0xFF &&
+            cfg->auto_rotate_order2[i] >= ARP_IDX_MAX) {
+            cfg->auto_rotate_order2[i] = 0xFF;
+            fixed = true;
+        }
+    }
     if (cfg->update_rate_s < 1 || cfg->update_rate_s > 10) {
         cfg->update_rate_s = 2;
         fixed = true;
@@ -2716,8 +2795,14 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 45) {
+        /* v45 → v46: added auto_rotate_order2 (each image source is a distinct slideshow stop) */
+        migrate_from_v45(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 44) {
-        /* v44 → v45: added Custom Image URL source (custom_image_url, custom_orientation, custom_update_interval_s) */
+        /* v44 → v46: added Custom Image URL source, then auto_rotate_order2 */
         migrate_from_v44(raw, stored_size, &s_config);
         validate_config(&s_config);
         nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -13,8 +13,40 @@ extern "C" {
 // Maximum number of NINA instances supported
 #define MAX_NINA_INSTANCES 3
 
+/* Auto-rotate slideshow stop indices (auto_rotate_order2[] entries).
+ * Each value names a distinct slideshow stop. Indices 0-7 match the legacy
+ * auto_rotate bitmask bit positions exactly; indices 8-11 split the former
+ * single "Image Display" stop (old bit-index 8) into one stop per image source.
+ *   0  ARP_IDX_SUMMARY    -> PAGE_IDX_SUMMARY (4)
+ *   1  ARP_IDX_NINA1      -> NINA_PAGE_OFFSET+0 (5)
+ *   2  ARP_IDX_NINA2      -> NINA_PAGE_OFFSET+1 (6)
+ *   3  ARP_IDX_NINA3      -> NINA_PAGE_OFFSET+2 (7)
+ *   4  ARP_IDX_SYSINFO    -> SYSINFO_PAGE_IDX
+ *   5  ARP_IDX_ALLSKY     -> PAGE_IDX_ALLSKY (0)
+ *   6  ARP_IDX_SPOTIFY    -> PAGE_IDX_SPOTIFY (1)
+ *   7  ARP_IDX_CLOCK      -> PAGE_IDX_CLOCK (2)
+ *   8  ARP_IDX_IMG_GOES   -> PAGE_IDX_IMAGE_DISPLAY (3), image source 0
+ *   9  ARP_IDX_IMG_MOON   -> PAGE_IDX_IMAGE_DISPLAY (3), image source 1
+ *  10  ARP_IDX_IMG_SOLAR  -> PAGE_IDX_IMAGE_DISPLAY (3), image source 2
+ *  11  ARP_IDX_IMG_CUSTOM -> PAGE_IDX_IMAGE_DISPLAY (3), image source 3
+ */
+#define ARP_IDX_SUMMARY     0
+#define ARP_IDX_NINA1       1
+#define ARP_IDX_NINA2       2
+#define ARP_IDX_NINA3       3
+#define ARP_IDX_SYSINFO     4
+#define ARP_IDX_ALLSKY      5
+#define ARP_IDX_SPOTIFY     6
+#define ARP_IDX_CLOCK       7
+#define ARP_IDX_IMG_GOES    8
+#define ARP_IDX_IMG_MOON    9
+#define ARP_IDX_IMG_SOLAR  10
+#define ARP_IDX_IMG_CUSTOM 11
+#define ARP_IDX_MAX        12   /* exclusive validation bound */
+#define ARP_ORDER_CAPACITY 16   /* size of auto_rotate_order2[] */
+
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 45
+#define APP_CONFIG_VERSION 46
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -210,6 +242,12 @@ typedef struct {
     char     custom_image_url[256];      // user-supplied JPEG image URL
     uint8_t  custom_orientation;         // render rotation: 0=0°,1=90°,2=180°,3=270° CW (mirrors solar_orientation)
     uint16_t custom_update_interval_s;   // poll interval in seconds (10-7200, default 60)
+
+    // Added after v45 — must stay at end to preserve NVS binary compatibility
+    // Ordered slideshow stop list: array of ARP_IDX_* values, 0xFF terminator.
+    // Replaces the legacy auto_rotate_order[8] + auto_rotate_order_ext encoding;
+    // each image source is now its own distinct stop (see ARP_IDX_* above).
+    uint8_t  auto_rotate_order2[16];
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -432,6 +470,124 @@ _Static_assert(offsetof(app_config_t, custom_image_url) ==
                    offsetof(app_config_v44_t, nav_grace_s) +
                        sizeof(((app_config_v44_t *)0)->nav_grace_s),
                "app_config_v44_t snapshot drifted from app_config_t layout");
+
+/* ── Version 45 config struct — used only for NVS migration to v46 ────── */
+/* Byte-identical to app_config_t minus the trailing auto_rotate_order2[].  */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+    char     custom_image_url[256];
+    uint8_t  custom_orientation;
+    uint16_t custom_update_interval_s;
+} app_config_v45_t;
+
+/* auto_rotate_order2 (uint8[16], align 1) appends directly after the uint16
+ * custom_update_interval_s with no padding, so offsetof == end-of-last-field.
+ * Same technique as the v44 custom_image_url assert: compare against the end
+ * of the last v45 field to catch any field inserted/reordered ahead of the
+ * new block. */
+_Static_assert(offsetof(app_config_t, auto_rotate_order2) ==
+                   offsetof(app_config_v45_t, custom_update_interval_s) +
+                       sizeof(((app_config_v45_t *)0)->custom_update_interval_s),
+               "app_config_v45_t snapshot drifted from app_config_t layout");
 
 // v17 snapshot — AllSky fields without allsky_enabled
 typedef struct {

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1341,7 +1341,7 @@
           <div id="customGroup" style="display:none">
           <div class="field" style="margin-top:16px">
             <label class="field-label">Image URL</label>
-            <input class="input" id="customImageUrl" type="url" placeholder="https://picsum.photos/720" onchange="applyImageDisplay();checkDirty()">
+            <input class="input" id="customImageUrl" type="url" placeholder="https://picsum.photos/720" onchange="applyImageDisplay();updateImgCustomPillHint();checkDirty()">
             <div class="field-hint">JPEG only. Max 1024x1024 pixels, max 1 MB. PNG and WebP are not supported.</div>
           </div>
           <div class="field" style="margin-top:16px">
@@ -1474,7 +1474,7 @@
             <div class="pn-section-label">Pages in Rotation</div>
             <div style="font-size:0.72rem;color:var(--text-muted);margin:-8px 0 10px;opacity:0.7">Drag to reorder</div>
             <div class="pn-pill-grid reorderable" id="arp-container"></div>
-            <div class="field-hint">The ordered set of pages Auto Cycle moves through; drag the pills to set the order.</div>
+            <div class="field-hint">Pick which pages and image sources rotate, and drag to set the order.</div>
           </div>
         </div>
 
@@ -2189,7 +2189,10 @@
         ['arp_allsky','AllSky'],
         ['arp_spotify','Spotify'],
         ['arp_clock','Clock'],
-        ['arp_image_display','Image Display']
+        ['arp_img_goes','Img: GOES'],
+        ['arp_img_moon','Img: Moon'],
+        ['arp_img_solar','Img: Solar'],
+        ['arp_img_custom','Img: Custom']
       ];
       var c=$('arp-container');
       if(!c) return;
@@ -2583,9 +2586,9 @@
 
     /* === Rotation slideshow list === */
     /* Single ordered slideshow list: membership == order.
-       data-arp-idx equals the page's rotation bit index (0..8).
-       Saved array holds the bit indices of CHECKED pills in on-screen order,
-       padded to 9 slots with 0xFF (255 = unused). Slot 9 is auto_rotate_order_ext. */
+       data-arp-idx equals the page/image-source rotation index (0..11).
+       Saved array holds the indices of CHECKED pills in on-screen order,
+       padded to 16 slots with 0xFF (255 = unused). */
     function getRotateOrder(){
       var pills=$('arp-container').querySelectorAll('.pn-pill[data-arp-idx]');
       var order=[];
@@ -2593,8 +2596,8 @@
         var cb=p.querySelector('input[type="checkbox"]');
         if(cb&&cb.checked) order.push(parseInt(p.getAttribute('data-arp-idx')));
       });
-      while(order.length<9) order.push(255);
-      return order.slice(0,9);
+      while(order.length<16/* keep in sync with ARP_ORDER_CAPACITY in app_config.h */) order.push(255);
+      return order.slice(0,16/* keep in sync with ARP_ORDER_CAPACITY in app_config.h */);
     }
 
     function setRotateOrder(orderArr){
@@ -2603,8 +2606,8 @@
       var pills=Array.from(container.querySelectorAll('.pn-pill[data-arp-idx]'));
       var pillMap={};
       pills.forEach(function(p){ pillMap[p.getAttribute('data-arp-idx')]=p; });
-      /* Members (in order) = entries that are not the 0xFF/255 sentinel. */
-      var members=orderArr.map(function(v){return parseInt(v);}).filter(function(v){return !isNaN(v)&&v>=0&&v!==255&&v<pills.length;});
+      /* Members (in order) = valid indices 0..11 that are not the 0xFF/255 sentinel. */
+      var members=orderArr.map(function(v){return parseInt(v);}).filter(function(v){return !isNaN(v)&&v>=0&&v!==255&&v<12/* keep in sync with ARP_IDX_MAX in app_config.h */;});
       /* Reorder members to the front in saved order, set their checkbox on. */
       members.forEach(function(idx){
         var p=pillMap[idx];
@@ -2617,6 +2620,23 @@
           var cb=p.querySelector('input[type="checkbox"]'); if(cb) cb.checked=false;
         }
       });
+    }
+
+    /* Cosmetic hint on the Img: Custom pill when no custom URL is configured.
+       The pill stays selectable; the device skips it at runtime when empty. */
+    function updateImgCustomPillHint(){
+      var c=$('arp-container');
+      if(!c) return;
+      var pill=c.querySelector('.pn-pill[data-arp-idx="11"]');
+      if(!pill) return;
+      var u=$('customImageUrl')?$('customImageUrl').value.trim():'';
+      if(u){
+        pill.style.opacity='';
+        pill.removeAttribute('title');
+      } else {
+        pill.style.opacity='0.55';
+        pill.title='No custom URL configured';
+      }
     }
 
     /* === Config Data Assembly === */
@@ -2657,7 +2677,7 @@
         auto_rotate_interval_s:parseInt($('auto_rotate_interval').value)||30,
         auto_rotate_effect:parseInt($('auto_rotate_effect').value),
         auto_rotate_skip_disconnected:!!$('auto_rotate_skip').checked,
-        auto_rotate_order:getRotateOrder(),
+        auto_rotate_order2:getRotateOrder(),
         nav_grace_s:parseInt($('nav_grace_s').value)||10,
         update_rate_s:parseInt($('update_rate').value)||2,
         graph_update_interval_s:parseInt($('graph_interval').value)||5,
@@ -2846,7 +2866,8 @@
       $('auto_rotate_effect').value=data.auto_rotate_effect||0;
       $('auto_rotate_skip').checked=!!data.auto_rotate_skip_disconnected;
       if($('nav_grace_s')) $('nav_grace_s').value=(data.nav_grace_s||10);
-      if(data.auto_rotate_order) setRotateOrder(data.auto_rotate_order);
+      if(data.auto_rotate_order2) setRotateOrder(data.auto_rotate_order2);
+      else if(data.auto_rotate_order) setRotateOrder(data.auto_rotate_order);
 
       updateNodeLabels();
 
@@ -2887,6 +2908,7 @@
       if($('imageSource2')) $('imageSource2').checked=(imgSrc===2);
       if($('imageSource3')) $('imageSource3').checked=(imgSrc===3);
       if($('customImageUrl')) $('customImageUrl').value=data.custom_image_url||'';
+      updateImgCustomPillHint();
       if($('customOrientation')) $('customOrientation').value=String(data.custom_orientation||0);
       if($('customInterval')) $('customInterval').value=String(data.custom_update_interval_s||60);
       if($('moonBg')) $('moonBg').value=String(data.moon_bg_style||0);

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -30,6 +30,7 @@ static void set_error_msg(goes_data_t *d, const char *m)
 void goes_data_init(goes_data_t *data)
 {
     memset(data, 0, sizeof(*data));
+    data->src_kind = -1;
     data->mutex = xSemaphoreCreateMutex();
 }
 
@@ -54,6 +55,7 @@ void goes_client_cleanup(goes_data_t *data)
         }
         data->image_w = 0;
         data->image_h = 0;
+        data->src_kind = -1;
         data->connected = false;
         goes_data_unlock(data);
     }
@@ -118,9 +120,13 @@ static const char *SOLAR_LABELS[SOLAR_BAND_COUNT] = {
 const char *solar_band_url(uint8_t idx)   { return idx < SOLAR_BAND_COUNT ? SOLAR_URLS[idx]   : SOLAR_URLS[0]; }
 const char *solar_band_label(uint8_t idx) { return idx < SOLAR_BAND_COUNT ? SOLAR_LABELS[idx] : SOLAR_LABELS[0]; }
 
-/* All solar imagery (SDO/AIA and SOHO) needs a vertical flip to display upright
- * on this panel, same as the GOES path. */
-bool solar_band_vflip(uint8_t idx) { (void)idx; return true; }
+/* Solar source images (SDO/AIA via sdo.gsfc.nasa.gov, SOHO/HMI via
+ * soho.nascom.nasa.gov) are delivered upright (north up, caption at bottom), so
+ * no vertical flip is applied. Any build-environment orientation difference is
+ * corrected by the per-source `solar_orientation` rotation setting, not here.
+ * (A vertical flip is a mirror and would put the caption at the top and mirror
+ * sunspot positions, which no rotation setting can undo.) */
+bool solar_band_vflip(uint8_t idx) { (void)idx; return false; }
 
 /* Per-band center-crop percentage (100 = no crop). AIA (0..9) and SOHO EIT
  * (12..15) have a wide source border, so 88% zooms past the timestamp/label.
@@ -195,10 +201,10 @@ esp_err_t goes_client_poll(const char *region, goes_data_t *data)
      * NESDIS GOES JPEG must be flipped (vflip=true) to display north-up. This matches
      * the Solar path, which also uses vflip=true. Verified on-device: vflip=false
      * renders the image upside-down (issue #166 regression). */
-    return goes_client_poll_url(url, data, true, goes_region_name(region));
+    return goes_client_poll_url(url, data, true, goes_region_name(region), 0 /* GOES */);
 }
 
-esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, const char *label)
+esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, const char *label, int8_t src_kind)
 {
     if (!url || !data) return ESP_ERR_INVALID_ARG;
 
@@ -349,6 +355,7 @@ esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, c
         data->vflip = vflip;
         if (label) { strlcpy(data->label, label, sizeof(data->label)); }
         else       { data->label[0] = '\0'; }
+        data->src_kind = src_kind;
         data->error_msg[0] = '\0';   /* clear: this fetch succeeded */
         data->connected = true;
         data->last_poll_ms = esp_timer_get_time() / 1000;

--- a/main/goes_client.h
+++ b/main/goes_client.h
@@ -15,6 +15,7 @@ typedef struct {
     bool              vflip;        /* true: buffer is vertically flipped (sw JPEG) */
     char              label[48];    /* human-readable name of the source this buffer holds (region/band); rendered verbatim by the page so it can never desync from image_buf */
     char              error_msg[48]; /* human-readable failure reason shown on-screen when a fetch fails; "" when last fetch succeeded */
+    int8_t            src_kind;      /* source the current image_buf belongs to: 0=GOES 1=Moon 2=Solar 3=Custom, -1=unknown */
     SemaphoreHandle_t mutex;
 } goes_data_t;
 
@@ -22,7 +23,7 @@ void      goes_data_init(goes_data_t *data);
 bool      goes_data_lock(goes_data_t *data, int timeout_ms);
 void      goes_data_unlock(goes_data_t *data);
 esp_err_t goes_client_poll(const char *region, goes_data_t *data);
-esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, const char *label);
+esp_err_t goes_client_poll_url(const char *url, goes_data_t *data, bool vflip, const char *label, int8_t src_kind);
 void      goes_client_cleanup(goes_data_t *data);
 
 /* NESDIS sector code -> human-readable region name. Returns the code itself

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -172,7 +172,60 @@ static TaskHandle_t allsky_task_handle = NULL;
 TaskHandle_t goes_task_handle = NULL;
 _Atomic bool image_display_page_active = false;
 goes_data_t goes_data;
+/* Spare buffer the slideshow prefetch loads the NEXT source into (Phase 4).
+ * static: tasks.c is the sole writer/reader; narrowing scope prevents accidental
+ * unlocked cross-task access (no extern in tasks.h). */
+static goes_data_t goes_prefetch_data;
+
+/* Runtime image-source override (RAM only — never persisted to NVS).
+ * -1 = no override (use the persisted cfg->image_display_source);
+ * 0-3 = the slideshow-selected source (GOES/Moon/Solar/Custom).
+ * Written by the navigation arbiter (another task), read by goes_poll_task and
+ * the Image Display UI — int8 atomics are lock-free, so a plain load/store is
+ * the correct cross-task pattern. */
+static _Atomic int8_t s_image_source_override = -1;
+/* Source the background prefetch should load (set by image_source_trigger_prefetch,
+ * consumed in Phase 4). -1 = nothing pending. */
+static _Atomic int8_t s_prefetch_source = -1;
+/* Phase 4 prefetch hand-off. s_prefetch_ready is set by the prefetch PRODUCER in
+ * goes_poll_task once a NEXT-source frame has been fetched/rendered into
+ * goes_prefetch_data, and cleared by the SWAP CONSUMER at the top of the loop the
+ * moment it installs that buffer into goes_data. s_prefetch_ready_src records which
+ * image source (0=GOES,1=Moon,2=Solar,3=Custom) the ready buffer holds so the
+ * consumer can tell whether the swap already satisfies the current effective source
+ * and skip a redundant foreground fetch this iteration. Both are written ONLY by
+ * goes_poll_task (single writer); the atomics make the producer-then-consumer
+ * publish/consume safe within that one task across loop iterations. */
+static _Atomic bool   s_prefetch_ready = false;
+static _Atomic int8_t s_prefetch_ready_src = -1;
+
 static demo_task_params_t demo_params;
+
+/* ── Image-source override / prefetch plumbing ──
+ * The persisted default lives in cfg->image_display_source and is only changed
+ * by the web config POST handler. The slideshow drives the RAM-only override
+ * above so rotation never touches NVS. */
+void image_source_set_override(int8_t src)
+{
+    atomic_store(&s_image_source_override, src);
+}
+
+int8_t image_source_get_effective(void)
+{
+    int8_t ov = atomic_load(&s_image_source_override);
+    if (ov >= 0) {
+        return ov;
+    }
+    return (int8_t)app_config_get()->image_display_source;
+}
+
+void image_source_trigger_prefetch(int8_t src)
+{
+    atomic_store(&s_prefetch_source, src);
+    if (goes_task_handle) {
+        xTaskNotifyGive(goes_task_handle);
+    }
+}
 
 /**
  * @brief Page-change callback from the dashboard — signals the data task to re-tune polling.
@@ -755,6 +808,99 @@ void moon_overlay_info(char *age,  size_t age_sz,
     fmt_moon_event(set,  set_sz,  "Set",  s_rs_set,  s_rs_set_v,  now, use_24h);
 }
 
+/* ── Prefetch PRODUCER (Phase 4) ────────────────────────────────────────────
+ * Consume any pending prefetch request (s_prefetch_source, set by the arbiter via
+ * image_source_trigger_prefetch) and build that source's frame INTO
+ * goes_prefetch_data — never goes_data — so a later rotation to it can swap in a
+ * ready buffer with no network round-trip. Runs at the END of each goes_poll_task
+ * foreground iteration (both the moon path and the network path call it), so it
+ * only ever executes in the single goes_poll_task context that owns both structs.
+ *
+ * On success it sets s_prefetch_ready + s_prefetch_ready_src so the swap consumer
+ * at the top of the loop can install the buffer and decide whether it satisfies the
+ * then-current effective source. A failure (or an empty/invalid Custom URL) leaves
+ * s_prefetch_ready false, so the consumer simply does a normal foreground fetch
+ * later — the existing "Loading image..." graceful-miss path, no new code.
+ *
+ * MEMORY: every frame written here is heap_caps_malloc'd in PSRAM by the fetch/
+ * render helper (goes_client_poll* allocate the decoded RGB565; moon_sphere_render
+ * allocates the rendered RGB565). The buffer is owned by goes_prefetch_data until
+ * EITHER the swap consumer moves it into goes_data (and NULLs prefetch.image_buf),
+ * OR a subsequent prefetch overwrites it — so this helper frees any unconsumed
+ * prefetch frame before installing a new one, preventing a leak when two prefetch
+ * requests land without an intervening swap. */
+static void image_prefetch_run(const app_config_t *cfg)
+{
+    int8_t pf = atomic_exchange(&s_prefetch_source, -1);
+    if (pf < 0) return;
+
+    /* A prior prefetch frame that was never swapped in would leak when the new
+     * fetch below replaces the pointer (goes_client_poll* free the OLD buffer they
+     * find in the target, but the moon render assigns directly), so clear it here
+     * under the prefetch lock and drop the stale ready flag. */
+    if (goes_data_lock(&goes_prefetch_data, 1000)) {
+        if (goes_prefetch_data.image_buf) {
+            heap_caps_free(goes_prefetch_data.image_buf);
+            goes_prefetch_data.image_buf = NULL;
+        }
+        goes_data_unlock(&goes_prefetch_data);
+    }
+    atomic_store(&s_prefetch_ready, false);
+    atomic_store(&s_prefetch_ready_src, -1);
+
+    esp_err_t err = ESP_FAIL;
+    if (pf == 1) {
+        /* Moon: render locally (synchronous, ~300ms). Skip until the clock is
+         * valid so the phase/orientation is correct. */
+        time_t now; time(&now);
+        bool time_valid = (now > (time_t)1577836800);
+        if (time_valid && moon_sphere_init()) {
+            double lat = cfg->moon_lat, lon = cfg->moon_lon;
+            if (lat == 0.0 && lon == 0.0) { lat = cfg->weather_lat; lon = cfg->weather_lon; }
+            moon_state_t live;
+            moon_compute(now, lat, lon, &live);
+            uint16_t *img = moon_sphere_render(SCREEN_SIZE, SCREEN_SIZE, &live,
+                                               96, 48, cfg->moon_bg_style);
+            if (img) {
+                if (goes_data_lock(&goes_prefetch_data, 1000)) {
+                    goes_prefetch_data.image_buf    = (uint8_t *)img;
+                    goes_prefetch_data.image_w      = SCREEN_SIZE;
+                    goes_prefetch_data.image_h      = SCREEN_SIZE;
+                    goes_prefetch_data.vflip        = false;
+                    goes_prefetch_data.label[0]     = '\0';
+                    goes_prefetch_data.src_kind     = 1;   /* Moon */
+                    goes_prefetch_data.error_msg[0] = '\0';
+                    goes_prefetch_data.connected    = true;
+                    goes_prefetch_data.last_poll_ms = esp_timer_get_time() / 1000;
+                    goes_data_unlock(&goes_prefetch_data);
+                    err = ESP_OK;
+                } else {
+                    heap_caps_free(img);
+                }
+            }
+        }
+    } else if (pf == 3) {                                       /* Custom image URL */
+        if (cfg->custom_image_url[0] != '\0') {
+            err = goes_client_poll_url(cfg->custom_image_url, &goes_prefetch_data, true, "Custom", 3 /* Custom */);
+        }
+    } else if (pf == 2) {                                       /* Solar (SDO/AIA) */
+        const char *url = solar_band_url(cfg->solar_band);
+        if (url && url[0]) {
+            err = goes_client_poll_url(url, &goes_prefetch_data,
+                                       solar_band_vflip(cfg->solar_band),
+                                       solar_band_label(cfg->solar_band),
+                                       2 /* Solar */);
+        }
+    } else if (pf == 0 && cfg->goes_region[0] != '\0') {        /* GOES */
+        err = goes_client_poll(cfg->goes_region, &goes_prefetch_data);
+    }
+
+    if (err == ESP_OK) {
+        atomic_store(&s_prefetch_ready_src, pf);
+        atomic_store(&s_prefetch_ready, true);
+    }
+}
+
 void goes_poll_task(void *arg)
 {
     ESP_LOGI(TAG, "GOES poll task started");
@@ -769,9 +915,118 @@ void goes_poll_task(void *arg)
          * app_config_t onto this task's small stack. */
         const app_config_t *cfg = app_config_get();
 
+        /* Effective source for THIS iteration: the slideshow override if active,
+         * else the persisted default. Read ONCE so a mid-iteration arbiter change
+         * cannot make the fetch dispatch and the interval/label logic disagree. */
+        int8_t eff_src = image_source_get_effective();
+
+        /* ── Prefetch SWAP CONSUMER (Phase 4) ───────────────────────────────────
+         * The producer (end of this loop) may have fetched/rendered the NEXT
+         * slideshow image source into goes_prefetch_data ahead of time. When the
+         * arbiter then rotates to that source, install the pre-built buffer into
+         * goes_data here — instantly, with no network round-trip and no "Loading
+         * image..." overlay — instead of fetching it in the foreground below.
+         *
+         * Lock order is goes_data FIRST, then goes_prefetch_data, matching the
+         * single-writer invariant (only this task touches either struct) and the
+         * reader contract (nina_image_display_update locks goes_data, never the
+         * prefetch struct). Holding goes_data's lock across the buffer pointer move
+         * means the UI reader never sees a torn buffer. After the move the prefetch
+         * struct's image_buf is NULLed so ownership is transferred and a later
+         * prefetch re-mallocs cleanly (no double-free).
+         *
+         * swap_satisfies_eff records whether the swapped-in buffer is the source we
+         * are about to display this iteration. If it is, we skip the redundant
+         * foreground fetch (the screen already shows the right frame); if it is not
+         * (the prefetch was for a different source, e.g. the user manually navigated
+         * away from the slideshow's predicted next stop), the swap is discarded-in-
+         * place by leaving it installed but still falling through to fetch eff_src. */
+        bool swap_satisfies_eff = false;
+        {
+            bool ready = atomic_exchange(&s_prefetch_ready, false);
+            int8_t swapped_src = atomic_exchange(&s_prefetch_ready_src, -1);
+            if (ready && goes_prefetch_data.image_buf) {
+                bool moved = false;
+                if (goes_data_lock(&goes_data, 1000)) {
+                    if (goes_data_lock(&goes_prefetch_data, 1000)) {
+                        /* Free the frame being displaced, then move ownership of the
+                         * prefetched frame + its metadata into goes_data. */
+                        if (goes_data.image_buf) heap_caps_free(goes_data.image_buf);
+                        goes_data.image_buf    = goes_prefetch_data.image_buf;
+                        goes_data.image_w      = goes_prefetch_data.image_w;
+                        goes_data.image_h      = goes_prefetch_data.image_h;
+                        goes_data.vflip        = goes_prefetch_data.vflip;
+                        goes_data.src_kind     = goes_prefetch_data.src_kind;
+                        goes_data.connected    = goes_prefetch_data.connected;
+                        goes_data.last_poll_ms = esp_timer_get_time() / 1000;
+                        strlcpy(goes_data.label, goes_prefetch_data.label, sizeof(goes_data.label));
+                        goes_data.error_msg[0] = '\0';   /* a successful prefetch clears any stale error */
+                        goes_prefetch_data.image_buf = NULL;   /* ownership transferred */
+                        goes_data_unlock(&goes_prefetch_data);
+                        moved = true;
+                    }
+                    goes_data_unlock(&goes_data);
+                }
+
+                if (moved) {
+                    /* Signal the UI exactly like the moon resting commit does: push
+                     * the swapped frame to the panel immediately under the display
+                     * lock (force_redraw bypasses the new-image timestamp gate so a
+                     * same-millisecond stamp can't be skipped), and wake
+                     * data_update_task so its periodic image refresh also re-runs. */
+                    if (image_display_page_active) {
+                        if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                            nina_image_display_force_redraw();
+                            nina_image_display_update(&goes_data);
+                            bsp_display_unlock();
+                        }
+                    }
+                    if (data_task_handle) xTaskNotifyGive(data_task_handle);
+
+                    /* Only claim the foreground fetch is unnecessary when the frame
+                     * actually landed in goes_data AND it is the source we display
+                     * this iteration. A lock-miss (moved == false) falls through to a
+                     * normal foreground fetch — the graceful-miss path. */
+                    swap_satisfies_eff = (swapped_src == eff_src);
+                }
+
+                /* Lock-miss recovery: the ready flags were already cleared by the
+                 * atomic_exchange above, but a lock timeout (moved == false) left the
+                 * ~1MB prefetched PSRAM buffer stranded in goes_prefetch_data. Re-arm
+                 * the ready state so the next loop iteration retries the swap instead
+                 * of orphaning the buffer for the rest of the session (a leak if
+                 * rotation later stops and no further prefetch ever runs). */
+                if (!moved) {
+                    atomic_store(&s_prefetch_ready_src, swapped_src);
+                    atomic_store(&s_prefetch_ready, true);
+                }
+            }
+        }
+
+        /* The swap already installed the frame for the current effective source —
+         * skip the foreground fetch/render this iteration and just sleep until the
+         * next refresh tick. A prefetch for a DIFFERENT source (swap_satisfies_eff
+         * false) falls through to fetch eff_src normally (graceful miss). */
+        if (swap_satisfies_eff) {
+            uint32_t interval_ms;
+            if (eff_src == 3) {
+                interval_ms = (uint32_t)cfg->custom_update_interval_s * 1000;
+                if (interval_ms < 10000)   interval_ms = 10000;
+                if (interval_ms > 7200000) interval_ms = 7200000;
+            } else if (eff_src == 1) {
+                interval_ms = 60000;   /* moon recompute cadence */
+            } else {
+                interval_ms = (uint32_t)cfg->goes_update_interval_s * 1000;
+                if (interval_ms < 300000)  interval_ms = 300000;
+                if (interval_ms > 7200000) interval_ms = 7200000;
+            }
+            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(interval_ms));
+            continue;
+        }
+
         /* Moon source: render locally on-device, no network. The result is
          * pushed into the same goes_data RGB565 sink the crossfade page reads. */
-        if (cfg->image_display_source == 1) {
+        if (eff_src == 1) {
             time_t now; time(&now);
             /* The moon phase/orientation needs a correct wall clock. Before SNTP
              * sets the time (near-epoch at boot), rendering would show the wrong
@@ -889,7 +1144,7 @@ void goes_poll_task(void *arg)
                 int64_t prev_frame_us = esp_timer_get_time();
                 freespin_hold = false;   /* re-evaluated for this outer iteration */
                 while (!moon_drag_settled()) {
-                    if (!image_display_page_active || cfg->image_display_source != 1) break;
+                    if (!image_display_page_active || eff_src != 1) break;
                     ran_drag = true;   /* a drag frame is about to be shown */
                     int64_t frame_t0 = esp_timer_get_time();
 
@@ -1013,6 +1268,7 @@ void goes_poll_task(void *arg)
                                 goes_data.image_h = MOON_DRAG_SZ_TOUCH;
                                 goes_data.vflip = false;
                                 goes_data.label[0] = '\0';
+                                goes_data.src_kind = 1;   /* Moon */
                                 goes_data.connected = true;
                                 goes_data.last_poll_ms = esp_timer_get_time() / 1000;
                                 goes_data_unlock(&goes_data);
@@ -1055,7 +1311,7 @@ void goes_poll_task(void *arg)
                     uint16_t *hold_img = moon_sphere_render_ex(SCREEN_SIZE, SCREEN_SIZE, &live,
                                                                96, 48, cfg->moon_bg_style,
                                                                hy, hp, (moon_light_mode_t)cfg->moon_drag_light_mode);
-                    if (hold_img && image_display_page_active && cfg->image_display_source == 1 &&
+                    if (hold_img && image_display_page_active && eff_src == 1 &&
                         !moon_drag_active()) {
                         if (goes_data_lock(&goes_data, 1000)) {
                             if (goes_data.image_buf) heap_caps_free(goes_data.image_buf);
@@ -1064,6 +1320,7 @@ void goes_poll_task(void *arg)
                             goes_data.image_h = SCREEN_SIZE;
                             goes_data.vflip = false;
                             goes_data.label[0] = '\0';
+                            goes_data.src_kind = 1;   /* Moon */
                             goes_data.connected = true;
                             goes_data.last_poll_ms = esp_timer_get_time() / 1000;
                             goes_data_unlock(&goes_data);
@@ -1082,7 +1339,7 @@ void goes_poll_task(void *arg)
                     /* Sleep-poll the hold window. The configured seconds are read each
                      * iteration so a live web-UI change takes effect within one poll step. */
                     for (;;) {
-                        if (!image_display_page_active || cfg->image_display_source != 1) break;
+                        if (!image_display_page_active || eff_src != 1) break;
                         if (moon_drag_active()) break;   /* re-touch: outer continue re-enters the drag loop */
                         /* Mode switched to rubber band mid-hold, or the hold was cleared:
                          * resolve by snapping home (acceptable per spec). */
@@ -1109,7 +1366,7 @@ void goes_poll_task(void *arg)
                 if (ran_drag) {
                     int waited_ms = 0;
                     while (waited_ms < MOON_DRAG_REST_GRACE_MS) {
-                        if (!image_display_page_active || cfg->image_display_source != 1) break;
+                        if (!image_display_page_active || eff_src != 1) break;
                         if (moon_drag_active()) { regrabbed = true; break; }
                         vTaskDelay(pdMS_TO_TICKS(20));
                         waited_ms += 20;
@@ -1179,6 +1436,7 @@ void goes_poll_task(void *arg)
                         goes_data.image_h = MOON_SZ;
                         goes_data.vflip = false;
                         goes_data.label[0] = '\0';
+                        goes_data.src_kind = 1;   /* Moon */
                         goes_data.connected = true;
                         goes_data.last_poll_ms = esp_timer_get_time() / 1000;
                         goes_data_unlock(&goes_data);
@@ -1196,7 +1454,7 @@ void goes_poll_task(void *arg)
                          * instant (matching every other moon frame) so there is no
                          * midpoint brightness dip. */
                         if (image_display_page_active &&
-                            cfg->image_display_source == 1) {
+                            eff_src == 1) {
                             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                                 nina_image_display_force_redraw();
                                 nina_image_display_update(&goes_data);
@@ -1208,6 +1466,9 @@ void goes_poll_task(void *arg)
                     }
                 }
             }
+            /* Prefetch the NEXT slideshow image source (if the arbiter scheduled
+             * one) before sleeping, so a rotation to it swaps in instantly. */
+            image_prefetch_run(cfg);
             /* Recompute ~every 60s once time is valid so orientation tracks the
              * sky; poll every ~3s while waiting for the clock to sync. */
             ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(time_valid ? 60000 : 3000));
@@ -1230,7 +1491,7 @@ void goes_poll_task(void *arg)
         bool manual_fetch = atomic_exchange(&image_display_manual_fetch, false);
         bool show_wait = false;
         if (image_display_page_active) {
-            const char *band_name = (cfg->image_display_source == 2)
+            const char *band_name = (eff_src == 2)
                                         ? solar_band_label(cfg->solar_band) : NULL;
             /* Only treat the overlay as shown if the lock was acquired and the
              * show actually ran — otherwise the error-hide below would be a
@@ -1246,7 +1507,7 @@ void goes_poll_task(void *arg)
         }
 
         esp_err_t fetch_err = ESP_OK;
-        if (cfg->image_display_source == 3) {                       /* Custom image URL */
+        if (eff_src == 3) {                                         /* Custom image URL */
             if (cfg->custom_image_url[0] == '\0') {
                 /* No URL configured: skip the fetch and surface the reason so the
                  * page shows why nothing loads instead of a stuck overlay. */
@@ -1258,13 +1519,13 @@ void goes_poll_task(void *arg)
             } else {
                 /* Custom uses the same software JPEG decode path as GOES/Solar,
                  * which needs a vertical flip to display upright. */
-                fetch_err = goes_client_poll_url(cfg->custom_image_url, &goes_data, true, "Custom");
+                fetch_err = goes_client_poll_url(cfg->custom_image_url, &goes_data, true, "Custom", 3 /* Custom */);
             }
-        } else if (cfg->image_display_source == 2) {                /* Solar (SDO/AIA) */
+        } else if (eff_src == 2) {                                  /* Solar (SDO/AIA) */
             const char *url = solar_band_url(cfg->solar_band);
             /* All solar bands need a vertical flip to display upright (see solar_band_vflip). */
             if (url && url[0]) {
-                fetch_err = goes_client_poll_url(url, &goes_data, solar_band_vflip(cfg->solar_band), solar_band_label(cfg->solar_band));
+                fetch_err = goes_client_poll_url(url, &goes_data, solar_band_vflip(cfg->solar_band), solar_band_label(cfg->solar_band), 2 /* Solar */);
             } else {
                 fetch_err = ESP_ERR_INVALID_ARG;
             }
@@ -1288,11 +1549,16 @@ void goes_poll_task(void *arg)
             nina_toast_show(TOAST_WARNING, "Failed to load image");
         }
 
+        /* Prefetch the NEXT slideshow image source (if the arbiter scheduled one)
+         * after the foreground fetch and before sleeping, so a rotation to it swaps
+         * in instantly. No-op when nothing is pending. */
+        image_prefetch_run(cfg);
+
         /* Sleep for the configured interval. The satellite sources (GOES/Solar)
          * clamp to 5min-2h to respect the image cadence; the custom source uses
          * its own interval (10s-2h) since the user controls the endpoint. */
         uint32_t interval_ms;
-        if (cfg->image_display_source == 3) {
+        if (eff_src == 3) {
             interval_ms = (uint32_t)cfg->custom_update_interval_s * 1000;
             if (interval_ms < 10000) interval_ms = 10000;
             if (interval_ms > 7200000) interval_ms = 7200000;
@@ -1926,6 +2192,7 @@ void data_update_task(void *arg) {
         /* Initialize GOES data struct so its mutex exists even in demo mode
          * (a later web-handler enable + page entry would otherwise NULL-deref). */
         goes_data_init(&goes_data);
+        goes_data_init(&goes_prefetch_data);
 
         instance_count = app_config_get_instance_count();
         instance_count = 3;  /* demo mode always shows all 3 instance profiles */
@@ -2098,6 +2365,7 @@ boot_update_check_done:
      * goes_data_init must run UNCONDITIONALLY so the mutex exists before any
      * later web-handler-triggered enable + page entry. */
     goes_data_init(&goes_data);
+    goes_data_init(&goes_prefetch_data);
     if (app_config_get()->image_display_enabled) {
         goes_ensure_task_running();
     }

--- a/main/tasks.h
+++ b/main/tasks.h
@@ -73,6 +73,20 @@ extern TaskHandle_t goes_task_handle;
 extern _Atomic bool image_display_page_active;
 extern goes_data_t goes_data;
 
+/** Runtime image-source override (RAM only — never persisted).
+ *  The slideshow/arbiter sets this so the Image Display page can rotate through
+ *  GOES/Moon/Solar/Custom without writing the persisted image_display_source.
+ *  src -1 clears the override (revert to the configured default). */
+void image_source_set_override(int8_t src);
+
+/** Effective image source: the override if set (>=0), otherwise the persisted
+ *  config value (app_config_get()->image_display_source). */
+int8_t image_source_get_effective(void);
+
+/** Request a background prefetch of image source @p src (Phase 4 consumes it).
+ *  Stores the requested source and wakes goes_poll_task. */
+void image_source_trigger_prefetch(int8_t src);
+
 /** Set by the moon-page tap handler to request a one-shot cycle+spin animation.
  *  Consumed (cleared) once by goes_poll_task via atomic_exchange. */
 extern _Atomic bool moon_anim_request;

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -775,7 +775,7 @@ static void gesture_event_cb(lv_event_t *e) {
      * can only be true in that case. A clean quick flick (little finger travel)
      * leaves was_rotate false and still navigates. */
     if (active_page == PAGE_IDX_IMAGE_DISPLAY && image_display_obj != NULL &&
-        app_config_get()->image_display_source == 1 && moon_drag_was_rotate()) {
+        image_source_get_effective() == 1 && moon_drag_was_rotate()) {
         return;
     }
 
@@ -814,6 +814,14 @@ static void gesture_event_cb(lv_event_t *e) {
      * instant swipe feedback AND record a USER claim so the grace window
      * (nav_grace_s) protects this page from lower-priority sources until the
      * next resolve(). */
+    if (new_page == PAGE_IDX_IMAGE_DISPLAY) {
+        /* Clear any stale slideshow image-source override BEFORE the page
+         * becomes active, so the image page renders the correct source on the
+         * very first goes_poll_task iteration. nav_arbiter_submit_user() below
+         * also clears it, but only after the page is already visible, leaving a
+         * one-frame window of the wrong source. */
+        image_source_set_override(-1);
+    }
     nina_dashboard_show_page_animated(new_page, 0, 0);
     nav_arbiter_submit_user(new_page, esp_timer_get_time() / 1000);
 }

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -192,7 +192,7 @@ static void moon_tap_cb(lv_event_t *e)
 {
     (void)e;
     /* Only the Moon source animates; ignore taps on the GOES image. */
-    if (app_config_get()->image_display_source != 1) return;
+    if (image_source_get_effective() != 1) return;
     atomic_store(&moon_anim_request, true);
     if (goes_task_handle) xTaskNotifyGive(goes_task_handle);
 }
@@ -213,7 +213,7 @@ static bool moon_indev_point(lv_point_t *p)
 static void moon_drag_pressed_cb(lv_event_t *e)
 {
     (void)e;
-    if (app_config_get()->image_display_source != 1) return;   /* Moon only */
+    if (image_source_get_effective() != 1) return;   /* Moon only */
     lv_point_t p;
     if (!moon_indev_point(&p)) return;
     moon_drag_begin((float)p.x, (float)p.y);
@@ -226,7 +226,7 @@ static void moon_drag_pressed_cb(lv_event_t *e)
 static void moon_drag_pressing_cb(lv_event_t *e)
 {
     (void)e;
-    if (app_config_get()->image_display_source != 1) return;   /* Moon only */
+    if (image_source_get_effective() != 1) return;   /* Moon only */
     lv_point_t p;
     if (!moon_indev_point(&p)) return;
     moon_drag_move((float)p.x, (float)p.y);
@@ -240,7 +240,7 @@ static void moon_drag_pressing_cb(lv_event_t *e)
 static void moon_drag_released_cb(lv_event_t *e)
 {
     (void)e;
-    if (app_config_get()->image_display_source != 1) return;   /* Moon only */
+    if (image_source_get_effective() != 1) return;   /* Moon only */
     moon_drag_end();
     if (goes_task_handle) xTaskNotifyGive(goes_task_handle);
 }
@@ -471,7 +471,7 @@ void nina_image_display_update(goes_data_t *data)
      * the caption text and bail. A successful fetch clears error_msg, so the
      * normal swap path below runs and overwrites the caption — no stale error.
      * Scoped to source 3, so GOES/Solar/Moon are visually unchanged. */
-    if (app_config_get()->image_display_source == 3 && data->error_msg[0] != '\0') {
+    if (image_source_get_effective() == 3 && data->error_msg[0] != '\0') {
         char err_copy[48];
         strlcpy(err_copy, data->error_msg, sizeof(err_copy));
         goes_data_unlock(data);
@@ -510,14 +510,24 @@ void nina_image_display_update(goes_data_t *data)
     extern uint8_t solar_band_crop_pct(uint8_t idx);
     extern bool    solar_band_text_mask(uint8_t idx, float *x0, float *y0, float *x1, float *y1);
     const app_config_t *cfg = app_config_get();
+    /* Source of the buffer CURRENTLY in goes_data, captured under the goes lock
+     * (alongside sw/sh/label_copy). Every per-source render decision below (crop,
+     * caption mask, orientation, instant-vs-crossfade, labels) keys off THIS tag,
+     * not image_source_get_effective() (intent). The two can disagree during a
+     * prefetch swap or rotation transition; keying off the buffer's own tag is the
+     * only way to guarantee, e.g., a Moon buffer is never center-cropped because a
+     * pending intent says GOES/Solar. Fall back to intent when the tag is unknown
+     * (-1: a buffer written before this field existed, or an edge case). */
+    int8_t buf_src = data->src_kind;
+    if (buf_src < 0) buf_src = image_source_get_effective();
     uint16_t w = sw, h = sh, ox = 0, oy = 0;
-    uint8_t crop_pct = (cfg->image_display_source == 2)
+    uint8_t crop_pct = (buf_src == 2)
                            ? solar_band_crop_pct(cfg->solar_band)
                            : 88;
     /* Custom Image URL (source 3) is arbitrary user content: never center-crop
      * it (treat like Moon source 1 — show the full image, width-fit). */
-    if (cfg->image_display_crop && cfg->image_display_source != 1 &&
-        cfg->image_display_source != 3 && crop_pct < 100) {
+    if (cfg->image_display_crop && buf_src != 1 &&
+        buf_src != 3 && crop_pct < 100) {
         w  = (uint16_t)((uint32_t)sw * crop_pct / 100);
         h  = (uint16_t)((uint32_t)sh * crop_pct / 100);
         ox = (uint16_t)((sw - w) / 2);
@@ -553,7 +563,7 @@ void nina_image_display_update(goes_data_t *data)
     int   mx0 = 0, mx1 = 0, my0 = 0, my1 = 0, sample_col = 0;
     /* Gate the caption mask on the same crop/clean toggle as the crop, so turning
      * the toggle off shows the raw frame (incl. burned-in timestamp). */
-    if (cfg->image_display_crop && cfg->image_display_source == 2) {
+    if (cfg->image_display_crop && buf_src == 2) {
         float fx0, fy0, fx1, fy1;
         if (solar_band_text_mask(cfg->solar_band, &fx0, &fy0, &fx1, &fy1)) {
             mask_on = true;
@@ -609,10 +619,10 @@ void nina_image_display_update(goes_data_t *data)
      * runs on the upright `copy` produced above (after vflip + caption mask).
      * orient: 0/1/2/3 = 0/90/180/270 degrees CLOCKWISE. Moon (source 1) never
      * rotates. 90/270 swap width<->height. */
-    uint8_t orient = (cfg->image_display_source == 0)   ? cfg->goes_orientation
-                     : (cfg->image_display_source == 2) ? cfg->solar_orientation
-                     : (cfg->image_display_source == 3) ? cfg->custom_orientation
-                                                        : 0;
+    uint8_t orient = (buf_src == 0)   ? cfg->goes_orientation
+                     : (buf_src == 2) ? cfg->solar_orientation
+                     : (buf_src == 3) ? cfg->custom_orientation
+                                      : 0;
     if (orient != 0) {
         uint16_t rw, rh;
         if (orient == 2) {            /* 180deg: same dims */
@@ -703,7 +713,7 @@ void nina_image_display_update(goes_data_t *data)
      * there hit the same midpoint brightness dip, reading as a visible jump as the
      * crisp resting frame faded in. Instant matches every other moon frame swap. */
     bool instant = first_image ||
-                   forced || (app_config_get()->image_display_source == 1);
+                   forced || (buf_src == 1);
     /* poll_ms == displayed_poll_ms on a forced re-crop (same cached frame), so
      * this assignment leaves displayed_poll_ms unchanged and a later real
      * download (higher last_poll_ms) still passes the new-image gate. */
@@ -746,8 +756,8 @@ void nina_image_display_update(goes_data_t *data)
         lv_anim_start(&a_out);
     }
 
-    /* cfg is already fetched above (crop check). */
-    if (cfg->image_display_source == 1) {           /* Moon */
+    /* cfg / buf_src are already fetched above (crop check). */
+    if (buf_src == 1) {                              /* Moon */
         extern void moon_caption(char *name_out, size_t name_sz,
                                  char *pct_out, size_t pct_sz);
         char name[24], pct[16];
@@ -755,7 +765,7 @@ void nina_image_display_update(goes_data_t *data)
         lv_label_set_text(lbl_region, name);
         lv_label_set_text(lbl_timestamp, pct);
         update_moon_corner_labels();
-    } else if (cfg->image_display_source == 2) {     /* Solar (SDO/AIA) */
+    } else if (buf_src == 2) {                       /* Solar (SDO/AIA) */
         lv_label_set_text(lbl_region, label_copy);
         time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);
         char ts[32]; strftime(ts, sizeof(ts), "Updated %H:%M", &ti);
@@ -986,7 +996,7 @@ void nina_image_display_set_overlay_visible(bool visible)
     /* Corner labels follow the overlay visibility, but only ever show for Moon.
      * When making visible, restore them only if we are actually on the Moon source;
      * when hiding, always hide unconditionally. */
-    if (visible && app_config_get()->image_display_source == 1) {
+    if (visible && image_source_get_effective() == 1) {
         update_moon_corner_labels();
     } else {
         hide_moon_corner_labels();

--- a/main/ui/nina_nav_arbiter.c
+++ b/main/ui/nina_nav_arbiter.c
@@ -14,6 +14,9 @@
 #include "nina_idle_indicator.h"
 #include "bsp/esp-bsp.h"
 #include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "tasks.h"   /* image_source_* override API + goes_task_handle */
 
 static const char *TAG = "nav_arb";
 
@@ -28,6 +31,10 @@ static struct {
     bool     slideshow_advance;    /* interval timer fired since last resolve */
     bool     idle_claim_active;    /* IDLE was the resolved source last commit */
     int      current_committed;    /* last page the arbiter committed */
+    int8_t   pending_img_source;       /* image source the next/desired Image Display
+                                        * stop wants (0-3), or -1 if not an image stop */
+    int8_t   current_committed_img_source; /* image source last committed to the
+                                        * Image Display page, or -1 */
 } s_arb;
 
 void nav_arbiter_init(void) {
@@ -37,6 +44,8 @@ void nav_arbiter_init(void) {
     s_arb.modal_depth = 0;
     s_arb.slideshow_advance = false;
     s_arb.idle_claim_active = false;
+    s_arb.pending_img_source = -1;
+    s_arb.current_committed_img_source = -1;
     s_arb.current_committed = nina_dashboard_get_active_page();
     ESP_LOGI(TAG, "nav arbiter init (committed page=%d)", s_arb.current_committed);
 }
@@ -44,6 +53,14 @@ void nav_arbiter_init(void) {
 void nav_arbiter_submit_user(int abs_page, int64_t now_ms) {
     s_arb.user_page = abs_page;
     s_arb.user_stamp_ms = now_ms;
+    /* Manual navigation to the Image Display page shows the persisted default
+     * source, not whatever the slideshow last set. Clear the runtime override
+     * and forget the last committed slideshow source so the commit block treats
+     * this as an image-source change and re-applies the default. */
+    if (abs_page == PAGE_IDX_IMAGE_DISPLAY) {
+        image_source_set_override(-1);
+        s_arb.current_committed_img_source = -1;
+    }
 }
 
 void nav_arbiter_notify_topology_changed(void) { s_arb.topology_dirty = true; }
@@ -144,18 +161,22 @@ static int idle_target_page(void) {
     return idx;
 }
 
-/** Slideshow advance: build the ordered candidate list from the single
- *  membership list (auto_rotate_order[0..7] + auto_rotate_order_ext), map each
- *  bit index to an absolute page, skip unavailable pages and (when configured)
- *  disconnected NINA pages, then advance from the current committed position.
- *  Returns Home Page if no page is available. */
-static int slideshow_next(void) {
+/** Build the ordered slideshow candidate list from auto_rotate_order2[0..15].
+ *  Each entry is an ARP_IDX_* bit index mapped to an absolute page; unavailable
+ *  pages and (when configured) disconnected NINA pages are skipped. For each
+ *  surviving candidate the per-stop image source (0-3 for the four Image Display
+ *  sources, else -1) is recorded in src_out[] in lockstep with cand_out[].
+ *  Returns the candidate count. Pure: reads config + connection/availability
+ *  level state only, writes no arbiter state. */
+static int slideshow_build_candidates(int cand_out[ARP_ORDER_CAPACITY],
+                                      int8_t src_out[ARP_ORDER_CAPACITY]) {
     const app_config_t *c = app_config_get();
-    int cand[9]; int n = 0;
-    for (int i = 0; i < 9; i++) {
-        uint8_t bit = (i < 8) ? c->auto_rotate_order[i] : c->auto_rotate_order_ext;
-        if (bit == 0xFF || bit > 8) continue;
+    int n = 0;
+    for (int i = 0; i < ARP_ORDER_CAPACITY; i++) {
+        uint8_t bit = c->auto_rotate_order2[i];
+        if (bit == 0xFF || bit >= ARP_IDX_MAX) continue;
         int p = -1;
+        int8_t img_src = -1;
         switch (bit) {
             case 0: p = PAGE_IDX_SUMMARY; break;
             case 1: p = nina_dashboard_slot_available(0) ? NINA_PAGE_OFFSET+0 : -1; break;
@@ -165,20 +186,61 @@ static int slideshow_next(void) {
             case 5: p = c->allsky_enabled ? PAGE_IDX_ALLSKY : -1; break;
             case 6: p = c->spotify_enabled ? PAGE_IDX_SPOTIFY : -1; break;
             case 7: p = PAGE_IDX_CLOCK; break;
-            case 8: p = c->image_display_enabled ? PAGE_IDX_IMAGE_DISPLAY : -1; break;
+            case 8: p = c->image_display_enabled ? PAGE_IDX_IMAGE_DISPLAY : -1; img_src = 0; break;
+            case 9: p = c->image_display_enabled ? PAGE_IDX_IMAGE_DISPLAY : -1; img_src = 1; break;
+            case 10: p = c->image_display_enabled ? PAGE_IDX_IMAGE_DISPLAY : -1; img_src = 2; break;
+            case 11: {
+                if (c->image_display_enabled && c->custom_image_url[0] != '\0') {
+                    p = PAGE_IDX_IMAGE_DISPLAY;
+                    img_src = 3;
+                } else {
+                    p = -1;
+                }
+                break;
+            }
         }
         if (p < 0 || !nina_dashboard_page_is_available(p)) continue;
         int inst = p - NINA_PAGE_OFFSET;
         if (inst >= 0 && inst < MAX_NINA_INSTANCES
             && c->auto_rotate_skip_disconnected
             && !nina_connection_is_connected(inst)) continue;
-        cand[n++] = p;
+        src_out[n] = img_src;
+        cand_out[n] = p;
+        n++;
     }
-    if (n == 0) return home_page();
-    /* advance from current committed position */
+    return n;
+}
+
+/** Resolve the slideshow stop that follows `from_page` in the candidate order.
+ *  Writes the chosen stop's image source (0-3, or -1) to *img_src_out.
+ *  Returns Home Page (with *img_src_out = -1) if no candidate is available.
+ *  Pure: does not mutate arbiter state, so it serves both the real advance and
+ *  the prefetch lookahead peek. */
+static int slideshow_advance_from(int from_page, int8_t from_img_src, int8_t *img_src_out) {
+    int cand[ARP_ORDER_CAPACITY];
+    int8_t src[ARP_ORDER_CAPACITY];
+    int n = slideshow_build_candidates(cand, src);
+    if (n == 0) {
+        *img_src_out = -1;
+        return home_page();
+    }
     int cur = -1;
-    for (int i = 0; i < n; i++) if (cand[i] == s_arb.current_committed) { cur = i; break; }
-    return cand[(cur + 1) % n];
+    for (int i = 0; i < n; i++) {
+        if (cand[i] == from_page && src[i] == from_img_src) { cur = i; break; }
+    }
+    int next = (cur + 1) % n;
+    *img_src_out = src[next];
+    return cand[next];
+}
+
+/** Slideshow advance from the current committed position. Records the chosen
+ *  stop's image source in s_arb.pending_img_source. Returns Home Page if no
+ *  page is available. */
+static int slideshow_next(void) {
+    int8_t img_src = -1;
+    int p = slideshow_advance_from(s_arb.current_committed, s_arb.current_committed_img_source, &img_src);
+    s_arb.pending_img_source = img_src;
+    return p;
 }
 
 void nav_arbiter_resolve(int64_t now_ms) {
@@ -206,6 +268,11 @@ void nav_arbiter_resolve(int64_t now_ms) {
     /* Tie-break: auto-rotate wins if both flags are somehow set. */
     bool auto_rotate = c->auto_rotate_enabled;
 
+    /* Default: no slideshow image source for this resolve. Only slideshow_next()
+     * sets a concrete 0-3 source; every other rung leaves the override cleared so
+     * a non-slideshow arrival at the image page shows the persisted default. */
+    s_arb.pending_img_source = -1;
+
     if (user_active) {
         desired = s_arb.user_page; src = NAV_SRC_USER;
     } else if (auto_rotate) {
@@ -214,6 +281,9 @@ void nav_arbiter_resolve(int64_t now_ms) {
             desired = slideshow_next();
         } else {
             desired = s_arb.current_committed;   /* hold between intervals */
+            /* Hold the committed source too, so img_src_changed stays false and
+             * we do not spuriously re-commit / clear the override mid-dwell. */
+            s_arb.pending_img_source = s_arb.current_committed_img_source;
         }
         src = NAV_SRC_SLIDESHOW;
     } else {
@@ -242,13 +312,38 @@ void nav_arbiter_resolve(int64_t now_ms) {
      * Mark the page committed ONLY on a successful lock+switch; a lock timeout
      * leaves current_committed unchanged so the next resolve retries (otherwise
      * desired==current_committed would suppress the retry forever). */
-    if (desired != s_arb.current_committed) {
+    bool img_src_changed = (desired == PAGE_IDX_IMAGE_DISPLAY)
+        && (s_arb.pending_img_source != s_arb.current_committed_img_source);
+
+    if (desired != s_arb.current_committed || img_src_changed) {
         int effect = (src == NAV_SRC_SLIDESHOW) ? c->auto_rotate_effect : 0;
+        /* Apply the runtime image-source override BEFORE switching the page so
+         * the Image Display page fetches/renders the right source. pending is -1
+         * for non-image stops, which clears the override (persisted default). */
+        image_source_set_override(s_arb.pending_img_source);
+        if (desired == PAGE_IDX_IMAGE_DISPLAY && goes_task_handle) {
+            xTaskNotifyGive(goes_task_handle);   /* wake fetch for new source */
+        }
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             nina_dashboard_show_page_animated(desired, 0, effect);
             bsp_display_unlock();
             s_arb.current_committed = desired;
-            ESP_LOGI(TAG, "commit page=%d src=%d", desired, (int)src);
+            s_arb.current_committed_img_source = s_arb.pending_img_source;
+            ESP_LOGI(TAG, "commit page=%d src=%d img_src=%d",
+                     desired, (int)src, (int)s_arb.pending_img_source);
+
+            /* Prefetch lookahead (schedule only; fetch/swap is Phase 4). After
+             * committing an image stop during a slideshow, peek the source the
+             * NEXT advance would select WITHOUT mutating arbiter state, and ask
+             * the goes task to warm it. next_src is 0-3 for an image stop, else
+             * -1 (non-image next stop => nothing to prefetch). */
+            if (src == NAV_SRC_SLIDESHOW && desired == PAGE_IDX_IMAGE_DISPLAY) {
+                int8_t next_src = -1;
+                (void)slideshow_advance_from(s_arb.current_committed, s_arb.current_committed_img_source, &next_src);
+                if (next_src >= 0) {
+                    image_source_trigger_prefetch(next_src);
+                }
+            }
         }
     }
 }

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -102,6 +102,18 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
         }
         cJSON_AddItemToObject(obj, "auto_rotate_order", order_arr);
     }
+    {
+        /* New flat slideshow list: 16 ARP_IDX_* slots, 0xFF terminates/skips. */
+        cJSON *order2_arr = cJSON_CreateArray();
+        for (int i = 0; i < ARP_ORDER_CAPACITY; i++) {
+            uint8_t v = cfg->auto_rotate_order2[i];
+            if (v == 0xFF) {
+                continue;   /* unused slot */
+            }
+            cJSON_AddItemToArray(order2_arr, cJSON_CreateNumber(v));
+        }
+        cJSON_AddItemToObject(obj, "auto_rotate_order2", order2_arr);
+    }
     cJSON_AddNumberToObject(obj, "update_rate_s", cfg->update_rate_s);
     cJSON_AddNumberToObject(obj, "graph_update_interval_s", cfg->graph_update_interval_s);
     cJSON_AddNumberToObject(obj, "connection_timeout_s", cfg->connection_timeout_s);
@@ -980,6 +992,27 @@ static app_config_t *parse_config_from_json(cJSON *root)
             cfg->auto_rotate_order[i] = 0xFF;
         }
         if (count < 9) cfg->auto_rotate_order_ext = 0xFF;
+    }
+
+    /* New flat slideshow list: 16 ARP_IDX_* slots. When present it is the
+     * authoritative source for auto_rotate_order2[]; the legacy parse above
+     * still populates the deprecated auto_rotate_order[] harmlessly. */
+    cJSON *order2_arr = cJSON_GetObjectItem(root, "auto_rotate_order2");
+    if (cJSON_IsArray(order2_arr)) {
+        int count2 = cJSON_GetArraySize(order2_arr);
+        if (count2 > ARP_ORDER_CAPACITY) count2 = ARP_ORDER_CAPACITY;
+        for (int i = 0; i < count2; i++) {
+            cJSON *item2 = cJSON_GetArrayItem(order2_arr, i);
+            uint8_t v = 0xFF;
+            if (cJSON_IsNumber(item2) &&
+                item2->valueint >= 0 && item2->valueint < ARP_IDX_MAX) {
+                v = (uint8_t)item2->valueint;
+            }
+            cfg->auto_rotate_order2[i] = v;
+        }
+        for (int i = count2; i < ARP_ORDER_CAPACITY; i++) {
+            cfg->auto_rotate_order2[i] = 0xFF;
+        }
     }
 
     cJSON *ur_item = cJSON_GetObjectItem(root, "update_rate_s");


### PR DESCRIPTION
### Summary
Users can now configure each image source (GOES, Moon, Solar, Custom) as a distinct stop in the auto-rotation sequence, allowing for more varied slideshows. The update also corrects solar image orientation and prevents incorrect cropping of Moon images.

### Changes
*   The device configuration now supports individual image sources (GOES, Moon, Solar, Custom) as distinct entries in the auto-rotation order.
*   The slideshow rotation logic cycles through each configured image source independently, rather than a single generic "Image Display" entry.
*   A runtime mechanism temporarily overrides the image source during rotation, ensuring the user's default image display setting remains unchanged.
*   The next image in the rotation sequence is pre-fetched in the background, making transitions between images smoother.
*   The web configuration interface now displays separate pills for each image source (e.g., "Img: GOES", "Img: Moon") in the rotation order list, giving users granular control.
*   Solar images are no longer vertically flipped, ensuring they display with the correct orientation.
*   Image buffers are tagged with their source type, preventing incorrect rendering operations like cropping from being applied to Moon images.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-27T03:20:31.733Z | Generated by GitHub Actions</sub>