### PR TITLE
fix(ota): distinguish check failure from up-to-date

### DIFF
--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -4552,6 +4552,7 @@
       fetch('/api/check-update-json').then(function(r){return r.json();}).then(function(data){
         btn.disabled=false; btn.textContent='Check for Updates';
         result.style.display='block';
+        if(data.error){ resultText.innerHTML='⚠️ '+escHtml(data.error); summary.style.display='none'; installBtn.style.display='none'; return; }
         if(data.update_available){
           if(data.requires_full_erase){
             // Manual-update release: block GitHub OTA, show caution copy instead of the install button.
@@ -4654,6 +4655,7 @@
       var pill=$('updatePill');
       if(!pill) return;
       fetch('/api/check-update-json').then(function(r){return r.json();}).then(function(data){
+        if(data&&data.error) return;
         if(data&&data.update_available){
           _updateInfo=data;
           pill.innerHTML=escHtml(data.tag)+' \u2191';

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -330,8 +330,8 @@ static cJSON *fetch_releases_page(int page, bool *overflow_out) {
  * S3 asset). Used after a release target has been captured into *out. */
 static void resolve_ota_download_url(github_release_info_t *out);
 
-bool ota_github_check(int channel, const char *current_version, github_release_info_t *out) {
-    if (!current_version || !out) return false;
+ota_check_result_t ota_github_check(int channel, const char *current_version, github_release_info_t *out) {
+    if (!current_version || !out) return OTA_CHECK_ERROR;
 
     /* channel: 0 = Stable, 1 = Pre-releases / Beta, 2 = Alpha (snd). */
     const char *channel_name = (channel == 2) ? "alpha (snd)" :
@@ -347,12 +347,14 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
      * body marker is nina:full_erase=0). Scan pages for the snd-alpha release,
      * verify its sha marker against the running build, and offer it if newer. */
     if (channel == 2) {
+        bool alpha_fetch_error = false;
         for (int page = 1; page <= MAX_RELEASE_PAGES; page++) {
             bool overflow = false;
             cJSON *releases = fetch_releases_page(page, &overflow);
             if (!releases) {
                 ESP_LOGW(TAG, "Alpha (snd) fetch %s on page %d",
                          overflow ? "overflowed" : "failed", page);
+                alpha_fetch_error = true;
                 break;
             }
             int count = cJSON_GetArraySize(releases);
@@ -371,7 +373,7 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
                 if (!alpha_marker_indicates_update(body_str)) {
                     cJSON_Delete(releases);
                     ESP_LOGI(TAG, "Alpha (snd) up to date");
-                    return false;
+                    return OTA_CHECK_UP_TO_DATE;
                 }
 
                 /* Locate the OTA asset on the snd-alpha release. */
@@ -392,7 +394,7 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
                 if (!ota_url) {
                     ESP_LOGW(TAG, "Alpha (snd) release has no %s asset", OTA_ASSET_NAME);
                     cJSON_Delete(releases);
-                    return false;
+                    return OTA_CHECK_ERROR;
                 }
 
                 memset(out, 0, sizeof(*out));
@@ -407,12 +409,12 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
                 cJSON_Delete(releases);
                 ESP_LOGI(TAG, "Alpha (snd) update target: %s", out->tag);
                 resolve_ota_download_url(out);
-                return true;
+                return OTA_CHECK_UPDATE_AVAILABLE;
             }
             cJSON_Delete(releases);
         }
         ESP_LOGI(TAG, "No Alpha (snd) release found");
-        return false;
+        return alpha_fetch_error ? OTA_CHECK_ERROR : OTA_CHECK_UP_TO_DATE;
     }
 
     /* Detect channel switch: current version type doesn't match target channel.
@@ -444,6 +446,8 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
     bool any_marker = false;            /* OR of nina:full_erase=1 across the path */
     bool reached_installed = false;     /* a fetched in-channel release compared <= installed */
     bool fail_safe = false;             /* history could not be fully verified */
+    bool verify_error = false;          /* transient mid-path fetch failure (retry, not manual-flash) */
+    bool fetch_failed_no_target = false;/* page-1 fetch failed before any target captured */
     char full_erase_tag_local[32] = {0};/* newest marked tag on the path (written once) */
 
     for (int page = 1; page <= MAX_RELEASE_PAGES && !reached_installed; page++) {
@@ -457,14 +461,21 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
             if (found_target) {
                 ESP_LOGW(TAG, "Couldn't verify full update history: page %d fetch %s",
                          page, overflow ? "overflowed" : "failed");
-                fail_safe = true;
+                verify_error = true;
             } else {
                 ESP_LOGW(TAG, "GitHub release fetch failed on page %d with no target found", page);
+                fetch_failed_no_target = true;
             }
             break;
         }
 
         int count = cJSON_GetArraySize(releases);
+        if (count == 0) {
+            /* Empty page: natural end of the releases list, history fully covered. */
+            cJSON_Delete(releases);
+            reached_installed = true;
+            break;
+        }
         for (int i = 0; i < count && !reached_installed; i++) {
             cJSON *release = cJSON_GetArrayItem(releases, i);
             if (!release) continue;
@@ -560,17 +571,23 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
 
     /* Fail-safe (ERASE-05): a target was found but the scan ended without
      * reaching installed (page cap exhausted) — the history is not fully
-     * verified, so never offer OTA. The mid-path fetch-error case above
-     * already set fail_safe. */
-    if (found_target && !reached_installed && !fail_safe) {
+     * verified, so never offer OTA. The mid-path fetch-error case above set
+     * verify_error instead, which short-circuits to OTA_CHECK_ERROR below. */
+    if (found_target && !reached_installed && !fail_safe && !verify_error) {
         ESP_LOGW(TAG, "Couldn't verify full update history: page cap (%d) reached before installed version",
                  MAX_RELEASE_PAGES);
         fail_safe = true;
     }
 
+    /* Transient mid-path fetch failure: history unverifiable, but this is a retry
+     * condition, not a manual-flash requirement. out is caller-owned; leave it. */
+    if (verify_error) {
+        return OTA_CHECK_ERROR;
+    }
+
     if (!found_target) {
         ESP_LOGI(TAG, "No newer release found");
-        return false;
+        return fetch_failed_no_target ? OTA_CHECK_ERROR : OTA_CHECK_UP_TO_DATE;
     }
 
     /* Populate the erase determination on the captured target. */
@@ -584,7 +601,7 @@ bool ota_github_check(int channel, const char *current_version, github_release_i
     }
 
     resolve_ota_download_url(out);
-    return true;
+    return OTA_CHECK_UPDATE_AVAILABLE;
 }
 
 /* ── Resolve the OTA download URL (follow the GitHub 302 redirect) ─── */

--- a/main/ota_github.h
+++ b/main/ota_github.h
@@ -18,16 +18,26 @@ typedef struct {
                                // fail-safe fired on an unverifiable update history.
 } github_release_info_t;
 
+typedef enum {
+    OTA_CHECK_UP_TO_DATE = 0,   /* definitive: no newer release available */
+    OTA_CHECK_UPDATE_AVAILABLE, /* *out filled with the target release */
+    OTA_CHECK_ERROR,            /* transient: network/rate-limit/unverifiable — retry, NOT up-to-date, NOT manual-flash */
+} ota_check_result_t;
+
 /**
  * Check GitHub for a newer firmware release.
  * @param channel Update channel: 0 = Stable (released builds), 1 = Pre-releases
  *                / Beta (excluding the Alpha snd-alpha release), 2 = Alpha (snd)
  *                (only the rolling snd-alpha pre-release).
  * @param current_version Current firmware version string (e.g., "1.0.12")
- * @param out Filled with release info if update available
- * @return true if a newer release is available, false otherwise
+ * @param out Filled with release info when the result is OTA_CHECK_UPDATE_AVAILABLE
+ * @return OTA_CHECK_UPDATE_AVAILABLE when a newer release is available (*out filled);
+ *         OTA_CHECK_UP_TO_DATE when definitively on the latest release;
+ *         OTA_CHECK_ERROR on a transient failure (network/rate-limit/unverifiable
+ *         history) — the caller should retry and must not treat this as up-to-date
+ *         or as a manual-flash requirement.
  */
-bool ota_github_check(int channel, const char *current_version, github_release_info_t *out);
+ota_check_result_t ota_github_check(int channel, const char *current_version, github_release_info_t *out);
 
 /**
  * Download and flash an OTA binary from a URL.

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -2296,7 +2296,8 @@ void data_update_task(void *arg) {
         if (rel) {
             int update_channel = app_config_get()->update_channel;
             const char *cur_ver = ota_github_get_current_version();
-            if (ota_github_check(update_channel, cur_ver, rel)) {
+            ota_check_result_t chk = ota_github_check(update_channel, cur_ver, rel);
+            if (chk == OTA_CHECK_UPDATE_AVAILABLE) {
                 ESP_LOGI(TAG, "New firmware available: %s", rel->tag);
                 if (rel->requires_full_erase) {
                     /* This release cannot be installed over WiFi — show a
@@ -2362,6 +2363,8 @@ void data_update_task(void *arg) {
                         bsp_display_unlock();
                     }
                 }
+            } else if (chk == OTA_CHECK_ERROR) {
+                ESP_LOGW(TAG, "Boot firmware update check failed (network/GitHub); will retry next check");
             } else {
                 ESP_LOGI(TAG, "No firmware update available");
             }
@@ -2709,8 +2712,8 @@ main_loop:
             if (rel) {
                 int update_channel = app_config_get()->update_channel;
                 const char *cur_ver = ota_github_get_current_version();
-                bool update_found = ota_github_check(update_channel, cur_ver, rel);
-                if (update_found && rel->requires_full_erase) {
+                ota_check_result_t chk = ota_github_check(update_channel, cur_ver, rel);
+                if (chk == OTA_CHECK_UPDATE_AVAILABLE && rel->requires_full_erase) {
                     /* This release cannot be installed over WiFi — show a
                      * blocking warning and wait only for dismissal. */
                     ESP_LOGW(TAG, "Firmware %s requires manual USB erase+flash", rel->tag);
@@ -2721,7 +2724,7 @@ main_loop:
                     while (nina_ota_prompt_visible()) {
                         vTaskDelay(pdMS_TO_TICKS(200));
                     }
-                } else if (update_found) {
+                } else if (chk == OTA_CHECK_UPDATE_AVAILABLE) {
                     ESP_LOGI(TAG, "New firmware available: %s", rel->tag);
                     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                         nina_ota_prompt_show(rel->tag, cur_ver, rel->summary);
@@ -2768,6 +2771,16 @@ main_loop:
                             nina_ota_prompt_hide();
                             bsp_display_unlock();
                         }
+                    }
+                } else if (chk == OTA_CHECK_ERROR) {
+                    ESP_LOGW(TAG, "Firmware update check failed (network/GitHub)");
+                    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                        nina_ota_prompt_show("", cur_ver, NULL);
+                        nina_ota_prompt_show_status("Update check failed", "Update check failed - try again");
+                        bsp_display_unlock();
+                    }
+                    while (nina_ota_prompt_visible()) {
+                        vTaskDelay(pdMS_TO_TICKS(200));
                     }
                 } else {
                     ESP_LOGI(TAG, "No firmware update available");

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -402,13 +402,17 @@ esp_err_t check_update_json_handler(httpd_req_t *req)
     cJSON *root = cJSON_CreateObject();
     cJSON_AddStringToObject(root, "current_version", cur_ver);
 
-    if (ota_github_check(update_channel, cur_ver, rel)) {
+    ota_check_result_t chk = ota_github_check(update_channel, cur_ver, rel);
+    if (chk == OTA_CHECK_UPDATE_AVAILABLE) {
         cJSON_AddBoolToObject(root, "update_available", true);
         cJSON_AddStringToObject(root, "tag", rel->tag);
         cJSON_AddStringToObject(root, "summary", rel->summary);
         cJSON_AddBoolToObject(root, "is_prerelease", rel->is_prerelease);
         cJSON_AddBoolToObject(root, "requires_full_erase", rel->requires_full_erase);
         cJSON_AddStringToObject(root, "full_erase_tag", rel->full_erase_tag);
+    } else if (chk == OTA_CHECK_ERROR) {
+        cJSON_AddBoolToObject(root, "update_available", false);
+        cJSON_AddStringToObject(root, "error", "Could not reach GitHub. Try again.");
     } else {
         cJSON_AddBoolToObject(root, "update_available", false);
     }
@@ -450,7 +454,7 @@ esp_err_t ota_github_post_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    if (!ota_github_check(update_channel, cur_ver, rel)) {
+    if (ota_github_check(update_channel, cur_ver, rel) != OTA_CHECK_UPDATE_AVAILABLE) {
         heap_caps_free(rel);
         return send_400(req, "No update available");
     }


### PR DESCRIPTION
### Summary
The system now accurately reports OTA update status, distinguishing between an actual update being available, the firmware being up-to-date, or an error during the update check. This resolves issues where network failures or empty release pages led to misleading "latest firmware" or "manual update required" messages.

### Changes
*   Refactored the OTA update check function to return a tri-state result (up-to-date, update available, or error) instead of a simple true/false.
*   The OTA check now correctly terminates on an empty releases page, preventing false "manual update required" warnings.
*   Corrected OTA check behavior to report network failures or rate limits as an error, instead of falsely indicating the firmware is up-to-date.
*   Updated the `requires_full_erase` flag to reflect only explicit `nina:full_erase=1` markers.
*   Modified system tasks and web API handlers to correctly process the new tri-state OTA check results, including emitting an error key in JSON responses.
*   Updated the web user interface to display a distinct error state for OTA check failures, providing clearer feedback.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-07-01T23:08:19.473Z | Generated by GitHub Actions</sub>