### PR TITLE
feat: add navigation pin to suspend auto-rotate

### DIFF
--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -2978,6 +2978,32 @@
           <p class="api-purpose" style="margin-top:8px">The response may include "error_msg" carrying the reason of the last completed fetch failure.</p>
         </div>
 
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/nav/pin</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Pin the displayed page. While pinned, all automatic page changes are suspended (auto-rotate, session auto-follow, idle, and default re-home) and the current page is held until cleared. Manual navigation still works while pinned, and the chosen page persists. The pin is in-memory only and resets on reboot. It does not change the auto-rotate setting, it only suspends it while active.</p>
+          <div class="api-note">
+            Query parameters: <code>on</code> = 1 to pin, 0 to clear (required). Optional <code>id</code> = a page id from /api/pages to navigate to that page and pin it in one call.
+          </div>
+          <div class="api-snip-label">Request (pin current page)</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=1'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=1'</pre>
+          </div>
+          <div class="api-snip-label">Request (go to a page by id and pin)</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=1&amp;id=7'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=1&amp;id=7'</pre>
+          </div>
+          <div class="api-snip-label">Request (clear, resume automation)</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=0'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=0'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"pinned":true}</pre></div>
+          <p class="api-purpose" style="margin-top:8px">The same state is exposed as the <code>nav_pinned</code> Control item: GET /api/control/get?name=nav_pinned returns {"name":"nav_pinned","type":"bool","value":false,"label":"Off",...}. Toggle or set it like any bool (for example toggle?name=nav_pinned), so a macro key can show Pinned or Auto (On or Off) and flip it. The pin overrides auto-rotate while active.</p>
+        </div>
+
         <div class="api-note">
           <strong>Behavior notes.</strong> cycle wraps from max to min; set and adjust clamp to the range; toggle works on bool items only. The special item name <code>page</code> controls the current page and is the one item that navigates rather than saving config: cycle moves to the next available page, and set selects a page by id. Item names match the config field names used elsewhere in this documentation.
         </div>

--- a/main/control_registry.c
+++ b/main/control_registry.c
@@ -18,7 +18,7 @@
 #include "ui/nina_dashboard.h"      /* nina_dashboard_apply_theme, get_active_page */
 #include "ui/nina_dashboard_internal.h" /* PAGE_IDX_IMAGE_DISPLAY */
 #include "ui/nina_image_display.h"  /* image_display_apply_live */
-#include "ui/nina_nav_arbiter.h"    /* nav_arbiter_notify_topology_changed */
+#include "ui/nina_nav_arbiter.h"    /* nav_arbiter_notify_topology_changed, nav_arbiter_is_pinned */
 #include "ui/page_registry.h"       /* page_ref_*, PAGE_REF_* */
 
 /* ===================================================================== */
@@ -63,6 +63,14 @@ static int get_page(const control_item_t *it, const app_config_t *c)
     (void)it;
     (void)c;
     return control_page_current_id();
+}
+
+/* PIN item get — live navigation-pin state (non-config; cfg ignored). */
+static int get_nav_pinned(const control_item_t *it, const app_config_t *c)
+{
+    (void)it;
+    (void)c;
+    return nav_arbiter_is_pinned() ? 1 : 0;
 }
 
 /* ===================================================================== */
@@ -224,6 +232,12 @@ static const control_item_t s_items[] = {
      * (resolves to PAGE_REF_ID_MAX-1). The handler performs set/cycle specially
      * via control_page_set_by_id() / control_page_cycle_next(). */
     { "page",                         CTRL_TYPE_PAGE, 0, -1, 1, NULL, 0, get_page,                         NULL,                             NULL },
+
+    /* ---- Special: navigation pin (NON-CONFIG; arbiter-backed bool) ----
+     * Reported as a bool with On/Off labels. Does not snapshot/save: the handler
+     * special-cases it (like the page item) and drives nav_arbiter_set_pin().
+     * set=NULL, apply=NULL; get returns the live arbiter pin state. */
+    { "nav_pinned",                   CTRL_TYPE_PIN,  0, 1, 1, NULL, 0, get_nav_pinned,                   NULL,                             NULL },
 };
 
 #undef LBL
@@ -287,7 +301,7 @@ const char *control_item_label(const control_item_t *item, int value)
     if (!item) {
         return NULL;
     }
-    if (item->type == CTRL_TYPE_BOOL) {
+    if (item->type == CTRL_TYPE_BOOL || item->type == CTRL_TYPE_PIN) {
         return value ? "On" : "Off";
     }
     if (strcmp(item->name, "theme") == 0) {

--- a/main/control_registry.h
+++ b/main/control_registry.h
@@ -22,6 +22,7 @@ typedef enum {
     CTRL_TYPE_ENUM = 1,
     CTRL_TYPE_INT  = 2,
     CTRL_TYPE_PAGE = 3,   /* special non-config item: current page */
+    CTRL_TYPE_PIN  = 4,   /* special non-config bool: navigation pin (arbiter) */
 } ctrl_type_t;
 
 typedef struct control_item control_item_t;

--- a/main/ui/nina_nav_arbiter.c
+++ b/main/ui/nina_nav_arbiter.c
@@ -41,6 +41,11 @@ static struct {
                                         * stop wants (0-3), or -1 if not an image stop */
     int8_t   current_committed_img_source; /* image source last committed to the
                                         * Image Display page, or -1 */
+    _Atomic bool pinned;           /* in-memory navigation pin: hold the USER page,
+                                    * skip the automatic ladder; resets on reboot.
+                                    * Atomic: written by the web/LVGL task
+                                    * (set_pin), read by the data task (resolve),
+                                    * mirroring user_stamp_ms's cross-core guard. */
 } s_arb;
 
 void nav_arbiter_init(void) {
@@ -54,6 +59,7 @@ void nav_arbiter_init(void) {
     s_arb.idle_claim_active = false;
     s_arb.pending_img_source = -1;
     s_arb.current_committed_img_source = -1;
+    s_arb.pinned = false;
     s_arb.current_committed = nina_dashboard_get_active_page();
     ESP_LOGI(TAG, "nav arbiter init (committed page=%d)", s_arb.current_committed);
 }
@@ -93,6 +99,31 @@ void nav_arbiter_notify_modal_close(int64_t now_ms) {
 void nav_arbiter_notify_slideshow_tick(void) { s_arb.slideshow_advance = true; }
 
 bool nav_arbiter_idle_active(void) { return s_arb.idle_claim_active; }
+
+void nav_arbiter_set_pin(bool on, int abs_page, int8_t img_src, int64_t now_ms) {
+    if (on) {
+        s_arb.pinned = true;
+        if (abs_page >= 0) {
+            s_arb.user_page = abs_page;
+            s_arb.user_img_source = img_src;
+        } else if (s_arb.user_page < 0) {
+            s_arb.user_page = s_arb.current_committed;
+            s_arb.user_img_source = s_arb.current_committed_img_source;
+        }
+    } else {
+        s_arb.pinned = false;
+        /* Restamp grace so the current page holds for nav_grace_s before the
+         * automatic ladder resumes (no jarring instant jump). */
+        s_arb.user_stamp_ms = now_ms;
+    }
+    /* Wake the data task so the arbiter re-resolves promptly (mirrors
+     * nav_arbiter_submit_user's wake). */
+    if (data_task_handle) {
+        xTaskNotifyGive(data_task_handle);
+    }
+}
+
+bool nav_arbiter_is_pinned(void) { return s_arb.pinned; }
 
 /* ── Ladder helpers (Task 3.2) ──
  *
@@ -321,7 +352,19 @@ void nav_arbiter_resolve(int64_t now_ms) {
      * a non-slideshow arrival at the image page shows the persisted default. */
     s_arb.pending_img_source = -1;
 
-    if (user_active) {
+    if (s_arb.pinned) {
+        /* PIN rung: hold the USER selection with no grace expiry; slideshow,
+         * session, idle, and default are all skipped. Manual navigation while
+         * pinned updates s_arb.user_page via nav_arbiter_submit_user(), so the
+         * held page follows manual nav and persists until the pin is cleared. */
+        if (s_arb.user_page < 0) {
+            s_arb.user_page = s_arb.current_committed;
+            s_arb.user_img_source = s_arb.current_committed_img_source;
+        }
+        desired = s_arb.user_page;
+        src = NAV_SRC_USER;
+        s_arb.pending_img_source = s_arb.user_img_source;
+    } else if (user_active) {
         desired = s_arb.user_page; src = NAV_SRC_USER;
         /* Pin the user's chosen image source (0-3) so the commit block does not
          * clobber the override back to the persisted default. -1 for non-image

--- a/main/ui/nina_nav_arbiter.h
+++ b/main/ui/nina_nav_arbiter.h
@@ -63,6 +63,21 @@ void nav_arbiter_resolve(int64_t now_ms);
 /** True while the IDLE claim is the resolved source (for the idle indicator). */
 bool nav_arbiter_idle_active(void);
 
+/** Set or clear the in-memory navigation pin. While pinned, the arbiter holds
+ *  the USER-selected page and skips slideshow/session/idle/default with no grace
+ *  expiry. RUNTIME ONLY: resets to off on reboot.
+ *  on=true:  pin on. If abs_page >= 0 the pin holds that page (with img_src as
+ *            the Image Display source, 0-3 or -1); otherwise it holds whatever
+ *            page is currently shown.
+ *  on=false: pin off; the current page is restamped into the USER grace window
+ *            so it holds for nav_grace_s before the automatic ladder resumes.
+ *  Either way the data task is woken so resolve() runs promptly. now_ms is the
+ *  caller's monotonic millisecond clock. */
+void nav_arbiter_set_pin(bool on, int abs_page, int8_t img_src, int64_t now_ms);
+
+/** True if the navigation pin is currently engaged. */
+bool nav_arbiter_is_pinned(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/web_handlers_control.c
+++ b/main/web_handlers_control.c
@@ -16,10 +16,12 @@
 
 #include "web_server_internal.h"
 #include "control_registry.h"
+#include "ui/nina_nav_arbiter.h"   /* nav_arbiter_set_pin / nav_arbiter_is_pinned */
 #include "cJSON.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
+#include "esp_timer.h"             /* esp_timer_get_time */
 #include <string.h>
 #include <strings.h>   /* strcasecmp */
 #include <stdlib.h>
@@ -67,11 +69,12 @@ static cJSON *control_item_to_json(const control_item_t *it,
     cJSON_AddStringToObject(o, "name", it->name);
 
     const char *type_str = (it->type == CTRL_TYPE_BOOL) ? "bool" :
+                           (it->type == CTRL_TYPE_PIN)  ? "bool" :
                            (it->type == CTRL_TYPE_INT)  ? "int"  :
                            (it->type == CTRL_TYPE_PAGE) ? "enum" : "enum";
     cJSON_AddStringToObject(o, "type", type_str);
 
-    if (it->type == CTRL_TYPE_BOOL) {
+    if (it->type == CTRL_TYPE_BOOL || it->type == CTRL_TYPE_PIN) {
         cJSON_AddBoolToObject(o, "value", v != 0);
     } else {
         cJSON_AddNumberToObject(o, "value", v);
@@ -251,6 +254,12 @@ esp_err_t control_toggle_post_handler(httpd_req_t *req)
     if (!it) {
         return send_400(req, "unknown name");
     }
+    if (it->type == CTRL_TYPE_PIN) {
+        /* Non-config: flip the navigation pin via the arbiter (no snapshot/save). */
+        nav_arbiter_set_pin(!nav_arbiter_is_pinned(), -1, -1,
+                            esp_timer_get_time() / 1000);
+        return send_item(req, it);
+    }
     if (it->type != CTRL_TYPE_BOOL) {
         return send_400(req, "toggle requires a bool item");
     }
@@ -307,7 +316,7 @@ esp_err_t control_set_post_handler(httpd_req_t *req)
     }
 
     int target;
-    if (it->type == CTRL_TYPE_BOOL) {
+    if (it->type == CTRL_TYPE_BOOL || it->type == CTRL_TYPE_PIN) {
         if (strcasecmp(valuebuf, "true") == 0) {
             target = 1;
         } else if (strcasecmp(valuebuf, "false") == 0) {
@@ -317,6 +326,12 @@ esp_err_t control_set_post_handler(httpd_req_t *req)
         }
     } else {
         target = ctrl_parse_int(valuebuf);
+    }
+
+    if (it->type == CTRL_TYPE_PIN) {
+        /* Non-config: drive the navigation pin via the arbiter (no snapshot/save). */
+        nav_arbiter_set_pin(target != 0, -1, -1, esp_timer_get_time() / 1000);
+        return send_item(req, it);
     }
 
     if (it->type == CTRL_TYPE_PAGE) {
@@ -352,6 +367,9 @@ esp_err_t control_adjust_post_handler(httpd_req_t *req)
     }
     if (it->type == CTRL_TYPE_BOOL) {
         return send_400(req, "adjust not supported for bool");
+    }
+    if (it->type == CTRL_TYPE_PIN) {
+        return send_400(req, "adjust not supported for nav_pinned");
     }
 
     int delta = ctrl_parse_int(deltabuf);

--- a/main/web_handlers_pages.c
+++ b/main/web_handlers_pages.c
@@ -1,9 +1,12 @@
 #include "web_server_internal.h"
 #include "ui/page_registry.h"
+#include "ui/nina_nav_arbiter.h"
 #include "cJSON.h"
 #include "esp_http_server.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include <string.h>
+#include <strings.h>   /* strcasecmp */
 #include <stdlib.h>
 
 static const char *PAGES_TAG __attribute__((unused)) = "web_pages";
@@ -114,5 +117,75 @@ esp_err_t navigate_post_handler(httpd_req_t *req)
 
     page_ref_navigate(entry->id);
     httpd_resp_sendstr(req, "OK");
+    return ESP_OK;
+}
+
+/* POST /api/nav/pin?on=<1|0|true|false>[&id=<page_ref id>]
+ * Engage or release the in-memory navigation pin. While pinned the arbiter holds
+ * the selected page and suspends all automatic page changes. RUNTIME ONLY: the
+ * pin resets to off on reboot (no config field). Optional id selects the page to
+ * pin (resolved via page_ref_navigate); omitted pins the current page. */
+esp_err_t nav_pin_post_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    char qbuf[160] = {0};
+    char onbuf[16] = {0};
+    char idbuf[16] = {0};
+    bool have_on = false;
+    bool have_id = false;
+
+    if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+        if (httpd_query_key_value(qbuf, "on", onbuf, sizeof(onbuf)) == ESP_OK &&
+            onbuf[0] != '\0') {
+            have_on = true;
+        }
+        if (httpd_query_key_value(qbuf, "id", idbuf, sizeof(idbuf)) == ESP_OK &&
+            idbuf[0] != '\0') {
+            have_id = true;
+        }
+    }
+
+    if (!have_on) {
+        return send_400(req, "missing on");
+    }
+
+    bool on;
+    if (strcasecmp(onbuf, "true") == 0 || strcmp(onbuf, "1") == 0) {
+        on = true;
+    } else if (strcasecmp(onbuf, "false") == 0 || strcmp(onbuf, "0") == 0) {
+        on = false;
+    } else {
+        return send_400(req, "invalid on");
+    }
+
+    int64_t now_ms = esp_timer_get_time() / 1000;
+
+    if (on) {
+        if (have_id) {
+            /* Bounds-checked parse: reject non-numeric (endptr) and out-of-range
+             * ids before casting to page_ref_t. Mirrors ctrl_parse_int's strtol
+             * style; atoi() would treat garbage as 0 and is UB on overflow. */
+            char *end = NULL;
+            long idv = strtol(idbuf, &end, 10);
+            if (end == idbuf || *end != '\0' || idv < 0 ||
+                idv >= (long)PAGE_REF_ID_MAX) {
+                return send_400(req, "invalid id");
+            }
+            /* Move the USER selection to the requested page first, then pin it. */
+            if (!page_ref_navigate((page_ref_t)idv)) {
+                return send_400(req, "page not available");
+            }
+        }
+        nav_arbiter_set_pin(true, -1, -1, now_ms);
+    } else {
+        nav_arbiter_set_pin(false, -1, -1, now_ms);
+    }
+
+    char resp[24];
+    snprintf(resp, sizeof(resp), "{\"pinned\":%s}",
+             nav_arbiter_is_pinned() ? "true" : "false");
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_sendstr(req, resp);
     return ESP_OK;
 }

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -236,7 +236,7 @@ void start_web_server(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.stack_size = 16384;
-    config.max_uri_handlers = 68;
+    config.max_uri_handlers = 69;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -312,6 +312,7 @@ void start_web_server(void)
         { "/api/pages",              HTTP_GET,  pages_get_handler,     NULL },
         { "/api/navigate",           HTTP_GET,  navigate_post_handler, NULL },
         { "/api/navigate",           HTTP_POST, navigate_post_handler, NULL },
+        { "/api/nav/pin",            HTTP_POST, nav_pin_post_handler,  NULL },
         { "/api/control/list",       HTTP_GET,  control_list_get_handler,    NULL },
         { "/api/control/get",        HTTP_GET,  control_get_get_handler,     NULL },
         { "/api/control/toggle",     HTTP_POST, control_toggle_post_handler, NULL },
@@ -321,10 +322,10 @@ void start_web_server(void)
         { "/api/image-display/refresh", HTTP_POST, image_display_refresh_post_handler, NULL },
     };
 
-    /* Keep config.max_uri_handlers (set to 68 above) in sync with the route
+    /* Keep config.max_uri_handlers (set to 69 above) in sync with the route
      * table; a route that overflows it would be silently dropped at
      * registration. Bump both together when adding routes. */
-    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 68,
+    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 69,
                    "max_uri_handlers too small for route table");
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -115,6 +115,7 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req);
 esp_err_t image_display_refresh_post_handler(httpd_req_t *req);
 esp_err_t pages_get_handler(httpd_req_t *req);
 esp_err_t navigate_post_handler(httpd_req_t *req);
+esp_err_t nav_pin_post_handler(httpd_req_t *req);
 esp_err_t control_list_get_handler(httpd_req_t *req);
 esp_err_t control_get_get_handler(httpd_req_t *req);
 esp_err_t control_toggle_post_handler(httpd_req_t *req);


### PR DESCRIPTION
### Summary
A new navigation pin feature allows users to hold the current page, preventing automatic page changes from auto-rotate, session follow, or idle timeouts. This provides manual control over the displayed content while automation is suspended.

### Changes
*   Add a new `/api/nav/pin` endpoint to enable or disable a navigation pin, which can also navigate to a specific page.
*   Introduce a `nav_pinned` control item for toggling the navigation pin and reading its current state.
*   Update the navigation arbiter to prioritize the navigation pin, suspending automatic page changes like auto-rotate, session follow, and idle timeouts.
*   Modify page cycling to be stateful, ensuring pages advance reliably based on the last issued target.
*   Increase the maximum number of supported URI handlers from 68 to 69.
*   Document the new navigation pin API within the web UI's API tab.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-28T00:53:02.694Z | Generated by GitHub Actions</sub>