### PR TITLE
feat: add per-source image flip

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -820,6 +820,14 @@ static void set_defaults(app_config_t *cfg) {
     cfg->custom_orientation = 0;          // 0=0°,1=90°,2=180°,3=270° clockwise
     cfg->custom_update_interval_s = 60;   // poll interval (10-7200s)
 
+    // Per-source Image Display mirror flips (0=no flip = current behavior)
+    cfg->goes_vflip = 0;
+    cfg->goes_hflip = 0;
+    cfg->solar_vflip = 0;
+    cfg->solar_hflip = 0;
+    cfg->custom_vflip = 0;
+    cfg->custom_hflip = 0;
+
     // Auth is on by default — protects device from open-LAN access
     cfg->auth_enabled = true;
 }
@@ -2186,6 +2194,29 @@ static void migrate_from_v46(const void *raw, size_t raw_size, app_config_t *cfg
     ESP_LOGI(TAG, "Migrated config v46 -> v%d (page-ref remap)", APP_CONFIG_VERSION);
 }
 
+/* --- v47 → v48 migration: appends 6 per-source Image Display mirror-flip
+ *     bytes (goes/solar/custom v/hflip). Layout ahead is unchanged; the new
+ *     fields are additive and default 0 (no flip = current behavior). --- */
+static void migrate_from_v47(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v47_t) ? raw_size : sizeof(app_config_v47_t);
+    memcpy(cfg, raw, copy);
+
+    /* The 6 flip fields are appended past the v47 snapshot, so memcpy(copy)
+     * never touches them. set_defaults() already zeroed the whole struct, but
+     * set them explicitly for documentation (0 = no flip = current behavior). */
+    cfg->goes_vflip   = 0;
+    cfg->goes_hflip   = 0;
+    cfg->solar_vflip  = 0;
+    cfg->solar_hflip  = 0;
+    cfg->custom_vflip = 0;
+    cfg->custom_hflip = 0;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v47 to v%d", APP_CONFIG_VERSION);
+}
+
 static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -2876,6 +2907,13 @@ static bool validate_config(app_config_t *cfg) {
         cfg->custom_update_interval_s = 60;
         fixed = true;
     }
+    /* Per-source Image Display mirror flips — normalize each to 0/1. */
+    if (cfg->goes_vflip > 1)   { cfg->goes_vflip   = (cfg->goes_vflip   != 0) ? 1 : 0; fixed = true; }
+    if (cfg->goes_hflip > 1)   { cfg->goes_hflip   = (cfg->goes_hflip   != 0) ? 1 : 0; fixed = true; }
+    if (cfg->solar_vflip > 1)  { cfg->solar_vflip  = (cfg->solar_vflip  != 0) ? 1 : 0; fixed = true; }
+    if (cfg->solar_hflip > 1)  { cfg->solar_hflip  = (cfg->solar_hflip  != 0) ? 1 : 0; fixed = true; }
+    if (cfg->custom_vflip > 1) { cfg->custom_vflip = (cfg->custom_vflip != 0) ? 1 : 0; fixed = true; }
+    if (cfg->custom_hflip > 1) { cfg->custom_hflip = (cfg->custom_hflip != 0) ? 1 : 0; fixed = true; }
     if (cfg->image_display_source > 3) {   /* 0=GOES, 1=Moon, 2=Solar, 3=Custom URL */
         cfg->image_display_source = 0;
         fixed = true;
@@ -2997,6 +3035,12 @@ void app_config_init(void) {
             nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
             nvs_commit(handle);
         }
+    } else if (version_check == 47) {
+        /* v47 → v48: added per-source Image Display mirror flips (goes/solar/custom v/hflip) */
+        migrate_from_v47(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 46) {
         /* v46 → v47: remap active_page_override + idle_page_override_target onto page_registry ids */
         migrate_from_v46(raw, stored_size, &s_config);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -46,7 +46,7 @@ extern "C" {
 #define ARP_ORDER_CAPACITY 16   /* size of auto_rotate_order2[] */
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 47
+#define APP_CONFIG_VERSION 48
 
 #define WIDGET_STYLE_COUNT 13
 
@@ -250,6 +250,16 @@ typedef struct {
     // Replaces the legacy auto_rotate_order[8] + auto_rotate_order_ext encoding;
     // each image source is now its own distinct stop (see ARP_IDX_* above).
     uint8_t  auto_rotate_order2[16];
+
+    // Added after v47 — must stay at end to preserve NVS binary compatibility
+    // Per-source Image Display mirror flips. 0/1 each; 0 = no flip (current
+    // behavior). vflip mirrors top<->bottom, hflip mirrors left<->right.
+    uint8_t  goes_vflip;     // GOES source: mirror top<->bottom (default 0)
+    uint8_t  goes_hflip;     // GOES source: mirror left<->right (default 0)
+    uint8_t  solar_vflip;    // Solar source: mirror top<->bottom (default 0)
+    uint8_t  solar_hflip;    // Solar source: mirror left<->right (default 0)
+    uint8_t  custom_vflip;   // Custom source: mirror top<->bottom (default 0)
+    uint8_t  custom_hflip;   // Custom source: mirror left<->right (default 0)
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -703,7 +713,133 @@ typedef struct {
     uint8_t  auto_rotate_order2[16];
 } app_config_v46_t;
 
-_Static_assert(sizeof(app_config_v46_t) == sizeof(app_config_t),
+/* v46_t's assert lives just below the v47_t definition (it compares against
+ * sizeof(app_config_v47_t), which must be a complete type first). */
+
+/* ── Version 47 config struct — used only for NVS migration to v48 ────── */
+/* Byte-identical to app_config_t minus the trailing per-source flip bytes  */
+/* (goes/solar/custom v/hflip). Verbatim copy of the v47 struct body.       */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+    char     custom_image_url[256];
+    uint8_t  custom_orientation;
+    uint16_t custom_update_interval_s;
+    uint8_t  auto_rotate_order2[16];
+} app_config_v47_t;
+
+/* The 6 new uint8 flips (align 1) append directly after auto_rotate_order2[16]
+ * (also align 1) with no padding, so offsetof == end-of-last-v47-field. Compare
+ * against the end of auto_rotate_order2 to catch any field inserted/reordered
+ * ahead of the new block without tripping on tail padding. */
+_Static_assert(offsetof(app_config_t, goes_vflip) ==
+                   offsetof(app_config_v47_t, auto_rotate_order2) +
+                       sizeof(((app_config_v47_t *)0)->auto_rotate_order2),
+               "app_config_v47_t snapshot drifted from app_config_t layout");
+
+/* v46_t and v47_t have byte-identical bodies (v48 only appends 6 trailing flip
+ * bytes past the v47 layout), so v46 stays valid by matching v47_t's size
+ * rather than app_config_t's — avoids any tail-padding ambiguity from the
+ * appended uint8 block. */
+_Static_assert(sizeof(app_config_v46_t) == sizeof(app_config_v47_t),
                "app_config_v46_t snapshot drifted from app_config_t layout");
 
 // v17 snapshot — AllSky fields without allsky_enabled

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1309,6 +1309,16 @@
             </select>
             <div class="field-hint">Rotate the satellite image clockwise.</div>
           </div>
+          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Flip vertical</span>
+            <label class="toggle"><input type="checkbox" id="goesVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the satellite image top-to-bottom.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Flip horizontal</span>
+            <label class="toggle"><input type="checkbox" id="goesHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the satellite image left-to-right.</div>
           <div class="field" style="margin-top:16px">
             <button onclick="fetchGoesPreview()" class="btn btn-primary" id="goesPreviewBtn" style="width:100%">Fetch Preview</button>
           </div>
@@ -1441,6 +1451,16 @@
             </select>
             <div class="field-hint">Rotate the solar image clockwise.</div>
           </div>
+          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Flip vertical</span>
+            <label class="toggle"><input type="checkbox" id="solarVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the solar image top-to-bottom.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Flip horizontal</span>
+            <label class="toggle"><input type="checkbox" id="solarHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the solar image left-to-right.</div>
           </div>
           <div id="customGroup" style="display:none">
           <div class="field" style="margin-top:16px">
@@ -1458,6 +1478,16 @@
             </select>
             <div class="field-hint">Rotate the custom image clockwise.</div>
           </div>
+          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Flip vertical</span>
+            <label class="toggle"><input type="checkbox" id="customVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the custom image top-to-bottom.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Flip horizontal</span>
+            <label class="toggle"><input type="checkbox" id="customHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the custom image left-to-right.</div>
           <div class="field" style="margin-top:16px">
             <label class="field-label">Update Interval</label>
             <select class="input" id="customInterval" onchange="applyImageDisplay();checkDirty()">
@@ -2804,10 +2834,16 @@
                 <tr><td>goes_region</td><td>string</td><td>region code</td><td>GOES region id.</td></tr>
                 <tr><td>goes_update_interval_s</td><td>int</td><td>300 to 7200 (clamped)</td><td>GOES refresh interval in seconds.</td></tr>
                 <tr><td>goes_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant (0/90/180/270 degrees).</td></tr>
+                <tr><td>goes_vflip</td><td>int</td><td>0 or 1</td><td>Flip GOES image vertically (top/bottom).</td></tr>
+                <tr><td>goes_hflip</td><td>int</td><td>0 or 1</td><td>Flip GOES image horizontally (left/right).</td></tr>
                 <tr><td>solar_band</td><td>int</td><td>0 to 17</td><td>Solar / SDO / SOHO band index. An invalid value falls back to 0.</td></tr>
                 <tr><td>solar_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant.</td></tr>
+                <tr><td>solar_vflip</td><td>int</td><td>0 or 1</td><td>Flip solar image vertically (top/bottom).</td></tr>
+                <tr><td>solar_hflip</td><td>int</td><td>0 or 1</td><td>Flip solar image horizontally (left/right).</td></tr>
                 <tr><td>custom_image_url</td><td>string (max 256)</td><td>must start with http:// or https:// (empty string clears it)</td><td>Custom image source URL. Validated server-side.</td></tr>
                 <tr><td>custom_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant.</td></tr>
+                <tr><td>custom_vflip</td><td>int</td><td>0 or 1</td><td>Flip custom image vertically (top/bottom).</td></tr>
+                <tr><td>custom_hflip</td><td>int</td><td>0 or 1</td><td>Flip custom image horizontally (left/right).</td></tr>
                 <tr><td>custom_update_interval_s</td><td>int</td><td>10 to 7200 (clamped)</td><td>Custom image refresh interval in seconds.</td></tr>
                 <tr><td>moon_bg_style</td><td>int</td><td>0 to 3</td><td>Moon page background style. An invalid value falls back to 0.</td></tr>
                 <tr><td>moon_lat</td><td>float</td><td>latitude</td><td>Observer latitude for moon libration.</td></tr>
@@ -3937,12 +3973,18 @@
       if($('customImageUrl')) $('customImageUrl').value=data.custom_image_url||'';
       updateImgCustomPillHint();
       if($('customOrientation')) $('customOrientation').value=String(data.custom_orientation||0);
+      if($('customVflip')) $('customVflip').checked=!!data.custom_vflip;
+      if($('customHflip')) $('customHflip').checked=!!data.custom_hflip;
       if($('customInterval')) $('customInterval').value=String(data.custom_update_interval_s||60);
       if($('moonBg')) $('moonBg').value=String(data.moon_bg_style||0);
       if($('moonDragLight')) $('moonDragLight').value=String(data.moon_drag_light_mode||0);
       if($('solarBand')) $('solarBand').value=String(data.solar_band||0);
       if($('goesOrientation')) $('goesOrientation').value=String(data.goes_orientation||0);
+      if($('goesVflip')) $('goesVflip').checked=!!data.goes_vflip;
+      if($('goesHflip')) $('goesHflip').checked=!!data.goes_hflip;
       if($('solarOrientation')) $('solarOrientation').value=String(data.solar_orientation||0);
+      if($('solarVflip')) $('solarVflip').checked=!!data.solar_vflip;
+      if($('solarHflip')) $('solarHflip').checked=!!data.solar_hflip;
       var mlat=data.moon_lat, mlon=data.moon_lon;
       // Prefill from weather location when moon coords are unset
       if((!mlat && !mlon) && (data.weather_lat || data.weather_lon)){ mlat=data.weather_lat; mlon=data.weather_lon; }
@@ -4445,9 +4487,19 @@
        `data` is a /api/check-update-json response; `tag` is substituted live. */
     function fullEraseCautionHtml(data){
       var tag=escHtml((data&&data.tag)||'');
+      var eraseTag=escHtml((data&&data.full_erase_tag)||'');
       var relUrl=(data&&(data.release_url||data.html_url))||'https://github.com/chvvkumar/ESP32-P4-NINA-Display/releases';
       relUrl=escHtml(relUrl);
-      return 'Firmware <strong>'+tag+'</strong> requires a manual update. It cannot be installed over the air. '+
+      // Name the intermediate release that forces the manual update when it differs
+      // from the target. Empty eraseTag (history-incomplete fail-safe) or eraseTag
+      // equal to the target keeps the existing single-version wording.
+      var lead;
+      if(eraseTag && eraseTag!==tag){
+        lead='Updating to <strong>'+tag+'</strong> requires a manual update, because release <strong>'+eraseTag+'</strong> on the way requires a full erase. It cannot be installed over the air. ';
+      } else {
+        lead='Firmware <strong>'+tag+'</strong> requires a manual update. It cannot be installed over the air. ';
+      }
+      return lead+
         'First back up your settings on the Backup tab (Download Backup). '+
         'Then flash nina-display-factory.bin at address 0x0000 using the '+
         '<a href="https://espressif.github.io/esptool-js/" target="_blank" rel="noopener">ESP Web Flasher</a>. '+
@@ -5240,9 +5292,15 @@
         moon_spin_return_s: parseInt($('moon_spin_return_s').value,10)||3,
         solar_band: parseInt($('solarBand').value,10)||0,
         goes_orientation: parseInt($('goesOrientation').value,10)||0,
+        goes_vflip: $('goesVflip')&&$('goesVflip').checked?1:0,
+        goes_hflip: $('goesHflip')&&$('goesHflip').checked?1:0,
         solar_orientation: parseInt($('solarOrientation').value,10)||0,
+        solar_vflip: $('solarVflip')&&$('solarVflip').checked?1:0,
+        solar_hflip: $('solarHflip')&&$('solarHflip').checked?1:0,
         custom_image_url: $('customImageUrl')?$('customImageUrl').value.trim():'',
         custom_orientation: $('customOrientation')?parseInt($('customOrientation').value,10)||0:0,
+        custom_vflip: $('customVflip')&&$('customVflip').checked?1:0,
+        custom_hflip: $('customHflip')&&$('customHflip').checked?1:0,
         custom_update_interval_s: $('customInterval')?parseInt($('customInterval').value,10)||60:60
       }).then(function(r){
         if(!r.ok){ showToast('Failed to save image settings','error'); return; }

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -18,8 +18,11 @@
       --accent-hover: #9dbcff;
       --accent-glow: rgba(var(--accent-rgb), 0.15);
       --text: #e2e8f0;
+      --text-secondary: #b8c2d0;
       --text-muted: #94a3b8;
       --text-hint: #7a8ba4;
+      --accent-strong: #5a86e8;
+      --accent-strong-hover: #4a72d8;
       --danger: #f87171;
       --danger-hover: #ef4444;
       --warning: #fbbf24;
@@ -40,7 +43,7 @@
     * { box-sizing: border-box; margin: 0; padding: 0; -webkit-tap-highlight-color: transparent; }
 
     body {
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
       background: var(--bg);
       background-image:
         radial-gradient(ellipse at 20% 0%, rgba(122, 162, 247, 0.05) 0%, transparent 50%),
@@ -154,14 +157,20 @@
       display: block; font-size: 0.82rem; color: var(--text-muted);
       margin-bottom: 8px; font-weight: 500; letter-spacing: 0.01em;
     }
-    .field-hint { font-size: 0.72rem; color: var(--text-hint); margin-top: 6px; opacity: 0.7; }
+    .field-hint { font-size: 0.72rem; color: var(--text-hint); margin-top: 6px; }
     /* Section help popover (inline expandable, toggled by info icon in card title) */
     .card-title-label { display:inline-flex; align-items:center; min-width:0; }
     .help-btn {
+      position:relative;
       display:inline-flex; align-items:center; justify-content:center;
       width:18px; height:18px; padding:0; margin-left:8px; flex-shrink:0;
       border:none; background:transparent; cursor:pointer; color:var(--text-muted);
       border-radius:50%; vertical-align:middle; transition:color 0.2s ease, background 0.2s ease;
+    }
+    /* Expand the tap target to >=44x44px without enlarging the 18px visible box or shifting inline layout */
+    .help-btn::before {
+      content:""; position:absolute; left:50%; top:50%; transform:translate(-50%, -50%);
+      width:44px; height:44px;
     }
     .help-btn:hover { color:var(--accent); background:var(--accent-glow); }
     .help-btn svg { width:14px; height:14px; display:block; pointer-events:none; }
@@ -1745,7 +1754,7 @@
           <label class="toggle"><input type="checkbox" id="notify_cat_2" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
         </div>
         <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Focuser</span>
+          <span class="toggle-label">Focuser Events</span>
           <label class="toggle"><input type="checkbox" id="notify_cat_3" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
         </div>
         <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
@@ -1983,9 +1992,11 @@
           <label class="toggle"><input type="checkbox" id="debug_mode"><span class="toggle-track"></span></label>
         </div>
         <div class="field-hint" style="margin-top:4px;margin-bottom:16px">Shows extra performance and diagnostic info.</div>
-        <span class="toggle-label">Enable Demo Mode</span>
-        <label class="toggle"><input type="checkbox" id="demo_mode"><span class="toggle-track"></span></label>
-        <p style="color:#888;font-size:0.85em;margin:2px 0 8px 0;">Generates simulated astrophotography data. Reboot for the change to fully take effect.</p>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable Demo Mode</span>
+          <label class="toggle"><input type="checkbox" id="demo_mode"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px;margin-bottom:16px">Generates simulated astrophotography data. Reboot for the change to fully take effect.</div>
         <button class="btn btn-outline" id="ssBtn" onclick="takeScreenshot()">Capture Screenshot</button>
         <div id="ssContainer" style="display:none;margin-top:16px">
           <img id="ssImage" style="width:100%;border-radius:var(--radius-sm);border:1px solid var(--border)">

--- a/main/control_registry.c
+++ b/main/control_registry.c
@@ -38,6 +38,12 @@ static int get_image_display_source(const control_item_t *it, const app_config_t
 static int get_goes_orientation(const control_item_t *it, const app_config_t *c)           { (void)it; return c->goes_orientation; }
 static int get_solar_orientation(const control_item_t *it, const app_config_t *c)          { (void)it; return c->solar_orientation; }
 static int get_custom_orientation(const control_item_t *it, const app_config_t *c)         { (void)it; return c->custom_orientation; }
+static int get_goes_vflip(const control_item_t *it, const app_config_t *c)                 { (void)it; return c->goes_vflip ? 1 : 0; }
+static int get_goes_hflip(const control_item_t *it, const app_config_t *c)                 { (void)it; return c->goes_hflip ? 1 : 0; }
+static int get_solar_vflip(const control_item_t *it, const app_config_t *c)                { (void)it; return c->solar_vflip ? 1 : 0; }
+static int get_solar_hflip(const control_item_t *it, const app_config_t *c)                { (void)it; return c->solar_hflip ? 1 : 0; }
+static int get_custom_vflip(const control_item_t *it, const app_config_t *c)               { (void)it; return c->custom_vflip ? 1 : 0; }
+static int get_custom_hflip(const control_item_t *it, const app_config_t *c)               { (void)it; return c->custom_hflip ? 1 : 0; }
 static int get_solar_band(const control_item_t *it, const app_config_t *c)                 { (void)it; return c->solar_band; }
 static int get_goes_update_interval_s(const control_item_t *it, const app_config_t *c)     { (void)it; return c->goes_update_interval_s; }
 static int get_custom_update_interval_s(const control_item_t *it, const app_config_t *c)   { (void)it; return c->custom_update_interval_s; }
@@ -90,6 +96,12 @@ static void set_image_display_source(const control_item_t *it, app_config_t *c, 
 static void set_goes_orientation(const control_item_t *it, app_config_t *c, int v)           { (void)it; c->goes_orientation = (uint8_t)v; }
 static void set_solar_orientation(const control_item_t *it, app_config_t *c, int v)          { (void)it; c->solar_orientation = (uint8_t)v; }
 static void set_custom_orientation(const control_item_t *it, app_config_t *c, int v)         { (void)it; c->custom_orientation = (uint8_t)v; }
+static void set_goes_vflip(const control_item_t *it, app_config_t *c, int v)                 { (void)it; c->goes_vflip = (uint8_t)(v != 0); }
+static void set_goes_hflip(const control_item_t *it, app_config_t *c, int v)                 { (void)it; c->goes_hflip = (uint8_t)(v != 0); }
+static void set_solar_vflip(const control_item_t *it, app_config_t *c, int v)                { (void)it; c->solar_vflip = (uint8_t)(v != 0); }
+static void set_solar_hflip(const control_item_t *it, app_config_t *c, int v)                { (void)it; c->solar_hflip = (uint8_t)(v != 0); }
+static void set_custom_vflip(const control_item_t *it, app_config_t *c, int v)               { (void)it; c->custom_vflip = (uint8_t)(v != 0); }
+static void set_custom_hflip(const control_item_t *it, app_config_t *c, int v)               { (void)it; c->custom_hflip = (uint8_t)(v != 0); }
 static void set_solar_band(const control_item_t *it, app_config_t *c, int v)                 { (void)it; c->solar_band = (uint8_t)v; }
 static void set_goes_update_interval_s(const control_item_t *it, app_config_t *c, int v)     { (void)it; c->goes_update_interval_s = (uint16_t)v; }
 static void set_custom_update_interval_s(const control_item_t *it, app_config_t *c, int v)   { (void)it; c->custom_update_interval_s = (uint16_t)v; }
@@ -205,6 +217,12 @@ static const control_item_t s_items[] = {
     { "goes_orientation",           CTRL_TYPE_ENUM, 0, 3, 1, LBL(orient_labels), get_goes_orientation,   set_goes_orientation,   apply_image_display },
     { "solar_orientation",          CTRL_TYPE_ENUM, 0, 3, 1, LBL(orient_labels), get_solar_orientation,  set_solar_orientation,  apply_image_display },
     { "custom_orientation",         CTRL_TYPE_ENUM, 0, 3, 1, LBL(orient_labels), get_custom_orientation, set_custom_orientation, apply_image_display },
+    { "goes_vflip",                 CTRL_TYPE_BOOL, 0, 1, 1, NULL, 0, get_goes_vflip,         set_goes_vflip,         apply_image_display },
+    { "goes_hflip",                 CTRL_TYPE_BOOL, 0, 1, 1, NULL, 0, get_goes_hflip,         set_goes_hflip,         apply_image_display },
+    { "solar_vflip",                CTRL_TYPE_BOOL, 0, 1, 1, NULL, 0, get_solar_vflip,        set_solar_vflip,        apply_image_display },
+    { "solar_hflip",                CTRL_TYPE_BOOL, 0, 1, 1, NULL, 0, get_solar_hflip,        set_solar_hflip,        apply_image_display },
+    { "custom_vflip",               CTRL_TYPE_BOOL, 0, 1, 1, NULL, 0, get_custom_vflip,       set_custom_vflip,       apply_image_display },
+    { "custom_hflip",               CTRL_TYPE_BOOL, 0, 1, 1, NULL, 0, get_custom_hflip,       set_custom_hflip,       apply_image_display },
     /* solar_band: enum with no labels -> control_item_label() returns NULL so the
      * handler formats the numeric band index as the label string. */
     { "solar_band",                 CTRL_TYPE_ENUM, 0, 17, 1, NULL, 0, get_solar_band,             set_solar_band,             apply_image_display },

--- a/main/login.html
+++ b/main/login.html
@@ -13,15 +13,20 @@
     --border:rgba(255,255,255,0.08);
     --border-em:rgba(255,255,255,0.15);
     --text:#e2e8f0;
+    --text-secondary:#b8c2d0;
     --text-muted:#94a3b8;
     --text-hint:#7a8ba4;
     --accent:#7aa2f7;
+    --accent-rgb:122, 162, 247;
     --accent-hover:#9dbcff;
     --accent-strong:#5a86e8;
     --accent-strong-hover:#4a72d8;
     --danger:#f87171;
+    --danger-hover:#ef4444;
+    --success:#4ade80;
+    --warning:#fbbf24;
   }
-  html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--text);font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif}
   body{display:flex;align-items:center;justify-content:center;min-height:100vh;background-image:linear-gradient(135deg,#0a0c14 0%,#0f1320 100%)}
   .card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:28px 28px 24px;width:320px;box-shadow:0 8px 32px rgba(0,0,0,0.4)}
   h1{font-size:18px;margin:0 0 4px;font-weight:600;letter-spacing:.2px}

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -16,7 +16,12 @@
 
 static const char *TAG = "ota_github";
 
-#define GITHUB_API_URL    "https://api.github.com/repos/chvvkumar/ESP32-P4-NINA-Display/releases?per_page=5"
+/* Releases endpoint, paginated. per_page=10 keeps each page's JSON under the
+ * 128 KB MAX_RESPONSE_SIZE buffer (measured worst case ~93 KB). The full per-page
+ * URL is composed by appending "&page=N" into a stack buffer (see fetch_releases_page). */
+#define GITHUB_API_URL    "https://api.github.com/repos/chvvkumar/ESP32-P4-NINA-Display/releases?per_page=10"
+#define MAX_RELEASE_PAGES 10       /* safety cap: 10 pages x per_page=10 = 100 releases (>2x current 43) */
+#define RELEASE_URL_BUF   256      /* generous bound for GITHUB_API_URL + "&page=NN" */
 #define OTA_BUF_SIZE      4096
 #define MAX_RESPONSE_SIZE (128 * 1024)
 #define OTA_ASSET_NAME    "nina-display-ota.bin"
@@ -191,25 +196,31 @@ static esp_err_t redirect_event_handler(esp_http_client_event_t *evt) {
     return ESP_OK;
 }
 
-/* ── Check GitHub for updates ─────────────────────────────────────── */
+/* ── Fetch one page of the releases list ──────────────────────────── */
 
-bool ota_github_check(bool include_prereleases, const char *current_version, github_release_info_t *out) {
-    if (!current_version || !out) return false;
-
-    ESP_LOGI(TAG, "Checking GitHub for updates (current: %s, channel: %s)",
-             current_version, include_prereleases ? "pre-release" : "stable");
-
+/*
+ * Fetch a single page (?per_page=10&page=N) of the GitHub releases list and
+ * parse it into a cJSON array. Returns the parsed array (caller owns it and must
+ * cJSON_Delete it), or NULL on ANY failure: HTTP error, non-200 status, response
+ * buffer overflow, or JSON parse failure. *overflow_out is set true only when the
+ * 128 KB response buffer overflowed (so the caller can apply the history fail-safe);
+ * it is left untouched on other failures. The helper frees its own response buffer.
+ */
+static cJSON *fetch_releases_page(int page, bool *overflow_out) {
     http_response_t resp = {0};
     resp.buffer_size = MAX_RESPONSE_SIZE;
     resp.buffer = heap_caps_malloc(resp.buffer_size, MALLOC_CAP_SPIRAM);
     if (!resp.buffer) {
-        ESP_LOGE(TAG, "Failed to allocate response buffer");
-        return false;
+        ESP_LOGE(TAG, "Failed to allocate response buffer (page %d)", page);
+        return NULL;
     }
     resp.buffer[0] = '\0';
 
+    char url[RELEASE_URL_BUF];
+    snprintf(url, sizeof(url), "%s&page=%d", GITHUB_API_URL, page);
+
     esp_http_client_config_t config = {
-        .url = GITHUB_API_URL,
+        .url = url,
         .event_handler = http_event_handler,
         .user_data = &resp,
         .timeout_ms = 10000,
@@ -220,9 +231,9 @@ bool ota_github_check(bool include_prereleases, const char *current_version, git
 
     esp_http_client_handle_t client = esp_http_client_init(&config);
     if (!client) {
-        ESP_LOGE(TAG, "Failed to init HTTP client");
+        ESP_LOGE(TAG, "Failed to init HTTP client (page %d)", page);
         free(resp.buffer);
-        return false;
+        return NULL;
     }
 
     esp_http_client_set_header(client, "User-Agent", "ESP32-NINA-Display");
@@ -233,27 +244,44 @@ bool ota_github_check(bool include_prereleases, const char *current_version, git
     esp_http_client_cleanup(client);
 
     if (err != ESP_OK || status != 200) {
-        ESP_LOGW(TAG, "GitHub API request failed (err=%s, status=%d)", esp_err_to_name(err), status);
+        ESP_LOGW(TAG, "GitHub API request failed (page %d, err=%s, status=%d)",
+                 page, esp_err_to_name(err), status);
         free(resp.buffer);
-        return false;
+        return NULL;
     }
 
-    ESP_LOGI(TAG, "GitHub API response: %d bytes", resp.buffer_len);
+    ESP_LOGI(TAG, "GitHub API response (page %d): %d bytes", page, resp.buffer_len);
 
     if (resp.overflow) {
-        ESP_LOGE(TAG, "Response was truncated (buffer %d bytes too small)", resp.buffer_size);
+        ESP_LOGE(TAG, "Response was truncated (page %d, buffer %d bytes too small)",
+                 page, resp.buffer_size);
+        if (overflow_out) {
+            *overflow_out = true;
+        }
         free(resp.buffer);
-        return false;
+        return NULL;
     }
 
-    /* Parse JSON array of releases */
     cJSON *releases = cJSON_Parse(resp.buffer);
     free(resp.buffer);
     if (!releases || !cJSON_IsArray(releases)) {
-        ESP_LOGW(TAG, "Failed to parse GitHub releases JSON");
-        if (releases) cJSON_Delete(releases);
-        return false;
+        ESP_LOGW(TAG, "Failed to parse GitHub releases JSON (page %d)", page);
+        if (releases) {
+            cJSON_Delete(releases);
+        }
+        return NULL;
     }
+
+    return releases;
+}
+
+/* ── Check GitHub for updates ─────────────────────────────────────── */
+
+bool ota_github_check(bool include_prereleases, const char *current_version, github_release_info_t *out) {
+    if (!current_version || !out) return false;
+
+    ESP_LOGI(TAG, "Checking GitHub for updates (current: %s, channel: %s)",
+             current_version, include_prereleases ? "pre-release" : "stable");
 
     /* Detect channel switch: current version type doesn't match target channel.
      * When switching channels (e.g. pre-release → stable), the normal version
@@ -270,74 +298,153 @@ bool ota_github_check(bool include_prereleases, const char *current_version, git
                  include_prereleases ? "pre-release" : "stable");
     }
 
-    bool found = false;
-    int count = cJSON_GetArraySize(releases);
-    for (int i = 0; i < count && !found; i++) {
-        cJSON *release = cJSON_GetArrayItem(releases, i);
-        if (!release) continue;
+    /* ── Paginated path scan (newest-first) ──────────────────────────────
+     * Walk pages 1..MAX_RELEASE_PAGES. The TARGET is the newest in-channel
+     * release newer than installed (first qualifying release, newest-first).
+     * The full-erase marker is OR'd across EVERY in-channel release on the
+     * path (installed < v <= target), so a marker on a skipped intermediate
+     * release suppresses the OTA even when the target itself is unmarked.
+     * full_erase_tag records the FIRST marked release encountered = newest
+     * marked. Scanning stops once a release at-or-below installed is seen
+     * (path fully covered). Fail-safe: if the page cap is hit before reaching
+     * installed, or a fetch errors/overflows mid-path, force manual-flash. */
+    bool found_target = false;          /* an OTA target release has been captured */
+    bool any_marker = false;            /* OR of nina:full_erase=1 across the path */
+    bool reached_installed = false;     /* a fetched in-channel release compared <= installed */
+    bool fail_safe = false;             /* history could not be fully verified */
+    char full_erase_tag_local[32] = {0};/* newest marked tag on the path (written once) */
 
-        /* Skip drafts */
-        cJSON *draft = cJSON_GetObjectItem(release, "draft");
-        if (cJSON_IsTrue(draft)) continue;
+    for (int page = 1; page <= MAX_RELEASE_PAGES && !reached_installed; page++) {
+        bool overflow = false;
+        cJSON *releases = fetch_releases_page(page, &overflow);
+        if (!releases) {
+            /* Page-1 failure with nothing found yet → behave as the old
+             * "request failed → return false" path. A MID-PATH failure (after a
+             * target was captured, before reaching installed) means the history
+             * is unverifiable → fail-safe to manual-flash. */
+            if (found_target) {
+                ESP_LOGW(TAG, "Couldn't verify full update history: page %d fetch %s",
+                         page, overflow ? "overflowed" : "failed");
+                fail_safe = true;
+            } else {
+                ESP_LOGW(TAG, "GitHub release fetch failed on page %d with no target found", page);
+            }
+            break;
+        }
 
-        /* Check pre-release flag — each channel only sees its own releases */
-        cJSON *prerelease = cJSON_GetObjectItem(release, "prerelease");
-        bool is_pre = cJSON_IsTrue(prerelease);
-        if (is_pre && !include_prereleases) continue;   /* stable channel: skip pre-releases */
-        if (!is_pre && include_prereleases) continue;    /* pre-release channel: skip stable */
+        int count = cJSON_GetArraySize(releases);
+        for (int i = 0; i < count && !reached_installed; i++) {
+            cJSON *release = cJSON_GetArrayItem(releases, i);
+            if (!release) continue;
 
-        /* Get tag name */
-        cJSON *tag = cJSON_GetObjectItem(release, "tag_name");
-        if (!cJSON_IsString(tag) || !tag->valuestring) continue;
+            /* Skip drafts */
+            cJSON *draft = cJSON_GetObjectItem(release, "draft");
+            if (cJSON_IsTrue(draft)) continue;
 
-        /* Compare versions — skip check when switching channels so the latest
-         * release from the target channel is always offered. */
-        if (!channel_switch && compare_versions(tag->valuestring, current_version) <= 0) continue;
+            /* Check pre-release flag — each channel only sees its own releases */
+            cJSON *prerelease = cJSON_GetObjectItem(release, "prerelease");
+            bool is_pre = cJSON_IsTrue(prerelease);
+            if (is_pre && !include_prereleases) continue;   /* stable channel: skip pre-releases */
+            if (!is_pre && include_prereleases) continue;    /* pre-release channel: skip stable */
 
-        /* Find OTA asset */
-        cJSON *assets = cJSON_GetObjectItem(release, "assets");
-        if (!cJSON_IsArray(assets)) continue;
+            /* Get tag name */
+            cJSON *tag = cJSON_GetObjectItem(release, "tag_name");
+            if (!cJSON_IsString(tag) || !tag->valuestring) continue;
 
-        const char *ota_url = NULL;
-        int asset_count = cJSON_GetArraySize(assets);
-        for (int j = 0; j < asset_count; j++) {
-            cJSON *asset = cJSON_GetArrayItem(assets, j);
-            cJSON *name = cJSON_GetObjectItem(asset, "name");
-            if (cJSON_IsString(name) && strcmp(name->valuestring, OTA_ASSET_NAME) == 0) {
-                cJSON *url = cJSON_GetObjectItem(asset, "browser_download_url");
-                if (cJSON_IsString(url)) {
-                    ota_url = url->valuestring;
-                }
+            /* Classify by version. When switching channels the version check is
+             * skipped so the latest in-channel release is always the target. */
+            if (!channel_switch && compare_versions(tag->valuestring, current_version) <= 0) {
+                /* At-or-below installed: the path is fully covered. This release is
+                 * NOT on the installed→target path, so its marker is irrelevant. */
+                reached_installed = true;
                 break;
+            }
+
+            /* This is a path release (installed < v, in channel). */
+            cJSON *body = cJSON_GetObjectItem(release, "body");
+            const char *body_str = cJSON_IsString(body) ? body->valuestring : "";
+
+            /* OR the full-erase marker across the path; record the newest marked tag. */
+            if (strstr(body_str, "nina:full_erase=1") != NULL) {
+                any_marker = true;
+                if (full_erase_tag_local[0] == '\0') {
+                    strncpy(full_erase_tag_local, tag->valuestring, sizeof(full_erase_tag_local) - 1);
+                    full_erase_tag_local[sizeof(full_erase_tag_local) - 1] = '\0';
+                }
+            }
+
+            /* Capture the FIRST qualifying release (newest-first) as the OTA target. */
+            if (!found_target) {
+                cJSON *assets = cJSON_GetObjectItem(release, "assets");
+                const char *ota_url = NULL;
+                if (cJSON_IsArray(assets)) {
+                    int asset_count = cJSON_GetArraySize(assets);
+                    for (int j = 0; j < asset_count; j++) {
+                        cJSON *asset = cJSON_GetArrayItem(assets, j);
+                        cJSON *name = cJSON_GetObjectItem(asset, "name");
+                        if (cJSON_IsString(name) && strcmp(name->valuestring, OTA_ASSET_NAME) == 0) {
+                            cJSON *url = cJSON_GetObjectItem(asset, "browser_download_url");
+                            if (cJSON_IsString(url)) {
+                                ota_url = url->valuestring;
+                            }
+                            break;
+                        }
+                    }
+                }
+
+                if (!ota_url) {
+                    /* No OTA asset on the newest release: it cannot be the OTA target,
+                     * but its marker still counts toward the path determination above.
+                     * Keep scanning for an older release that does carry the asset. */
+                    ESP_LOGW(TAG, "Release %s has no %s asset, skipping as target",
+                             tag->valuestring, OTA_ASSET_NAME);
+                } else {
+                    memset(out, 0, sizeof(*out));
+                    strncpy(out->tag, tag->valuestring, sizeof(out->tag) - 1);
+                    out->tag[sizeof(out->tag) - 1] = '\0';
+                    extract_summary(body_str, out->summary, sizeof(out->summary));
+                    strncpy(out->ota_url, ota_url, sizeof(out->ota_url) - 1);
+                    out->ota_url[sizeof(out->ota_url) - 1] = '\0';
+                    out->is_prerelease = is_pre;
+                    found_target = true;
+                    ESP_LOGI(TAG, "Update target: %s (pre-release: %s)", out->tag, is_pre ? "yes" : "no");
+
+                    /* Under channel_switch there is no installed-version boundary to
+                     * reach, so the latest in-channel release is the whole path. */
+                    if (channel_switch) {
+                        reached_installed = true;
+                        break;
+                    }
+                }
             }
         }
 
-        if (!ota_url) {
-            ESP_LOGW(TAG, "Release %s has no %s asset, skipping", tag->valuestring, OTA_ASSET_NAME);
-            continue;
-        }
-
-        /* Extract summary from release body */
-        cJSON *body = cJSON_GetObjectItem(release, "body");
-        const char *body_str = cJSON_IsString(body) ? body->valuestring : "";
-
-        /* Fill output */
-        memset(out, 0, sizeof(*out));
-        strncpy(out->tag, tag->valuestring, sizeof(out->tag) - 1);
-        extract_summary(body_str, out->summary, sizeof(out->summary));
-        strncpy(out->ota_url, ota_url, sizeof(out->ota_url) - 1);
-        out->is_prerelease = is_pre;
-        out->requires_full_erase = (strstr(body_str, "nina:full_erase=1") != NULL);
-
-        ESP_LOGI(TAG, "Update available: %s (pre-release: %s)", out->tag, is_pre ? "yes" : "no");
-        found = true;
+        cJSON_Delete(releases);
     }
 
-    cJSON_Delete(releases);
+    /* Fail-safe (ERASE-05): a target was found but the scan ended without
+     * reaching installed (page cap exhausted) — the history is not fully
+     * verified, so never offer OTA. The mid-path fetch-error case above
+     * already set fail_safe. */
+    if (found_target && !reached_installed && !fail_safe) {
+        ESP_LOGW(TAG, "Couldn't verify full update history: page cap (%d) reached before installed version",
+                 MAX_RELEASE_PAGES);
+        fail_safe = true;
+    }
 
-    if (!found) {
+    if (!found_target) {
         ESP_LOGI(TAG, "No newer release found");
         return false;
+    }
+
+    /* Populate the erase determination on the captured target. */
+    out->requires_full_erase = any_marker || fail_safe;
+    if (fail_safe) {
+        /* History-incomplete variant: empty tag signals "couldn't verify". */
+        out->full_erase_tag[0] = '\0';
+    } else {
+        strncpy(out->full_erase_tag, full_erase_tag_local, sizeof(out->full_erase_tag) - 1);
+        out->full_erase_tag[sizeof(out->full_erase_tag) - 1] = '\0';
     }
 
     /*

--- a/main/ota_github.h
+++ b/main/ota_github.h
@@ -13,6 +13,9 @@ typedef struct {
     char ota_url[2048];        // Pre-signed S3 URL can be ~1KB with auth tokens
     bool is_prerelease;
     bool requires_full_erase;  // Release requires manual USB erase+flash (cannot OTA)
+    char full_erase_tag[32];   // Newest release tag on the install path carrying the full-erase
+                               // marker; empty when no path release is marked, or when the
+                               // fail-safe fired on an unverifiable update history.
 } github_release_info_t;
 
 /**

--- a/main/setup_ui.html
+++ b/main/setup_ui.html
@@ -13,17 +13,20 @@
     --border:rgba(255,255,255,0.08);
     --border-em:rgba(255,255,255,0.15);
     --text:#e2e8f0;
+    --text-secondary:#b8c2d0;
     --text-muted:#94a3b8;
     --text-hint:#7a8ba4;
     --accent:#7aa2f7;
+    --accent-rgb:122, 162, 247;
     --accent-hover:#9dbcff;
     --accent-strong:#5a86e8;
     --accent-strong-hover:#4a72d8;
     --danger:#f87171;
+    --danger-hover:#ef4444;
     --success:#4ade80;
     --warning:#fbbf24;
   }
-  html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif}
+  html,body{margin:0;padding:0;height:100%;background:var(--bg);color:var(--text);font-family:system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif}
   body{display:flex;align-items:center;justify-content:center;min-height:100vh;padding:16px;box-sizing:border-box;background-image:linear-gradient(135deg,#0a0c14 0%,#0f1320 100%)}
   .card{background:var(--surface);border:1px solid var(--border);border-radius:10px;padding:28px;width:100%;max-width:420px;box-shadow:0 8px 32px rgba(0,0,0,0.4)}
   h1{font-size:18px;margin:0 0 4px;font-weight:600;letter-spacing:.2px}

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -2303,7 +2303,7 @@ void data_update_task(void *arg) {
                      * blocking warning and wait only for dismissal. */
                     ESP_LOGW(TAG, "Firmware %s requires manual USB erase+flash", rel->tag);
                     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                        nina_ota_prompt_show_manual_flash(rel->tag);
+                        nina_ota_prompt_show_manual_flash(rel->tag, rel->full_erase_tag);
                         bsp_display_unlock();
                     }
                     while (nina_ota_prompt_visible()) {
@@ -2715,7 +2715,7 @@ main_loop:
                      * blocking warning and wait only for dismissal. */
                     ESP_LOGW(TAG, "Firmware %s requires manual USB erase+flash", rel->tag);
                     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                        nina_ota_prompt_show_manual_flash(rel->tag);
+                        nina_ota_prompt_show_manual_flash(rel->tag, rel->full_erase_tag);
                         bsp_display_unlock();
                     }
                     while (nina_ota_prompt_visible()) {

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -620,6 +620,51 @@ void nina_image_display_update(goes_data_t *data)
     strlcpy(label_copy, data->label, sizeof(label_copy));
     goes_data_unlock(data);
 
+    /* Per-source logical mirror pass. Runs on the upright `copy` (after vflip +
+     * caption mask) and BEFORE the rotation block, so flips compose naturally
+     * with rotation. vflip reverses row order (top<->bottom); hflip reverses the
+     * pixel order within each row (left<->right). Moon (source 1) is excluded —
+     * it has its own moon_flip_u/v handling elsewhere. Dimensions are unchanged. */
+    uint8_t do_vflip = (buf_src == 0)   ? cfg->goes_vflip
+                       : (buf_src == 2) ? cfg->solar_vflip
+                       : (buf_src == 3) ? cfg->custom_vflip
+                                        : 0;
+    uint8_t do_hflip = (buf_src == 0)   ? cfg->goes_hflip
+                       : (buf_src == 2) ? cfg->solar_hflip
+                       : (buf_src == 3) ? cfg->custom_hflip
+                                        : 0;
+    if (do_vflip) {
+        /* Swap row y with row (h-1-y) using one PSRAM temp row of dst_stride. */
+        uint8_t *tmp_row = heap_caps_malloc(dst_stride, MALLOC_CAP_SPIRAM);
+        if (!tmp_row) {
+            ESP_LOGE(TAG, "PSRAM alloc failed for vflip temp row (%u bytes)",
+                     (unsigned)dst_stride);
+            heap_caps_free(copy);
+            /* goes lock already released above; just retire the wait overlay. */
+            nina_wait_overlay_hide();
+            return;
+        }
+        for (uint32_t y = 0; y < h / 2; y++) {
+            uint8_t *row_a = (uint8_t *)copy + (size_t)y * dst_stride;
+            uint8_t *row_b = (uint8_t *)copy + (size_t)(h - 1 - y) * dst_stride;
+            memcpy(tmp_row, row_a, dst_stride);
+            memcpy(row_a, row_b, dst_stride);
+            memcpy(row_b, tmp_row, dst_stride);
+        }
+        heap_caps_free(tmp_row);
+    }
+    if (do_hflip) {
+        /* Reverse the w pixels in each row: swap col x with (w-1-x). */
+        for (uint32_t y = 0; y < h; y++) {
+            uint16_t *row = (uint16_t *)((uint8_t *)copy + (size_t)y * dst_stride);
+            for (uint32_t x = 0; x < (uint32_t)w / 2; x++) {
+                uint16_t t          = row[x];
+                row[x]              = row[w - 1 - x];
+                row[w - 1 - x]      = t;
+            }
+        }
+    }
+
     /* Per-source logical rotation pass. Rotates the decoded RGB565 pixel buffer
      * (NOT via an LVGL transform) so it is independent of display rotation and
      * runs on the upright `copy` produced above (after vflip + caption mask).

--- a/main/ui/nina_ota_prompt.c
+++ b/main/ui/nina_ota_prompt.c
@@ -504,7 +504,7 @@ void nina_ota_prompt_show_status(const char *title, const char *message) {
     lv_label_set_text(lbl_error, message ? message : "");
 }
 
-void nina_ota_prompt_show_manual_flash(const char *tag) {
+void nina_ota_prompt_show_manual_flash(const char *tag, const char *full_erase_tag) {
     if (!ota_overlay) return;
 
     /* No accept/skip in this mode — only dismissal */
@@ -520,14 +520,30 @@ void nina_ota_prompt_show_manual_flash(const char *tag) {
     lv_obj_add_flag(error_cont, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(manual_cont, LV_OBJ_FLAG_HIDDEN);
 
-    /* Explanation text (no 0x0000 device line) */
-    char body[320];
-    snprintf(body, sizeof(body),
-             "Firmware %s can't be installed over WiFi.\n"
-             "Back up settings first: web UI > Backup > Download Backup.\n"
-             "On a computer, connect by USB and flash nina-display-factory.bin "
-             "with the ESP Web Flasher. Full steps on the GitHub release page.",
-             tag ? tag : "");
+    const char *tag_s = tag ? tag : "";
+
+    /* When the full-erase marker is on an INTERMEDIATE release (different from the
+     * target), name that triggering version. When full_erase_tag is empty (the
+     * history-incomplete fail-safe) or equals the target, the single-version copy
+     * is correct. Buffer sized for the longest (two-tag) variant: ~420 chars + NUL. */
+    char body[512];
+    if (full_erase_tag && full_erase_tag[0] && strcmp(full_erase_tag, tag_s) != 0) {
+        snprintf(body, sizeof(body),
+                 "Firmware %s can't be installed over WiFi.\n"
+                 "Release %s on the way to %s needs a full erase, so the whole "
+                 "update must be flashed by USB.\n"
+                 "Back up settings first: web UI > Backup > Download Backup.\n"
+                 "On a computer, connect by USB and flash nina-display-factory.bin "
+                 "with the ESP Web Flasher. Full steps on the GitHub release page.",
+                 tag_s, full_erase_tag, tag_s);
+    } else {
+        snprintf(body, sizeof(body),
+                 "Firmware %s can't be installed over WiFi.\n"
+                 "Back up settings first: web UI > Backup > Download Backup.\n"
+                 "On a computer, connect by USB and flash nina-display-factory.bin "
+                 "with the ESP Web Flasher. Full steps on the GitHub release page.",
+                 tag_s);
+    }
     lv_label_set_text(lbl_manual_body, body);
 
     /* Show overlay */

--- a/main/ui/nina_ota_prompt.h
+++ b/main/ui/nina_ota_prompt.h
@@ -10,7 +10,7 @@ void nina_ota_prompt_show_progress(void);
 void nina_ota_prompt_set_progress(int percent);
 void nina_ota_prompt_show_error(const char *error_msg);
 void nina_ota_prompt_show_status(const char *title, const char *message);
-void nina_ota_prompt_show_manual_flash(const char *tag);
+void nina_ota_prompt_show_manual_flash(const char *tag, const char *full_erase_tag);
 void nina_ota_prompt_apply_theme(void);
 bool nina_ota_prompt_update_accepted(void);
 bool nina_ota_prompt_skipped(void);

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -163,6 +163,12 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     cJSON_AddNumberToObject(obj, "moon_lon", (double)cfg->moon_lon);
     cJSON_AddNumberToObject(obj, "solar_band", cfg->solar_band);
     cJSON_AddNumberToObject(obj, "moon_drag_light_mode", cfg->moon_drag_light_mode);
+    cJSON_AddNumberToObject(obj, "goes_vflip", cfg->goes_vflip);
+    cJSON_AddNumberToObject(obj, "goes_hflip", cfg->goes_hflip);
+    cJSON_AddNumberToObject(obj, "solar_vflip", cfg->solar_vflip);
+    cJSON_AddNumberToObject(obj, "solar_hflip", cfg->solar_hflip);
+    cJSON_AddNumberToObject(obj, "custom_vflip", cfg->custom_vflip);
+    cJSON_AddNumberToObject(obj, "custom_hflip", cfg->custom_hflip);
     cJSON_AddNumberToObject(obj, "moon_flip_u", cfg->moon_flip_u);
     cJSON_AddNumberToObject(obj, "moon_flip_v", cfg->moon_flip_v);
     cJSON_AddNumberToObject(obj, "moon_roll_offset", (double)cfg->moon_roll_offset);
@@ -363,6 +369,12 @@ static const backup_field_t s_backup_fields[] = {
     {"moon_lon",                   "Moon Longitude",       "Image Display", false, false},
     {"solar_band",                 "Solar Band",           "Image Display", false, false},
     {"moon_drag_light_mode",       "Moon Drag Lighting",   "Image Display", false, false},
+    {"goes_vflip",                 "GOES Flip Vertical",   "Image Display", false, false},
+    {"goes_hflip",                 "GOES Flip Horizontal", "Image Display", false, false},
+    {"solar_vflip",                "Solar Flip Vertical",  "Image Display", false, false},
+    {"solar_hflip",                "Solar Flip Horizontal","Image Display", false, false},
+    {"custom_vflip",               "Custom Flip Vertical", "Image Display", false, false},
+    {"custom_hflip",               "Custom Flip Horizontal","Image Display", false, false},
     {"moon_flip_u",                "Moon Flip U",          "Image Display", false, false},
     {"moon_flip_v",                "Moon Flip V",          "Image Display", false, false},
     {"moon_roll_offset",           "Moon Roll Offset",     "Image Display", false, false},
@@ -1187,6 +1199,19 @@ static app_config_t *parse_config_from_json(cJSON *root)
 
     JSON_TO_INT(root, "solar_band", cfg->solar_band);
     JSON_TO_INT(root, "moon_drag_light_mode", cfg->moon_drag_light_mode);
+
+    cJSON *jgoesvf = cJSON_GetObjectItem(root, "goes_vflip");
+    if (jgoesvf && cJSON_IsNumber(jgoesvf)) cfg->goes_vflip = (jgoesvf->valueint != 0) ? 1 : 0;
+    cJSON *jgoeshf = cJSON_GetObjectItem(root, "goes_hflip");
+    if (jgoeshf && cJSON_IsNumber(jgoeshf)) cfg->goes_hflip = (jgoeshf->valueint != 0) ? 1 : 0;
+    cJSON *jsolarvf = cJSON_GetObjectItem(root, "solar_vflip");
+    if (jsolarvf && cJSON_IsNumber(jsolarvf)) cfg->solar_vflip = (jsolarvf->valueint != 0) ? 1 : 0;
+    cJSON *jsolarhf = cJSON_GetObjectItem(root, "solar_hflip");
+    if (jsolarhf && cJSON_IsNumber(jsolarhf)) cfg->solar_hflip = (jsolarhf->valueint != 0) ? 1 : 0;
+    cJSON *jcustomvf = cJSON_GetObjectItem(root, "custom_vflip");
+    if (jcustomvf && cJSON_IsNumber(jcustomvf)) cfg->custom_vflip = (jcustomvf->valueint != 0) ? 1 : 0;
+    cJSON *jcustomhf = cJSON_GetObjectItem(root, "custom_hflip");
+    if (jcustomhf && cJSON_IsNumber(jcustomhf)) cfg->custom_hflip = (jcustomhf->valueint != 0) ? 1 : 0;
 
     cJSON *jflipu = cJSON_GetObjectItem(root, "moon_flip_u");
     if (jflipu && cJSON_IsNumber(jflipu)) cfg->moon_flip_u = (jflipu->valueint != 0) ? 1 : 0;

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -47,7 +47,13 @@ void image_display_apply_live(const app_config_t *prev, const app_config_t *cur,
         bool crop_changed = cur->image_display_crop != prev->image_display_crop;
         bool orient_changed = (cur->goes_orientation != prev->goes_orientation) ||
                               (cur->solar_orientation != prev->solar_orientation) ||
-                              (cur->custom_orientation != prev->custom_orientation);
+                              (cur->custom_orientation != prev->custom_orientation) ||
+                              (cur->goes_vflip   != prev->goes_vflip) ||
+                              (cur->goes_hflip   != prev->goes_hflip) ||
+                              (cur->solar_vflip  != prev->solar_vflip) ||
+                              (cur->solar_hflip  != prev->solar_hflip) ||
+                              (cur->custom_vflip != prev->custom_vflip) ||
+                              (cur->custom_hflip != prev->custom_hflip);
 
         if (source_band_region_changed) {
             /* Source/band/region needs a genuinely new image: flag the next
@@ -132,9 +138,15 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "moon_lon", cfg->moon_lon);
     cJSON_AddNumberToObject(root, "solar_band", cfg->solar_band);
     cJSON_AddNumberToObject(root, "goes_orientation", cfg->goes_orientation);
+    cJSON_AddNumberToObject(root, "goes_vflip", cfg->goes_vflip);
+    cJSON_AddNumberToObject(root, "goes_hflip", cfg->goes_hflip);
     cJSON_AddNumberToObject(root, "solar_orientation", cfg->solar_orientation);
+    cJSON_AddNumberToObject(root, "solar_vflip", cfg->solar_vflip);
+    cJSON_AddNumberToObject(root, "solar_hflip", cfg->solar_hflip);
     cJSON_AddStringToObject(root, "custom_image_url", cfg->custom_image_url);
     cJSON_AddNumberToObject(root, "custom_orientation", cfg->custom_orientation);
+    cJSON_AddNumberToObject(root, "custom_vflip", cfg->custom_vflip);
+    cJSON_AddNumberToObject(root, "custom_hflip", cfg->custom_hflip);
     cJSON_AddNumberToObject(root, "custom_update_interval_s", cfg->custom_update_interval_s);
     cJSON_AddNumberToObject(root, "moon_drag_light_mode", cfg->moon_drag_light_mode);
     cJSON_AddNumberToObject(root, "moon_flip_u", cfg->moon_flip_u);
@@ -240,13 +252,25 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     if (cJSON_IsNumber(sb)) { int v = sb->valueint; cur->solar_band = (v >= 0 && v <= 17) ? (uint8_t)v : 0; }
     cJSON *go = cJSON_GetObjectItem(root, "goes_orientation");
     if (cJSON_IsNumber(go)) { int v = go->valueint; cur->goes_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    cJSON *gvf = cJSON_GetObjectItem(root, "goes_vflip");
+    if (cJSON_IsNumber(gvf)) { cur->goes_vflip = (gvf->valueint != 0) ? 1 : 0; }
+    cJSON *ghf = cJSON_GetObjectItem(root, "goes_hflip");
+    if (cJSON_IsNumber(ghf)) { cur->goes_hflip = (ghf->valueint != 0) ? 1 : 0; }
     cJSON *so = cJSON_GetObjectItem(root, "solar_orientation");
     if (cJSON_IsNumber(so)) { int v = so->valueint; cur->solar_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    cJSON *svf = cJSON_GetObjectItem(root, "solar_vflip");
+    if (cJSON_IsNumber(svf)) { cur->solar_vflip = (svf->valueint != 0) ? 1 : 0; }
+    cJSON *shf = cJSON_GetObjectItem(root, "solar_hflip");
+    if (cJSON_IsNumber(shf)) { cur->solar_hflip = (shf->valueint != 0) ? 1 : 0; }
     /* Custom image URL: length + scheme already validated above; copy bounded
      * into the 256-byte field. */
     JSON_TO_STRING(root, "custom_image_url", cur->custom_image_url);
     cJSON *co = cJSON_GetObjectItem(root, "custom_orientation");
     if (cJSON_IsNumber(co)) { int v = co->valueint; cur->custom_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0; }
+    cJSON *cvf = cJSON_GetObjectItem(root, "custom_vflip");
+    if (cJSON_IsNumber(cvf)) { cur->custom_vflip = (cvf->valueint != 0) ? 1 : 0; }
+    cJSON *chf = cJSON_GetObjectItem(root, "custom_hflip");
+    if (cJSON_IsNumber(chf)) { cur->custom_hflip = (chf->valueint != 0) ? 1 : 0; }
     cJSON *ci = cJSON_GetObjectItem(root, "custom_update_interval_s");
     if (cJSON_IsNumber(ci)) { int v = ci->valueint; if (v < 10) v = 10; if (v > 7200) v = 7200; cur->custom_update_interval_s = (uint16_t)v; }
     cJSON *dlm = cJSON_GetObjectItem(root, "moon_drag_light_mode");

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -408,6 +408,7 @@ esp_err_t check_update_json_handler(httpd_req_t *req)
         cJSON_AddStringToObject(root, "summary", rel->summary);
         cJSON_AddBoolToObject(root, "is_prerelease", rel->is_prerelease);
         cJSON_AddBoolToObject(root, "requires_full_erase", rel->requires_full_erase);
+        cJSON_AddStringToObject(root, "full_erase_tag", rel->full_erase_tag);
     } else {
         cJSON_AddBoolToObject(root, "update_available", false);
     }


### PR DESCRIPTION
### Summary
This PR adds new controls to vertically or horizontally flip images from GOES, Solar, and Custom sources, correcting common satellite image inversions. It also improves the web configuration UI's accessibility and consistency, making it easier to use for all users. Minor updates to the OTA process are included.

### Changes
*   Add vertical and horizontal image flip toggles for GOES, Solar, and Custom image sources to correct inverted satellite images.
*   Update application configuration to version 48 to store new image flip settings.
*   Implement in-place image flipping within the display logic, applied before rotation.
*   Improve web configuration UI accessibility by defining a global secondary text color, increasing help button touch targets, and adjusting hint text opacity to meet WCAG AA standards.
*   Unify font stacks and semantic color tokens across configuration, login, and setup pages for a consistent visual style.
*   Rename "Focuser" to "Focuser Events" and wrap Demo Mode in a standard toggle row with a hint.
*   Add an erase check to the OTA update process.

---
<sub>Analyzed **4** commit(s) | Updated: 2026-06-28T23:25:18.087Z | Generated by GitHub Actions</sub>