### PR TITLE
fix: 3 DPI framebuffers to stop image-page tearing

### DIFF
--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -70,7 +70,11 @@ CONFIG_FREERTOS_USE_TICKLESS_IDLE=y
 
 # PPA requires full-screen DPI framebuffers (avoid_tearing mode)
 # Partial buffers (720*50*2=72000) are not cache-line aligned (72000%128!=0)
-CONFIG_BSP_LCD_DPI_BUFFER_NUMS=2
+# 3 framebuffers (not 2): with only 2, avoid-tear tears when a full-screen
+# redraw overruns VSYNC (e.g. software crossfade of a large uncropped custom
+# image). A 3rd buffer holds the last good frame while the next renders, so an
+# overrun can never be scanned out half-drawn. +1.01MB PSRAM, allocated at boot.
+CONFIG_BSP_LCD_DPI_BUFFER_NUMS=3
 CONFIG_BSP_DISPLAY_LVGL_AVOID_TEAR=y
 CONFIG_BSP_DISPLAY_LVGL_FULL_REFRESH=y
 


### PR DESCRIPTION
### Summary
A third framebuffer is now used to prevent screen tearing during full-screen redraws, especially when large images are displayed. This ensures that the display always shows a complete frame, even if the next frame isn't fully rendered yet.

### Changes
*   Enabled a third DPI framebuffer in the device configuration.
*   Increased PSRAM usage by 1.01MB at boot to support the additional framebuffer.
*   This change stops image-page tearing when full-screen redraws exceed the display's refresh rate.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-06-30T01:50:55.236Z | Generated by GitHub Actions</sub>