### PR TITLE
feat: add Alpha firmware update channel

### DIFF
--- a/.github/workflows/build-snd.yml
+++ b/.github/workflows/build-snd.yml
@@ -1,0 +1,304 @@
+name: Build Firmware (snd)
+
+on:
+  push:
+    branches: [snd]
+  workflow_dispatch:
+
+env:
+  IDF_VERSION: v5.5.2
+  IDF_TARGET: esp32p4
+  CCACHE_DIR: /opt/actions-runner-esp32/.ccache
+  CCACHE_MAXSIZE: 1G
+  CCACHE_COMPRESSLEVEL: 6
+
+permissions:
+  contents: write
+
+jobs:
+  check-changes:
+    name: Check Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      has_code_changes: ${{ steps.filter.outputs.has_code_changes }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check if code files changed
+        id: filter
+        run: |
+          # A manual run (workflow_dispatch) always builds; github.event.before is
+          # unset there, so short-circuit before the diff to avoid an empty BASE.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
+            echo "Manual run requested, build will run"
+            exit 0
+          fi
+          BASE=${{ github.event.before }}
+          HEAD=${{ github.sha }}
+          CODE_CHANGES=$(git diff --name-only "$BASE" "$HEAD" -- \
+            ':!**/*.md' ':!docs/**' ':!images/**' ':!tests/**' ':!LICENSE' ':!.gitignore' ':!.github/workflows/**' \
+            | head -1)
+
+          if [ -n "$CODE_CHANGES" ]; then
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
+            echo "Code changes detected, build will run"
+          else
+            echo "has_code_changes=false" >> $GITHUB_OUTPUT
+            echo "Only docs/workflow/non-code changes, skipping build"
+          fi
+
+  build:
+    needs: check-changes
+    if: needs.check-changes.outputs.has_code_changes == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: self-hosted
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          clean: false
+
+      - name: Check for skip CI
+        id: check_skip
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=%B)
+          if echo "$COMMIT_MSG" | grep -qi '\[skip ci\]'; then
+            echo "Skipping CI due to [skip ci] in commit message"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Read version
+        if: steps.check_skip.outputs.skip != 'true'
+        id: version
+        run: |
+          VERSION=$(cat version.txt | tr -d '[:space:]')
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BRANCH=${GITHUB_REF_NAME//\//-}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+
+      - name: Determine embedded version override
+        if: steps.check_skip.outputs.skip != 'true'
+        id: tag
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+
+          # Force the build to embed a snd-<sha> tag so the rolling alpha
+          # release's firmware reports a recognizable, commit-pinned version.
+          # generate_version.cmake reads BUILD_GIT_TAG_OVERRIDE.
+          echo "BUILD_GIT_TAG_OVERRIDE=snd-${SHORT_SHA}" >> $GITHUB_ENV
+
+          echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
+
+      - name: Set ESP-IDF paths
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          echo "IDF_PATH=$HOME/esp/esp-idf" >> $GITHUB_ENV
+          echo "IDF_TOOLS_PATH=$HOME/esp/tools" >> $GITHUB_ENV
+
+      - name: Ensure ESP-IDF ${{ env.IDF_VERSION }} is installed
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          # Check if ESP-IDF is already installed and at the correct version
+          if [ -f "$IDF_PATH/export.sh" ]; then
+            INSTALLED_VERSION=$(git -C "$IDF_PATH" describe --tags --exact-match 2>/dev/null || echo "")
+            if [ -z "$INSTALLED_VERSION" ] && [ -f "$IDF_PATH/version.txt" ]; then
+              INSTALLED_VERSION="v$(cat "$IDF_PATH/version.txt" | tr -d '[:space:]')"
+            fi
+            echo "ESP-IDF found: ${INSTALLED_VERSION:-unknown}"
+            if [ "$INSTALLED_VERSION" = "$IDF_VERSION" ]; then
+              echo "Correct version already installed. Skipping."
+              exit 0
+            else
+              echo "Version mismatch ($INSTALLED_VERSION != $IDF_VERSION). Reinstalling..."
+              rm -rf "$IDF_PATH"
+              rm -rf "$IDF_TOOLS_PATH"
+            fi
+          fi
+
+          echo "Installing ESP-IDF $IDF_VERSION..."
+
+          echo "::group::Clone ESP-IDF $IDF_VERSION"
+          mkdir -p "$(dirname "$IDF_PATH")" "$(dirname "$IDF_TOOLS_PATH")"
+          git clone --branch "$IDF_VERSION" --depth 1 --recursive \
+            https://github.com/espressif/esp-idf.git "$IDF_PATH"
+          echo "::endgroup::"
+
+          echo "::group::Install ESP-IDF tools for $IDF_TARGET"
+          "$IDF_PATH/install.sh" "$IDF_TARGET"
+          echo "::endgroup::"
+
+          echo "ESP-IDF $IDF_VERSION installation complete."
+
+      - name: Setup ESP-IDF environment
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          . $IDF_PATH/export.sh
+          echo "IDF version: $(idf.py --version)"
+
+      - name: Setup ccache
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          # Install ccache if not present
+          if ! command -v ccache &>/dev/null; then
+            echo "Installing ccache..."
+            sudo apt-get update -qq && sudo apt-get install -y -qq ccache
+          fi
+          echo "ccache version: $(ccache --version | head -1)"
+          ccache --zero-stats
+          ccache --show-config | grep -E "max_size|cache_dir|compression"
+
+      - name: Clean build state (always rebuild config)
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          # Decide whether managed_components also needs purging BEFORE removing
+          # build/, since the comparison hash lives in build/.build_config_hash.
+          NEEDS_DEPS_CLEAN=false
+          if [ -f build/.build_config_hash ]; then
+            OLD_HASH=$(cat build/.build_config_hash)
+            NEW_HASH=$(cat sdkconfig.defaults main/idf_component.yml main/CMakeLists.txt CMakeLists.txt dependencies.lock 2>/dev/null | sha256sum | cut -d' ' -f1)
+            if [ "$OLD_HASH" != "$NEW_HASH" ]; then
+              echo "Build config changed, will also purge managed_components"
+              NEEDS_DEPS_CLEAN=true
+            fi
+          else
+            echo "No previous successful build hash found, will also purge managed_components"
+            NEEDS_DEPS_CLEAN=true
+          fi
+
+          # Always purge build/ and sdkconfig: a stale sdkconfig selects the wrong
+          # display pipeline and a stale build/ keeps a stale build_version.h and
+          # object files. ccache (separate CCACHE_DIR) is untouched, so recompiles
+          # stay fast.
+          rm -rf build sdkconfig
+          echo "Removed build and sdkconfig"
+
+          # Only re-download managed_components when the dependency/config hash
+          # changed: it is pinned by dependencies.lock, and re-fetching from the
+          # component registry every run adds a network failure point.
+          if [ "$NEEDS_DEPS_CLEAN" = "true" ]; then
+            rm -rf managed_components
+            echo "Removed managed_components"
+          else
+            echo "Config unchanged, reusing managed_components"
+          fi
+
+      - name: Build project
+        if: steps.check_skip.outputs.skip != 'true'
+        env:
+          IDF_CCACHE_ENABLE: 1
+        run: |
+          . $IDF_PATH/export.sh
+          idf.py build
+
+      - name: Save build config hash
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          cat sdkconfig.defaults main/idf_component.yml main/CMakeLists.txt CMakeLists.txt dependencies.lock 2>/dev/null | sha256sum | cut -d' ' -f1 > build/.build_config_hash
+
+      - name: Show ccache stats
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          ccache --show-stats
+
+      - name: Generate firmware binaries
+        if: steps.check_skip.outputs.skip != 'true'
+        run: |
+          . $IDF_PATH/export.sh
+          mkdir -p firmware
+
+          # Detect app binary from project_description.json
+          APP_BIN=$(python3 -c "
+          import json
+          with open('build/project_description.json') as f:
+              d = json.load(f)
+          print('build/' + d['app_bin'])
+          ")
+
+          # Merge factory binary (bootloader + partition table + app)
+          python3 -m esptool --chip esp32p4 merge_bin \
+            --flash_mode dio \
+            --flash_size 32MB \
+            --flash_freq 80m \
+            -o firmware/nina-display-factory.bin \
+            0x2000  build/bootloader/bootloader.bin \
+            0x8000  build/partition_table/partition-table.bin \
+            0x20000 "$APP_BIN"
+
+          # Copy app binary as OTA file
+          cp "$APP_BIN" firmware/nina-display-ota.bin
+
+          # Keep bootloader + partition table on disk (build/ tree) for local
+          # inspection only. They are not uploaded as release assets.
+          cp build/bootloader/bootloader.bin firmware/bootloader.bin
+          cp build/partition_table/partition-table.bin firmware/partition-table.bin
+
+          # Copy ELF for crash backtrace decoding
+          APP_ELF=$(python3 -c "
+          import json
+          with open('build/project_description.json') as f:
+              d = json.load(f)
+          print('build/' + d['app_elf'])
+          ")
+          cp "$APP_ELF" firmware/nina-display.elf
+
+          # Report sizes
+          echo "Factory: $(du -h firmware/nina-display-factory.bin | cut -f1)"
+          echo "OTA:     $(du -h firmware/nina-display-ota.bin | cut -f1)"
+
+      - name: Check for network_adapter.bin
+        if: steps.check_skip.outputs.skip != 'true'
+        id: network_adapter
+        run: |
+          if [ -f "network_adapter.bin" ]; then
+            cp network_adapter.bin firmware/
+            echo "included=true" >> $GITHUB_OUTPUT
+          else
+            echo "included=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Publish rolling alpha pre-release
+        if: steps.check_skip.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="snd-alpha"
+          SHORT_SHA="${{ steps.tag.outputs.short_sha }}"
+
+          # Move the rolling tag to this commit and force-push it.
+          git tag -f "$TAG"
+          git push origin "$TAG" --force
+
+          # Delete the existing rolling pre-release so only ONE remains
+          # (no accumulation across snd pushes).
+          gh release delete "$TAG" --yes 2>/dev/null || true
+
+          # Build the release body. The HTML-comment markers below are parsed
+          # by the device's update checker; the nina:sha marker carries the
+          # full 40-char commit SHA.
+          cat > /tmp/snd-notes.md << EOF
+          Rolling alpha build from the snd branch. This pre-release is overwritten on every push to snd.
+          Commit: ${GITHUB_SHA}
+
+          <!-- nina:channel=alpha -->
+          <!-- nina:sha=${GITHUB_SHA} -->
+          <!-- nina:full_erase=0 -->
+          EOF
+
+          # --target pins the release (and the rolling tag) to the commit
+          # actually built.
+          gh release create "$TAG" \
+            firmware/nina-display-factory.bin \
+            firmware/nina-display-ota.bin \
+            firmware/nina-display.elf \
+            --target "$GITHUB_SHA" \
+            --title "snd-alpha (${SHORT_SHA})" \
+            --notes-file /tmp/snd-notes.md \
+            --prerelease

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -2781,6 +2781,11 @@ static bool validate_config(app_config_t *cfg) {
         cfg->brightness = 50;
         fixed = true;
     }
+    /* Update channel: 0=Stable, 1=Pre-releases/Beta, 2=Alpha (snd). */
+    if (cfg->update_channel > 2) {
+        cfg->update_channel = 0;
+        fixed = true;
+    }
     if (cfg->mqtt_topic_prefix[0] == '\0') {
         strcpy(cfg->mqtt_topic_prefix, "ninadisplay");
         fixed = true;

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -185,6 +185,11 @@
     .help-popover p { margin:0 0 8px; color:var(--text-muted); }
     .help-popover p:last-child { margin-bottom:0; }
     .help-popover ul { margin:6px 0 8px; padding-left:18px; color:var(--text-muted); }
+    .help-popover table.help-scenario { width:100%; border-collapse:collapse; margin:8px 0 2px; font-size:0.75rem; }
+    .help-popover table.help-scenario th { text-align:left; color:var(--text-muted); font-weight:600; padding:4px 10px 5px 0; border-bottom:1px solid var(--border); }
+    .help-popover table.help-scenario td { padding:6px 10px 6px 0; color:var(--text-secondary); vertical-align:top; border-bottom:1px solid rgba(255,255,255,0.05); line-height:1.4; }
+    .help-popover table.help-scenario td:last-child { color:var(--accent); }
+    .help-popover table.help-scenario tr:last-child td { border-bottom:none; }
     .help-popover li { margin:0 0 5px; }
     .help-popover li:last-child { margin-bottom:0; }
     .help-popover strong { color:var(--text); font-weight:600; }
@@ -1563,11 +1568,11 @@
 
       <div class="card">
         <div class="card-title"><span class="card-title-label">Page Navigation <span id="pm_summary" style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted);font-size:0.7rem"></span> <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Page Navigation</div><p>The display picks which page to show on its own, based on a few simple rules. You can always swipe or tap to take over for a while; after the stay-on-page time passes, the display goes back to deciding on its own.</p><p>There are two main controls. <strong>Home Page</strong> is where the display settles when nothing else is happening. If you set Home Page to a NINA instance, the display also returns there while that instance is imaging. <strong>Auto Cycle</strong> rotates through the pages you pick. Turning Auto Cycle on replaces the resting-on-Home-Page behavior, so only one of the two is active at a time.</p><p>Examples:</p><ul><li><strong>Home Page set to a NINA instance, Auto Cycle off:</strong> the display rests on that instance and returns to it while it is imaging.</li><li><strong>Auto Cycle on with a few pages selected:</strong> the display rotates through just those pages, one after another.</li><li><strong>You swipe to another page:</strong> it stays on that page for the stay-on-page time, then returns to its automatic choice.</li><li><strong>All NINA instances disconnected, no-connections page turned on:</strong> the display switches to the page you chose for that situation.</li><li><strong>Home Page set to Clock or Summary, nothing imaging:</strong> the display rests on that page.</li></ul></div>
+        <div class="help-popover"><div class="help-popover-title">Page Navigation</div><p>The display chooses a page automatically. Swipe or tap any time to take over; it returns to its automatic choice after the stay-on-page time. This table shows what appears in each situation.</p><table class="help-scenario"><thead><tr><th>In this situation</th><th>You'll see</th></tr></thead><tbody><tr><td>You just swiped or tapped</td><td>That page, held briefly</td></tr><tr><td>Auto Cycle is on</td><td>Pages rotate in turn</td></tr><tr><td>One NINA instance online</td><td>That instance's dashboard</td></tr><tr><td>Several instances online</td><td>Your Home instance if it is one of them, otherwise the Summary page</td></tr><tr><td>All instances offline, "Switch when no connections" on</td><td>Your chosen fallback page</td></tr><tr><td>All instances offline, that option off</td><td>Your Home Page</td></tr><tr><td>Quiet, nothing happening</td><td>Your Home Page</td></tr></tbody></table></div>
 
         <div class="pn-section-label">Home Page</div>
         <div class="pn-pill-grid" id="start-page-pills"></div>
-        <div class="field-hint">The page the display settles on; when set to a NINA instance, the display also returns to that instance during an imaging session.</div>
+        <div class="field-hint">The page the display settles on; when set to a NINA instance, the display also returns to that instance whenever it is online.</div>
 
         <div class="pn-divider"></div>
 

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1991,8 +1991,9 @@
           <select class="input" id="update_channel">
             <option value="0">Stable only</option>
             <option value="1">Include pre-releases</option>
+            <option value="2">Alpha (snd)</option>
           </select>
-          <div class="field-hint">Stable only skips pre-release builds; Include pre-releases also offers beta firmware.</div>
+          <div class="field-hint">Stable only skips pre-release builds; Include pre-releases also offers beta firmware. Alpha (snd) installs experimental snd-branch builds; expect frequent changes.</div>
         </div>
         <button class="btn btn-primary" style="margin-top:12px;width:100%" id="checkUpdateBtn" onclick="checkForUpdates()">Check for Updates</button>
         <div id="updateResult" style="display:none;margin-top:12px;padding:12px;border-radius:10px;border:1px solid rgba(255,255,255,0.08);background:rgba(255,255,255,0.03)">
@@ -4698,7 +4699,8 @@
             var rel=releases[i];
             if(rel.draft===true) continue;
             var isPre=rel.prerelease===true;
-            if(channel===1){ if(!isPre) continue; }   // pre-release channel: only pre-releases
+            if(channel===2){ if(rel.tag_name!=='snd-alpha') continue; }  // alpha channel: only the snd-alpha rolling release
+            else if(channel===1){ if(!isPre || rel.tag_name==='snd-alpha') continue; }  // pre-release channel: pre-releases except snd-alpha
             else { if(isPre) continue; }              // stable channel: only stable releases
             if(rel.tag_name===_updateInfo.current_version) break;
             if(count>=20) break;

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -12,6 +12,7 @@
 #include "freertos/semphr.h"
 #include "cJSON.h"
 #include <string.h>
+#include <strings.h>
 #include <stdlib.h>
 
 static const char *TAG = "ota_github";
@@ -25,6 +26,7 @@ static const char *TAG = "ota_github";
 #define OTA_BUF_SIZE      4096
 #define MAX_RESPONSE_SIZE (128 * 1024)
 #define OTA_ASSET_NAME    "nina-display-ota.bin"
+#define SND_ALPHA_TAG     "snd-alpha"   /* fixed tag of the rolling Alpha (snd) pre-release */
 
 /* ── Semver comparison ──────────────────────────────────────────────── */
 
@@ -72,6 +74,53 @@ static int compare_versions(const char *v1, const char *v2) {
     }
 
     return 0;  /* neither has suffix */
+}
+
+/* ── Alpha (snd) freshness via commit-sha marker ──────────────────── */
+
+/*
+ * The Alpha (snd) release tag is constant ("snd-alpha"), so semver comparison
+ * cannot tell a fresh build from the installed one. Instead the release body
+ * carries a marker: "<!-- nina:sha=<commit sha> -->". This returns true when the
+ * marker sha differs from the running firmware's BUILD_GIT_SHA (update available).
+ *
+ * Comparison is case-insensitive over min(strlen(marker), strlen(BUILD_GIT_SHA))
+ * characters, requiring at least 7 hex chars compared (BUILD_GIT_SHA is the short
+ * sha). A missing or too-short marker is treated as "no update" (fail safe).
+ */
+static bool alpha_marker_indicates_update(const char *body_str) {
+    if (!body_str) return false;
+
+    const char *m = strstr(body_str, "nina:sha=");
+    if (!m) return false;
+    m += strlen("nina:sha=");
+
+    /* Copy the hex sha up to the next whitespace or end-of-marker. */
+    char marker_sha[64] = {0};
+    size_t n = 0;
+    while (m[n] && n < sizeof(marker_sha) - 1) {
+        char c = m[n];
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '-' || c == '>') break;
+        marker_sha[n] = c;
+        n++;
+    }
+    marker_sha[n] = '\0';
+
+    size_t mlen = strlen(marker_sha);
+    size_t blen = strlen(BUILD_GIT_SHA);
+    size_t cmp = (mlen < blen) ? mlen : blen;
+    if (cmp < 7) {
+        ESP_LOGW(TAG, "Alpha sha marker too short (%u chars), not offering update", (unsigned)mlen);
+        return false;   /* fail safe: do not offer */
+    }
+
+    if (strncasecmp(marker_sha, BUILD_GIT_SHA, cmp) == 0) {
+        ESP_LOGI(TAG, "Alpha sha matches running build (%.*s), no update", (int)cmp, BUILD_GIT_SHA);
+        return false;   /* same commit → no update */
+    }
+
+    ESP_LOGI(TAG, "Alpha sha differs (marker=%s build=%s), update available", marker_sha, BUILD_GIT_SHA);
+    return true;
 }
 
 /* ── Strip markdown images ![alt](url) from a string in-place ─────── */
@@ -277,11 +326,94 @@ static cJSON *fetch_releases_page(int page, bool *overflow_out) {
 
 /* ── Check GitHub for updates ─────────────────────────────────────── */
 
-bool ota_github_check(bool include_prereleases, const char *current_version, github_release_info_t *out) {
+/* Resolve the OTA download URL in-place (follows the GitHub 302 redirect to the
+ * S3 asset). Used after a release target has been captured into *out. */
+static void resolve_ota_download_url(github_release_info_t *out);
+
+bool ota_github_check(int channel, const char *current_version, github_release_info_t *out) {
     if (!current_version || !out) return false;
 
+    /* channel: 0 = Stable, 1 = Pre-releases / Beta, 2 = Alpha (snd). */
+    const char *channel_name = (channel == 2) ? "alpha (snd)" :
+                               (channel == 1) ? "pre-release" : "stable";
     ESP_LOGI(TAG, "Checking GitHub for updates (current: %s, channel: %s)",
-             current_version, include_prereleases ? "pre-release" : "stable");
+             current_version, channel_name);
+    bool include_prereleases = (channel == 1);
+
+    /* ── Alpha (snd) channel ──────────────────────────────────────────────
+     * The Alpha release is a single rolling pre-release with the constant tag
+     * SND_ALPHA_TAG. Freshness is determined by the commit-sha marker in the
+     * release body (not semver), and requires_full_erase is always false (the
+     * body marker is nina:full_erase=0). Scan pages for the snd-alpha release,
+     * verify its sha marker against the running build, and offer it if newer. */
+    if (channel == 2) {
+        for (int page = 1; page <= MAX_RELEASE_PAGES; page++) {
+            bool overflow = false;
+            cJSON *releases = fetch_releases_page(page, &overflow);
+            if (!releases) {
+                ESP_LOGW(TAG, "Alpha (snd) fetch %s on page %d",
+                         overflow ? "overflowed" : "failed", page);
+                break;
+            }
+            int count = cJSON_GetArraySize(releases);
+            for (int i = 0; i < count; i++) {
+                cJSON *release = cJSON_GetArrayItem(releases, i);
+                if (!release) continue;
+                cJSON *draft = cJSON_GetObjectItem(release, "draft");
+                if (cJSON_IsTrue(draft)) continue;
+                cJSON *tag = cJSON_GetObjectItem(release, "tag_name");
+                if (!cJSON_IsString(tag) || !tag->valuestring) continue;
+                if (strcmp(tag->valuestring, SND_ALPHA_TAG) != 0) continue;  /* only snd-alpha */
+
+                cJSON *body = cJSON_GetObjectItem(release, "body");
+                const char *body_str = cJSON_IsString(body) ? body->valuestring : "";
+
+                if (!alpha_marker_indicates_update(body_str)) {
+                    cJSON_Delete(releases);
+                    ESP_LOGI(TAG, "Alpha (snd) up to date");
+                    return false;
+                }
+
+                /* Locate the OTA asset on the snd-alpha release. */
+                const char *ota_url = NULL;
+                cJSON *assets = cJSON_GetObjectItem(release, "assets");
+                if (cJSON_IsArray(assets)) {
+                    int asset_count = cJSON_GetArraySize(assets);
+                    for (int j = 0; j < asset_count; j++) {
+                        cJSON *asset = cJSON_GetArrayItem(assets, j);
+                        cJSON *name = cJSON_GetObjectItem(asset, "name");
+                        if (cJSON_IsString(name) && strcmp(name->valuestring, OTA_ASSET_NAME) == 0) {
+                            cJSON *url = cJSON_GetObjectItem(asset, "browser_download_url");
+                            if (cJSON_IsString(url)) ota_url = url->valuestring;
+                            break;
+                        }
+                    }
+                }
+                if (!ota_url) {
+                    ESP_LOGW(TAG, "Alpha (snd) release has no %s asset", OTA_ASSET_NAME);
+                    cJSON_Delete(releases);
+                    return false;
+                }
+
+                memset(out, 0, sizeof(*out));
+                strncpy(out->tag, tag->valuestring, sizeof(out->tag) - 1);
+                out->tag[sizeof(out->tag) - 1] = '\0';
+                extract_summary(body_str, out->summary, sizeof(out->summary));
+                strncpy(out->ota_url, ota_url, sizeof(out->ota_url) - 1);
+                out->ota_url[sizeof(out->ota_url) - 1] = '\0';
+                out->is_prerelease = true;
+                out->requires_full_erase = false;   /* alpha body marker is nina:full_erase=0 */
+                out->full_erase_tag[0] = '\0';
+                cJSON_Delete(releases);
+                ESP_LOGI(TAG, "Alpha (snd) update target: %s", out->tag);
+                resolve_ota_download_url(out);
+                return true;
+            }
+            cJSON_Delete(releases);
+        }
+        ESP_LOGI(TAG, "No Alpha (snd) release found");
+        return false;
+    }
 
     /* Detect channel switch: current version type doesn't match target channel.
      * When switching channels (e.g. pre-release → stable), the normal version
@@ -350,6 +482,10 @@ bool ota_github_check(bool include_prereleases, const char *current_version, git
             /* Get tag name */
             cJSON *tag = cJSON_GetObjectItem(release, "tag_name");
             if (!cJSON_IsString(tag) || !tag->valuestring) continue;
+
+            /* The Alpha (snd) rolling release belongs only to channel 2 (handled
+             * above); never offer it on the Stable or Pre-release/Beta channels. */
+            if (strcmp(tag->valuestring, SND_ALPHA_TAG) == 0) continue;
 
             /* Classify by version. When switching channels the version check is
              * skipped so the latest in-channel release is always the target. */
@@ -447,20 +583,28 @@ bool ota_github_check(bool include_prereleases, const char *current_version, git
         out->full_erase_tag[sizeof(out->full_erase_tag) - 1] = '\0';
     }
 
-    /*
-     * Resolve redirect chain: browser_download_url redirects via 302 from
-     * github.com to objects.githubusercontent.com (S3).  We resolve here
-     * because the OTA download task uses open/read which doesn't follow
-     * redirects.  With auto-redirect disabled, the client won't retain the
-     * Location header internally, so we capture it via an event handler
-     * during HTTP_EVENT_ON_HEADER.  Using GET+perform() with auto-redirect
-     * off — perform() completes at the 302 without chasing the redirect.
-     */
+    resolve_ota_download_url(out);
+    return true;
+}
+
+/* ── Resolve the OTA download URL (follow the GitHub 302 redirect) ─── */
+
+/*
+ * Resolve redirect chain: browser_download_url redirects via 302 from
+ * github.com to objects.githubusercontent.com (S3).  We resolve here
+ * because the OTA download task uses open/read which doesn't follow
+ * redirects.  With auto-redirect disabled, the client won't retain the
+ * Location header internally, so we capture it via an event handler
+ * during HTTP_EVENT_ON_HEADER.  Using GET+perform() with auto-redirect
+ * off — perform() completes at the 302 without chasing the redirect.
+ * On any failure out->ota_url is left at the original (still valid) URL.
+ */
+static void resolve_ota_download_url(github_release_info_t *out) {
     ESP_LOGI(TAG, "Resolving OTA download URL...");
     char *resolved_url = heap_caps_calloc(1, 2048, MALLOC_CAP_SPIRAM);
     if (!resolved_url) {
         ESP_LOGE(TAG, "Failed to allocate resolved_url");
-        return true;  /* URL still valid, just unresolved */
+        return;  /* URL still valid, just unresolved */
     }
     redirect_ctx_t redir_ctx = {
         .url_buf = resolved_url,
@@ -495,7 +639,6 @@ bool ota_github_check(bool include_prereleases, const char *current_version, git
     }
 
     free(resolved_url);
-    return true;
 }
 
 /* ── Download and flash OTA binary ────────────────────────────────── */

--- a/main/ota_github.h
+++ b/main/ota_github.h
@@ -20,12 +20,14 @@ typedef struct {
 
 /**
  * Check GitHub for a newer firmware release.
- * @param include_prereleases If true, also consider pre-release versions
+ * @param channel Update channel: 0 = Stable (released builds), 1 = Pre-releases
+ *                / Beta (excluding the Alpha snd-alpha release), 2 = Alpha (snd)
+ *                (only the rolling snd-alpha pre-release).
  * @param current_version Current firmware version string (e.g., "1.0.12")
  * @param out Filled with release info if update available
  * @return true if a newer release is available, false otherwise
  */
-bool ota_github_check(bool include_prereleases, const char *current_version, github_release_info_t *out);
+bool ota_github_check(int channel, const char *current_version, github_release_info_t *out);
 
 /**
  * Download and flash an OTA binary from a URL.

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -2294,9 +2294,9 @@ void data_update_task(void *arg) {
         ESP_LOGI(TAG, "Checking for firmware updates...");
         github_release_info_t *rel = heap_caps_calloc(1, sizeof(github_release_info_t), MALLOC_CAP_SPIRAM);
         if (rel) {
-            bool include_pre = (app_config_get()->update_channel == 1);
+            int update_channel = app_config_get()->update_channel;
             const char *cur_ver = ota_github_get_current_version();
-            if (ota_github_check(include_pre, cur_ver, rel)) {
+            if (ota_github_check(update_channel, cur_ver, rel)) {
                 ESP_LOGI(TAG, "New firmware available: %s", rel->tag);
                 if (rel->requires_full_erase) {
                     /* This release cannot be installed over WiFi — show a
@@ -2707,9 +2707,9 @@ main_loop:
             ESP_LOGI(TAG, "On-demand firmware update check...");
             github_release_info_t *rel = heap_caps_calloc(1, sizeof(github_release_info_t), MALLOC_CAP_SPIRAM);
             if (rel) {
-                bool include_pre = (app_config_get()->update_channel == 1);
+                int update_channel = app_config_get()->update_channel;
                 const char *cur_ver = ota_github_get_current_version();
-                bool update_found = ota_github_check(include_pre, cur_ver, rel);
+                bool update_found = ota_github_check(update_channel, cur_ver, rel);
                 if (update_found && rel->requires_full_erase) {
                     /* This release cannot be installed over WiFi — show a
                      * blocking warning and wait only for dismissal. */

--- a/main/ui/settings_tab_system.c
+++ b/main/ui/settings_tab_system.c
@@ -481,7 +481,7 @@ static void create_firmware_card(lv_obj_t *parent) {
         }
 
         dd_update_channel = lv_dropdown_create(row);
-        lv_dropdown_set_options(dd_update_channel, "Stable\nPre-releases");
+        lv_dropdown_set_options(dd_update_channel, "Stable\nPre-releases\nAlpha (snd)");
         lv_obj_set_width(dd_update_channel, 180);
         lv_obj_set_style_text_font(dd_update_channel, &lv_font_montserrat_16, 0);
         if (current_theme) {

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -1100,7 +1100,8 @@ static app_config_t *parse_config_from_json(cJSON *root)
     cJSON *update_ch = cJSON_GetObjectItem(root, "update_channel");
     if (cJSON_IsNumber(update_ch)) {
         int v = update_ch->valueint;
-        cfg->update_channel = (v == 1) ? 1 : 0;
+        if (v < 0 || v > 2) v = 0;
+        cfg->update_channel = (uint8_t)v;
     }
 
     cJSON *rot_item = cJSON_GetObjectItem(root, "screen_rotation");

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -390,7 +390,7 @@ esp_err_t version_get_handler(httpd_req_t *req)
 // Handler for checking GitHub OTA updates (returns JSON result to web UI)
 esp_err_t check_update_json_handler(httpd_req_t *req)
 {
-    bool include_pre = (app_config_get()->update_channel == 1);
+    int update_channel = app_config_get()->update_channel;
     const char *cur_ver = ota_github_get_current_version();
 
     github_release_info_t *rel = heap_caps_calloc(1, sizeof(github_release_info_t), MALLOC_CAP_SPIRAM);
@@ -402,7 +402,7 @@ esp_err_t check_update_json_handler(httpd_req_t *req)
     cJSON *root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "current_version", cur_ver);
 
-    if (ota_github_check(include_pre, cur_ver, rel)) {
+    if (ota_github_check(update_channel, cur_ver, rel)) {
         cJSON_AddBoolToObject(root, "update_available", true);
         cJSON_AddStringToObject(root, "tag", rel->tag);
         cJSON_AddStringToObject(root, "summary", rel->summary);
@@ -441,7 +441,7 @@ esp_err_t ota_github_post_handler(httpd_req_t *req)
     body[received] = '\0';
 
     /* Re-check GitHub for the release to get the OTA URL */
-    bool include_pre = (app_config_get()->update_channel == 1);
+    int update_channel = app_config_get()->update_channel;
     const char *cur_ver = ota_github_get_current_version();
 
     github_release_info_t *rel = heap_caps_calloc(1, sizeof(github_release_info_t), MALLOC_CAP_SPIRAM);
@@ -450,7 +450,7 @@ esp_err_t ota_github_post_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    if (!ota_github_check(include_pre, cur_ver, rel)) {
+    if (!ota_github_check(update_channel, cur_ver, rel)) {
         heap_caps_free(rel);
         return send_400(req, "No update available");
     }


### PR DESCRIPTION
### Summary
Adds a new "Alpha (snd)" firmware update channel, allowing users to opt into pre-release builds for early testing. It also updates the web interface's help text for page navigation, correcting inaccuracies and improving clarity for users.

### Changes
*   Add a new "Alpha (snd)" firmware update channel (value 2) for pre-release builds.
*   Update OTA logic to specifically handle Alpha channel builds, using a SHA marker for freshness and always reporting no full erase needed.
*   Web and on-device interfaces now show an "Alpha (snd)" option for the update channel.
*   Configuration validation for the update channel now accepts the new Alpha channel value.
*   Replace the web UI's page navigation help with a clearer table explaining display behavior.
*   Correct inaccuracies in the page navigation help regarding instance connection status and Home instance priority.
*   Adjust the Home Page field hint to accurately describe when the display returns to a NINA instance.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-06-30T07:00:48.673Z | Generated by GitHub Actions</sub>