### PR TITLE
perf: speed up web UI load and fix settings tab flash

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,7 +2,7 @@ set(LV_DEMO_DIR ../managed_components/lvgl__lvgl/demos)
 file(GLOB_RECURSE LV_DEMOS_SOURCES ${LV_DEMO_DIR}/*.c)
 
 idf_component_register(
-    SRCS main.c tasks.c axi_qos.c power_mgmt.c jpeg_utils.c stb_image.c perf_monitor.c ota_github.c
+    SRCS main.c tasks.c axi_qos.c power_mgmt.c jpeg_utils.c stb_image.c image_red_remap.c perf_monitor.c ota_github.c
          nina_connection.c nina_client.c nina_api_fetchers.c nina_sequence.c nina_websocket.c
          allsky_client.c goes_client.c weather_client.c moon_ephemeris.c moon_render.c moon_sphere.cpp moon_interaction.c spotify_auth.c spotify_client.c demo_data.c
          app_config.c control_registry.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_image_display.c web_handlers_pages.c web_handlers_control.c web_handlers_auth.c web_handlers_wifi.c web_handlers_logs.c log_capture.c crash_log.c mqtt_ha.c

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -808,13 +808,13 @@
 
     /* === WIFI SCAN PANEL === */
     .wifi-scan-panel{border:1px solid rgba(var(--accent-rgb),0.25);border-radius:10px;padding:14px;margin-bottom:18px;background:rgba(var(--accent-rgb),0.04)}
-    .wifi-scan-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;cursor:pointer}
+    .wifi-scan-header{display:flex;justify-content:space-between;align-items:center;margin-bottom:0;cursor:pointer}
     .wifi-scan-title{color:var(--accent);font-weight:600;font-size:0.82rem;display:flex;align-items:center;gap:6px}
     .wifi-scan-title .chevron{transition:transform 0.2s;display:inline-block}
     .wifi-scan-title .chevron.collapsed{transform:rotate(-90deg)}
     .wifi-scan-rescan{color:var(--accent);font-size:0.72rem;cursor:pointer;border:1px solid rgba(var(--accent-rgb),0.35);padding:3px 10px;border-radius:5px;background:rgba(var(--accent-rgb),0.08);transition:background 0.2s}
     .wifi-scan-rescan:hover{background:rgba(var(--accent-rgb),0.15)}
-    .wifi-scan-list{overflow:hidden;transition:max-height 0.3s ease,opacity 0.3s ease;max-height:500px;opacity:1}
+    .wifi-scan-list{overflow:hidden;transition:max-height 0.3s ease,opacity 0.3s ease;max-height:500px;opacity:1;margin-top:10px}
     .wifi-scan-list.collapsed{max-height:0;opacity:0;margin:0}
     .wifi-scan-row{padding:10px 12px;border-radius:8px;background:rgba(255,255,255,0.06);margin-bottom:4px;display:flex;justify-content:space-between;align-items:center;transition:background 0.15s}
     .wifi-scan-row:hover{background:rgba(255,255,255,0.1)}
@@ -884,7 +884,7 @@
   <!-- ======== BOTTOM NAVIGATION (MOBILE) ======== -->
   <nav class="bottom-nav">
     <div class="nav-items" id="bottomTabs">
-      <button class="nav-btn active" data-tab="nodes">
+      <button class="nav-btn" data-tab="nodes">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
         N.I.N.A.
       </button>
@@ -1810,10 +1810,10 @@
         <div class="help-popover"><div class="help-popover-title">Network and time</div><p>The device connects to your WiFi and also broadcasts its own setup WiFi network at the same time. It joins one of the three configured networks to reach your NINA computers; its own setup network uses the device hostname as the network name with password 12345678, so you can reach the settings for first-time setup without a separate screen. The three networks are priority-ordered: Network 1 is tried first, then 2, then 3.</p><p>Hostname is used on your network, as the setup network name, and as the Home Assistant device name. NTP server and timezone set the clock used on the clock page and in timestamps; the timezone list carries the correct local-time and daylight-saving rules.</p><p>Example: hostname ninadash1 produces access point SSID ninadash1 and the device is reachable at ninadash1.lan. Changes here take effect after a reboot.</p></div>
         <div class="wifi-scan-panel" id="wifiScanPanel">
           <div class="wifi-scan-header" onclick="toggleScanPanel()">
-            <span class="wifi-scan-title"><span class="chevron" id="scanChevron">&#x25BC;</span> Available Networks</span>
+            <span class="wifi-scan-title"><span class="chevron collapsed" id="scanChevron">&#x25BC;</span> Available Networks</span>
             <span class="wifi-scan-rescan" id="scanRescanBtn" onclick="event.stopPropagation();scanWifi()">&#x21bb; Rescan</span>
           </div>
-          <div class="wifi-scan-list" id="wifiScanList">
+          <div class="wifi-scan-list collapsed" id="wifiScanList">
             <div class="wifi-scan-status" id="wifiScanStatus">Scanning for networks...</div>
           </div>
         </div>
@@ -3044,6 +3044,21 @@
   </div>
 
   <script>
+    /* Early tab restore: apply the saved tab's active class at parse time so the
+       first paint shows the correct tab (no nodes-first flash). Matches the class
+       names switchTab() toggles ('active' on .tab-panel + [data-tab]). The later
+       switchTab(saved) call is then a visual no-op but still runs per-tab handlers. */
+    (function(){
+      var name='nodes';
+      try{var s=localStorage.getItem('nina_tab');if(s&&document.getElementById('tab-'+s))name=s;}catch(e){}
+      var p=document.getElementById('tab-'+name);
+      if(p)p.classList.add('active');
+      var btns=document.querySelectorAll('[data-tab="'+name+'"]');
+      for(var i=0;i<btns.length;i++)btns[i].classList.add('active');
+    })();
+  </script>
+
+  <script>
     /* ============================================================
        NINA Display — Config UI JavaScript
        Tab IDs: display | nodes | behavior | system
@@ -3059,14 +3074,19 @@
        "no connections" target dropdown are built from this list so their
        values are page-registry numeric ids. */
     var _pageRegistry=[];
+    var _pageRegistryPromise=null;
     function fetchPageRegistry(){
-      return fetch('/api/pages').then(function(r){
+      /* Promise-cached so it can be kicked off at init (in parallel with
+         /api/config) and re-awaited by populateConfig without a second fetch. */
+      if(_pageRegistryPromise) return _pageRegistryPromise;
+      _pageRegistryPromise=fetch('/api/pages').then(function(r){
         return r.ok?r.json():[];
       }).then(function(j){
         _pageRegistry=Array.isArray(j)?j:[];
       }).catch(function(){
         _pageRegistry=[];
       });
+      return _pageRegistryPromise;
     }
     /* Pages the user may target as a Home Page or idle page. */
     function targetablePages(){
@@ -4116,6 +4136,7 @@
     }
 
     function scanWifi(){
+      window._wifiScanned=true;
       var list=$('wifiScanList');
       var status=$('wifiScanStatus');
       list.classList.remove('collapsed');
@@ -4202,11 +4223,16 @@
       var chev=$('scanChevron');
       list.classList.toggle('collapsed');
       chev.classList.toggle('collapsed');
+      /* Scan lazily on the first unfurl of "Available Networks" (the ~4.7s scan
+         is no longer fired on page load). Manual Rescan still works regardless. */
+      if(!list.classList.contains('collapsed') && !window._wifiScanned && typeof scanWifi==='function') scanWifi();
     }
 
     function loadConfig(){
-      fetch('/api/config').then(r=>r.json()).then(populateConfig).catch(e=>console.error('Failed to load config',e));
-      scanWifi();
+      /* Returns the chain so init can defer heavy startup work after populate.
+         scanWifi() is no longer fired here; it runs lazily on first unfurl of the
+         "Available Networks" panel. */
+      return fetch('/api/config').then(r=>r.json()).then(populateConfig).catch(e=>console.error('Failed to load config',e));
     }
 
     /* === Version Load === */
@@ -6009,11 +6035,21 @@
 
     /* === Init === */
     populateTimezones();
-    loadConfig();
-    loadVersion();
-    checkUpdateBadge();
-    refreshNavMetrics();
-    setInterval(refreshNavMetrics, 5000);
+    /* Start /api/pages at t=0 in parallel with /api/config; populateConfig
+       awaits this same cached promise instead of starting it after config. */
+    fetchPageRegistry();
+    /* Defer version load and the 5s status poller until after config is populated,
+       so they don't fire onto the device's few httpd workers mid-load. The GitHub
+       update check (~7s) runs once in the background, lightly delayed, after that
+       work so the badge populates on every tab without opening System. */
+    loadConfig().then(function(){
+      loadVersion();
+      refreshNavMetrics();
+      setInterval(refreshNavMetrics, 5000);
+      setTimeout(function(){
+        if(!window._updateChecked && typeof checkUpdateBadge==='function'){ window._updateChecked=true; checkUpdateBadge(); }
+      }, 1500);
+    });
   </script>
 </body>
 </html>

--- a/main/image_red_remap.c
+++ b/main/image_red_remap.c
@@ -1,0 +1,39 @@
+#include "image_red_remap.h"
+#include "ui/nina_dashboard.h"
+#include "ui/themes.h"
+
+bool image_red_remap_active(void)
+{
+    const theme_t *t = nina_dashboard_get_theme();
+    if (t == NULL) {
+        return false;
+    }
+    return theme_is_red_night(t);
+}
+
+void image_red_remap_rgb565(uint16_t *buf, size_t px_count)
+{
+    if (!image_red_remap_active()) {
+        return;
+    }
+    image_red_remap_rgb565_force(buf, px_count);
+}
+
+void image_red_remap_rgb565_force(uint16_t *buf, size_t px_count)
+{
+    if (buf == NULL || px_count == 0) {
+        return;
+    }
+    for (size_t i = 0; i < px_count; i++) {
+        uint16_t px = buf[i];
+        uint8_t r5 = (uint8_t)((px >> 11) & 0x1f);
+        uint8_t g6 = (uint8_t)((px >> 5) & 0x3f);
+        uint8_t b5 = (uint8_t)(px & 0x1f);
+        uint8_t r8 = (uint8_t)((r5 << 3) | (r5 >> 2));
+        uint8_t g8 = (uint8_t)((g6 << 2) | (g6 >> 4));
+        uint8_t b8 = (uint8_t)((b5 << 3) | (b5 >> 2));
+        uint8_t luma8 = (uint8_t)((77 * r8 + 150 * g8 + 29 * b8) >> 8);
+        uint8_t r5o = (uint8_t)(luma8 >> 3);
+        buf[i] = (uint16_t)(r5o << 11);
+    }
+}

--- a/main/image_red_remap.h
+++ b/main/image_red_remap.h
@@ -1,0 +1,12 @@
+#ifndef IMAGE_RED_REMAP_H
+#define IMAGE_RED_REMAP_H
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+// True when the active theme is Red Night (star-party). Reads live theme.
+bool image_red_remap_active(void);
+// In-place: map each RGB565 pixel to a red shade by luminance (R=luma, G=0, B=0). No-op unless image_red_remap_active().
+void image_red_remap_rgb565(uint16_t *buf, size_t px_count);
+// Same remap, always applied regardless of active theme (caller already gated).
+void image_red_remap_rgb565_force(uint16_t *buf, size_t px_count);
+#endif

--- a/main/main.c
+++ b/main/main.c
@@ -50,6 +50,8 @@
 #include "ui/nina_thumbnail.h"
 #include "ui/nina_setup_screen.h"
 #include "ui/nina_nav_arbiter.h"
+#include "ui/themes.h"
+#include "image_red_remap.h"
 
 /* Embedded splash logo (JPEG, hardware-decoded at boot) */
 extern const uint8_t logo_jpg_start[] asm("_binary_logo_jpg_start");
@@ -718,6 +720,14 @@ void app_main(void)
                     jpeg_del_decoder_engine(decoder);
 
                     if (err == ESP_OK && out_size > 0) {
+                        /* Red Night gate: live theme pointer is not set yet at splash,
+                         * so resolve the SAVED theme directly from config (loaded before
+                         * the display in app_main) and remap the logo to red/black if so. */
+                        const theme_t *saved_theme = themes_get(app_config_get()->theme_index);
+                        if (theme_is_red_night(saved_theme)) {
+                            image_red_remap_rgb565_force((uint16_t *)rgb_buf,
+                                                         (size_t)out_w * (size_t)out_h);
+                        }
                         splash_dsc.header.magic  = LV_IMAGE_HEADER_MAGIC;
                         splash_dsc.header.w      = (int32_t)out_w;
                         splash_dsc.header.h      = (int32_t)out_h;

--- a/main/moon_render.c
+++ b/main/moon_render.c
@@ -6,6 +6,7 @@
 #include <math.h>
 #include <string.h>
 #include "stb_image.h"
+#include "image_red_remap.h"
 
 static const char *TAG = "moon_render";
 
@@ -184,6 +185,11 @@ uint16_t *moon_render(int w, int h, const moon_state_t *st, uint8_t bg_style)
             }
         }
     }
+
+    /* Red Night: remap the fully-rendered buffer (moon disc, starfield, halo)
+     * to red shades by luminance. Self-gates; no-op under non-red themes, so
+     * the warm/white moon is preserved exactly outside Red Night. */
+    image_red_remap_rgb565(buf, (size_t)w * h);
 
     if (s_tex_mtx) xSemaphoreGive(s_tex_mtx);
     return buf;

--- a/main/ui/nina_allsky.c
+++ b/main/ui/nina_allsky.c
@@ -228,9 +228,7 @@ static inline void set_bar_value_if_changed(lv_obj_t *bar, int *cached, int valu
 }
 
 static inline bool is_red_theme(void) {
-    return current_theme &&
-           (strcmp(current_theme->name, "Red Night") == 0 ||
-            strcmp(current_theme->name, "Night Vision Red") == 0);
+    return theme_is_red_night(current_theme);
 }
 
 static uint32_t parse_hex_color(const char *str, uint32_t fallback) {

--- a/main/ui/nina_clock.c
+++ b/main/ui/nina_clock.c
@@ -83,6 +83,18 @@ static lv_obj_t *forecast_row  = NULL;
 static lv_obj_t *forecast_bars[FORECAST_BARS];
 static lv_obj_t *forecast_lbls[FORECAST_BARS];
 
+/* Dividers — captured so apply_theme can recolor them */
+#define CLK_RULE_COUNT 2
+#define CLK_VDIV_COUNT 3
+static lv_obj_t *rules[CLK_RULE_COUNT];
+static int rule_count = 0;
+static lv_obj_t *vdividers[CLK_VDIV_COUNT];
+static int vdivider_count = 0;
+
+/* Last-known metric flag, so apply_theme can recolor forecast bars
+ * (which depend on temperature) without live weather data on hand. */
+static bool last_is_metric = false;
+
 /* Timer */
 static lv_timer_t *clock_timer = NULL;
 
@@ -126,6 +138,9 @@ static lv_obj_t *make_rule(lv_obj_t *parent) {
     lv_obj_set_style_bg_opa(rule, LV_OPA_COVER, 0);
     lv_obj_remove_flag(rule, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_clear_flag(rule, LV_OBJ_FLAG_CLICKABLE);
+    if (rule_count < CLK_RULE_COUNT) {
+        rules[rule_count++] = rule;
+    }
     return rule;
 }
 
@@ -139,8 +154,19 @@ static float to_fahrenheit(float temp, bool is_metric) {
 
 /**
  * Get bar color based on temperature (compared in Fahrenheit).
+ *
+ * When @p red_night is true, every band maps to a shade of pure red whose
+ * brightness rises with temperature (cold = dark red, hot = bright red).
+ * No green/blue/orange under Red Night. Otherwise the fixed editorial
+ * green/blue/orange/olive palette is returned unchanged.
  */
-static uint32_t bar_color_for_temp(float temp_f) {
+static uint32_t bar_color_for_temp(float temp_f, bool red_night) {
+    if (red_night) {
+        if (temp_f > 75.0f)  return 0xFF0000;  /* hot  — bright red */
+        if (temp_f >= 65.0f) return 0xC00000;  /* warm — medium-bright red */
+        if (temp_f >= 55.0f) return 0x800000;  /* cool — medium-dark red */
+        return 0x500000;                        /* cold — dark red */
+    }
     if (temp_f > 75.0f) return CLK_BAR_HOT;
     if (temp_f >= 65.0f) return CLK_BAR_WARM;
     if (temp_f >= 55.0f) return CLK_BAR_COOL;
@@ -177,6 +203,9 @@ static lv_obj_t *make_vdivider(lv_obj_t *parent) {
     lv_obj_set_style_bg_opa(div, LV_OPA_COVER, 0);
     lv_obj_remove_flag(div, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_clear_flag(div, LV_OBJ_FLAG_CLICKABLE);
+    if (vdivider_count < CLK_VDIV_COUNT) {
+        vdividers[vdivider_count++] = div;
+    }
     return div;
 }
 
@@ -200,6 +229,10 @@ static void clock_timer_cb(lv_timer_t *timer) {
 /* ── Page creation ───────────────────────────────────────────────────── */
 
 lv_obj_t *clock_page_create(lv_obj_t *parent) {
+    /* Reset divider registries so re-creation cannot overflow the arrays */
+    rule_count = 0;
+    vdivider_count = 0;
+
     /* Root — full screen, own background, overrides parent padding */
     clock_root = lv_obj_create(parent);
     lv_obj_set_size(clock_root, SCREEN_SIZE, SCREEN_SIZE);
@@ -359,6 +392,8 @@ void clock_page_update(void) {
     const app_config_t *cfg = app_config_get();
     bool is_24h = (cfg->weather_time_format == 1);
     bool is_metric = (cfg->weather_units == 1);
+    last_is_metric = is_metric;
+    bool red_night = theme_is_red_night(current_theme);
 
     /* ── Time & date ── */
     time_t now = time(NULL);
@@ -491,7 +526,7 @@ void clock_page_update(void) {
         /* Bar color based on temperature in Fahrenheit */
         float temp_f = to_fahrenheit(wd.hourly_temps[i], is_metric);
         lv_obj_set_style_bg_color(forecast_bars[i],
-                                   lv_color_hex(bar_color_for_temp(temp_f)), 0);
+                                   lv_color_hex(bar_color_for_temp(temp_f, red_night)), 0);
 
         /* Hour label */
         uint8_t hr = wd.hourly_hours[i];
@@ -509,10 +544,135 @@ void clock_page_update(void) {
     lv_obj_remove_flag(forecast_row, LV_OBJ_FLAG_HIDDEN);
 }
 
-/* ── Theme (no-op) ───────────────────────────────────────────────────── */
+/* ── Theme ───────────────────────────────────────────────────────────── */
 
+/**
+ * Set a label's text color, guarding against a NULL widget.
+ */
+static void set_label_color(lv_obj_t *lbl, uint32_t color_hex) {
+    if (lbl) {
+        lv_obj_set_style_text_color(lbl, lv_color_hex(color_hex), 0);
+    }
+}
+
+/**
+ * Recolor the whole clock page for the active theme.
+ *
+ * Under Red Night every pixel becomes a red shade or black: background black,
+ * text bright/secondary red, dividers dark red, and forecast bars red shades
+ * scaled by temperature. In every non-red theme the fixed editorial cream/warm
+ * palette is restored byte-for-byte, so those themes look identical to before.
+ */
 void clock_page_apply_theme(void) {
-    /* Editorial colors are fixed — nothing to do. */
+    if (!clock_root) return;
+
+    bool red_night = theme_is_red_night(current_theme);
+
+    /* Resolve the palette: red-night pulls from the active theme, otherwise
+     * the fixed editorial constants are used verbatim. */
+    uint32_t bg, primary, secondary, tertiary, dim, condition, rule, bar_label;
+    if (red_night) {
+        bg        = current_theme->bg_main;        /* black */
+        primary   = current_theme->text_color;     /* bright red */
+        secondary = current_theme->text_color;     /* bright red */
+        tertiary  = current_theme->label_color;    /* dim red */
+        dim       = current_theme->label_color;    /* dim red */
+        condition = current_theme->label_color;    /* dim red */
+        rule      = current_theme->bento_border;   /* dark red */
+        bar_label = current_theme->label_color;    /* dim red */
+    } else {
+        bg        = CLK_BG;
+        primary   = CLK_PRIMARY;
+        secondary = CLK_SECONDARY;
+        tertiary  = CLK_TERTIARY;
+        dim       = CLK_DIM;
+        condition = CLK_CONDITION;
+        rule      = CLK_RULE;
+        bar_label = CLK_BAR_LABEL;
+    }
+
+    /* Background */
+    lv_obj_set_style_bg_color(clock_root, lv_color_hex(bg), 0);
+
+    /* Date stack (tertiary) */
+    set_label_color(lbl_day,  tertiary);
+    set_label_color(lbl_date, tertiary);
+    set_label_color(lbl_year, tertiary);
+
+    /* Weather header */
+    set_label_color(lbl_temp, primary);
+    set_label_color(lbl_deg,  primary);
+    set_label_color(lbl_cond, condition);
+    set_label_color(lbl_hilo, dim);
+
+    /* Time */
+    set_label_color(lbl_time, primary);
+    set_label_color(lbl_ampm, dim);
+
+    /* Stats strip values (secondary). Their labels are children created
+     * inline with CLK_DIM; recolor those too via the stat columns. */
+    set_label_color(lbl_humid_val, secondary);
+    set_label_color(lbl_dew_val,   secondary);
+    set_label_color(lbl_wind_val,  secondary);
+    set_label_color(lbl_uv_val,    secondary);
+
+    /* Stat unit labels: the second child of each value's parent column. */
+    lv_obj_t *val_labels[4] = {
+        lbl_humid_val, lbl_dew_val, lbl_wind_val, lbl_uv_val
+    };
+    for (int i = 0; i < 4; i++) {
+        if (!val_labels[i]) continue;
+        lv_obj_t *col = lv_obj_get_parent(val_labels[i]);
+        if (!col) continue;
+        uint32_t child_cnt = lv_obj_get_child_count(col);
+        for (uint32_t c = 0; c < child_cnt; c++) {
+            lv_obj_t *child = lv_obj_get_child(col, c);
+            if (child && child != val_labels[i]) {
+                set_label_color(child, dim);
+            }
+        }
+    }
+
+    /* Horizontal rules */
+    for (int i = 0; i < rule_count; i++) {
+        if (rules[i]) {
+            lv_obj_set_style_bg_color(rules[i], lv_color_hex(rule), 0);
+        }
+    }
+
+    /* Vertical dividers */
+    for (int i = 0; i < vdivider_count; i++) {
+        if (vdividers[i]) {
+            lv_obj_set_style_bg_color(vdividers[i], lv_color_hex(rule), 0);
+        }
+    }
+
+    /* Forecast labels */
+    for (int i = 0; i < FORECAST_BARS; i++) {
+        set_label_color(forecast_lbls[i], bar_label);
+    }
+
+    /* Forecast bars: recolor from the last-known weather sample so the red
+     * map applies immediately on theme switch. When no weather is present
+     * the bars stay hidden, so the placeholder color is harmless. */
+    weather_data_t wd;
+    weather_client_get_data(&wd);
+    if (wd.valid) {
+        for (int i = 0; i < FORECAST_BARS; i++) {
+            if (!forecast_bars[i]) continue;
+            float temp_f = to_fahrenheit(wd.hourly_temps[i], last_is_metric);
+            lv_obj_set_style_bg_color(forecast_bars[i],
+                lv_color_hex(bar_color_for_temp(temp_f, red_night)), 0);
+        }
+    } else {
+        /* No data: give every bar the neutral cool/cold base for the theme. */
+        uint32_t base = red_night ? 0x500000 : CLK_BAR_COOL;
+        for (int i = 0; i < FORECAST_BARS; i++) {
+            if (forecast_bars[i]) {
+                lv_obj_set_style_bg_color(forecast_bars[i], lv_color_hex(base), 0);
+            }
+        }
+    }
 }
 
 void clock_page_request_update(void) {

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -261,7 +261,7 @@ static void apply_theme_to_page(dashboard_page_t *p) {
 
     if (p->lbl_instance_name) {
         uint32_t glow_color;
-        if (strcmp(current_theme->name, "Red Night") == 0) {
+        if (theme_is_red_night(current_theme)) {
             glow_color = app_config_apply_brightness(
                 p->nina_connected ? current_theme->text_color : current_theme->label_color, gb);
         } else {
@@ -298,10 +298,17 @@ static void apply_theme_to_page(dashboard_page_t *p) {
         if (p->lbl_pwr_title[i]) lv_obj_set_style_text_color(p->lbl_pwr_title[i], lv_color_hex(app_config_apply_brightness(current_theme->text_color, gb)), 0);
     }
 
+    if (p->empty_state_cont) {
+        nina_empty_state_apply_theme(p->empty_state_cont, current_theme, gb);
+    }
 }
 
 const theme_t *nina_dashboard_get_current_theme(void) {
     return current_theme;
+}
+
+const theme_t *nina_dashboard_get_theme(void) {
+    return nina_dashboard_get_current_theme();
 }
 
 void nina_dashboard_apply_theme(int theme_index) {
@@ -393,7 +400,7 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     p->lbl_instance_name = lv_label_create(top_row);
     {
         uint32_t glow_color = 0xf87171;
-        if (current_theme && strcmp(current_theme->name, "Red Night") == 0) {
+        if (theme_is_red_night(current_theme)) {
             glow_color = current_theme->label_color;
         }
         lv_obj_set_style_text_color(p->lbl_instance_name, lv_color_hex(glow_color), 0);
@@ -439,7 +446,7 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     lv_obj_set_style_text_font(lbl_seq_title, &lv_font_montserrat_14, 0);
 
     p->lbl_seq_container = lv_label_create(seq_left);
-    lv_obj_set_style_text_color(p->lbl_seq_container, lv_color_hex(0x4FC3F7), 0);
+    lv_obj_set_style_text_color(p->lbl_seq_container, lv_color_hex(theme_is_red_night(current_theme) ? current_theme->header_text_color : 0x4FC3F7), 0);
     lv_obj_set_style_text_font(p->lbl_seq_container, &lv_font_montserrat_24, 0);
     lv_label_set_text(p->lbl_seq_container, "----");
 
@@ -447,7 +454,7 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     extern const lv_font_t lv_font_material_safety;
     p->safety_icon = lv_label_create(box_seq);
     lv_obj_set_style_text_font(p->safety_icon, &lv_font_material_safety, 0);
-    lv_obj_set_style_text_color(p->safety_icon, lv_color_hex(0x999999), 0);
+    lv_obj_set_style_text_color(p->safety_icon, lv_color_hex(theme_is_red_night(current_theme) ? current_theme->label_color : 0x999999), 0);
     lv_label_set_text(p->safety_icon, "");
     lv_obj_clear_flag(p->safety_icon, LV_OBJ_FLAG_CLICKABLE);
     lv_obj_clear_flag(p->safety_icon, LV_OBJ_FLAG_SCROLLABLE);
@@ -689,7 +696,7 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     /* Stale data indicator — floating label in upper-right corner */
     p->lbl_stale = lv_label_create(p->page);
     lv_obj_add_flag(p->lbl_stale, LV_OBJ_FLAG_FLOATING);
-    lv_obj_set_style_text_color(p->lbl_stale, lv_color_hex(0xfbbf24), 0);  /* amber */
+    lv_obj_set_style_text_color(p->lbl_stale, lv_color_hex(theme_is_red_night(current_theme) ? current_theme->text_color : 0xfbbf24), 0);  /* amber; bright red under Red Night */
     lv_obj_set_style_text_font(p->lbl_stale, &lv_font_montserrat_14, 0);
     lv_obj_set_style_bg_color(p->lbl_stale, lv_color_hex(0x000000), 0);
     lv_obj_set_style_bg_opa(p->lbl_stale, LV_OPA_70, 0);

--- a/main/ui/nina_dashboard.h
+++ b/main/ui/nina_dashboard.h
@@ -48,6 +48,9 @@ int nina_dashboard_get_active_page(void);
 /** Get the currently active theme. */
 const theme_t *nina_dashboard_get_current_theme(void);
 
+/** Alias for nina_dashboard_get_current_theme(). */
+const theme_t *nina_dashboard_get_theme(void);
+
 /**
  * @brief Apply a specific theme to all dashboard pages
  * @param theme_index Index of the theme to apply

--- a/main/ui/nina_dashboard_update.c
+++ b/main/ui/nina_dashboard_update.c
@@ -730,7 +730,7 @@ static void update_stale_indicator(dashboard_page_t *p, const nina_client_t *d) 
         /* Stale color: dim for warning, bright for severe */
         uint32_t stale_color;
         if (theme_is_red_night(current_theme)) {
-            stale_color = (stale_ms > STALE_DIM_MS) ? 0xff0000 : 0xcc0000;
+            stale_color = (stale_ms > STALE_DIM_MS) ? 0xff0000 : current_theme->text_color;
         } else {
             stale_color = (stale_ms > STALE_DIM_MS) ? 0xf87171 : 0xfbbf24;
         }
@@ -780,8 +780,10 @@ static void update_safety_icon(dashboard_page_t *p, const nina_client_t *data, i
         }
     } else {
         set_label_if_changed(p->safety_icon, ICON_GPP_MAYBE);
+        uint32_t unknown_color = theme_is_red_night(current_theme)
+            ? current_theme->label_color : 0x999999;
         set_text_color_if_changed(p->safety_icon,
-            lv_color_hex(app_config_apply_brightness(0x999999, gb)), 0);
+            lv_color_hex(app_config_apply_brightness(unknown_color, gb)), 0);
     }
 }
 

--- a/main/ui/nina_idle_indicator.c
+++ b/main/ui/nina_idle_indicator.c
@@ -6,6 +6,7 @@
 #include "nina_idle_indicator.h"
 #include "app_config.h"
 #include "display_defs.h"
+#include "nina_dashboard_internal.h"  /* current_theme, themes.h (theme_is_red_night) */
 #include "esp_lvgl_port.h"
 
 #include <string.h>
@@ -60,14 +61,25 @@ static void apply_red(indicator_entry_t *ind)
 
 static void apply_green(indicator_entry_t *ind)
 {
+    /* Under Red Night, the connected/reconnecting pill must use red shades or
+     * black only (no sage green). Dark red bg/border from the bento palette,
+     * dot/border accent from progress (fallback to text) color. */
+    bool red = theme_is_red_night(current_theme);
+    uint32_t bg_col     = red ? current_theme->bento_bg     : GREEN_BG;
+    uint32_t border_col = red ? current_theme->bento_border : GREEN_BORDER;
+    uint32_t dot_col    = red
+        ? (current_theme->progress_color ? current_theme->progress_color
+                                         : current_theme->text_color)
+        : GREEN_DOT;
+
     if (ind->pill) {
-        lv_obj_set_style_bg_color(ind->pill, lv_color_hex(GREEN_BG), 0);
+        lv_obj_set_style_bg_color(ind->pill, lv_color_hex(bg_col), 0);
         lv_obj_set_style_bg_opa(ind->pill, GREEN_BG_OPA, 0);
-        lv_obj_set_style_border_color(ind->pill, lv_color_hex(GREEN_BORDER), 0);
+        lv_obj_set_style_border_color(ind->pill, lv_color_hex(red ? dot_col : border_col), 0);
         lv_obj_set_style_border_opa(ind->pill, GREEN_BORDER_OPA, 0);
     }
-    lv_obj_set_style_bg_color(ind->dot, lv_color_hex(GREEN_DOT), 0);
-    lv_obj_set_style_shadow_color(ind->dot, lv_color_hex(GREEN_DOT), 0);
+    lv_obj_set_style_bg_color(ind->dot, lv_color_hex(dot_col), 0);
+    lv_obj_set_style_shadow_color(ind->dot, lv_color_hex(dot_col), 0);
 }
 
 /* ── Public API ─────────────────────────────────────────────────────── */

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -14,6 +14,7 @@
 #include "nina_image_display.h"
 #include "nina_wait_overlay.h"
 #include "nina_dashboard_internal.h"
+#include "image_red_remap.h"   /* image_red_remap_rgb565 — self-gates on red-night */
 #include "moon_interaction.h"
 #include "app_config.h"
 #include "display_defs.h"
@@ -248,10 +249,15 @@ static void moon_drag_released_cb(lv_event_t *e)
 /* Apply the "chip" style to a label: small translucent rounded background that
  * keeps text legible when the main overlay bar is nearly transparent.
  * bg_opa=120 (~47%), corner radius=8, horizontal pad=8, vertical pad=3.
- * The label's own bg colour is set to black; text colour is always white so it
- * is never inadvertently overridden by apply_theme() later. */
+ * Non-red themes keep the historic black chip + white text exactly. Under the
+ * Red Night theme (gated by theme_is_red_night) the chip background stays black
+ * and the text becomes the theme's red (text_color) so the page emits only red
+ * shades or black. nina_image_display_apply_theme() re-runs this on theme change. */
 static void apply_chip_style(lv_obj_t *lbl)
 {
+    const theme_t *th = current_theme;
+    bool red = theme_is_red_night(th);
+    lv_color_t txt = red ? lv_color_hex(th->text_color) : lv_color_white();
     lv_obj_set_style_bg_color(lbl,   lv_color_black(), 0);
     lv_obj_set_style_bg_opa(lbl,     120,              0);
     lv_obj_set_style_radius(lbl,     8,                0);
@@ -259,7 +265,7 @@ static void apply_chip_style(lv_obj_t *lbl)
     lv_obj_set_style_pad_right(lbl,  8,                0);
     lv_obj_set_style_pad_top(lbl,    3,                0);
     lv_obj_set_style_pad_bottom(lbl, 3,                0);
-    lv_obj_set_style_text_color(lbl, lv_color_white(), 0);
+    lv_obj_set_style_text_color(lbl, txt, 0);
 }
 
 /* extern declaration for moon_overlay_info — owned by moon_ephemeris.c,
@@ -677,6 +683,12 @@ void nina_image_display_update(goes_data_t *data)
         buf_size = rot_size;
     }
 
+    /* Red Night: recolour the decoded image to red shades (luma->red, in place).
+     * Self-gates inside the helper (no-op for every non-red theme), so call it
+     * unconditionally on the final upright/cropped/rotated `copy` before it is
+     * handed to LVGL. w*h is the committed pixel count. */
+    image_red_remap_rgb565((uint16_t *)copy, (size_t)w * h);
+
     /* Point the BACK slot's descriptor at the new copy. release_dsc() frees the
      * previous buffer unless it was borrowed (moon-drag), and clears that flag —
      * this owned copy is not borrowed. */
@@ -818,6 +830,11 @@ void nina_image_display_show_scaled(const uint16_t *buf, int w, int h)
     }
     memcpy(moon_copy_buf[ci], buf, need);
 
+    /* Red Night: recolour the owned copy to red shades in place (self-gates to a
+     * no-op for non-red themes). A second remap of an already-red moon buffer
+     * leaves red as red, so calling unconditionally here is safe. */
+    image_red_remap_rgb565(moon_copy_buf[ci], (size_t)w * h);
+
     /* Point the BACK slot at the owned copy. release_dsc() frees any prior OWNED
      * buffer; these copy buffers are module-owned and persistent, so we mark the
      * slot "borrowed" (release_dsc then skips the free) and free them ourselves in
@@ -890,6 +907,12 @@ void nina_image_display_show_borrowed(const uint16_t *buf, int w, int h)
     lv_image_dsc_t *back_dsc = front_is_a ? &img_dsc_b : &img_dsc_a;
     release_dsc(back_dsc, back_is_a);          /* free prior OWNED buffer if any */
     size_t need = (size_t)w * h * 2;
+    /* Red Night: recolour the borrowed full-panel buffer in place (self-gates to a
+     * no-op for non-red themes). The moon renderer already remaps this buffer under
+     * red-night, so a second in-place remap leaves red as red — harmless. The buffer
+     * is mutable PSRAM owned by the moon-drag loop; the const here is only on the
+     * incoming pointer type. */
+    image_red_remap_rgb565((uint16_t *)buf, (size_t)w * h);
     back_dsc->data          = (const uint8_t *)buf;
     back_dsc->data_size     = need;
     back_dsc->header.magic  = LV_IMAGE_HEADER_MAGIC;
@@ -1005,9 +1028,15 @@ void nina_image_display_set_overlay_visible(bool visible)
 
 void nina_image_display_apply_theme(void)
 {
-    /* lbl_region text colour is now enforced white by apply_chip_style() so the
-     * phase name remains legible regardless of theme.  The function is kept for
-     * future per-theme customisation of this page and for callers that invoke it
-     * unconditionally. */
-    (void)current_theme;
+    /* Re-apply the chip style to every existing caption/corner label so a theme
+     * switch recolours them live. apply_chip_style() reads current_theme and,
+     * under Red Night, emits red text on a black chip; non-red themes keep the
+     * historic white-on-black look unchanged. Each label is NULL-guarded so this
+     * is safe before create() or after cleanup(). */
+    if (lbl_region)    apply_chip_style(lbl_region);
+    if (lbl_timestamp) apply_chip_style(lbl_timestamp);
+    if (lbl_moon_age)  apply_chip_style(lbl_moon_age);
+    if (lbl_moon_next) apply_chip_style(lbl_moon_next);
+    if (lbl_moon_rise) apply_chip_style(lbl_moon_rise);
+    if (lbl_moon_set)  apply_chip_style(lbl_moon_set);
 }

--- a/main/ui/nina_info_filter.c
+++ b/main/ui/nina_info_filter.c
@@ -354,7 +354,9 @@ void populate_filter_data(const filter_detail_data_t *data) {
     lv_label_set_text(lbl_moving_val, data->connected ? "Yes" : "No");
 
     if (current_theme) {
-        uint32_t conn_col = data->connected ? 0x4ade80 : current_theme->label_color;
+        uint32_t conn_col = data->connected
+            ? (theme_is_red_night(current_theme) ? current_theme->progress_color : 0x4ade80)
+            : current_theme->label_color;
         lv_obj_set_style_text_color(lbl_moving_val,
             lv_color_hex(app_config_apply_brightness(conn_col, gb)), 0);
     }

--- a/main/ui/nina_settings_tabview.c
+++ b/main/ui/nina_settings_tabview.c
@@ -671,7 +671,11 @@ lv_obj_t *settings_tabview_create(lv_obj_t *parent) {
     lbl_save_btn = lv_label_create(save_bar);
     lv_label_set_text(lbl_save_btn, LV_SYMBOL_SAVE " Save");
     lv_obj_set_style_text_font(lbl_save_btn, &lv_font_montserrat_20, 0);
-    lv_obj_set_style_text_color(lbl_save_btn, lv_color_white(), 0);
+    if (theme_is_red_night(current_theme)) {
+        lv_obj_set_style_text_color(lbl_save_btn, lv_color_hex(current_theme->text_color), 0);
+    } else {
+        lv_obj_set_style_text_color(lbl_save_btn, lv_color_white(), 0);
+    }
     lv_obj_center(lbl_save_btn);
 
     /* ── Floating back button — bottom-right corner (like graph/sysinfo) ── */

--- a/main/ui/nina_setup_screen.c
+++ b/main/ui/nina_setup_screen.c
@@ -1,8 +1,12 @@
 #include "nina_setup_screen.h"
 #include "app_config.h"
+#include "themes.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/portmacro.h"
+
+/* Provided by nina_dashboard.c; returns the active theme or NULL before init. */
+const theme_t *nina_dashboard_get_theme(void);
 
 static const char *TAG = "setup_screen";
 
@@ -23,6 +27,21 @@ void nina_setup_screen_create(lv_obj_t *parent)
 {
     ESP_LOGI(TAG, "Creating setup screen");
 
+    /* Under the Red Night theme, substitute red shades for the hardcoded
+     * white/gray/blue colors so the wizard does not leak bright colors.
+     * When the theme is not yet initialized (NULL) or is not Red Night,
+     * keep the original colors exactly. */
+    const theme_t *t = nina_dashboard_get_theme();
+    bool red = (t && theme_is_red_night(t));
+
+    uint32_t col_title = red ? t->text_color : 0xFFFFFF;
+    uint32_t col_secondary = red ? t->label_color : 0xCCCCCC;
+    uint32_t col_divider = red ? t->bento_border : 0x444444;
+    uint32_t col_waiting = red ? t->label_color : 0x555555;
+    uint32_t col_value = red ? t->text_color : 0x3b82f6;
+    uint32_t col_spin_ind = red ? t->progress_color : 0x3b82f6;
+    uint32_t col_spin_track = red ? t->bento_border : 0x222222;
+
     /* Full-screen background */
     s_setup_cont = lv_obj_create(parent);
     lv_obj_remove_style_all(s_setup_cont);
@@ -42,7 +61,7 @@ void nina_setup_screen_create(lv_obj_t *parent)
     lv_label_set_text(title, "WiFi Setup Required");
     lv_obj_set_width(title, lv_pct(100));
     lv_obj_set_style_text_font(title, &lv_font_montserrat_24, 0);
-    lv_obj_set_style_text_color(title, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_color(title, lv_color_hex(col_title), 0);
     lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, 0);
 
     /* Subtitle */
@@ -50,14 +69,14 @@ void nina_setup_screen_create(lv_obj_t *parent)
     lv_label_set_text(subtitle, "Connect to this device's WiFi network\nand open the setup page in your browser.");
     lv_obj_set_width(subtitle, lv_pct(90));
     lv_obj_set_style_text_font(subtitle, &lv_font_montserrat_20, 0);
-    lv_obj_set_style_text_color(subtitle, lv_color_hex(0xCCCCCC), 0);
+    lv_obj_set_style_text_color(subtitle, lv_color_hex(col_secondary), 0);
     lv_obj_set_style_text_align(subtitle, LV_TEXT_ALIGN_CENTER, 0);
 
     /* First divider */
     lv_obj_t *div1 = lv_obj_create(s_setup_cont);
     lv_obj_remove_style_all(div1);
     lv_obj_set_size(div1, lv_pct(80), 1);
-    lv_obj_set_style_bg_color(div1, lv_color_hex(0x444444), 0);
+    lv_obj_set_style_bg_color(div1, lv_color_hex(col_divider), 0);
     lv_obj_set_style_bg_opa(div1, LV_OPA_60, 0);
 
     /* Info rows */
@@ -78,34 +97,34 @@ void nina_setup_screen_create(lv_obj_t *parent)
         lv_obj_t *lbl = lv_label_create(row);
         lv_label_set_text(lbl, labels[i]);
         lv_obj_set_style_text_font(lbl, &lv_font_montserrat_18, 0);
-        lv_obj_set_style_text_color(lbl, lv_color_hex(0xCCCCCC), 0);
+        lv_obj_set_style_text_color(lbl, lv_color_hex(col_secondary), 0);
 
         lv_obj_t *val = lv_label_create(row);
         lv_label_set_text(val, values[i]);
         lv_obj_set_style_text_font(val, &lv_font_montserrat_22, 0);
-        lv_obj_set_style_text_color(val, lv_color_hex(0x3b82f6), 0);
+        lv_obj_set_style_text_color(val, lv_color_hex(col_value), 0);
     }
 
     /* Second divider */
     lv_obj_t *div2 = lv_obj_create(s_setup_cont);
     lv_obj_remove_style_all(div2);
     lv_obj_set_size(div2, lv_pct(80), 1);
-    lv_obj_set_style_bg_color(div2, lv_color_hex(0x444444), 0);
+    lv_obj_set_style_bg_color(div2, lv_color_hex(col_divider), 0);
     lv_obj_set_style_bg_opa(div2, LV_OPA_60, 0);
 
     /* Waiting text */
     lv_obj_t *waiting = lv_label_create(s_setup_cont);
     lv_label_set_text(waiting, "Waiting for configuration...");
     lv_obj_set_style_text_font(waiting, &lv_font_montserrat_18, 0);
-    lv_obj_set_style_text_color(waiting, lv_color_hex(0x555555), 0);
+    lv_obj_set_style_text_color(waiting, lv_color_hex(col_waiting), 0);
     lv_obj_set_style_text_align(waiting, LV_TEXT_ALIGN_CENTER, 0);
 
     /* Spinner */
     lv_obj_t *spinner = lv_spinner_create(s_setup_cont);
     lv_obj_set_size(spinner, 40, 40);
     lv_spinner_set_anim_params(spinner, 1000, 270);
-    lv_obj_set_style_arc_color(spinner, lv_color_hex(0x3b82f6), LV_PART_INDICATOR);
-    lv_obj_set_style_arc_color(spinner, lv_color_hex(0x222222), LV_PART_MAIN);
+    lv_obj_set_style_arc_color(spinner, lv_color_hex(col_spin_ind), LV_PART_INDICATOR);
+    lv_obj_set_style_arc_color(spinner, lv_color_hex(col_spin_track), LV_PART_MAIN);
     lv_obj_set_style_arc_width(spinner, 4, LV_PART_INDICATOR);
     lv_obj_set_style_arc_width(spinner, 4, LV_PART_MAIN);
 

--- a/main/ui/nina_spotify.c
+++ b/main/ui/nina_spotify.c
@@ -21,6 +21,7 @@
 #include "app_config.h"
 #include "spotify_auth.h"
 #include "nina_empty_state.h"
+#include "image_red_remap.h"
 
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
@@ -1002,6 +1003,11 @@ void nina_spotify_set_album_art(const uint8_t *rgb565_data, uint32_t w, uint32_t
     art_dsc.data = current_art_buf;
     art_dsc.data_size = data_size;
 
+    /* Red Night: remap album art to red shades in place (self-gates; no-op
+     * in non-red themes, so Spotify branding is untouched otherwise).
+     * w*h is the committed RGB565 pixel count. */
+    image_red_remap_rgb565((uint16_t *)current_art_buf, (size_t)w * h);
+
     lv_image_set_src(img_album_art, &art_dsc);
 
     /* Hide status panel now that we have album art */
@@ -1088,6 +1094,170 @@ void nina_spotify_set_idle(void)
 void spotify_page_apply_theme(void)
 {
     if (!spotify_page || !current_theme) return;
+
+    /* Red Night (star-party) only: recolor the player chrome that is normally
+     * left in Spotify-branded fixed colors (white/gray text, white buttons,
+     * blue progress). Every chrome pixel becomes a red shade or black. All
+     * other themes preserve the branded colors exactly (this branch is skipped).
+     */
+    if (theme_is_red_night(current_theme)) {
+        lv_color_t title_c  = lv_color_hex(current_theme->text_color);   /* bright red */
+        lv_color_t label_c  = lv_color_hex(current_theme->label_color);  /* dim red */
+        lv_color_t track_c  = lv_color_hex(current_theme->bento_border); /* dark red */
+        lv_color_t prog_c   = lv_color_hex(current_theme->progress_color);
+        lv_color_t btn_bg_c = lv_color_hex(current_theme->bento_bg);     /* dark red */
+        lv_color_t icon_c   = lv_color_hex(current_theme->text_color);   /* bright red */
+
+        /* Titles -> bright red */
+        if (lbl_track_title) {
+            lv_obj_set_style_text_color(lbl_track_title, title_c, 0);
+        }
+        if (minimal_track_title) {
+            lv_obj_set_style_text_color(minimal_track_title, title_c, 0);
+        }
+
+        /* Subtitles / artist / album -> dim red */
+        if (lbl_track_subtitle) {
+            lv_obj_set_style_text_color(lbl_track_subtitle, label_c, 0);
+        }
+        if (lbl_artist_name) {
+            lv_obj_set_style_text_color(lbl_artist_name, label_c, 0);
+        }
+        if (lbl_album_name) {
+            lv_obj_set_style_text_color(lbl_album_name, label_c, 0);
+        }
+        if (minimal_track_subtitle) {
+            lv_obj_set_style_text_color(minimal_track_subtitle, label_c, 0);
+        }
+        if (minimal_artist_name) {
+            lv_obj_set_style_text_color(minimal_artist_name, label_c, 0);
+        }
+        if (minimal_album_name) {
+            lv_obj_set_style_text_color(minimal_album_name, label_c, 0);
+        }
+
+        /* Time labels -> dim red */
+        if (lbl_time_elapsed) {
+            lv_obj_set_style_text_color(lbl_time_elapsed, label_c, 0);
+        }
+        if (lbl_time_total) {
+            lv_obj_set_style_text_color(lbl_time_total, label_c, 0);
+        }
+
+        /* Progress bars: track -> dark red, indicator -> theme progress red */
+        if (bar_progress) {
+            lv_obj_set_style_bg_color(bar_progress, track_c, LV_PART_MAIN);
+            lv_obj_set_style_bg_color(bar_progress, prog_c, LV_PART_INDICATOR);
+        }
+        if (minimal_progress) {
+            lv_obj_set_style_bg_color(minimal_progress, track_c, LV_PART_MAIN);
+            lv_obj_set_style_bg_color(minimal_progress, prog_c, LV_PART_INDICATOR);
+        }
+
+        /* Buttons: dark red backgrounds (full opacity), bright red icons */
+        if (btn_prev) {
+            lv_obj_set_style_bg_color(btn_prev, btn_bg_c, 0);
+            lv_obj_set_style_bg_opa(btn_prev, LV_OPA_COVER, 0);
+            lv_obj_t *icon = lv_obj_get_child(btn_prev, 0);
+            if (icon) {
+                lv_obj_set_style_text_color(icon, icon_c, 0);
+            }
+        }
+        if (btn_next) {
+            lv_obj_set_style_bg_color(btn_next, btn_bg_c, 0);
+            lv_obj_set_style_bg_opa(btn_next, LV_OPA_COVER, 0);
+            lv_obj_t *icon = lv_obj_get_child(btn_next, 0);
+            if (icon) {
+                lv_obj_set_style_text_color(icon, icon_c, 0);
+            }
+        }
+        if (btn_play_pause) {
+            lv_obj_set_style_bg_color(btn_play_pause, track_c, 0);
+            lv_obj_t *icon = lv_obj_get_child(btn_play_pause, 0);
+            if (icon) {
+                lv_obj_set_style_text_color(icon, icon_c, 0);
+            }
+        }
+
+        /* Status panel + empty state still use theme colors (handled below). */
+    } else {
+        /* Non-red themes: restore the exact Spotify-branded chrome colors so a
+         * switch away from Red Night reverts cleanly. These mirror the literals
+         * used in create_track_info_container / create_controls /
+         * create_minimal_widgets, keeping non-red themes identical to as-built.
+         */
+        if (lbl_track_title) {
+            lv_obj_set_style_text_color(lbl_track_title, lv_color_white(), 0);
+        }
+        if (minimal_track_title) {
+            lv_obj_set_style_text_color(minimal_track_title, lv_color_white(), 0);
+        }
+        if (lbl_track_subtitle) {
+            lv_obj_set_style_text_color(lbl_track_subtitle,
+                lv_color_make(0xAA, 0xAA, 0xAA), 0);
+        }
+        if (lbl_artist_name) {
+            lv_obj_set_style_text_color(lbl_artist_name,
+                lv_color_make(0xAA, 0xAA, 0xAA), 0);
+        }
+        if (lbl_album_name) {
+            lv_obj_set_style_text_color(lbl_album_name,
+                lv_color_make(0x77, 0x77, 0x77), 0);
+        }
+        if (minimal_track_subtitle) {
+            lv_obj_set_style_text_color(minimal_track_subtitle,
+                lv_color_make(0xAA, 0xAA, 0xAA), 0);
+        }
+        if (minimal_artist_name) {
+            lv_obj_set_style_text_color(minimal_artist_name,
+                lv_color_make(0xD1, 0xD5, 0xDB), 0);
+        }
+        if (minimal_album_name) {
+            lv_obj_set_style_text_color(minimal_album_name,
+                lv_color_make(0x9C, 0xA3, 0xAF), 0);
+        }
+        if (lbl_time_elapsed) {
+            lv_obj_set_style_text_color(lbl_time_elapsed,
+                lv_color_make(0x88, 0x88, 0x88), 0);
+        }
+        if (lbl_time_total) {
+            lv_obj_set_style_text_color(lbl_time_total,
+                lv_color_make(0x88, 0x88, 0x88), 0);
+        }
+        if (bar_progress) {
+            lv_obj_set_style_bg_color(bar_progress,
+                lv_color_make(0x44, 0x44, 0x44), LV_PART_MAIN);
+        }
+        if (minimal_progress) {
+            lv_obj_set_style_bg_color(minimal_progress,
+                lv_color_hex(0x1F2937), LV_PART_MAIN);
+            /* Indicator is set to progress_color by the shared code below,
+             * matching original non-red behavior. */
+        }
+        if (btn_prev) {
+            lv_obj_set_style_bg_color(btn_prev, lv_color_make(0x33, 0x33, 0x33), 0);
+            lv_obj_set_style_bg_opa(btn_prev, LV_OPA_70, 0);
+            lv_obj_t *icon = lv_obj_get_child(btn_prev, 0);
+            if (icon) {
+                lv_obj_set_style_text_color(icon, lv_color_white(), 0);
+            }
+        }
+        if (btn_next) {
+            lv_obj_set_style_bg_color(btn_next, lv_color_make(0x33, 0x33, 0x33), 0);
+            lv_obj_set_style_bg_opa(btn_next, LV_OPA_70, 0);
+            lv_obj_t *icon = lv_obj_get_child(btn_next, 0);
+            if (icon) {
+                lv_obj_set_style_text_color(icon, lv_color_white(), 0);
+            }
+        }
+        if (btn_play_pause) {
+            lv_obj_set_style_bg_color(btn_play_pause, lv_color_white(), 0);
+            lv_obj_t *icon = lv_obj_get_child(btn_play_pause, 0);
+            if (icon) {
+                lv_obj_set_style_text_color(icon, lv_color_black(), 0);
+            }
+        }
+    }
 
     /* The Spotify page uses mostly fixed dark colors (white text on album art),
      * so theme application is minimal. Apply theme accent to progress bar. */

--- a/main/ui/nina_summary.c
+++ b/main/ui/nina_summary.c
@@ -585,7 +585,9 @@ static void create_card(summary_card_t *sc, lv_obj_t *parent, int instance_index
 
         sc->lbl_safety = lv_label_create(safety_block);
         lv_obj_set_style_text_font(sc->lbl_safety, &lv_font_material_safety, 0);
-        lv_obj_set_style_text_color(sc->lbl_safety, lv_color_hex(0x999999), 0);
+        uint32_t safety_unknown_color = theme_is_red_night(current_theme)
+            ? current_theme->label_color : 0x999999;
+        lv_obj_set_style_text_color(sc->lbl_safety, lv_color_hex(safety_unknown_color), 0);
         lv_label_set_text(sc->lbl_safety, ICON_GPP_MAYBE);
         lv_obj_add_flag(sc->lbl_safety, LV_OBJ_FLAG_HIDDEN);
     }
@@ -1272,7 +1274,8 @@ void summary_page_update(const nina_client_t *instances, int count) {
                 }
             } else {
                 set_label_if_changed(sc->lbl_safety, ICON_GPP_MAYBE);
-                set_text_color_cached(sc->lbl_safety, &sc->cached_safety_color, 0x999999);
+                set_text_color_cached(sc->lbl_safety, &sc->cached_safety_color,
+                    theme_is_red_night(current_theme) ? current_theme->label_color : 0x999999);
             }
         }
     }

--- a/main/ui/nina_thumbnail.c
+++ b/main/ui/nina_thumbnail.c
@@ -9,6 +9,8 @@
 #include "nina_thumbnail.h"
 #include "nina_dashboard_internal.h"
 #include "nina_nav_arbiter.h"
+#include "themes.h"
+#include "image_red_remap.h"
 #include "jpeg_utils.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
@@ -51,6 +53,15 @@ static uint32_t fit_scale = 256;
 static uint32_t orig_w = 0;
 static uint32_t orig_h = 0;
 static uint32_t last_click_time = 0;
+
+/* Foreground color for overlay chrome (zoom badge text, back-arrow icon).
+ * Under Red Night use a bright red from the theme; otherwise keep white. */
+static uint32_t thumbnail_chrome_fg_color(void) {
+    if (theme_is_red_night(current_theme)) {
+        return current_theme->text_color;
+    }
+    return 0xFFFFFF;
+}
 
 void nina_thumbnail_init(void) {
     thumbnail_scaled_buf = heap_caps_aligned_calloc(128, 1, SCALED_BUF_MAX_SIZE, MALLOC_CAP_SPIRAM);
@@ -238,7 +249,7 @@ void nina_thumbnail_create(lv_obj_t *parent) {
 
     zoom_badge_lbl = lv_label_create(zoom_badge);
     lv_obj_set_style_text_font(zoom_badge_lbl, &lv_font_montserrat_20, 0);
-    lv_obj_set_style_text_color(zoom_badge_lbl, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_color(zoom_badge_lbl, lv_color_hex(thumbnail_chrome_fg_color()), 0);
     lv_label_set_text(zoom_badge_lbl, "");
 
     /* --- Back button (floating child of overlay, bottom-right) --- */
@@ -256,7 +267,7 @@ void nina_thumbnail_create(lv_obj_t *parent) {
     btn_back_lbl = lv_label_create(btn_back);
     lv_label_set_text(btn_back_lbl, LV_SYMBOL_LEFT);
     lv_obj_set_style_text_font(btn_back_lbl, &lv_font_montserrat_20, 0);
-    lv_obj_set_style_text_color(btn_back_lbl, lv_color_hex(0xFFFFFF), 0);
+    lv_obj_set_style_text_color(btn_back_lbl, lv_color_hex(thumbnail_chrome_fg_color()), 0);
     lv_obj_center(btn_back_lbl);
 
     lv_obj_add_event_cb(btn_back, back_btn_cb, LV_EVENT_CLICKED, NULL);
@@ -290,6 +301,11 @@ void nina_dashboard_set_thumbnail(const uint8_t *rgb565_data, uint32_t w, uint32
 
     /* Take ownership of the buffer */
     thumbnail_original_buf = (uint8_t *)rgb565_data;
+
+    /* Under Red Night, remap the camera image to red shades in-place before it
+     * is shown. Self-gates: no-op unless the active theme is Red Night. Done on
+     * the original buffer so PPA-scaled zoom buffers inherit the remap. */
+    image_red_remap_rgb565((uint16_t *)thumbnail_original_buf, (size_t)w * h);
 
     /* Set up LVGL image descriptor with original buffer */
     update_image_descriptor(thumbnail_original_buf, w, h, data_size);
@@ -376,7 +392,7 @@ void nina_thumbnail_apply_theme(void) {
         lv_obj_set_style_bg_color(btn_back, lv_color_hex(current_theme ? current_theme->progress_color : 0x4FC3F7), LV_STATE_PRESSED);
     }
     if (btn_back_lbl) {
-        lv_obj_set_style_text_color(btn_back_lbl, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_set_style_text_color(btn_back_lbl, lv_color_hex(thumbnail_chrome_fg_color()), 0);
     }
     if (thumbnail_loading_lbl) {
         lv_obj_set_style_text_color(thumbnail_loading_lbl,
@@ -387,6 +403,6 @@ void nina_thumbnail_apply_theme(void) {
         lv_obj_set_style_bg_opa(zoom_badge, LV_OPA_70, 0);
     }
     if (zoom_badge_lbl) {
-        lv_obj_set_style_text_color(zoom_badge_lbl, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_set_style_text_color(zoom_badge_lbl, lv_color_hex(thumbnail_chrome_fg_color()), 0);
     }
 }

--- a/main/ui/settings_color_picker.c
+++ b/main/ui/settings_color_picker.c
@@ -154,9 +154,13 @@ void color_picker_show(uint32_t current_color,
         lv_obj_add_flag(sw, LV_OBJ_FLAG_CLICKABLE);
         lv_obj_clear_flag(sw, LV_OBJ_FLAG_SCROLLABLE);
 
-        /* Current color (position 0) gets a white border */
+        /* Current color (position 0) gets a white border (red under Red Night) */
         if (i == 0) {
-            lv_obj_set_style_border_color(sw, lv_color_hex(0xFFFFFF), 0);
+            if (theme_is_red_night(current_theme)) {
+                lv_obj_set_style_border_color(sw, lv_color_hex(current_theme->text_color), 0);
+            } else {
+                lv_obj_set_style_border_color(sw, lv_color_hex(0xFFFFFF), 0);
+            }
             lv_obj_set_style_border_width(sw, CURRENT_BORDER_WIDTH, 0);
             lv_obj_set_style_border_opa(sw, LV_OPA_COVER, 0);
         }

--- a/main/ui/settings_tab_behavior.c
+++ b/main/ui/settings_tab_behavior.c
@@ -805,7 +805,11 @@ void settings_tab_behavior_create(lv_obj_t *parent) {
         lv_obj_t *idle_hint = lv_label_create(idle_card);
         lv_label_set_text(idle_hint, "Disabled while auto-rotate is active");
         lv_obj_set_style_text_font(idle_hint, &lv_font_montserrat_14, 0);
-        lv_obj_set_style_text_color(idle_hint, lv_color_hex(0x888888), 0);
+        if (theme_is_red_night(current_theme)) {
+            lv_obj_set_style_text_color(idle_hint, lv_color_hex(current_theme->label_color), 0);
+        } else {
+            lv_obj_set_style_text_color(idle_hint, lv_color_hex(0x888888), 0);
+        }
     }
 }
 

--- a/main/ui/settings_tab_display.c
+++ b/main/ui/settings_tab_display.c
@@ -621,7 +621,11 @@ static void create_page_nav_card(lv_obj_t *parent)
     lv_obj_t *ar_hint = lv_label_create(cont_cycle);
     lv_label_set_text(ar_hint, "When enabled, overrides \"Switch page when idle\"");
     lv_obj_set_style_text_font(ar_hint, &lv_font_montserrat_14, 0);
-    lv_obj_set_style_text_color(ar_hint, lv_color_hex(0x888888), 0);
+    if (theme_is_red_night(current_theme)) {
+        lv_obj_set_style_text_color(ar_hint, lv_color_hex(current_theme->label_color), 0);
+    } else {
+        lv_obj_set_style_text_color(ar_hint, lv_color_hex(0x888888), 0);
+    }
 
     /* ── Determine initial mode from config ──
      * active_page_override always holds a concrete page_ref id now (no -1/Auto),

--- a/main/ui/settings_tab_system.c
+++ b/main/ui/settings_tab_system.c
@@ -245,11 +245,16 @@ static void create_network_card(lv_obj_t *parent) {
                 lv_obj_set_style_text_opa(label, LV_OPA_30, 0);
             }
 
-            /* Highlight active network with green border */
+            /* Highlight active network with green border (red under Red Night) */
             if (i == active && configured) {
                 lv_obj_set_style_border_width(wifi_net_btns[i], 2, 0);
-                lv_obj_set_style_border_color(wifi_net_btns[i],
-                    lv_palette_main(LV_PALETTE_GREEN), 0);
+                if (theme_is_red_night(current_theme)) {
+                    lv_obj_set_style_border_color(wifi_net_btns[i],
+                        lv_color_hex(current_theme->progress_color), 0);
+                } else {
+                    lv_obj_set_style_border_color(wifi_net_btns[i],
+                        lv_palette_main(LV_PALETTE_GREEN), 0);
+                }
             }
 
             lv_obj_add_event_cb(wifi_net_btns[i], wifi_net_btn_cb,
@@ -891,8 +896,13 @@ void settings_tab_system_refresh(void) {
 
             if (i == active && configured) {
                 lv_obj_set_style_border_width(wifi_net_btns[i], 2, 0);
-                lv_obj_set_style_border_color(wifi_net_btns[i],
-                    lv_palette_main(LV_PALETTE_GREEN), 0);
+                if (theme_is_red_night(current_theme)) {
+                    lv_obj_set_style_border_color(wifi_net_btns[i],
+                        lv_color_hex(current_theme->progress_color), 0);
+                } else {
+                    lv_obj_set_style_border_color(wifi_net_btns[i],
+                        lv_palette_main(LV_PALETTE_GREEN), 0);
+                }
             } else {
                 lv_obj_set_style_border_width(wifi_net_btns[i], 0, 0);
             }

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -78,8 +78,22 @@ static lv_obj_t *ota_bar_glow = NULL;
 #define OTA_ACCENT_DIM   0x005566   /* Dimmed cyan for track */
 #define OTA_GLOW_OPA     LV_OPA_40
 
+/* Active theme accessor (defined in nina_dashboard.c by the dashboard module) */
+const theme_t *nina_dashboard_get_theme(void);
+
 static void ota_show_overlay(const char *message) {
     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+        /* ── Theme-aware colors: under Red Night use red shades / black only ── */
+        const theme_t *t = nina_dashboard_get_theme();
+        bool red_night = (t && theme_is_red_night(t));
+
+        uint32_t title_color   = red_night ? t->text_color     : 0xFFFFFF;
+        uint32_t accent_color  = red_night ? t->text_color     : OTA_ACCENT;
+        uint32_t glow_color    = red_night ? t->progress_color : OTA_ACCENT;
+        uint32_t hint_color    = red_night ? t->label_color    : 0x555555;
+        uint32_t track_color   = red_night ? t->bento_border   : OTA_ACCENT_DIM;
+        uint32_t grad_color    = red_night ? t->bento_border   : 0x0088FF;
+
         /* ── Fullscreen black overlay ── */
         ota_overlay = lv_obj_create(lv_scr_act());
         lv_obj_remove_style_all(ota_overlay);
@@ -91,7 +105,7 @@ static void ota_show_overlay(const char *message) {
         /* ── Title — upper third ── */
         lv_obj_t *title = lv_label_create(ota_overlay);
         lv_label_set_text(title, message);
-        lv_obj_set_style_text_color(title, lv_color_hex(0xFFFFFF), 0);
+        lv_obj_set_style_text_color(title, lv_color_hex(title_color), 0);
         lv_obj_set_style_text_font(title, &lv_font_montserrat_36, 0);
         lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_set_width(title, LV_PCT(90));
@@ -100,7 +114,7 @@ static void ota_show_overlay(const char *message) {
         /* ── Large percentage — center ── */
         ota_progress_label = lv_label_create(ota_overlay);
         lv_label_set_text(ota_progress_label, "0%");
-        lv_obj_set_style_text_color(ota_progress_label, lv_color_hex(OTA_ACCENT), 0);
+        lv_obj_set_style_text_color(ota_progress_label, lv_color_hex(accent_color), 0);
         lv_obj_set_style_text_font(ota_progress_label, &lv_font_montserrat_48, 0);
         lv_obj_set_style_text_align(ota_progress_label, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_align(ota_progress_label, LV_ALIGN_CENTER, 0, 20);
@@ -108,7 +122,7 @@ static void ota_show_overlay(const char *message) {
         /* ── "Do not power off" hint ── */
         lv_obj_t *hint = lv_label_create(ota_overlay);
         lv_label_set_text(hint, "Do not power off");
-        lv_obj_set_style_text_color(hint, lv_color_hex(0x555555), 0);
+        lv_obj_set_style_text_color(hint, lv_color_hex(hint_color), 0);
         lv_obj_set_style_text_font(hint, &lv_font_montserrat_20, 0);
         lv_obj_set_style_text_align(hint, LV_TEXT_ALIGN_CENTER, 0);
         lv_obj_align(hint, LV_ALIGN_CENTER, 0, 70);
@@ -124,7 +138,7 @@ static void ota_show_overlay(const char *message) {
         lv_obj_set_style_bg_opa(ota_bar_glow, LV_OPA_TRANSP, LV_PART_MAIN);
         lv_obj_set_style_radius(ota_bar_glow, 12, LV_PART_MAIN);
         /* Indicator: soft glow */
-        lv_obj_set_style_bg_color(ota_bar_glow, lv_color_hex(OTA_ACCENT), LV_PART_INDICATOR);
+        lv_obj_set_style_bg_color(ota_bar_glow, lv_color_hex(glow_color), LV_PART_INDICATOR);
         lv_obj_set_style_bg_opa(ota_bar_glow, OTA_GLOW_OPA, LV_PART_INDICATOR);
         lv_obj_set_style_radius(ota_bar_glow, 12, LV_PART_INDICATOR);
 
@@ -136,13 +150,13 @@ static void ota_show_overlay(const char *message) {
         lv_bar_set_range(ota_bar, 0, 100);
         lv_bar_set_value(ota_bar, 0, LV_ANIM_OFF);
         /* Track: dark rounded pill */
-        lv_obj_set_style_bg_color(ota_bar, lv_color_hex(OTA_ACCENT_DIM), LV_PART_MAIN);
+        lv_obj_set_style_bg_color(ota_bar, lv_color_hex(track_color), LV_PART_MAIN);
         lv_obj_set_style_bg_opa(ota_bar, LV_OPA_30, LV_PART_MAIN);
         lv_obj_set_style_radius(ota_bar, 6, LV_PART_MAIN);
         /* Indicator: bright accent with gradient */
-        lv_obj_set_style_bg_color(ota_bar, lv_color_hex(OTA_ACCENT), LV_PART_INDICATOR);
+        lv_obj_set_style_bg_color(ota_bar, lv_color_hex(accent_color), LV_PART_INDICATOR);
         lv_obj_set_style_bg_opa(ota_bar, LV_OPA_COVER, LV_PART_INDICATOR);
-        lv_obj_set_style_bg_grad_color(ota_bar, lv_color_hex(0x0088FF), LV_PART_INDICATOR);
+        lv_obj_set_style_bg_grad_color(ota_bar, lv_color_hex(grad_color), LV_PART_INDICATOR);
         lv_obj_set_style_bg_grad_dir(ota_bar, LV_GRAD_DIR_HOR, LV_PART_INDICATOR);
         lv_obj_set_style_radius(ota_bar, 6, LV_PART_INDICATOR);
 


### PR DESCRIPTION
### Summary
The web user interface now loads much faster and no longer flashes the wrong tab on startup. The red theme has been consistently applied across new and updated display elements, including a new Spotify interface.

### Changes
*   Web UI now loads significantly faster by parallelizing API calls and deferring non-critical operations like update checks and WiFi scans.
*   Fixed the web UI settings tab flashing issue by restoring the saved tab before the page renders.
*   Deferred version fetching and initial data polling until after the configuration populates, improving initial responsiveness.
*   WiFi network scanning no longer runs automatically on page load, only when the available networks panel is opened.
*   Extended the red theme to consistently cover new and updated UI components, including the Spotify interface, clock, and dashboard.
*   Updated image remapping logic to support the red theme across various UI elements.
*   Added a new Spotify UI component.
*   Centered the header for the collapsed WiFi Available Networks panel.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-06-28T17:22:20.791Z | Generated by GitHub Actions</sub>