### PR TITLE
feat: restore MQTT brightness on boot

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -1905,6 +1905,10 @@ static void migrate_from_v23(const app_config_v23_t *old, app_config_t *cfg) {
     ESP_LOGI(TAG, "Migrated config from v23 to v%d", APP_CONFIG_VERSION);
 }
 
+/* Reconstruct the flat slideshow list from the legacy rotation mask+order for
+ * pre-v43 migrations (defined after build_order2_from_legacy). */
+static void rebuild_slideshow_from_legacy_mask(app_config_t *cfg);
+
 /* --- v37 → v40 migration (added moon orientation tuning, moon_north_up, moon touch-spin) --- */
 static void migrate_from_v37(const void *raw, size_t raw_size, app_config_t *cfg)
 {
@@ -1929,6 +1933,7 @@ static void migrate_from_v37(const void *raw, size_t raw_size, app_config_t *cfg
     /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
     cfg->crash_log_retention_days = 30;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 37);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -1951,6 +1956,7 @@ static void migrate_from_v38(const void *raw, size_t raw_size, app_config_t *cfg
     /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
     cfg->crash_log_retention_days = 30;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 38);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -1970,6 +1976,7 @@ static void migrate_from_v39(const void *raw, size_t raw_size, app_config_t *cfg
     /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
     cfg->crash_log_retention_days = 30;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 39);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -1985,6 +1992,7 @@ static void migrate_from_v40(const void *raw, size_t raw_size, app_config_t *cfg
     /* crash_log_retention_days: new in v41 — default already set by set_defaults() */
     cfg->crash_log_retention_days = 30;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 40);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2003,6 +2011,7 @@ static void migrate_from_v41(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->auto_rotate_pages_hi = 0;
     cfg->auto_rotate_order_ext = 8;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 41);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2020,6 +2029,7 @@ static void migrate_from_v42(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->goes_orientation = 0;
     cfg->solar_orientation = 0;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 42);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2059,6 +2069,37 @@ static void build_order2_from_legacy(app_config_t *cfg)
         }
         cfg->auto_rotate_order2[dn++] = mapped;
     }
+}
+
+/* Pre-v43 migrations otherwise leave auto_rotate_order2[] at its set_defaults()
+ * value, discarding the user's saved slideshow selection. Derive that selection
+ * the same way migrate_from_v43 does: filter the legacy 9-slot order by the
+ * effective rotation mask (auto_rotate_pages | pages_hi<<8 — pages_hi is 0 for
+ * vintages predating it), rewrite the legacy order, then rebuild the flat list
+ * and settle nav-mode exclusivity. Operates on the fields already present in
+ * cfg after the migration's copy/fixups. */
+static void rebuild_slideshow_from_legacy_mask(app_config_t *cfg)
+{
+    uint16_t eff_mask = (uint16_t)cfg->auto_rotate_pages
+                      | ((uint16_t)cfg->auto_rotate_pages_hi << 8);
+    uint8_t derived[9];
+    int dn = 0;
+    for (int i = 0; i < 9; i++) {
+        uint8_t bit = (i < 8) ? cfg->auto_rotate_order[i] : cfg->auto_rotate_order_ext;
+        if (bit == 0xFF) continue;
+        if (bit > 8) continue;
+        if (!(eff_mask & (1u << bit))) continue;
+        /* de-dup */
+        bool seen = false;
+        for (int k = 0; k < dn; k++) if (derived[k] == bit) { seen = true; break; }
+        if (seen) continue;
+        derived[dn++] = bit;
+    }
+    for (int i = 0; i < 8; i++) cfg->auto_rotate_order[i] = (i < dn) ? derived[i] : 0xFF;
+    cfg->auto_rotate_order_ext = (dn > 8) ? derived[8] : 0xFF;
+
+    build_order2_from_legacy(cfg);
+    app_config_normalize_nav_exclusivity(cfg);
 }
 
 static void migrate_from_v43(const void *raw, size_t raw_size, app_config_t *cfg)
@@ -2248,6 +2289,7 @@ static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->moon_spin_mode = 0;
     cfg->moon_spin_return_s = 3;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 36);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2263,6 +2305,7 @@ static void migrate_from_v35(const void *raw, size_t raw_size, app_config_t *cfg
     /* image_display_crop field: new in v36 — defaults already set by set_defaults() */
     cfg->image_display_crop = false;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 35);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2278,6 +2321,7 @@ static void migrate_from_v34(const void *raw, size_t raw_size, app_config_t *cfg
     /* Solar band field: new in v35 — defaults already set by set_defaults() */
     cfg->solar_band = 0;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 34);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2296,6 +2340,7 @@ static void migrate_from_v33(const void *raw, size_t raw_size, app_config_t *cfg
     cfg->moon_lat = cfg->weather_lat;   /* prefill from weather */
     cfg->moon_lon = cfg->weather_lon;
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 33);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2315,6 +2360,7 @@ static void migrate_from_v32(const void *raw, size_t raw_size, app_config_t *cfg
         cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
     }
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 32);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2336,6 +2382,7 @@ static void migrate_from_v31(const void *raw, size_t raw_size, app_config_t *cfg
         cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
     }
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 31);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2359,6 +2406,7 @@ static void migrate_from_v30(const void *raw, size_t raw_size, app_config_t *cfg
         cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
     }
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 30);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2382,6 +2430,7 @@ static void migrate_from_v29(const void *raw, size_t raw_size, app_config_t *cfg
         cfg->idle_page_override_target = IDLE_TARGET_SYSINFO;  // now 4
     }
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 29);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2474,6 +2523,7 @@ static void migrate_from_v28(const void *raw, size_t raw_size, app_config_t *cfg
 
     /* New weather/idle fields stay at defaults from set_defaults() */
 
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 28);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2491,6 +2541,7 @@ static void migrate_from_v27(const void *raw, size_t raw_size, app_config_t *cfg
     for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
         cfg->toast_instance_muted[i] = false;
     }
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 27);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2509,6 +2560,7 @@ static void migrate_from_v26(const void *raw, size_t raw_size, app_config_t *cfg
     size_t copy = raw_size < sizeof(app_config_v32_t) ? raw_size : sizeof(app_config_v32_t);
     memcpy(cfg, raw, copy);
     for (int i = 0; i < 8; i++) cfg->auto_rotate_order[i] = (uint8_t)i;
+    rebuild_slideshow_from_legacy_mask(cfg);
     normalize_legacy_page_targets(cfg, 26);
 
     cfg->config_version = APP_CONFIG_VERSION;
@@ -2758,6 +2810,34 @@ static void migrate_from_v16(const app_config_v16_t *old, app_config_t *cfg) {
  */
 static bool validate_config(app_config_t *cfg) {
     bool fixed = false;
+
+    /* A raw NVS blob (or a truncated/corrupt one) can leave a char-array field
+     * without its terminating NUL; every reader below treats these as C
+     * strings. Force-terminate every char array before any of them is used. */
+    for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
+        cfg->api_url[i][sizeof(cfg->api_url[i]) - 1] = '\0';
+        cfg->filter_colors[i][sizeof(cfg->filter_colors[i]) - 1] = '\0';
+        cfg->rms_thresholds[i][sizeof(cfg->rms_thresholds[i]) - 1] = '\0';
+        cfg->hfr_thresholds[i][sizeof(cfg->hfr_thresholds[i]) - 1] = '\0';
+        cfg->wifi_networks[i].ssid[sizeof(cfg->wifi_networks[i].ssid) - 1] = '\0';
+        cfg->wifi_networks[i].password[sizeof(cfg->wifi_networks[i].password) - 1] = '\0';
+    }
+    cfg->ntp_server[sizeof(cfg->ntp_server) - 1] = '\0';
+    cfg->tz_string[sizeof(cfg->tz_string) - 1] = '\0';
+    cfg->mqtt_broker_url[sizeof(cfg->mqtt_broker_url) - 1] = '\0';
+    cfg->mqtt_username[sizeof(cfg->mqtt_username) - 1] = '\0';
+    cfg->mqtt_password[sizeof(cfg->mqtt_password) - 1] = '\0';
+    cfg->mqtt_topic_prefix[sizeof(cfg->mqtt_topic_prefix) - 1] = '\0';
+    cfg->hostname[sizeof(cfg->hostname) - 1] = '\0';
+    cfg->allsky_hostname[sizeof(cfg->allsky_hostname) - 1] = '\0';
+    cfg->allsky_field_config[sizeof(cfg->allsky_field_config) - 1] = '\0';
+    cfg->allsky_thresholds[sizeof(cfg->allsky_thresholds) - 1] = '\0';
+    cfg->spotify_client_id[sizeof(cfg->spotify_client_id) - 1] = '\0';
+    cfg->weather_api_key[sizeof(cfg->weather_api_key) - 1] = '\0';
+    cfg->weather_location_name[sizeof(cfg->weather_location_name) - 1] = '\0';
+    cfg->admin_password[sizeof(cfg->admin_password) - 1] = '\0';
+    cfg->goes_region[sizeof(cfg->goes_region) - 1] = '\0';
+    cfg->custom_image_url[sizeof(cfg->custom_image_url) - 1] = '\0';
 
     for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
         if (cfg->rms_thresholds[i][0] == '\0') {
@@ -3388,8 +3468,14 @@ void app_config_init(void) {
 
         nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
         nvs_commit(handle);
-    } else if (stored_size >= sizeof(app_config_v0_t)) {
-        /* Likely legacy v0 blob — attempt migration */
+    } else if (stored_size >= sizeof(app_config_v0_t) &&
+               !(version_check > APP_CONFIG_VERSION && version_check < 0x1000)) {
+        /* Likely legacy v0 blob — its first bytes are the wifi_ssid text, so
+         * version_check is either 0 (empty SSID) or a large printable-ASCII
+         * value (>= 0x1000). A small integer just above APP_CONFIG_VERSION is a
+         * future/unknown version (e.g. a firmware downgrade), not a v0 blob:
+         * let it fall through to the terminal defaults branch below instead of
+         * mis-migrating it as v0. */
         app_config_v0_t old;
         memcpy(&old, raw, sizeof(app_config_v0_t));
         migrate_from_v0(&old, &s_config);
@@ -3431,6 +3517,7 @@ void app_config_save(const app_config_t *config) {
 
     memcpy(&s_config, config, sizeof(app_config_t));
     s_config.config_version = APP_CONFIG_VERSION;  // Always stamp current version
+    validate_config(&s_config);
 
     app_config_normalize_nav_exclusivity(&s_config);
 
@@ -3467,6 +3554,7 @@ void app_config_apply(const app_config_t *config) {
     invalidate_json_caches();
     memcpy(&s_config, config, sizeof(app_config_t));
     s_config.config_version = APP_CONFIG_VERSION;
+    validate_config(&s_config);
     s_config_dirty = true;
     xSemaphoreGive(s_config_mutex);
 }
@@ -3717,16 +3805,20 @@ static void fill_threshold_config(const char *json, cJSON **cache,
 
 void app_config_get_rms_threshold_config(int instance_index, threshold_config_t *out) {
     if (instance_index < 0 || instance_index >= MAX_NINA_INSTANCES) instance_index = 0;
+    xSemaphoreTake(s_config_mutex, portMAX_DELAY);
     fill_threshold_config(s_config.rms_thresholds[instance_index],
                           &s_rms_thresholds_cache[instance_index],
                           0.5f, 1.0f, out);
+    xSemaphoreGive(s_config_mutex);
 }
 
 void app_config_get_hfr_threshold_config(int instance_index, threshold_config_t *out) {
     if (instance_index < 0 || instance_index >= MAX_NINA_INSTANCES) instance_index = 0;
+    xSemaphoreTake(s_config_mutex, portMAX_DELAY);
     fill_threshold_config(s_config.hfr_thresholds[instance_index],
                           &s_hfr_thresholds_cache[instance_index],
                           2.0f, 3.5f, out);
+    xSemaphoreGive(s_config_mutex);
 }
 
 /**
@@ -3748,9 +3840,23 @@ static bool filter_in_api_list(const char *name, const char *filter_names[], int
  */
 void app_config_sync_filters(const char *filter_names[], int count, int instance_index) {
     if (count <= 0) return;
+    if (instance_index < 0 || instance_index >= MAX_NINA_INSTANCES) instance_index = 0;
+
+    /* Runs on a poll-task stack: snapshot the config into a PSRAM heap copy
+     * (~7.6 KB) rather than mutating live s_config field-by-field. The merge
+     * works against the snapshot; app_config_save() commits it under the mutex
+     * (which also invalidates the JSON caches). */
+    app_config_t *snap = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+    if (!snap) {
+        ESP_LOGE(TAG, "Filter sync: failed to allocate config snapshot");
+        return;
+    }
+    xSemaphoreTake(s_config_mutex, portMAX_DELAY);
+    memcpy(snap, &s_config, sizeof(app_config_t));
+    xSemaphoreGive(s_config_mutex);
 
     bool needs_save = false;
-    char *field = get_filter_colors_field(instance_index);
+    char *field = snap->filter_colors[instance_index];
 
     // --- Sync filter_colors for this instance ---
     cJSON *colors = cJSON_Parse(field);
@@ -3793,12 +3899,12 @@ void app_config_sync_filters(const char *filter_names[], int count, int instance
     cJSON_Delete(colors);
 
     if (needs_save) {
-        invalidate_json_caches();
-        app_config_save(&s_config);
+        app_config_save(snap);
         ESP_LOGI(TAG, "Filter config synced with API and saved to NVS");
     } else {
         ESP_LOGI(TAG, "Filter config already in sync with API");
     }
+    free(snap);
 }
 
 int app_config_get_instance_count(void) {

--- a/main/crash_log.c
+++ b/main/crash_log.c
@@ -25,6 +25,7 @@
 #include "freertos/task.h"
 
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "esp_spiffs.h"
 #include "esp_heap_caps.h"
 #include "esp_attr.h"
@@ -320,12 +321,12 @@ static void append_crash_record(uint32_t reason, const char *panic_text)
 
     time_t now = time(NULL);
     bool synced = (now >= 1577836800);  /* Jan 1 2020 */
-    uint32_t uptime_ms = esp_log_timestamp();  /* ms since boot */
+    uint32_t uptime_s = (uint32_t)(esp_timer_get_time() / 1000000);  /* s since boot, wrap-safe */
 
     power_mgmt_crash_info_t info = power_mgmt_get_crash_info();
 
     cJSON_AddNumberToObject(o, "ts", synced ? (double)now : 0.0);
-    cJSON_AddNumberToObject(o, "uptime_s", (double)(uptime_ms / 1000u));
+    cJSON_AddNumberToObject(o, "uptime_s", (double)uptime_s);
     cJSON_AddNumberToObject(o, "reason", (double)reason);
     cJSON_AddStringToObject(o, "reason_str", power_mgmt_reset_reason_str(reason));
     cJSON_AddNumberToObject(o, "crash_count", (double)info.crash_count);

--- a/main/moon_ephemeris.c
+++ b/main/moon_ephemeris.c
@@ -14,6 +14,12 @@ static const char *PHASE_NAMES[8] = {
 
 static double rev(double x){ x = fmod(x, 360.0); return x < 0 ? x + 360.0 : x; }
 
+/* Single-precision degree-argument trig for the moon rise/set sample loop: the
+ * P4 FPU is single precision, so reduce the angle to [0,360) in double then
+ * evaluate the transcendental in float. */
+static inline float sind_f(double deg){ return sinf((float)(rev(deg) * DEG)); }
+static inline float cosd_f(double deg){ return cosf((float)(rev(deg) * DEG)); }
+
 static uint8_t phase_index_from_cycle(double cyc)
 {
     if      (cyc < 0.0335 || cyc >= 0.9665) return 0;
@@ -226,16 +232,16 @@ static void moon_ra_dec_at(time_t utc, double *ra_out, double *dec_out)
 {
     double d = (double)utc / 86400.0 + 2440587.5 - 2451543.5;
 
-    double oblecl = (23.4393 - 3.563e-7 * d) * DEG;
+    double oblecl_deg = 23.4393 - 3.563e-7 * d;   /* obliquity, degrees */
 
     /* Sun mean longitude for GMST0 and perturbation terms. */
     double ws = 282.9404 + 4.70935e-5 * d;
     double es = 0.016709 - 1.151e-9 * d;
     double Ms = rev(356.0470 + 0.9856002585 * d);
-    double Es = Ms + RAD * es * sin(Ms*DEG) * (1 + es*cos(Ms*DEG));
-    double xvs = cos(Es*DEG) - es;
-    double yvs = sqrt(1.0 - es*es) * sin(Es*DEG);
-    double vs  = atan2(yvs, xvs) * RAD;
+    double Es = Ms + RAD * es * sind_f(Ms) * (1.0 + es * cosd_f(Ms));
+    float  xvs = cosd_f(Es) - (float)es;
+    float  yvs = sqrtf((float)(1.0 - es*es)) * sind_f(Es);
+    float  vs  = atan2f(yvs, xvs) * (float)RAD;
     double slon = rev(vs + ws);
     double Ls   = rev(ws + Ms);
 
@@ -246,50 +252,50 @@ static void moon_ra_dec_at(time_t utc, double *ra_out, double *dec_out)
     double am = 60.2666;
     double em = 0.054900;
     double Mm = rev(115.3654 + 13.0649929509 * d);
-    double Em = Mm + RAD * em * sin(Mm*DEG) * (1 + em*cos(Mm*DEG));
-    Em = Em - (Em - RAD*em*sin(Em*DEG) - Mm) / (1 - em*cos(Em*DEG));
-    double xv = am * (cos(Em*DEG) - em);
-    double yv = am * (sqrt(1.0 - em*em) * sin(Em*DEG));
-    double vm = atan2(yv, xv) * RAD;
-    double rm = sqrt(xv*xv + yv*yv);
-    double xh = rm * (cos(Nm*DEG)*cos((vm+wm)*DEG) - sin(Nm*DEG)*sin((vm+wm)*DEG)*cos(im*DEG));
-    double yh = rm * (sin(Nm*DEG)*cos((vm+wm)*DEG) + cos(Nm*DEG)*sin((vm+wm)*DEG)*cos(im*DEG));
-    double zh = rm * (sin((vm+wm)*DEG)*sin(im*DEG));
-    double mlon = atan2(yh, xh) * RAD;
-    double mlat = atan2(zh, sqrt(xh*xh + yh*yh)) * RAD;
+    double Em = Mm + RAD * em * sind_f(Mm) * (1.0 + em * cosd_f(Mm));
+    Em = Em - (Em - RAD * em * sind_f(Em) - Mm) / (1.0 - em * cosd_f(Em));
+    float  xv = (float)am * (cosd_f(Em) - (float)em);
+    float  yv = (float)am * (sqrtf((float)(1.0 - em*em)) * sind_f(Em));
+    float  vm = atan2f(yv, xv) * (float)RAD;
+    float  rm = sqrtf(xv*xv + yv*yv);
+    float  xh = rm * (cosd_f(Nm)*cosd_f(vm+wm) - sind_f(Nm)*sind_f(vm+wm)*cosd_f(im));
+    float  yh = rm * (sind_f(Nm)*cosd_f(vm+wm) + cosd_f(Nm)*sind_f(vm+wm)*cosd_f(im));
+    float  zh = rm * (sind_f(vm+wm)*sind_f(im));
+    float  mlon = atan2f(yh, xh) * (float)RAD;
+    float  mlat = atan2f(zh, sqrtf(xh*xh + yh*yh)) * (float)RAD;
 
     /* Perturbations. */
     double Lm = rev(Nm + wm + Mm);
     double D  = rev(Lm - Ls);
     double F  = rev(Lm - Nm);
-    mlon += -1.274 * sin((Mm - 2*D)*DEG)
-          +  0.658 * sin((2*D)*DEG)
-          -  0.186 * sin(Ms*DEG)
-          -  0.059 * sin((2*Mm - 2*D)*DEG)
-          -  0.057 * sin((Mm - 2*D + Ms)*DEG)
-          +  0.053 * sin((Mm + 2*D)*DEG)
-          +  0.046 * sin((2*D - Ms)*DEG)
-          +  0.041 * sin((Mm - Ms)*DEG)
-          -  0.035 * sin(D*DEG)
-          -  0.031 * sin((Mm + Ms)*DEG)
-          -  0.015 * sin((2*F - 2*D)*DEG)
-          +  0.011 * sin((Mm - 4*D)*DEG);
-    mlat += -0.173 * sin((F - 2*D)*DEG)
-          -  0.055 * sin((Mm - F - 2*D)*DEG)
-          -  0.046 * sin((Mm + F - 2*D)*DEG)
-          +  0.033 * sin((F + 2*D)*DEG)
-          +  0.017 * sin((2*Mm + F)*DEG);
-    mlon = rev(mlon);
+    mlon += -1.274f * sind_f(Mm - 2*D)
+          +  0.658f * sind_f(2*D)
+          -  0.186f * sind_f(Ms)
+          -  0.059f * sind_f(2*Mm - 2*D)
+          -  0.057f * sind_f(Mm - 2*D + Ms)
+          +  0.053f * sind_f(Mm + 2*D)
+          +  0.046f * sind_f(2*D - Ms)
+          +  0.041f * sind_f(Mm - Ms)
+          -  0.035f * sind_f(D)
+          -  0.031f * sind_f(Mm + Ms)
+          -  0.015f * sind_f(2*F - 2*D)
+          +  0.011f * sind_f(Mm - 4*D);
+    mlat += -0.173f * sind_f(F - 2*D)
+          -  0.055f * sind_f(Mm - F - 2*D)
+          -  0.046f * sind_f(Mm + F - 2*D)
+          +  0.033f * sind_f(F + 2*D)
+          +  0.017f * sind_f(2*Mm + F);
+    mlon = (float)rev(mlon);
 
     /* Ecliptic -> equatorial. */
-    double xg = cos(mlon*DEG) * cos(mlat*DEG);
-    double yg = sin(mlon*DEG) * cos(mlat*DEG);
-    double zg = sin(mlat*DEG);
-    double xe  = xg;
-    double ye  = yg*cos(oblecl) - zg*sin(oblecl);
-    double ze  = yg*sin(oblecl) + zg*cos(oblecl);
-    *ra_out  = rev(atan2(ye, xe) * RAD);
-    *dec_out = atan2(ze, sqrt(xe*xe + ye*ye)) * RAD;
+    float xg = cosd_f(mlon) * cosd_f(mlat);
+    float yg = sind_f(mlon) * cosd_f(mlat);
+    float zg = sind_f(mlat);
+    float xe = xg;
+    float ye = yg*cosd_f(oblecl_deg) - zg*sind_f(oblecl_deg);
+    float ze = yg*sind_f(oblecl_deg) + zg*cosd_f(oblecl_deg);
+    *ra_out  = rev(atan2f(ye, xe) * (float)RAD);
+    *dec_out = atan2f(ze, sqrtf(xe*xe + ye*ye)) * (float)RAD;
 
     (void)slon; /* true solar longitude not needed here; suppress unused-variable warning */
 }

--- a/main/mqtt_ha.c
+++ b/main/mqtt_ha.c
@@ -51,6 +51,17 @@ static QueueHandle_t s_cmd_queue = NULL;
 
 static esp_mqtt_client_handle_t s_mqtt_client = NULL;
 static bool s_connected = false;
+
+/* Boot-time brightness restore (one-shot). MQTT brightness commands are
+ * live-only (never saved to NVS), so a reboot reverts to the NVS value until
+ * HA publishes again. The device publishes its screen/text state topics
+ * retained, so the broker already holds the last live brightness. On the
+ * first connect after boot we subscribe to our own state topics, apply the
+ * retained payload through the normal command queue, then unsubscribe. A
+ * non-retained message on a state topic is the echo of our own connect-time
+ * state publish and means the broker had no retained value — stop waiting. */
+static bool s_restore_screen_pending = true;
+static bool s_restore_text_pending = true;
 static char s_device_id[16];  // Last 6 hex chars of MAC
 static uint32_t s_backoff_ms = MQTT_BACKOFF_INITIAL_MS;
 static esp_timer_handle_t s_reconnect_timer = NULL;
@@ -464,6 +475,17 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base,
         esp_mqtt_client_subscribe(s_mqtt_client, s_topic_text_cmd, 1);
         esp_mqtt_client_subscribe(s_mqtt_client, s_topic_reboot_cmd, 1);
 
+        /* Boot-time restore: subscribe to our own retained state topics BEFORE
+         * the state publish below. TCP ordering guarantees the broker processes
+         * the SUBSCRIBE first, so the retained delivery snapshots the pre-reboot
+         * value even though we immediately publish the NVS state afterwards. */
+        if (s_restore_screen_pending) {
+            esp_mqtt_client_subscribe(s_mqtt_client, s_topic_screen_state, 1);
+        }
+        if (s_restore_text_pending) {
+            esp_mqtt_client_subscribe(s_mqtt_client, s_topic_text_state, 1);
+        }
+
         // Publish current state
         mqtt_ha_publish_state();
         break;
@@ -475,6 +497,37 @@ static void mqtt_event_handler(void *handler_args, esp_event_base_t base,
         break;
 
     case MQTT_EVENT_DATA:
+        /* Boot-time restore: our own state topics, subscribed one-shot above.
+         * The state payload {"state":...,"brightness":N} has the same shape as
+         * a command payload, so the command parsers apply directly. Retained
+         * flag REQUIRED here (opposite of the command-topic rule below): the
+         * retained message is the pre-reboot value; a non-retained message is
+         * the echo of our own connect-time publish (no retained value existed).
+         * Either way this topic's restore is finished — unsubscribe. */
+        if (event->topic && event->topic_len > 0) {
+            if (s_restore_screen_pending &&
+                event->topic_len == (int)strlen(s_topic_screen_state) &&
+                strncmp(event->topic, s_topic_screen_state, event->topic_len) == 0) {
+                if (event->retain) {
+                    handle_screen_command(event->data, event->data_len);
+                    ESP_LOGI(TAG, "Screen brightness restored from retained MQTT state");
+                }
+                s_restore_screen_pending = false;
+                esp_mqtt_client_unsubscribe(s_mqtt_client, s_topic_screen_state);
+                break;
+            }
+            if (s_restore_text_pending &&
+                event->topic_len == (int)strlen(s_topic_text_state) &&
+                strncmp(event->topic, s_topic_text_state, event->topic_len) == 0) {
+                if (event->retain) {
+                    handle_text_command(event->data, event->data_len);
+                    ESP_LOGI(TAG, "Text brightness restored from retained MQTT state");
+                }
+                s_restore_text_pending = false;
+                esp_mqtt_client_unsubscribe(s_mqtt_client, s_topic_text_state);
+                break;
+            }
+        }
         /* Ignore retained command messages. The screen/text/reboot topics are
          * Home Assistant command topics (momentary light-set / button-press); a
          * retained payload is a stale command the broker redelivers on every

--- a/main/nina_api_fetchers.c
+++ b/main/nina_api_fetchers.c
@@ -15,6 +15,20 @@
 
 static const char *TAG = "nina_fetch";
 
+/* Client-mutex write timeout for fetcher commits. The poll task is the primary
+ * writer; the WS handler and UI take the same lock. On timeout we skip the write
+ * for this cycle (data stays one cycle stale) rather than write lock-free. */
+#define FETCH_LOCK_MS 100
+
+/* Commit an offline state (connected=false, status=OFFLINE) under the lock. */
+static void nina_fetch_set_offline(nina_client_t *data) {
+    if (nina_client_lock(data, FETCH_LOCK_MS)) {
+        data->connected = false;
+        strcpy(data->status, "OFFLINE");
+        nina_client_unlock(data);
+    }
+}
+
 /**
  * @brief Fetch camera info - ALWAYS WORKS
  * Provides: IsExposing, ExposureEndTime, Temperature, CoolerPower, CameraState
@@ -26,8 +40,7 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
     cJSON *json = http_get_json(url);
     if (!json) {
         // Transport failure / non-2xx / empty body — API unreachable.
-        data->connected = false;
-        strcpy(data->status, "OFFLINE");
+        nina_fetch_set_offline(data);
         return;
     }
 
@@ -35,8 +48,7 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
     // not merely a non-NULL body. Recomputed every poll so a stuck `true` can't latch.
     if (!nina_api_envelope_ok(json)) {
         cJSON_Delete(json);
-        data->connected = false;
-        strcpy(data->status, "OFFLINE");
+        nina_fetch_set_offline(data);
         return;
     }
 
@@ -45,11 +57,14 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
         // Envelope OK but no Response object — treat as offline this poll
         // (symmetric with fetch_equipment_info_bundled).
         cJSON_Delete(json);
-        data->connected = false;
-        strcpy(data->status, "OFFLINE");
+        nina_fetch_set_offline(data);
         return;
     }
 
+    if (!nina_client_lock(data, FETCH_LOCK_MS)) {
+        cJSON_Delete(json);
+        return;
+    }
     data->connected = true;
     {
         // Camera name
@@ -101,6 +116,7 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
         }
         // Do NOT clear exposure_end_epoch when !is_exposing -- UI uses it to detect completion
     }
+    nina_client_unlock(data);
 
     cJSON_Delete(json);
 }
@@ -117,7 +133,7 @@ void fetch_filter_robust_ex(const char *base_url, nina_client_t *data, bool fetc
     if (!json) return;
 
     cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (response) {
+    if (response && nina_client_lock(data, FETCH_LOCK_MS)) {
         // Get current filter
         cJSON *selectedFilter = cJSON_GetObjectItem(response, "SelectedFilter");
         if (selectedFilter) {
@@ -151,6 +167,7 @@ void fetch_filter_robust_ex(const char *base_url, nina_client_t *data, bool fetc
             }
             ESP_LOGI(TAG, "Found %d available filters", data->filter_count);
         }
+        nina_client_unlock(data);
     }
     cJSON_Delete(json);
 }
@@ -195,7 +212,7 @@ void fetch_image_history_robust(const char *base_url, nina_client_t *data) {
     cJSON *response = cJSON_GetObjectItem(json, "Response");
     if (response && cJSON_IsArray(response) && cJSON_GetArraySize(response) > 0) {
         cJSON *latest = cJSON_GetArrayItem(response, 0);
-        if (latest) {
+        if (latest && nina_client_lock(data, FETCH_LOCK_MS)) {
             // Target name from last saved image (only if non-empty)
             cJSON *target = cJSON_GetObjectItem(latest, "TargetName");
             if (target && target->valuestring && target->valuestring[0] != '\0') {
@@ -240,6 +257,7 @@ void fetch_image_history_robust(const char *base_url, nina_client_t *data) {
             }
 
             ESP_LOGI(TAG, "Image stats: HFR=%.2f, Stars=%d", data->hfr, data->stars);
+            nina_client_unlock(data);
         }
     }
 
@@ -257,7 +275,7 @@ void fetch_profile_robust(const char *base_url, nina_client_t *data) {
     if (!json) return;
 
     cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (response && cJSON_IsArray(response)) {
+    if (response && cJSON_IsArray(response) && nina_client_lock(data, FETCH_LOCK_MS)) {
         cJSON *item = NULL;
         cJSON_ArrayForEach(item, response) {
             cJSON *isActive = cJSON_GetObjectItem(item, "IsActive");
@@ -270,6 +288,7 @@ void fetch_profile_robust(const char *base_url, nina_client_t *data) {
                 break;
             }
         }
+        nina_client_unlock(data);
     }
     cJSON_Delete(json);
 }
@@ -285,9 +304,16 @@ void fetch_guider_robust(const char *base_url, nina_client_t *data) {
     if (!json) return;
 
     cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (response) {
+    if (response && nina_client_lock(data, FETCH_LOCK_MS)) {
+        cJSON *connected = cJSON_GetObjectItem(response, "Connected");
         cJSON *rms = cJSON_GetObjectItem(response, "RMSError");
-        if (rms) {
+        // Guider disconnected or no RMS payload: zero the values so the UI does
+        // not render stale guiding numbers for a guider that is no longer guiding.
+        if ((connected && !cJSON_IsTrue(connected)) || !rms) {
+            data->guider.rms_total = 0;
+            data->guider.rms_ra = 0;
+            data->guider.rms_dec = 0;
+        } else {
             // Total RMS
             cJSON *total = cJSON_GetObjectItem(rms, "Total");
             if (total) {
@@ -318,6 +344,7 @@ void fetch_guider_robust(const char *base_url, nina_client_t *data) {
             ESP_LOGI(TAG, "Guiding RMS - Total: %.2f\", RA: %.2f\", DEC: %.2f\"",
                 data->guider.rms_total, data->guider.rms_ra, data->guider.rms_dec);
         }
+        nina_client_unlock(data);
     }
 
     cJSON_Delete(json);
@@ -334,11 +361,12 @@ void fetch_mount_robust(const char *base_url, nina_client_t *data) {
     if (!json) return;
 
     cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (response) {
+    if (response && nina_client_lock(data, FETCH_LOCK_MS)) {
         cJSON *flip_time = cJSON_GetObjectItem(response, "TimeToMeridianFlipString");
         if (flip_time && flip_time->valuestring) {
             strncpy(data->meridian_flip, flip_time->valuestring, sizeof(data->meridian_flip) - 1);
         }
+        nina_client_unlock(data);
     }
 
     cJSON_Delete(json);
@@ -355,11 +383,12 @@ void fetch_focuser_robust(const char *base_url, nina_client_t *data) {
     if (!json) return;
 
     cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (response) {
+    if (response && nina_client_lock(data, FETCH_LOCK_MS)) {
         cJSON *position = cJSON_GetObjectItem(response, "Position");
         if (position) {
             data->focuser.position = position->valueint;
         }
+        nina_client_unlock(data);
     }
     cJSON_Delete(json);
 }
@@ -476,8 +505,9 @@ void fetch_switch_info(const char *base_url, nina_client_t *data) {
     if (!json) return;
 
     cJSON *response = cJSON_GetObjectItem(json, "Response");
-    if (response) {
+    if (response && nina_client_lock(data, FETCH_LOCK_MS)) {
         parse_switch_response(response, data);
+        nina_client_unlock(data);
     }
 
     cJSON_Delete(json);
@@ -502,12 +532,13 @@ void fetch_safety_monitor_info(const char *base_url, nina_client_t *data) {
     }
 
     cJSON *connected = cJSON_GetObjectItem(response, "Connected");
-    if (connected && cJSON_IsTrue(connected)) {
+    if (connected && cJSON_IsTrue(connected) && nina_client_lock(data, FETCH_LOCK_MS)) {
         data->safety_connected = true;
         cJSON *is_safe = cJSON_GetObjectItem(response, "IsSafe");
         data->safety_is_safe = is_safe && cJSON_IsTrue(is_safe);
         ESP_LOGI(TAG, "Safety monitor: connected=%d, safe=%d",
                  data->safety_connected, data->safety_is_safe);
+        nina_client_unlock(data);
     }
 
     cJSON_Delete(json);
@@ -530,8 +561,7 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
     cJSON *json = http_get_json(url);
     if (!json) {
         // Transport failure / non-2xx / empty body — API unreachable.
-        data->connected = false;
-        strcpy(data->status, "OFFLINE");
+        nina_fetch_set_offline(data);
         return -1;
     }
 
@@ -539,8 +569,7 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
     // means the API is up but reported a failure — treat as offline this poll.
     if (!nina_api_envelope_ok(json)) {
         cJSON_Delete(json);
-        data->connected = false;
-        strcpy(data->status, "OFFLINE");
+        nina_fetch_set_offline(data);
         return -1;
     }
 
@@ -548,12 +577,17 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
     if (!response) {
         // Envelope OK but no Response object — may be a 404 or unsupported endpoint
         cJSON_Delete(json);
-        data->connected = false;
-        strcpy(data->status, "OFFLINE");
+        nina_fetch_set_offline(data);
         return -2;
     }
 
     // Envelope is OK with a Response object — the API is reachable this poll.
+    // Commit all parsed equipment fields atomically under the client lock. On
+    // timeout, skip the write section but still return success (data one cycle stale).
+    if (!nina_client_lock(data, FETCH_LOCK_MS)) {
+        cJSON_Delete(json);
+        return 0;
+    }
     data->connected = true;
 
     // ── Camera ──
@@ -604,8 +638,15 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
     // ── Guider ──
     cJSON *guider = cJSON_GetObjectItem(response, "Guider");
     if (guider) {
+        cJSON *guider_conn = cJSON_GetObjectItem(guider, "Connected");
         cJSON *rms = cJSON_GetObjectItem(guider, "RMSError");
-        if (rms) {
+        // Guider disconnected or no RMS payload: zero the values so the UI does
+        // not render stale guiding numbers for a guider that is no longer guiding.
+        if ((guider_conn && !cJSON_IsTrue(guider_conn)) || !rms) {
+            data->guider.rms_total = 0;
+            data->guider.rms_ra = 0;
+            data->guider.rms_dec = 0;
+        } else {
             cJSON *total = cJSON_GetObjectItem(rms, "Total");
             if (total) {
                 cJSON *arcsec = cJSON_GetObjectItem(total, "Arcseconds");
@@ -692,6 +733,7 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
             data->safety_is_safe = is_safe && cJSON_IsTrue(is_safe);
         }
     }
+    nina_client_unlock(data);
 
     /* Build equipment connected bitmask from Connected fields.
      * Bit positions match equipment_type_t in nina_websocket.c:

--- a/main/nina_client.c
+++ b/main/nina_client.c
@@ -552,15 +552,17 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
         state->static_fetched = false;
         state->cached_image_count = -1;
         nina_connection_set_static_data_ready(instance, false);
-        data->prev_target_container[0] = '\0';
+        if (nina_client_lock(data, 100)) {
+            data->prev_target_container[0] = '\0';
+            nina_client_unlock(data);
+        }
         state->http_client = (void *)reuse_handle;
         http_poll_ctx_set(NULL);
         return;
     }
 
     // --- Handle PROFILE-CHANGED: invalidate cached static data ---
-    if (data->profile_refresh_needed) {
-        data->profile_refresh_needed = false;
+    if (atomic_exchange(&data->profile_refresh_needed, false)) {
         state->static_fetched = false;
         state->cached_image_count = -1;
         nina_connection_set_static_data_ready(instance, false);
@@ -603,7 +605,7 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
          * real current-sub length (not the stale image-history total) before the
          * UI seeds the exposure arc on first connect. */
         data->sequence_poll_needed = true;
-    } else {
+    } else if (nina_client_lock(data, 100)) {
         snprintf(data->profile_name, sizeof(data->profile_name), "%s", state->cached_profile);
         if (state->cached_telescope[0] != '\0') {
             snprintf(data->telescope_name, sizeof(data->telescope_name), "%s", state->cached_telescope);
@@ -617,6 +619,7 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
             memcpy(state->cached_filters, data->filters, sizeof(state->cached_filters));
             state->cached_filter_count = data->filter_count;
         }
+        nina_client_unlock(data);
     }
 
     if (state->bundle_not_available) {
@@ -681,19 +684,22 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
     }
 
     // --- SEQUENCE: Timer-based + event-driven polling ---
+    bool sequence_event = atomic_exchange(&data->sequence_poll_needed, false);
     bool sequence_due = (now_ms - state->last_sequence_poll_ms >= NINA_POLL_SEQUENCE_MS);
-    if (sequence_due || data->sequence_poll_needed) {
-        if (data->sequence_poll_needed) {
+    if (sequence_due || sequence_event) {
+        if (sequence_event) {
             ESP_LOGD(TAG, "Event-driven sequence poll triggered");
         }
-        data->sequence_poll_needed = false;
         perf_timer_start(&g_perf.poll_sequence);
         fetch_sequence_counts_optional(base_url, data);
         perf_timer_stop(&g_perf.poll_sequence);
         state->last_sequence_poll_ms = now_ms;
     }
 
-    fixup_exposure_timing(data);
+    if (nina_client_lock(data, 100)) {
+        fixup_exposure_timing(data);
+        nina_client_unlock(data);
+    }
 
     // Save persistent HTTP client for next poll cycle
     state->http_client = (void *)reuse_handle;
@@ -727,7 +733,10 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
     int64_t now_ms = esp_timer_get_time() / 1000;
 
     // Mark disconnected before fetch — fetchers set connected=true on success.
-    data->connected = false;
+    if (nina_client_lock(data, 100)) {
+        data->connected = false;
+        nina_client_unlock(data);
+    }
 
     // --- Equipment fetch ---
     // Use the full bundle only on first connect (to seed static data: filters, switch, etc.).
@@ -746,7 +755,10 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
     }
 
     nina_conn_state_t conn_state = nina_connection_report_poll(instance, data->connected);
-    data->connected = (conn_state == NINA_CONN_CONNECTED);
+    if (nina_client_lock(data, 100)) {
+        data->connected = (conn_state == NINA_CONN_CONNECTED);
+        nina_client_unlock(data);
+    }
 
     if (!data->connected) {
         state->static_fetched = false;
@@ -758,8 +770,7 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
     }
 
     // --- Handle PROFILE-CHANGED: invalidate cached static data ---
-    if (data->profile_refresh_needed) {
-        data->profile_refresh_needed = false;
+    if (atomic_exchange(&data->profile_refresh_needed, false)) {
         state->static_fetched = false;
         state->cached_image_count = -1;
         nina_connection_set_static_data_ready(instance, false);
@@ -788,7 +799,7 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
         nina_connection_set_static_data_ready(instance, true);
         state->last_slow_poll_ms = now_ms;
         state->last_sequence_poll_ms = now_ms;
-    } else {
+    } else if (nina_client_lock(data, 100)) {
         snprintf(data->profile_name, sizeof(data->profile_name), "%s", state->cached_profile);
         if (state->cached_telescope[0] != '\0') {
             snprintf(data->telescope_name, sizeof(data->telescope_name), "%s", state->cached_telescope);
@@ -801,6 +812,7 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
             memcpy(state->cached_filters, data->filters, sizeof(state->cached_filters));
             state->cached_filter_count = data->filter_count;
         }
+        nina_client_unlock(data);
     }
 
     // --- SLOW: Focuser + Mount + Switch (every 30s, legacy only — bundle handles these) ---
@@ -870,23 +882,25 @@ bool nina_client_resolve_host(const char *host, char *ip_out, size_t ip_len) {
 
     int64_t now_ms = esp_timer_get_time() / 1000;
 
-    if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
-
-    // Check DNS cache for a valid (non-expired) entry
-    for (int i = 0; i < 3; i++) {
-        if (strcmp(s_dns_cache[i].hostname, host) == 0 &&
-            s_dns_cache[i].resolved_ip[0] != '\0') {
-            if (now_ms - s_dns_cache[i].resolve_time_ms < DNS_CACHE_TTL_MS) {
-                snprintf(ip_out, ip_len, "%s", s_dns_cache[i].resolved_ip);
-                ESP_LOGD(TAG, "DNS cache hit for %s -> %s", host, ip_out);
-                if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
-                return true;
+    // Check DNS cache for a valid (non-expired) entry. On a failed take, skip the
+    // cache entirely and fall through to a fresh lookup — never give a mutex we
+    // do not hold, and never touch the cache unlocked.
+    bool dns_locked = (s_dns_mutex && xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000)) == pdTRUE);
+    if (dns_locked) {
+        for (int i = 0; i < 3; i++) {
+            if (strcmp(s_dns_cache[i].hostname, host) == 0 &&
+                s_dns_cache[i].resolved_ip[0] != '\0') {
+                if (now_ms - s_dns_cache[i].resolve_time_ms < DNS_CACHE_TTL_MS) {
+                    snprintf(ip_out, ip_len, "%s", s_dns_cache[i].resolved_ip);
+                    ESP_LOGD(TAG, "DNS cache hit for %s -> %s", host, ip_out);
+                    xSemaphoreGive(s_dns_mutex);
+                    return true;
+                }
+                break;  // Found entry but expired — do fresh lookup
             }
-            break;  // Found entry but expired — do fresh lookup
         }
+        xSemaphoreGive(s_dns_mutex);
     }
-
-    if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
 
     // Cache miss or expired — perform real DNS lookup (outside mutex — can block)
     struct addrinfo hints = {0};
@@ -901,26 +915,29 @@ bool nina_client_resolve_host(const char *host, char *ip_out, size_t ip_len) {
         inet_ntoa_r(addr->sin_addr, ip_str, sizeof(ip_str));
         freeaddrinfo(result);
 
-        if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
-
-        // Find existing slot or first empty slot
-        int slot = -1;
-        for (int i = 0; i < 3; i++) {
-            if (strcmp(s_dns_cache[i].hostname, host) == 0 ||
-                s_dns_cache[i].hostname[0] == '\0') {
-                slot = i;
-                break;
+        // The resolved IP is in a local; return it regardless of the cache lock.
+        // Only update the shared cache when the take succeeded.
+        dns_locked = (s_dns_mutex && xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000)) == pdTRUE);
+        if (dns_locked) {
+            // Find existing slot or first empty slot
+            int slot = -1;
+            for (int i = 0; i < 3; i++) {
+                if (strcmp(s_dns_cache[i].hostname, host) == 0 ||
+                    s_dns_cache[i].hostname[0] == '\0') {
+                    slot = i;
+                    break;
+                }
             }
-        }
-        if (slot < 0) slot = 0;  // Evict first slot if all full
+            if (slot < 0) slot = 0;  // Evict first slot if all full
 
-        snprintf(s_dns_cache[slot].hostname, sizeof(s_dns_cache[slot].hostname), "%s", host);
-        snprintf(s_dns_cache[slot].resolved_ip, sizeof(s_dns_cache[slot].resolved_ip), "%s", ip_str);
-        s_dns_cache[slot].resolve_time_ms = now_ms;
+            snprintf(s_dns_cache[slot].hostname, sizeof(s_dns_cache[slot].hostname), "%s", host);
+            snprintf(s_dns_cache[slot].resolved_ip, sizeof(s_dns_cache[slot].resolved_ip), "%s", ip_str);
+            s_dns_cache[slot].resolve_time_ms = now_ms;
+
+            xSemaphoreGive(s_dns_mutex);
+        }
 
         snprintf(ip_out, ip_len, "%s", ip_str);
-
-        if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
 
         ESP_LOGD(TAG, "DNS cached %s -> %s", host, ip_str);
         return true;
@@ -928,19 +945,22 @@ bool nina_client_resolve_host(const char *host, char *ip_out, size_t ip_len) {
 
     if (result) freeaddrinfo(result);
 
-    // Lookup failed — try stale cache as fallback
-    if (s_dns_mutex) xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000));
-    for (int i = 0; i < 3; i++) {
-        if (strcmp(s_dns_cache[i].hostname, host) == 0 &&
-            s_dns_cache[i].resolved_ip[0] != '\0') {
-            snprintf(ip_out, ip_len, "%s", s_dns_cache[i].resolved_ip);
-            ESP_LOGW(TAG, "DNS lookup failed for %s, using stale cache -> %s",
-                     host, ip_out);
-            if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
-            return true;
+    // Lookup failed — try stale cache as fallback (only if the take succeeds;
+    // a failed take skips the stale-cache path and returns failure).
+    dns_locked = (s_dns_mutex && xSemaphoreTake(s_dns_mutex, pdMS_TO_TICKS(5000)) == pdTRUE);
+    if (dns_locked) {
+        for (int i = 0; i < 3; i++) {
+            if (strcmp(s_dns_cache[i].hostname, host) == 0 &&
+                s_dns_cache[i].resolved_ip[0] != '\0') {
+                snprintf(ip_out, ip_len, "%s", s_dns_cache[i].resolved_ip);
+                ESP_LOGW(TAG, "DNS lookup failed for %s, using stale cache -> %s",
+                         host, ip_out);
+                xSemaphoreGive(s_dns_mutex);
+                return true;
+            }
         }
+        xSemaphoreGive(s_dns_mutex);
     }
-    if (s_dns_mutex) xSemaphoreGive(s_dns_mutex);
 
     ESP_LOGD(TAG, "DNS check failed for %s (err %d), no cache available", host, err);
     return false;

--- a/main/nina_websocket.c
+++ b/main/nina_websocket.c
@@ -14,6 +14,8 @@
 #include "esp_websocket_client.h"
 #include "esp_log.h"
 #include "esp_timer.h"
+#include "esp_heap_caps.h"
+#include "freertos/task.h"
 #include "cJSON.h"
 #include <string.h>
 #include <stdarg.h>
@@ -32,6 +34,9 @@ static const char *TAG = "nina_ws";
 #define WS_BACKOFF_INITIAL_MS  5000
 #define WS_BACKOFF_MAX_MS      60000
 
+/* Fragmented-frame reassembly cap. Frames larger than this are dropped. */
+#define WS_REASM_MAX_BYTES     (16 * 1024)
+
 static esp_websocket_client_handle_t ws_clients[MAX_NINA_INSTANCES];
 static nina_client_t *ws_client_data[MAX_NINA_INSTANCES];
 
@@ -39,6 +44,36 @@ static nina_client_t *ws_client_data[MAX_NINA_INSTANCES];
 static _Atomic int ws_backoff_ms[MAX_NINA_INSTANCES];
 static _Atomic int64_t ws_disconnect_time_ms[MAX_NINA_INSTANCES];
 static _Atomic bool ws_needs_reconnect[MAX_NINA_INSTANCES];
+
+/* Per-instance lifecycle mutex — serializes stop/start/reconnect handle
+ * manipulation. Lock order: this mutex OUTER, nina_client_lock INNER.
+ * Lazily created (no init call site available in these files) via an
+ * atomic-elected static-allocation pattern so no heap alloc runs inside a
+ * critical section and exactly one task creates each mutex. */
+static SemaphoreHandle_t ws_life_mutex[MAX_NINA_INSTANCES];
+static StaticSemaphore_t ws_life_mutex_buf[MAX_NINA_INSTANCES];
+static _Atomic int       ws_life_mutex_state[MAX_NINA_INSTANCES]; // 0=uninit,1=creating,2=ready
+
+/* Per-instance fragment reassembly buffer (PSRAM, kept between messages). */
+static char    *ws_reasm_buf[MAX_NINA_INSTANCES];
+static int      ws_reasm_cap[MAX_NINA_INSTANCES];   // allocated capacity
+static int      ws_reasm_len[MAX_NINA_INSTANCES];   // expected total for active message
+static int      ws_reasm_have[MAX_NINA_INSTANCES];  // bytes accumulated
+static int64_t  ws_reasm_warn_ms[MAX_NINA_INSTANCES];
+
+static SemaphoreHandle_t ws_get_life_mutex(int index) {
+    int expected = 0;
+    if (atomic_compare_exchange_strong(&ws_life_mutex_state[index], &expected, 1)) {
+        ws_life_mutex[index] = xSemaphoreCreateMutexStatic(&ws_life_mutex_buf[index]);
+        ws_backoff_ms[index] = WS_BACKOFF_INITIAL_MS;  /* one-time backoff seed */
+        atomic_store(&ws_life_mutex_state[index], 2);
+    } else {
+        while (atomic_load(&ws_life_mutex_state[index]) != 2) {
+            vTaskDelay(1);
+        }
+    }
+    return ws_life_mutex[index];
+}
 
 /* ── Connect aggregation state ──────────────────────────────────────── */
 #define CONNECT_AGG_IDLE_TIMEOUT_MS 60000
@@ -744,13 +779,17 @@ static void handle_websocket_message(int index, const char *payload, int len) {
             nina_client_unlock(data);
         }
         /* Reset equipment mask — new profile may have different equipment */
+        portENTER_CRITICAL(&s_agg_lock);
         s_ever_connected[index] = 0;
+        portEXIT_CRITICAL(&s_agg_lock);
         if (toast_allowed(index, 9))
             ws_toast(index, TOAST_INFO, "Profile changed");
         nina_event_log_add(EVENT_SEV_INFO, index, "Profile changed");
     }
-    // AUTOFOCUS-FAILED: AF did not converge
-    else if (strcmp(evt->valuestring, "AUTOFOCUS-FAILED") == 0) {
+    // AUTOFOCUS-FAILED / ERROR-AF: AF did not converge (v2 emits ERROR-AF;
+    // keep AUTOFOCUS-FAILED for older plugin builds)
+    else if (strcmp(evt->valuestring, "AUTOFOCUS-FAILED") == 0 ||
+             strcmp(evt->valuestring, "ERROR-AF") == 0) {
         if (nina_client_lock(data, 50)) {
             data->autofocus.af_running = false;
             data->ui_refresh_needed = true;
@@ -939,6 +978,83 @@ static void handle_websocket_message(int index, const char *payload, int len) {
 }
 
 /**
+ * @brief Reassemble a possibly-fragmented text frame and dispatch it.
+ *
+ * esp_websocket_client posts payloads larger than buffer_size as multiple
+ * DATA events: the first carries op_code 0x01 with payload_offset 0, and
+ * continuation chunks carry op_code 0x00 with increasing payload_offset;
+ * payload_len is the full message length on every event. Accumulate into a
+ * per-instance PSRAM buffer and dispatch once complete. Runs only in the WS
+ * client task, so buffer state needs no lock; nina_websocket_stop frees the
+ * buffer after the client is destroyed (no concurrent handler).
+ */
+static void ws_handle_data_frame(int index, esp_websocket_event_data_t *d) {
+    int total = d->payload_len;
+    int off   = d->payload_offset;
+    int chunk = d->data_len;
+    if (total <= 0 || chunk < 0) return;
+
+    /* Whole message delivered in one frame — dispatch directly. */
+    if (off == 0 && chunk == total) {
+        handle_websocket_message(index, (const char *)d->data_ptr, total);
+        return;
+    }
+
+    /* Oversize message — discard with a rate-limited warning. */
+    if (total > WS_REASM_MAX_BYTES) {
+        int64_t now = esp_timer_get_time() / 1000;
+        if (now - ws_reasm_warn_ms[index] > 5000) {
+            ESP_LOGW(TAG, "WS[%d]: message %d bytes exceeds %d cap, dropped",
+                     index, total, WS_REASM_MAX_BYTES);
+            ws_reasm_warn_ms[index] = now;
+        }
+        ws_reasm_len[index] = 0;
+        ws_reasm_have[index] = 0;
+        return;
+    }
+
+    /* Start of a new message resets accumulator. */
+    if (off == 0) {
+        ws_reasm_len[index] = total;
+        ws_reasm_have[index] = 0;
+    } else if (off != ws_reasm_have[index] || total != ws_reasm_len[index]) {
+        /* Continuation without a matching active message (e.g. binary
+         * continuation, or a lost start) — drop and wait for a fresh start. */
+        ws_reasm_len[index] = 0;
+        ws_reasm_have[index] = 0;
+        return;
+    }
+
+    if (ws_reasm_cap[index] < total) {
+        char *nb = heap_caps_malloc(total, MALLOC_CAP_SPIRAM);
+        if (!nb) {
+            ESP_LOGW(TAG, "WS[%d]: reassembly alloc failed (%d bytes)", index, total);
+            ws_reasm_len[index] = 0;
+            ws_reasm_have[index] = 0;
+            return;
+        }
+        if (ws_reasm_buf[index]) heap_caps_free(ws_reasm_buf[index]);
+        ws_reasm_buf[index] = nb;
+        ws_reasm_cap[index] = total;
+    }
+
+    if (off + chunk > ws_reasm_cap[index]) {
+        ws_reasm_len[index] = 0;
+        ws_reasm_have[index] = 0;
+        return;
+    }
+
+    memcpy(ws_reasm_buf[index] + off, d->data_ptr, chunk);
+    ws_reasm_have[index] += chunk;
+
+    if (ws_reasm_have[index] >= ws_reasm_len[index]) {
+        handle_websocket_message(index, ws_reasm_buf[index], ws_reasm_len[index]);
+        ws_reasm_len[index] = 0;
+        ws_reasm_have[index] = 0;
+    }
+}
+
+/**
  * @brief WebSocket event handler callback.
  * handler_args carries the instance index as (void *)(intptr_t)index.
  */
@@ -976,8 +1092,10 @@ static void websocket_event_handler(void *handler_args, esp_event_base_t base,
         break;
 
     case WEBSOCKET_EVENT_DATA:
-        if (data->op_code == 0x01 && data->data_len > 0) {  // Text frame
-            handle_websocket_message(index, (const char *)data->data_ptr, data->data_len);
+        // Text frame (0x01) and continuation (0x00) — reassemble fragments.
+        // Binary/ping/pong/close opcodes are ignored.
+        if (data->op_code == 0x01 || data->op_code == 0x00) {
+            ws_handle_data_frame(index, data);
         }
         break;
 
@@ -1015,12 +1133,44 @@ static bool build_ws_url(const char *base_url, char *ws_url, size_t ws_url_size)
     return true;
 }
 
-void nina_websocket_start(int index, const char *base_url, nina_client_t *data) {
-    if (index < 0 || index >= MAX_NINA_INSTANCES) return;
+/* Stop/destroy the client. Caller must hold ws_life_mutex[index]. */
+static void ws_stop_locked(int index) {
+    if (ws_clients[index]) {
+        esp_websocket_client_stop(ws_clients[index]);
+        esp_websocket_client_destroy(ws_clients[index]);
+        ws_clients[index] = NULL;
+    }
+    if (ws_client_data[index]) {
+        if (nina_client_lock(ws_client_data[index], 50)) {
+            ws_client_data[index]->websocket_connected = false;
+            nina_connection_report_ws(index, false);
+            nina_client_unlock(ws_client_data[index]);
+        }
+        ws_client_data[index] = NULL;
+    }
 
+    // Stop aggregation timer and reset state
+    if (s_agg_timers[index]) {
+        esp_timer_stop(s_agg_timers[index]);
+    }
+    memset(&s_agg[index], 0, sizeof(connect_agg_state_t));
+
+    /* Free the reassembly buffer — safe now that the client (and its event
+     * handler) is destroyed, so no concurrent writer remains. */
+    if (ws_reasm_buf[index]) {
+        heap_caps_free(ws_reasm_buf[index]);
+        ws_reasm_buf[index] = NULL;
+    }
+    ws_reasm_cap[index] = 0;
+    ws_reasm_len[index] = 0;
+    ws_reasm_have[index] = 0;
+}
+
+/* Init/start the client. Caller must hold ws_life_mutex[index]. */
+static void ws_start_locked(int index, const char *base_url, nina_client_t *data) {
     if (ws_clients[index]) {
         ESP_LOGW(TAG, "WS[%d]: Already running, stopping first", index);
-        nina_websocket_stop(index);
+        ws_stop_locked(index);
     }
 
     char ws_url[192];
@@ -1032,8 +1182,9 @@ void nina_websocket_start(int index, const char *base_url, nina_client_t *data) 
     ESP_LOGI(TAG, "WS[%d]: Connecting to %s", index, ws_url);
 
     ws_client_data[index] = data;
-    ws_backoff_ms[index] = WS_BACKOFF_INITIAL_MS;
     ws_needs_reconnect[index] = false;
+    /* Backoff is reset on WEBSOCKET_EVENT_CONNECTED, not here — resetting on
+     * start would defeat the exponential backoff for offline rigs. */
 
     esp_websocket_client_config_t ws_cfg = {
         .uri = ws_url,
@@ -1067,28 +1218,20 @@ void nina_websocket_start(int index, const char *base_url, nina_client_t *data) 
      * from /equipment/info and persists across WS reconnects. */
 }
 
+void nina_websocket_start(int index, const char *base_url, nina_client_t *data) {
+    if (index < 0 || index >= MAX_NINA_INSTANCES) return;
+    SemaphoreHandle_t m = ws_get_life_mutex(index);
+    xSemaphoreTake(m, portMAX_DELAY);
+    ws_start_locked(index, base_url, data);
+    xSemaphoreGive(m);
+}
+
 void nina_websocket_stop(int index) {
     if (index < 0 || index >= MAX_NINA_INSTANCES) return;
-
-    if (ws_clients[index]) {
-        esp_websocket_client_stop(ws_clients[index]);
-        esp_websocket_client_destroy(ws_clients[index]);
-        ws_clients[index] = NULL;
-    }
-    if (ws_client_data[index]) {
-        if (nina_client_lock(ws_client_data[index], 50)) {
-            ws_client_data[index]->websocket_connected = false;
-            nina_connection_report_ws(index, false);
-            nina_client_unlock(ws_client_data[index]);
-        }
-        ws_client_data[index] = NULL;
-    }
-
-    // Stop aggregation timer and reset state
-    if (s_agg_timers[index]) {
-        esp_timer_stop(s_agg_timers[index]);
-    }
-    memset(&s_agg[index], 0, sizeof(connect_agg_state_t));
+    SemaphoreHandle_t m = ws_get_life_mutex(index);
+    xSemaphoreTake(m, portMAX_DELAY);
+    ws_stop_locked(index);
+    xSemaphoreGive(m);
 }
 
 void nina_websocket_stop_all(void) {
@@ -1111,8 +1254,11 @@ void nina_websocket_check_reconnect(int index, const char *base_url, nina_client
     if (ws_backoff_ms[index] > WS_BACKOFF_MAX_MS)
         ws_backoff_ms[index] = WS_BACKOFF_MAX_MS;
 
-    nina_websocket_stop(index);
-    nina_websocket_start(index, base_url, data);
+    SemaphoreHandle_t m = ws_get_life_mutex(index);
+    xSemaphoreTake(m, portMAX_DELAY);
+    ws_stop_locked(index);
+    ws_start_locked(index, base_url, data);
+    xSemaphoreGive(m);
 }
 
 void nina_websocket_check_deferred_alerts(int index) {
@@ -1131,5 +1277,7 @@ void nina_websocket_update_equipment_mask(int index, uint16_t connected_mask) {
     /* OR — accumulate bits. Equipment that was ever connected keeps its bit
      * even after disconnecting, so deferred disconnect toasts still fire.
      * Reset happens only on profile change or instance stop. */
+    portENTER_CRITICAL(&s_agg_lock);
     s_ever_connected[index] |= connected_mask;
+    portEXIT_CRITICAL(&s_agg_lock);
 }

--- a/main/perf_monitor.h
+++ b/main/perf_monitor.h
@@ -23,7 +23,7 @@ void     perf_timer_reset(perf_timer_t *t);
 
 // ── CPU Utilization ────────────────────────────────────────────────
 
-#define CPU_MAX_TRACKED_TASKS 24
+#define CPU_MAX_TRACKED_TASKS 40
 
 // Low-DMA-heap watchdog: when the largest contiguous DMA-capable internal
 // block (MALLOC_CAP_INTERNAL|MALLOC_CAP_DMA|MALLOC_CAP_8BIT) drops below this,

--- a/main/spotify_auth.c
+++ b/main/spotify_auth.c
@@ -33,6 +33,8 @@ static const char *TAG = "spotify_auth";
 #define TOKEN_RESPONSE_BUF_SIZE 4096    /* 4KB SPIRAM for token responses */
 #define HTTP_TIMEOUT_MS         10000
 #define POST_BODY_BUF_SIZE      2048    /* URL-encoded POST body */
+#define REFRESH_BACKOFF_INITIAL_MS 30000    /* 30s after first transient failure */
+#define REFRESH_BACKOFF_MAX_MS     600000   /* 10min cap */
 
 static SemaphoreHandle_t s_mutex;
 static char *s_access_token = NULL;
@@ -42,8 +44,27 @@ static char *s_refresh_token = NULL;
 static int64_t s_token_expiry_ms;       /* Monotonic ms when access token expires */
 static spotify_auth_state_t s_state = SPOTIFY_AUTH_NONE;
 
+/* A token request must never run under s_mutex (it performs blocking HTTPS).
+ * These guard against duplicate concurrent requests and rate-limit retries
+ * after transient failures. All accessed only while holding s_mutex. */
+static bool s_refresh_in_flight = false;
+static int64_t s_next_refresh_ms = 0;
+static int64_t s_refresh_backoff_ms = REFRESH_BACKOFF_INITIAL_MS;
+
+/* Parsed token-endpoint result. do_token_request fills this without touching
+ * module state, so callers can run it outside s_mutex and commit under it. */
+typedef struct {
+    int     http_status;
+    bool    got_tokens;     /* access_token + expires_in parsed */
+    bool    got_refresh;    /* endpoint returned a rotated refresh token */
+    bool    invalid_grant;  /* definitive rejection — refresh token is dead */
+    int64_t expiry_ms;      /* monotonic ms when access token expires */
+    char    access_token[ACCESS_TOKEN_SIZE];
+    char    refresh_token[REFRESH_TOKEN_SIZE];
+} token_result_t;
+
 /* Forward declarations */
-static esp_err_t do_token_request(const char *body, size_t body_len);
+static esp_err_t do_token_request(const char *body, size_t body_len, token_result_t *res);
 static void save_tokens_to_nvs(void);
 static void load_tokens_from_nvs(void);
 static void clear_tokens_from_nvs(void);
@@ -146,6 +167,7 @@ static void clear_tokens_from_nvs(void) {
  */
 static int url_encode_param(char *buf, int pos, int buf_size,
                             const char *key, const char *value) {
+    if (pos < 0 || buf_size <= 0) return -1;
     /* Simple append — Spotify token endpoint values are safe ASCII
      * (base64url codes, client IDs, redirect URIs with limited charset).
      * No full percent-encoding needed for these specific parameters. */
@@ -165,7 +187,15 @@ static int url_encode_param(char *buf, int pos, int buf_size,
 // Token request — core HTTPS POST to Spotify token endpoint
 // =============================================================================
 
-static esp_err_t do_token_request(const char *body, size_t body_len) {
+static esp_err_t do_token_request(const char *body, size_t body_len, token_result_t *res) {
+    res->http_status = 0;
+    res->got_tokens = false;
+    res->got_refresh = false;
+    res->invalid_grant = false;
+    res->expiry_ms = 0;
+    res->access_token[0] = '\0';
+    res->refresh_token[0] = '\0';
+
     esp_http_client_config_t http_cfg = {
         .url = TOKEN_ENDPOINT,
         .method = HTTP_METHOD_POST,
@@ -198,6 +228,7 @@ static esp_err_t do_token_request(const char *body, size_t body_len) {
 
     int content_length = esp_http_client_fetch_headers(client);
     int status = esp_http_client_get_status_code(client);
+    res->http_status = status;
 
     /* Determine buffer size */
     int buf_size = (content_length > 0 && content_length < TOKEN_RESPONSE_BUF_SIZE)
@@ -223,24 +254,29 @@ static esp_err_t do_token_request(const char *body, size_t body_len) {
 
     esp_http_client_cleanup(client);
 
-    if (status < 200 || status >= 300) {
-        ESP_LOGE(TAG, "Token request failed HTTP %d: %.256s", status, buffer);
-        free(buffer);
-        return ESP_FAIL;
-    }
-
-    if (total_read == 0) {
-        ESP_LOGE(TAG, "Empty token response body");
-        free(buffer);
-        return ESP_FAIL;
-    }
-
-    /* Parse JSON response */
-    cJSON *json = cJSON_Parse(buffer);
+    /* Parse JSON regardless of status so error bodies (e.g. invalid_grant)
+     * can classify the failure as definitive vs transient. */
+    cJSON *json = (total_read > 0) ? cJSON_Parse(buffer) : NULL;
     free(buffer);
 
+    if (status < 200 || status >= 300) {
+        const char *err_str = "unknown";
+        if (json) {
+            cJSON *error = cJSON_GetObjectItem(json, "error");
+            if (cJSON_IsString(error) && error->valuestring) {
+                err_str = error->valuestring;
+                if (strcmp(err_str, "invalid_grant") == 0) {
+                    res->invalid_grant = true;
+                }
+            }
+        }
+        ESP_LOGE(TAG, "Token request failed HTTP %d (error: %s)", status, err_str);
+        if (json) cJSON_Delete(json);
+        return ESP_FAIL;
+    }
+
     if (!json) {
-        ESP_LOGE(TAG, "Failed to parse token response JSON");
+        ESP_LOGE(TAG, "Empty or unparseable token response body");
         return ESP_FAIL;
     }
 
@@ -250,23 +286,20 @@ static esp_err_t do_token_request(const char *body, size_t body_len) {
     cJSON *expires_in = cJSON_GetObjectItem(json, "expires_in");
 
     if (cJSON_IsString(access) && cJSON_IsNumber(expires_in)) {
-        /* Update access token */
-        snprintf(s_access_token, ACCESS_TOKEN_SIZE, "%s", access->valuestring);
+        snprintf(res->access_token, ACCESS_TOKEN_SIZE, "%s", access->valuestring);
 
         /* Compute expiry in monotonic ms */
         int expires_s = expires_in->valueint;
-        s_token_expiry_ms = now_ms() + ((int64_t)expires_s * 1000);
+        res->expiry_ms = now_ms() + ((int64_t)expires_s * 1000);
 
-        /* Refresh token — Spotify may or may not return a new one.
-         * If present, update it; otherwise keep the existing one. */
+        /* Refresh token — Spotify may or may not return a new one. */
         cJSON *refresh = cJSON_GetObjectItem(json, "refresh_token");
         if (cJSON_IsString(refresh) && refresh->valuestring[0] != '\0') {
-            snprintf(s_refresh_token, REFRESH_TOKEN_SIZE, "%s", refresh->valuestring);
+            snprintf(res->refresh_token, REFRESH_TOKEN_SIZE, "%s", refresh->valuestring);
+            res->got_refresh = true;
         }
 
-        s_state = SPOTIFY_AUTH_AUTHORIZED;
-        save_tokens_to_nvs();
-
+        res->got_tokens = true;
         ESP_LOGI(TAG, "Token exchange OK — expires in %d s", expires_s);
         result = ESP_OK;
     } else {
@@ -351,18 +384,50 @@ esp_err_t spotify_auth_exchange_code(const char *code, const char *code_verifier
         return ESP_ERR_NO_MEM;
     }
 
+    /* Reserve the in-flight slot so a concurrent refresh cannot overlap. */
     xSemaphoreTake(s_mutex, portMAX_DELAY);
-    esp_err_t err = do_token_request(body, (size_t)pos);
+    if (s_refresh_in_flight) {
+        xSemaphoreGive(s_mutex);
+        free(body);
+        ESP_LOGW(TAG, "exchange_code: token request already in flight");
+        return ESP_FAIL;
+    }
+    s_refresh_in_flight = true;
     xSemaphoreGive(s_mutex);
 
-    free(body);
-
-    if (err != ESP_OK) {
+    token_result_t *res = heap_caps_malloc(sizeof(token_result_t), MALLOC_CAP_SPIRAM);
+    if (!res) {
         xSemaphoreTake(s_mutex, portMAX_DELAY);
-        s_state = SPOTIFY_AUTH_ERROR;
+        s_refresh_in_flight = false;
         xSemaphoreGive(s_mutex);
+        free(body);
+        return ESP_ERR_NO_MEM;
     }
 
+    esp_err_t err = do_token_request(body, (size_t)pos, res);
+    free(body);
+
+    /* Commit under the lock — do_token_request never touched module state. */
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    s_refresh_in_flight = false;
+    if (err == ESP_OK && res->got_tokens) {
+        snprintf(s_access_token, ACCESS_TOKEN_SIZE, "%s", res->access_token);
+        s_token_expiry_ms = res->expiry_ms;
+        if (res->got_refresh) {
+            snprintf(s_refresh_token, REFRESH_TOKEN_SIZE, "%s", res->refresh_token);
+        }
+        s_state = SPOTIFY_AUTH_AUTHORIZED;
+        save_tokens_to_nvs();
+        s_refresh_backoff_ms = REFRESH_BACKOFF_INITIAL_MS;
+        s_next_refresh_ms = 0;
+        err = ESP_OK;
+    } else {
+        s_state = SPOTIFY_AUTH_ERROR;
+        err = ESP_FAIL;
+    }
+    xSemaphoreGive(s_mutex);
+
+    free(res);
     return err;
 }
 
@@ -387,22 +452,42 @@ esp_err_t spotify_auth_get_access_token(char *buf, size_t buf_size) {
         return ESP_OK;
     }
 
-    /* Need to refresh */
-    ESP_LOGI(TAG, "Access token expired or missing — refreshing");
+    /* Need to refresh. Back off after transient failures so we do not hammer
+     * the token endpoint; the window is cleared on a successful refresh. */
+    if (s_next_refresh_ms != 0 && now_ms() < s_next_refresh_ms) {
+        xSemaphoreGive(s_mutex);
+        return ESP_FAIL;
+    }
+
+    /* Another caller is already refreshing — do not start a duplicate request. */
+    if (s_refresh_in_flight) {
+        xSemaphoreGive(s_mutex);
+        return ESP_FAIL;
+    }
 
     const app_config_t *cfg = app_config_get();
     if (cfg->spotify_client_id[0] == '\0') {
         ESP_LOGE(TAG, "Cannot refresh: no client_id configured");
-        s_state = SPOTIFY_AUTH_ERROR;
         xSemaphoreGive(s_mutex);
         return ESP_FAIL;
     }
+
+    /* Snapshot the inputs into locals so the HTTPS request runs unlocked. */
+    char refresh_local[REFRESH_TOKEN_SIZE];
+    char client_id_local[64];
+    snprintf(refresh_local, sizeof(refresh_local), "%s", s_refresh_token);
+    snprintf(client_id_local, sizeof(client_id_local), "%s", cfg->spotify_client_id);
+    s_refresh_in_flight = true;
+    xSemaphoreGive(s_mutex);
+
+    ESP_LOGI(TAG, "Access token expired or missing — refreshing");
 
     /* Build refresh POST body */
     char *body = heap_caps_malloc(POST_BODY_BUF_SIZE, MALLOC_CAP_SPIRAM);
     if (!body) {
         ESP_LOGE(TAG, "Failed to allocate refresh body buffer");
-        s_state = SPOTIFY_AUTH_ERROR;
+        xSemaphoreTake(s_mutex, portMAX_DELAY);
+        s_refresh_in_flight = false;
         xSemaphoreGive(s_mutex);
         return ESP_ERR_NO_MEM;
     }
@@ -411,31 +496,70 @@ esp_err_t spotify_auth_get_access_token(char *buf, size_t buf_size) {
     pos = url_encode_param(body, pos, POST_BODY_BUF_SIZE,
                            "grant_type", "refresh_token");
     pos = url_encode_param(body, pos, POST_BODY_BUF_SIZE,
-                           "refresh_token", s_refresh_token);
+                           "refresh_token", refresh_local);
     pos = url_encode_param(body, pos, POST_BODY_BUF_SIZE,
-                           "client_id", cfg->spotify_client_id);
+                           "client_id", client_id_local);
 
     if (pos < 0) {
         ESP_LOGE(TAG, "Refresh body overflow");
         free(body);
-        s_state = SPOTIFY_AUTH_ERROR;
+        xSemaphoreTake(s_mutex, portMAX_DELAY);
+        s_refresh_in_flight = false;
         xSemaphoreGive(s_mutex);
         return ESP_FAIL;
     }
 
-    esp_err_t err = do_token_request(body, (size_t)pos);
+    token_result_t *res = heap_caps_malloc(sizeof(token_result_t), MALLOC_CAP_SPIRAM);
+    if (!res) {
+        free(body);
+        xSemaphoreTake(s_mutex, portMAX_DELAY);
+        s_refresh_in_flight = false;
+        xSemaphoreGive(s_mutex);
+        return ESP_ERR_NO_MEM;
+    }
+
+    esp_err_t err = do_token_request(body, (size_t)pos, res);
     free(body);
 
-    if (err != ESP_OK) {
-        ESP_LOGE(TAG, "Token refresh failed");
-        s_state = SPOTIFY_AUTH_ERROR;
+    /* Commit under the lock. */
+    xSemaphoreTake(s_mutex, portMAX_DELAY);
+    s_refresh_in_flight = false;
+
+    if (err == ESP_OK && res->got_tokens) {
+        snprintf(s_access_token, ACCESS_TOKEN_SIZE, "%s", res->access_token);
+        s_token_expiry_ms = res->expiry_ms;
+        if (res->got_refresh) {
+            snprintf(s_refresh_token, REFRESH_TOKEN_SIZE, "%s", res->refresh_token);
+        }
+        s_state = SPOTIFY_AUTH_AUTHORIZED;
+        save_tokens_to_nvs();
+        s_refresh_backoff_ms = REFRESH_BACKOFF_INITIAL_MS;
+        s_next_refresh_ms = 0;
+        snprintf(buf, buf_size, "%s", s_access_token);
         xSemaphoreGive(s_mutex);
-        return ESP_FAIL;
+        free(res);
+        return ESP_OK;
     }
 
-    snprintf(buf, buf_size, "%s", s_access_token);
+    if (res->invalid_grant) {
+        /* Definitive rejection: the refresh token is dead — force re-auth. */
+        ESP_LOGE(TAG, "Token refresh rejected (invalid_grant) — re-auth required");
+        s_state = SPOTIFY_AUTH_ERROR;
+    } else {
+        /* Transient failure (network/5xx/timeout): stay AUTHORIZED so the next
+         * poll retries after the backoff window, and drop the expired token. */
+        ESP_LOGW(TAG, "Token refresh failed (transient) — will retry after backoff");
+        s_access_token[0] = '\0';
+        s_token_expiry_ms = 0;
+        s_next_refresh_ms = now_ms() + s_refresh_backoff_ms;
+        s_refresh_backoff_ms *= 2;
+        if (s_refresh_backoff_ms > REFRESH_BACKOFF_MAX_MS) {
+            s_refresh_backoff_ms = REFRESH_BACKOFF_MAX_MS;
+        }
+    }
     xSemaphoreGive(s_mutex);
-    return ESP_OK;
+    free(res);
+    return ESP_FAIL;
 }
 
 void spotify_auth_invalidate_token(void) {

--- a/main/spotify_client.c
+++ b/main/spotify_client.c
@@ -143,9 +143,16 @@ static esp_err_t send_control_request(const char *url, esp_http_client_method_t 
 // Public API — Init
 // =============================================================================
 
+/* Guards s_player_client and s_player_shutdown. Held for the full lifetime of
+ * any player/album-art HTTP request so spotify_client_prepare_shutdown can
+ * guarantee no request is in flight before it destroys the handle. */
+static SemaphoreHandle_t s_player_mutex;
+static bool s_player_shutdown = false;
+
 void spotify_client_init(void)
 {
     s_mutex = xSemaphoreCreateMutex();
+    s_player_mutex = xSemaphoreCreateMutex();
     memset(&s_cached_playback, 0, sizeof(s_cached_playback));
     spotify_action_queue = xQueueCreate(4, sizeof(spotify_action_t));
     ESP_LOGI(TAG, "Spotify client initialized");
@@ -159,6 +166,7 @@ void spotify_client_init(void)
  * Reusing the TLS session avoids a 2-5 second handshake on every poll. */
 static esp_http_client_handle_t s_player_client = NULL;
 
+/* Caller must hold s_player_mutex. */
 static void player_client_destroy(void)
 {
     if (s_player_client) {
@@ -167,8 +175,10 @@ static void player_client_destroy(void)
     }
 }
 
+/* Caller must hold s_player_mutex. */
 static esp_http_client_handle_t player_client_get(void)
 {
+    if (s_player_shutdown) return NULL;
     if (s_player_client) return s_player_client;
 
     esp_http_client_config_t http_cfg = {
@@ -188,15 +198,28 @@ static esp_http_client_handle_t player_client_get(void)
 esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
 {
     if (!out) return ESP_ERR_INVALID_ARG;
+    if (!s_player_mutex) return ESP_FAIL;
+
+    /* Hold the player mutex for the whole request so prepare_shutdown cannot
+     * destroy the handle mid-flight. This poll is the resumption point after a
+     * shutdown, so clear the flag before (re)creating the handle. */
+    if (xSemaphoreTake(s_player_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_FAIL;
+    }
+    s_player_shutdown = false;
+
+    esp_err_t ret = ESP_FAIL;
 
     esp_http_client_handle_t client = player_client_get();
     if (!client) {
         ESP_LOGE(TAG, "Failed to init HTTP client for currently-playing");
-        return ESP_FAIL;
+        ret = ESP_FAIL;
+        goto unlock;
     }
 
     if (set_auth_header(client) != ESP_OK) {
-        return ESP_FAIL;
+        ret = ESP_FAIL;
+        goto unlock;
     }
 
     esp_err_t err = esp_http_client_open(client, 0);
@@ -205,13 +228,14 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
         /* Connection stale or dropped — destroy and retry once */
         player_client_destroy();
         client = player_client_get();
-        if (!client) return ESP_FAIL;
-        if (set_auth_header(client) != ESP_OK) return ESP_FAIL;
+        if (!client) { ret = ESP_FAIL; goto unlock; }
+        if (set_auth_header(client) != ESP_OK) { ret = ESP_FAIL; goto unlock; }
         err = esp_http_client_open(client, 0);
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "HTTP open retry failed: %s", esp_err_to_name(err));
             player_client_destroy();
-            return ESP_FAIL;
+            ret = ESP_FAIL;
+            goto unlock;
         }
     }
 
@@ -224,19 +248,21 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
         ESP_LOGW(TAG, "Stale keep-alive connection — reconnecting");
         player_client_destroy();
         client = player_client_get();
-        if (!client) return ESP_FAIL;
-        if (set_auth_header(client) != ESP_OK) return ESP_FAIL;
+        if (!client) { ret = ESP_FAIL; goto unlock; }
+        if (set_auth_header(client) != ESP_OK) { ret = ESP_FAIL; goto unlock; }
         err = esp_http_client_open(client, 0);
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "HTTP open retry failed: %s", esp_err_to_name(err));
             player_client_destroy();
-            return ESP_FAIL;
+            ret = ESP_FAIL;
+            goto unlock;
         }
         content_length = esp_http_client_fetch_headers(client);
         status = esp_http_client_get_status_code(client);
         if (status == -1) {
             player_client_destroy();
-            return ESP_FAIL;
+            ret = ESP_FAIL;
+            goto unlock;
         }
     }
 
@@ -255,20 +281,32 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
         }
 
         memset(out, 0, sizeof(*out));
-        return ESP_ERR_NOT_FOUND;
+        ret = ESP_ERR_NOT_FOUND;
+        goto unlock;
     }
 
     if (status == 401) {
         ESP_LOGW(TAG, "HTTP 401 from currently-playing — invalidating token");
         spotify_auth_invalidate_token();
         player_client_destroy();
-        return ESP_FAIL;
+        ret = ESP_FAIL;
+        goto unlock;
     }
 
     if (status != 200) {
         ESP_LOGW(TAG, "Unexpected HTTP %d from currently-playing", status);
         player_client_destroy();
-        return ESP_FAIL;
+        ret = ESP_FAIL;
+        goto unlock;
+    }
+
+    /* A body larger than the cap cannot be parsed. Destroy the connection so
+     * the next poll starts clean rather than reading a truncated JSON. */
+    if (content_length > 0 && (content_length + 1) > SPOTIFY_RESPONSE_BUF_SIZE) {
+        ESP_LOGW(TAG, "currently-playing response too large: %d bytes", content_length);
+        player_client_destroy();
+        ret = ESP_FAIL;
+        goto unlock;
     }
 
     /* Allocate response buffer from SPIRAM */
@@ -281,7 +319,8 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
     if (!buffer) {
         ESP_LOGE(TAG, "Failed to allocate %d bytes for response", buf_size);
         player_client_destroy();
-        return ESP_FAIL;
+        ret = ESP_FAIL;
+        goto unlock;
     }
 
     /* Read response body */
@@ -299,7 +338,8 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
     if (total_read == 0) {
         ESP_LOGW(TAG, "Empty response body from currently-playing");
         free(buffer);
-        return ESP_FAIL;
+        ret = ESP_FAIL;
+        goto unlock;
     }
 
     /* Parse JSON */
@@ -307,8 +347,12 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
     free(buffer);
 
     if (!json) {
+        /* Likely a truncated/partial body on a reused connection — destroy so
+         * the next poll starts on a clean connection. */
         ESP_LOGW(TAG, "Failed to parse currently-playing JSON");
-        return ESP_FAIL;
+        player_client_destroy();
+        ret = ESP_FAIL;
+        goto unlock;
     }
 
     /* Extract fields */
@@ -389,7 +433,11 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
     ESP_LOGD(TAG, "Now playing: \"%s\" by %s (%s)", pb.track_title, pb.artist_name,
              pb.is_playing ? "playing" : "paused");
 
-    return ESP_OK;
+    ret = ESP_OK;
+
+unlock:
+    xSemaphoreGive(s_player_mutex);
+    return ret;
 }
 
 // =============================================================================
@@ -444,6 +492,19 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
     *out_buf = NULL;
     *out_size = 0;
 
+    if (!s_player_mutex) return ESP_FAIL;
+
+    /* Hold the player mutex so prepare_shutdown waits for this request too. */
+    if (xSemaphoreTake(s_player_mutex, portMAX_DELAY) != pdTRUE) {
+        return ESP_FAIL;
+    }
+    if (s_player_shutdown) {
+        xSemaphoreGive(s_player_mutex);
+        return ESP_FAIL;
+    }
+
+    esp_err_t ret = ESP_FAIL;
+
     esp_http_client_config_t http_cfg = {
         .url = url,
         .timeout_ms = SPOTIFY_HTTP_TIMEOUT_MS,
@@ -454,6 +515,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
     esp_http_client_handle_t client = esp_http_client_init(&http_cfg);
     if (!client) {
         ESP_LOGE(TAG, "Failed to init HTTP client for album art");
+        xSemaphoreGive(s_player_mutex);
         return ESP_FAIL;
     }
 
@@ -461,6 +523,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
     if (err != ESP_OK) {
         ESP_LOGW(TAG, "HTTP open failed for album art: %s", esp_err_to_name(err));
         esp_http_client_cleanup(client);
+        xSemaphoreGive(s_player_mutex);
         return ESP_FAIL;
     }
 
@@ -470,6 +533,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
     if (status != 200) {
         ESP_LOGW(TAG, "Album art HTTP %d for %s", status, url);
         esp_http_client_cleanup(client);
+        xSemaphoreGive(s_player_mutex);
         return ESP_FAIL;
     }
 
@@ -479,6 +543,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
         if ((size_t)content_length > SPOTIFY_ART_MAX_SIZE) {
             ESP_LOGW(TAG, "Album art too large: %d bytes", content_length);
             esp_http_client_cleanup(client);
+            xSemaphoreGive(s_player_mutex);
             return ESP_FAIL;
         }
         buf_size = (size_t)content_length;
@@ -491,6 +556,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
     if (!buffer) {
         ESP_LOGE(TAG, "Failed to allocate %zu bytes for album art", buf_size);
         esp_http_client_cleanup(client);
+        xSemaphoreGive(s_player_mutex);
         return ESP_FAIL;
     }
 
@@ -517,6 +583,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
                      (int)SPOTIFY_ART_MAX_SIZE);
             esp_http_client_cleanup(client);
             free(buffer);
+            xSemaphoreGive(s_player_mutex);
             return ESP_FAIL;
         }
     }
@@ -526,6 +593,7 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
     if (total_read == 0) {
         ESP_LOGW(TAG, "Empty album art response");
         free(buffer);
+        xSemaphoreGive(s_player_mutex);
         return ESP_FAIL;
     }
 
@@ -540,9 +608,11 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
 
     *out_buf = buffer;
     *out_size = total_read;
+    ret = ESP_OK;
 
     ESP_LOGD(TAG, "Album art fetched: %zu bytes from %s", total_read, url);
-    return ESP_OK;
+    xSemaphoreGive(s_player_mutex);
+    return ret;
 }
 
 // =============================================================================
@@ -551,5 +621,30 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
 
 void spotify_client_destroy_connection(void)
 {
-    player_client_destroy();
+    if (s_player_mutex && xSemaphoreTake(s_player_mutex, portMAX_DELAY) == pdTRUE) {
+        player_client_destroy();
+        xSemaphoreGive(s_player_mutex);
+    } else {
+        player_client_destroy();
+    }
+}
+
+void spotify_client_prepare_shutdown(void)
+{
+    if (!s_player_mutex) {
+        return;
+    }
+
+    /* Bounded wait: the in-flight request is capped by SPOTIFY_HTTP_TIMEOUT_MS,
+     * so 15s is long enough for it to finish. */
+    if (xSemaphoreTake(s_player_mutex, pdMS_TO_TICKS(15000)) == pdTRUE) {
+        s_player_shutdown = true;
+        player_client_destroy();
+        xSemaphoreGive(s_player_mutex);
+    } else {
+        /* Contract requires the handle destroyed on return; force it. */
+        ESP_LOGW(TAG, "prepare_shutdown: mutex wait timed out — forcing teardown");
+        s_player_shutdown = true;
+        player_client_destroy();
+    }
 }

--- a/main/spotify_client.h
+++ b/main/spotify_client.h
@@ -93,6 +93,16 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
  */
 void spotify_client_destroy_connection(void);
 
+/**
+ * Quiesce the Spotify client for teardown (e.g. before OTA reclaims network
+ * resources). Blocks until any in-flight Spotify HTTP request completes
+ * (bounded wait ~15 s), then destroys the persistent player handle. On return,
+ * no Spotify HTTP request is in flight and the handle is destroyed. Subsequent
+ * requests are rejected until the next successful currently-playing poll
+ * recreates the handle.
+ */
+void spotify_client_prepare_shutdown(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -49,6 +49,7 @@
 #include "esp_system.h"
 #include <time.h>
 #include <math.h>          /* expf — framerate-independent settle ease */
+#include <stdatomic.h>     /* atomic_exchange — read-and-clear WS event flags */
 #include "perf_monitor.h"
 #include "power_mgmt.h"
 #include "crash_log.h"
@@ -320,7 +321,12 @@ void input_task(void *arg) {
             }
         }
 
-        if (long_pressed && app_config_get()->deep_sleep_enabled) {
+        if (long_pressed && ota_in_progress) {
+            /* An OTA is flashing — deep sleep now would stop WiFi mid-write and
+             * silently discard the update. Skip it and tell the user. */
+            ESP_LOGW(TAG, "Long press ignored — firmware update in progress");
+            nina_toast_show(TOAST_WARNING, "Update in progress");
+        } else if (long_pressed && app_config_get()->deep_sleep_enabled) {
             /* Long press — enter deep sleep */
             ESP_LOGI(TAG, "Long press detected — entering deep sleep");
 
@@ -1830,9 +1836,13 @@ void spotify_poll_task(void *arg)
                                         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                                             nina_spotify_set_album_art(final_buf, final_w, final_h, final_size);
                                             bsp_display_unlock();
+                                            art_ok = true;
+                                            /* Ownership transferred to UI — don't free final_buf */
+                                        } else {
+                                            /* Lock timed out — free the buffer and leave
+                                             * art_ok false so the art is retried next poll. */
+                                            free(final_buf);
                                         }
-                                        art_ok = true;
-                                        /* Ownership transferred to UI — don't free final_buf */
                                     } else {
                                         perf_timer_stop(&g_perf.spotify_art_decode);
                                         ESP_LOGW(TAG, "HW JPEG decode failed, trying SW fallback");
@@ -1881,8 +1891,12 @@ void spotify_poll_task(void *arg)
                                 if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                                     nina_spotify_set_album_art(final_buf, final_w, final_h, final_size);
                                     bsp_display_unlock();
+                                    art_ok = true;
+                                } else {
+                                    /* Lock timed out — free the buffer and leave
+                                     * art_ok false so the art is retried next poll. */
+                                    free(final_buf);
                                 }
-                                art_ok = true;
                             } else {
                                 ESP_LOGW(TAG, "SW JPEG decode also failed for album art");
                             }
@@ -2325,10 +2339,18 @@ void data_update_task(void *arg) {
                     if (nina_ota_prompt_skipped())          { accepted = false; break; }
                     vTaskDelay(pdMS_TO_TICKS(200));
                 }
-                if (accepted) {
-                    /* Accepted — proceed with OTA download */
+                if (accepted && atomic_exchange(&ota_in_progress, true)) {
+                    /* Another OTA is already running — do not start a second
+                     * write stream against the same partition. */
+                    ESP_LOGW(TAG, "OTA already in progress — ignoring boot update request");
+                    nina_toast_show(TOAST_WARNING, "Update already in progress");
+                    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                        nina_ota_prompt_hide();
+                        bsp_display_unlock();
+                    }
+                } else if (accepted) {
+                    /* Accepted — ota_in_progress was set true by the exchange above. */
                     ESP_LOGI(TAG, "User accepted OTA update to %s", rel->tag);
-                    ota_in_progress = true;
                     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                         nina_ota_prompt_show_progress();
                         bsp_display_unlock();
@@ -2737,9 +2759,18 @@ main_loop:
                         if (nina_ota_prompt_skipped())          { accepted = false; break; }
                         vTaskDelay(pdMS_TO_TICKS(200));
                     }
-                    if (accepted) {
+                    if (accepted && atomic_exchange(&ota_in_progress, true)) {
+                        /* Another OTA is already running — do not start a second
+                         * write stream against the same partition. */
+                        ESP_LOGW(TAG, "OTA already in progress — ignoring update request");
+                        nina_toast_show(TOAST_WARNING, "Update already in progress");
+                        if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                            nina_ota_prompt_hide();
+                            bsp_display_unlock();
+                        }
+                    } else if (accepted) {
+                        /* Accepted — ota_in_progress was set true by the exchange above. */
                         ESP_LOGI(TAG, "User accepted OTA update to %s", rel->tag);
-                        ota_in_progress = true;
                         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                             nina_ota_prompt_show_progress();
                             bsp_display_unlock();
@@ -2812,7 +2843,7 @@ main_loop:
                 for (int j = 0; j < instance_count; j++)
                     locked[j] = nina_client_lock(&instances[j], 15);
                 if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                    summary_page_update(instances, instance_count);
+                    summary_page_update(instances, instance_count, locked);
                     bsp_display_unlock();
                 }
                 for (int j = 0; j < instance_count; j++)
@@ -2919,7 +2950,7 @@ main_loop:
             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                 if (g_perf.enabled) perf_timer_record(&g_perf.ui_lock_wait, esp_timer_get_time() - lock_start);
                 perf_timer_start(&g_perf.ui_summary_update);
-                summary_page_update(instances, instance_count);
+                summary_page_update(instances, instance_count, locked);
                 perf_timer_stop(&g_perf.ui_summary_update);
                 bsp_display_unlock();
             }
@@ -3127,8 +3158,7 @@ main_loop:
 
         // ── Event-driven UI refresh: check if any WS event needs immediate UI update ──
         if (active_nina_idx >= 0 && active_page_idx >= 0
-            && instances[active_nina_idx].ui_refresh_needed) {
-            instances[active_nina_idx].ui_refresh_needed = false;
+            && atomic_exchange(&instances[active_nina_idx].ui_refresh_needed, false)) {
             if (nina_client_lock(&instances[active_nina_idx], 15)) {
                 if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                     update_nina_dashboard_page(active_nina_idx, &instances[active_nina_idx]);

--- a/main/ui/nina_nav_arbiter.c
+++ b/main/ui/nina_nav_arbiter.c
@@ -24,9 +24,11 @@
 static const char *TAG = "nav_arb";
 
 static struct {
-    int      user_page;            /* last USER claim target, -1 if none */
-    int8_t   user_img_source;      /* image source the USER claim pins (0-3), or -1
-                                    * for a non-image target (clears the override) */
+    _Atomic uint32_t user_claim;   /* USER claim page + image source packed into one
+                                    * atomic word so the pair updates/reads without
+                                    * tearing across cores: (page+1)<<16 | (img_src+1),
+                                    * with -1 sentinels encoded as 0. See
+                                    * pack_claim()/unpack_claim() below. */
     _Atomic int64_t user_stamp_ms; /* when the USER claim was stamped; atomic to
                                     * close the cross-core torn-read window between
                                     * submit_user (LVGL/web task) and resolve
@@ -49,9 +51,19 @@ static struct {
                                     * mirroring user_stamp_ms's cross-core guard. */
 } s_arb;
 
+/* Pack/unpack the USER claim (page index + image source) into one 32-bit word.
+ * Both fields are >= -1, so (field+1) is non-negative and fits a uint16_t. */
+static inline uint32_t pack_claim(int page, int8_t img_src) {
+    return ((uint32_t)(uint16_t)(page + 1) << 16)
+         | (uint32_t)(uint16_t)((int)img_src + 1);
+}
+static inline void unpack_claim(uint32_t v, int *page, int8_t *img_src) {
+    *page    = (int)(uint16_t)(v >> 16) - 1;
+    *img_src = (int8_t)((int)(uint16_t)(v & 0xFFFFu) - 1);
+}
+
 void nav_arbiter_init(void) {
-    s_arb.user_page = -1;
-    s_arb.user_img_source = -1;
+    s_arb.user_claim = pack_claim(-1, -1);
     s_arb.user_stamp_ms = 0;
     s_arb.topology_dirty = false;
     s_arb.modal_depth = 0;
@@ -66,8 +78,7 @@ void nav_arbiter_init(void) {
 }
 
 void nav_arbiter_submit_user(int abs_page, int64_t now_ms, int8_t img_src) {
-    s_arb.user_page = abs_page;
-    s_arb.user_img_source = img_src;
+    s_arb.user_claim = pack_claim(abs_page, img_src);
     s_arb.user_stamp_ms = now_ms;
     /* Wake the data task so the arbiter resolves this claim on the next loop
      * iteration instead of waiting up to a full update_rate_s cycle. Idempotent
@@ -94,7 +105,9 @@ void nav_arbiter_notify_modal_open(void)  { s_arb.modal_depth++; }
 void nav_arbiter_notify_modal_close(int64_t now_ms) {
     if (s_arb.modal_depth > 0) s_arb.modal_depth--;
     s_arb.user_stamp_ms = now_ms;     /* restamp grace on close */
-    if (s_arb.user_page < 0) s_arb.user_page = nina_dashboard_get_active_page();
+    int up; int8_t us;
+    unpack_claim(s_arb.user_claim, &up, &us);
+    if (up < 0) s_arb.user_claim = pack_claim(nina_dashboard_get_active_page(), us);
 }
 
 void nav_arbiter_notify_slideshow_tick(void) { s_arb.slideshow_advance = true; }
@@ -105,11 +118,14 @@ void nav_arbiter_set_pin(bool on, int abs_page, int8_t img_src, int64_t now_ms) 
     if (on) {
         s_arb.pinned = true;
         if (abs_page >= 0) {
-            s_arb.user_page = abs_page;
-            s_arb.user_img_source = img_src;
-        } else if (s_arb.user_page < 0) {
-            s_arb.user_page = s_arb.current_committed;
-            s_arb.user_img_source = s_arb.current_committed_img_source;
+            s_arb.user_claim = pack_claim(abs_page, img_src);
+        } else {
+            int up; int8_t us;
+            unpack_claim(s_arb.user_claim, &up, &us);
+            if (up < 0) {
+                s_arb.user_claim = pack_claim(s_arb.current_committed,
+                                              s_arb.current_committed_img_source);
+            }
         }
     } else {
         s_arb.pinned = false;
@@ -342,7 +358,10 @@ void nav_arbiter_resolve(int64_t now_ms) {
     int desired;
     nav_source_t src;
 
-    bool user_active = (s_arb.user_page >= 0)
+    int user_page; int8_t user_img_source;
+    unpack_claim(s_arb.user_claim, &user_page, &user_img_source);
+
+    bool user_active = (user_page >= 0)
         && ((now_ms - s_arb.user_stamp_ms) < (int64_t)c->nav_grace_s * 1000);
 
     /* Tie-break: auto-rotate wins if both flags are somehow set. */
@@ -358,19 +377,20 @@ void nav_arbiter_resolve(int64_t now_ms) {
          * session, idle, and default are all skipped. Manual navigation while
          * pinned updates s_arb.user_page via nav_arbiter_submit_user(), so the
          * held page follows manual nav and persists until the pin is cleared. */
-        if (s_arb.user_page < 0) {
-            s_arb.user_page = s_arb.current_committed;
-            s_arb.user_img_source = s_arb.current_committed_img_source;
+        if (user_page < 0) {
+            user_page = s_arb.current_committed;
+            user_img_source = s_arb.current_committed_img_source;
+            s_arb.user_claim = pack_claim(user_page, user_img_source);
         }
-        desired = s_arb.user_page;
+        desired = user_page;
         src = NAV_SRC_USER;
-        s_arb.pending_img_source = s_arb.user_img_source;
+        s_arb.pending_img_source = user_img_source;
     } else if (user_active) {
-        desired = s_arb.user_page; src = NAV_SRC_USER;
+        desired = user_page; src = NAV_SRC_USER;
         /* Pin the user's chosen image source (0-3) so the commit block does not
          * clobber the override back to the persisted default. -1 for non-image
          * targets, which correctly clears the override. */
-        s_arb.pending_img_source = s_arb.user_img_source;
+        s_arb.pending_img_source = user_img_source;
     } else if (auto_rotate) {
         if (s_arb.slideshow_advance) {
             s_arb.slideshow_advance = false;

--- a/main/ui/nina_summary.c
+++ b/main/ui/nina_summary.c
@@ -934,7 +934,7 @@ static void animate_card_move(summary_card_t *sc, int32_t dy) {
 
 /* ── Data Update ───────────────────────────────────────────────────── */
 
-void summary_page_update(const nina_client_t *instances, int count) {
+void summary_page_update(const nina_client_t *instances, int count, const bool *locked) {
     if (!sum_page) return;
 
     int gb = app_config_get()->color_brightness;
@@ -1043,6 +1043,13 @@ void summary_page_update(const nina_client_t *instances, int count) {
             /* Card is hidden this cycle — drop any stale exposure anchor so the
              * interp timer doesn't keep driving an off-screen bar. */
             bar_reset_exposure_state(sc);
+            continue;
+        }
+
+        /* Trylock failed this cycle — the instance may be mid-commit, so leave
+         * the card's previous data-bearing contents intact rather than reading
+         * torn fields. The card stays visible; it refreshes next cycle. */
+        if (locked && !locked[i]) {
             continue;
         }
 

--- a/main/ui/nina_summary.h
+++ b/main/ui/nina_summary.h
@@ -36,8 +36,12 @@ void summary_page_rebuild(void);
  *
  * @param instances Array of nina_client_t data for all instances
  * @param count Number of instances
+ * @param locked Per-instance trylock results (length >= count); cards whose
+ *        locked[i] is false keep their previous data-bearing contents this
+ *        cycle instead of reading a mid-commit instance. May be NULL to update
+ *        every card unconditionally.
  */
-void summary_page_update(const nina_client_t *instances, int count);
+void summary_page_update(const nina_client_t *instances, int count, const bool *locked);
 
 /**
  * @brief Apply the current theme to the summary page.

--- a/main/weather_client.c
+++ b/main/weather_client.c
@@ -134,6 +134,29 @@ static char *http_get_body(const char *url) {
 
     int content_length = esp_http_client_fetch_headers(client);
     int status = esp_http_client_get_status_code(client);
+
+    /* Follow Location redirects manually: the streaming open()/fetch_headers()
+     * path does NOT auto-follow. Cap the chain to avoid loops. */
+    int redirects = 0;
+    while ((status == 301 || status == 302 || status == 307 || status == 308) &&
+           redirects < 3) {
+        err = esp_http_client_set_redirection(client);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "set_redirection failed: %s", esp_err_to_name(err));
+            break;
+        }
+        esp_http_client_close(client);
+        err = esp_http_client_open(client, 0);
+        if (err != ESP_OK) {
+            ESP_LOGW(TAG, "HTTP re-open failed: %s", esp_err_to_name(err));
+            esp_http_client_cleanup(client);
+            return NULL;
+        }
+        content_length = esp_http_client_fetch_headers(client);
+        status = esp_http_client_get_status_code(client);
+        redirects++;
+    }
+
     if (status < 200 || status >= 300) {
         ESP_LOGW(TAG, "HTTP %d for %s", status, url);
         esp_http_client_cleanup(client);
@@ -181,7 +204,7 @@ static bool fetch_owm(const app_config_t *cfg, weather_data_t *out) {
     /* ── Current weather ── */
     char url[320];
     snprintf(url, sizeof(url),
-             "http://api.openweathermap.org/data/2.5/weather?"
+             "https://api.openweathermap.org/data/2.5/weather?"
              "lat=%.4f&lon=%.4f&appid=%s&units=%s",
              cfg->weather_lat, cfg->weather_lon, cfg->weather_api_key, units);
 
@@ -246,7 +269,7 @@ static bool fetch_owm(const app_config_t *cfg, weather_data_t *out) {
 
     /* ── Forecast (3-hour intervals) ── */
     snprintf(url, sizeof(url),
-             "http://api.openweathermap.org/data/2.5/forecast?"
+             "https://api.openweathermap.org/data/2.5/forecast?"
              "lat=%.4f&lon=%.4f&appid=%s&units=%s&cnt=16",
              cfg->weather_lat, cfg->weather_lon, cfg->weather_api_key, units);
 

--- a/main/web_handlers_allsky.c
+++ b/main/web_handlers_allsky.c
@@ -46,9 +46,20 @@ esp_err_t allsky_config_get_handler(httpd_req_t *req)
 esp_err_t allsky_proxy_get_handler(httpd_req_t *req)
 {
     /* Snapshot the hostname into a local under the config mutex so the live
-     * config is not read field-by-field during the (slow) outbound fetch. */
-    app_config_t cfg = app_config_get_snapshot();
-    if (cfg.allsky_hostname[0] == '\0') {
+     * config is not read field-by-field during the (slow) outbound fetch.
+     * app_config_t is ~7.6 KB — too large for the httpd stack, so snapshot into
+     * a PSRAM heap copy, extract the hostname, and free before the fetch. */
+    app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+    if (!cfg) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    *cfg = app_config_get_snapshot();
+    char allsky_hostname[sizeof(cfg->allsky_hostname)];
+    strlcpy(allsky_hostname, cfg->allsky_hostname, sizeof(allsky_hostname));
+    heap_caps_free(cfg);
+
+    if (allsky_hostname[0] == '\0') {
         httpd_resp_set_status(req, "400 Bad Request");
         httpd_resp_set_type(req, "application/json");
         httpd_resp_send(req, "{\"error\":\"AllSky hostname not configured\"}", HTTPD_RESP_USE_STRLEN);
@@ -57,7 +68,7 @@ esp_err_t allsky_proxy_get_handler(httpd_req_t *req)
 
     /* Build URL: http://<hostname>/all */
     char url[192];
-    snprintf(url, sizeof(url), "http://%s/all", cfg.allsky_hostname);
+    snprintf(url, sizeof(url), "http://%s/all", allsky_hostname);
 
     esp_http_client_config_t http_cfg = {
         .url = url,

--- a/main/web_handlers_auth.c
+++ b/main/web_handlers_auth.c
@@ -82,8 +82,17 @@ esp_err_t auth_status_get_handler(httpd_req_t *req)
     bool is_default = (strcmp(cfg->admin_password, "changeme123!") == 0);
 
     cJSON *root = cJSON_CreateObject();
+    if (!root) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
     cJSON_AddBoolToObject(root, "default_password", is_default);
     char *json = cJSON_PrintUnformatted(root);
+    if (!json) {
+        cJSON_Delete(root);
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
     httpd_resp_set_type(req, "application/json");
     httpd_resp_sendstr(req, json);
     free(json);

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -11,6 +11,7 @@
 #include "ui/nina_dashboard_internal.h" /* PAGE_IDX_SUMMARY, SETTINGS_PAGE_IDX, SYSINFO_PAGE_IDX page-index macros */
 #include "ui/nina_nav_arbiter.h"        /* nav_arbiter_submit_user — live Home Page USER claim */
 #include "ui/page_registry.h"           /* page_ref_navigate, PAGE_REF_ID_MAX, PAGE_REF_SETTINGS */
+#include "ui/themes.h"                  /* themes_get_count() — theme_index clamp */
 
 extern const uint8_t config_html_start[] asm("_binary_config_ui_html_start");
 extern const uint8_t config_html_end[]   asm("_binary_config_ui_html_end");
@@ -899,7 +900,13 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_STRING(root, "url3",           cfg->api_url[2]);
     JSON_TO_STRING(root, "ntp",            cfg->ntp_server);
     JSON_TO_STRING(root, "timezone",       cfg->tz_string);
-    JSON_TO_INT   (root, "theme_index",    cfg->theme_index);
+    cJSON *ti_item = cJSON_GetObjectItem(root, "theme_index");
+    if (cJSON_IsNumber(ti_item)) {
+        int v = ti_item->valueint;
+        if (v < 0) v = 0;
+        if (v >= themes_get_count()) v = themes_get_count() - 1;
+        cfg->theme_index = v;
+    }
     cJSON *ws_item = cJSON_GetObjectItem(root, "widget_style");
     if (cJSON_IsNumber(ws_item)) {
         int v = ws_item->valueint;
@@ -1175,7 +1182,11 @@ static app_config_t *parse_config_from_json(cJSON *root)
         cfg->goes_update_interval_s = (uint16_t)v;
     }
 
-    JSON_TO_INT(root, "image_display_source", cfg->image_display_source);
+    cJSON *jimgsrc = cJSON_GetObjectItem(root, "image_display_source");
+    if (cJSON_IsNumber(jimgsrc)) {
+        int v = jimgsrc->valueint;
+        cfg->image_display_source = (v >= 0 && v <= 3) ? (uint8_t)v : 0;
+    }
 
     JSON_TO_STRING(root, "custom_image_url", cfg->custom_image_url);
     cJSON *custom_orient = cJSON_GetObjectItem(root, "custom_orientation");
@@ -1191,15 +1202,27 @@ static app_config_t *parse_config_from_json(cJSON *root)
         cfg->custom_update_interval_s = (uint16_t)v;
     }
 
-    JSON_TO_INT(root, "moon_bg_style",        cfg->moon_bg_style);
+    cJSON *jmoonbg = cJSON_GetObjectItem(root, "moon_bg_style");
+    if (cJSON_IsNumber(jmoonbg)) {
+        int v = jmoonbg->valueint;
+        cfg->moon_bg_style = (v >= 0 && v <= 3) ? (uint8_t)v : 0;
+    }
 
     cJSON *jmoonlat = cJSON_GetObjectItem(root, "moon_lat");
     if (jmoonlat && cJSON_IsNumber(jmoonlat)) cfg->moon_lat = (float)jmoonlat->valuedouble;
     cJSON *jmoonlon = cJSON_GetObjectItem(root, "moon_lon");
     if (jmoonlon && cJSON_IsNumber(jmoonlon)) cfg->moon_lon = (float)jmoonlon->valuedouble;
 
-    JSON_TO_INT(root, "solar_band", cfg->solar_band);
-    JSON_TO_INT(root, "moon_drag_light_mode", cfg->moon_drag_light_mode);
+    cJSON *jsolarband = cJSON_GetObjectItem(root, "solar_band");
+    if (cJSON_IsNumber(jsolarband)) {
+        int v = jsolarband->valueint;
+        cfg->solar_band = (v >= 0 && v <= 17) ? (uint8_t)v : 0;
+    }
+    cJSON *jmoondrag = cJSON_GetObjectItem(root, "moon_drag_light_mode");
+    if (cJSON_IsNumber(jmoondrag)) {
+        int v = jmoondrag->valueint;
+        cfg->moon_drag_light_mode = (v >= 0 && v <= 2) ? (uint8_t)v : 0;
+    }
 
     cJSON *jgoesvf = cJSON_GetObjectItem(root, "goes_vflip");
     if (jgoesvf && cJSON_IsNumber(jgoesvf)) cfg->goes_vflip = (jgoesvf->valueint != 0) ? 1 : 0;
@@ -1273,7 +1296,11 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_BOOL(root, "toast_instance_muted_3", cfg->toast_instance_muted[2]);
 
     // Weather
-    JSON_TO_INT(root, "weather_provider", cfg->weather_provider);
+    cJSON *jwxprov = cJSON_GetObjectItem(root, "weather_provider");
+    if (cJSON_IsNumber(jwxprov)) {
+        int v = jwxprov->valueint;
+        cfg->weather_provider = (v >= 0 && v <= 2) ? (uint8_t)v : 0;
+    }
     JSON_TO_STRING(root, "weather_api_key", cfg->weather_api_key);
 
     cJSON *jlat = cJSON_GetObjectItem(root, "weather_lat");

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -20,6 +20,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_timer.h"
+#include "esp_heap_caps.h"
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
@@ -178,7 +179,14 @@ esp_err_t brightness_post_handler(httpd_req_t *req)
         int brightness = val->valueint;
         if (brightness < 0) brightness = 0;
         if (brightness > 100) brightness = 100;
-        app_config_get()->brightness = brightness;
+        /* Live preview: apply to the in-memory config (no NVS write until Save). */
+        app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+        if (cfg) {
+            *cfg = app_config_get_snapshot();
+            cfg->brightness = brightness;
+            app_config_apply(cfg);
+            heap_caps_free(cfg);
+        }
         bsp_display_brightness_set(brightness);
         ESP_LOGI(TAG, "Brightness set to %d%%", brightness);
         mqtt_ha_publish_state();
@@ -221,8 +229,16 @@ esp_err_t color_brightness_post_handler(httpd_req_t *req)
         int cb = val->valueint;
         if (cb < 0) cb = 0;
         if (cb > 100) cb = 100;
-        app_config_t *cfg = app_config_get();
+        /* Live preview: apply to the in-memory config (no NVS write until Save). */
+        app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+        if (!cfg) {
+            cJSON_Delete(root);
+            httpd_resp_send_500(req);
+            return ESP_FAIL;
+        }
+        *cfg = app_config_get_snapshot();
         cfg->color_brightness = cb;
+        app_config_apply(cfg);
 
         // Re-apply theme to update static text brightness
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
@@ -231,6 +247,7 @@ esp_err_t color_brightness_post_handler(httpd_req_t *req)
         } else {
             ESP_LOGW(TAG, "Display lock timeout (color brightness)");
         }
+        heap_caps_free(cfg);
 
         ESP_LOGI(TAG, "Color brightness set to %d%%", cb);
         mqtt_ha_publish_state();
@@ -273,8 +290,17 @@ esp_err_t theme_post_handler(httpd_req_t *req)
         int idx = val->valueint;
         if (idx < 0) idx = 0;
         if (idx >= themes_get_count()) idx = themes_get_count() - 1;
-        app_config_t *cfg = app_config_get();
+        /* Live preview: apply to the in-memory config (no NVS write until Save). */
+        app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+        if (!cfg) {
+            cJSON_Delete(root);
+            httpd_resp_send_500(req);
+            return ESP_FAIL;
+        }
+        *cfg = app_config_get_snapshot();
         cfg->theme_index = idx;
+        app_config_apply(cfg);
+        heap_caps_free(cfg);
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             nina_dashboard_apply_theme(idx);
             bsp_display_unlock();
@@ -321,14 +347,23 @@ esp_err_t widget_style_post_handler(httpd_req_t *req)
         int idx = val->valueint;
         if (idx < 0) idx = 0;
         if (idx >= WIDGET_STYLE_COUNT) idx = WIDGET_STYLE_COUNT - 1;
-        app_config_t *cfg = app_config_get();
+        /* Live preview: apply to the in-memory config (no NVS write until Save). */
+        app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+        if (!cfg) {
+            cJSON_Delete(root);
+            httpd_resp_send_500(req);
+            return ESP_FAIL;
+        }
+        *cfg = app_config_get_snapshot();
         cfg->widget_style = (uint8_t)idx;
+        app_config_apply(cfg);
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             nina_dashboard_apply_theme(cfg->theme_index);
             bsp_display_unlock();
         } else {
             ESP_LOGW(TAG, "Display lock timeout (widget style switch)");
         }
+        heap_caps_free(cfg);
         ESP_LOGI(TAG, "Widget style set to %d", idx);
     }
 
@@ -420,8 +455,17 @@ esp_err_t screen_rotation_post_handler(httpd_req_t *req)
         int rot = val->valueint;
         if (rot < 0) rot = 0;
         if (rot > 3) rot = 3;
-        app_config_t *cfg = app_config_get();
+        /* Live preview: apply to the in-memory config (no NVS write until Save). */
+        app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+        if (!cfg) {
+            cJSON_Delete(root);
+            httpd_resp_send_500(req);
+            return ESP_FAIL;
+        }
+        *cfg = app_config_get_snapshot();
         cfg->screen_rotation = (uint8_t)rot;
+        app_config_apply(cfg);
+        heap_caps_free(cfg);
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             lv_display_set_rotation(lv_display_get_default(), rot);
             bsp_display_unlock();

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -358,9 +358,17 @@ esp_err_t image_display_refresh_post_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
 
-    app_config_t cfg = app_config_get_snapshot();
+    /* app_config_t is ~7.6 KB — snapshot into a PSRAM heap copy, not the stack. */
+    app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+    if (!cfg) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    *cfg = app_config_get_snapshot();
+    bool image_display_enabled = cfg->image_display_enabled;
+    heap_caps_free(cfg);
 
-    if (cfg.image_display_enabled) {
+    if (image_display_enabled) {
         atomic_store(&image_display_manual_fetch, true);
         goes_ensure_task_running();
         if (goes_task_handle) {

--- a/main/web_handlers_spotify.c
+++ b/main/web_handlers_spotify.c
@@ -2,6 +2,7 @@
 #include "spotify_auth.h"
 #include "spotify_client.h"
 #include "tasks.h"
+#include "esp_heap_caps.h"
 #include <string.h>
 
 /**
@@ -57,38 +58,47 @@ esp_err_t spotify_config_post_handler(httpd_req_t *req)
         return send_400(req, "spotify_client_id too long");
     }
 
-    /* Work on a mutex-protected snapshot copy; never field-write the live config. */
-    app_config_t cfg = app_config_get_snapshot();
+    /* Work on a mutex-protected snapshot copy; never field-write the live config.
+     * app_config_t is ~7.6 KB — snapshot into a PSRAM heap copy, not the stack. */
+    app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+    if (!cfg) {
+        cJSON_Delete(root);
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    *cfg = app_config_get_snapshot();
 
-    JSON_TO_BOOL(root, "spotify_enabled", cfg.spotify_enabled);
-    JSON_TO_STRING(root, "spotify_client_id", cfg.spotify_client_id);
+    JSON_TO_BOOL(root, "spotify_enabled", cfg->spotify_enabled);
+    JSON_TO_STRING(root, "spotify_client_id", cfg->spotify_client_id);
     cJSON *spi_item = cJSON_GetObjectItem(root, "spotify_poll_interval_ms");
     if (cJSON_IsNumber(spi_item)) {
         int v = spi_item->valueint;
         if (v < 1000) v = 1000;
         if (v > 30000) v = 30000;
-        cfg.spotify_poll_interval_ms = (uint16_t)v;
+        cfg->spotify_poll_interval_ms = (uint16_t)v;
     }
-    JSON_TO_BOOL(root, "spotify_show_progress_bar", cfg.spotify_show_progress_bar);
-    JSON_TO_BOOL(root, "spotify_minimal_mode", cfg.spotify_minimal_mode);
-    JSON_TO_BOOL(root, "spotify_scroll_text", cfg.spotify_scroll_text);
+    JSON_TO_BOOL(root, "spotify_show_progress_bar", cfg->spotify_show_progress_bar);
+    JSON_TO_BOOL(root, "spotify_minimal_mode", cfg->spotify_minimal_mode);
+    JSON_TO_BOOL(root, "spotify_scroll_text", cfg->spotify_scroll_text);
     cJSON *sot_item = cJSON_GetObjectItem(root, "spotify_overlay_timeout_s");
     if (cJSON_IsNumber(sot_item)) {
         int v = sot_item->valueint;
         if (v < 0) v = 0;
         if (v > 255) v = 255;   /* uint8_t; 0 = never hide */
-        cfg.spotify_overlay_timeout_s = (uint8_t)v;
+        cfg->spotify_overlay_timeout_s = (uint8_t)v;
     }
-    JSON_TO_BOOL(root, "spotify_overlay_visible", cfg.spotify_overlay_visible);
+    JSON_TO_BOOL(root, "spotify_overlay_visible", cfg->spotify_overlay_visible);
 
     cJSON_Delete(root);
 
     /* Single atomic memcpy under mutex + NVS persist. */
-    app_config_save(&cfg);
+    app_config_save(cfg);
 
     /* Live apply: the poll task reads the live config (now updated by save) on
      * its next cycle; ensure it is running when the feature is enabled. */
-    if (cfg.spotify_enabled) {
+    bool spotify_enabled = cfg->spotify_enabled;
+    heap_caps_free(cfg);
+    if (spotify_enabled) {
         spotify_ensure_task_running();
     }
 

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -8,6 +8,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include <string.h>
+#include <stdatomic.h>
 #include "esp_heap_caps.h"
 #include "nina_websocket.h"
 #include "mqtt_ha.h"
@@ -202,8 +203,10 @@ static void ota_stop_network(void) {
     ota_in_progress = true;
     /* Give tasks time to reach their suspend points */
     vTaskDelay(pdMS_TO_TICKS(200));
-    /* Free all TLS sessions to maximize bandwidth and DMA heap for OTA */
-    spotify_client_destroy_connection();
+    /* Free all TLS sessions to maximize bandwidth and DMA heap for OTA.
+     * prepare_shutdown blocks until any in-flight Spotify request completes,
+     * then destroys the handle so the poll task cannot touch a freed client. */
+    spotify_client_prepare_shutdown();
     nina_websocket_stop_all();
     mqtt_ha_stop();
 }
@@ -232,6 +235,14 @@ esp_err_t ota_post_handler(httpd_req_t *req)
 
     if (req->content_len > 16 * 1024 * 1024) {
         return send_400(req, "Firmware too large (max 16 MB)");
+    }
+
+    /* Mutual exclusion: reject a second concurrent OTA without touching network state */
+    if (atomic_exchange(&ota_in_progress, true)) {
+        httpd_resp_set_status(req, "409 Conflict");
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_sendstr(req, "{\"error\":\"Update already in progress\"}");
+        return ESP_OK;
     }
 
     /* ── Stop all network traffic and show OTA screen ── */
@@ -274,19 +285,29 @@ esp_err_t ota_post_handler(httpd_req_t *req)
     int received_total = 0;
     int last_progress_pct = -1;
     bool failed = false;
+    bool timed_out = false;
+    int timeout_count = 0;
 
     while (remaining > 0) {
         int to_read = remaining < OTA_BUF_SIZE ? remaining : OTA_BUF_SIZE;
         int received = httpd_req_recv(req, buf, to_read);
         if (received <= 0) {
             if (received == HTTPD_SOCK_ERR_TIMEOUT) {
-                /* Retry on timeout */
+                /* Bound consecutive timeouts so a stalled upload cannot loop forever */
+                if (++timeout_count >= 5) {
+                    ESP_LOGE(TAG, "OTA: aborting after %d consecutive recv timeouts at %d/%d bytes",
+                             timeout_count, received_total, total);
+                    failed = true;
+                    timed_out = true;
+                    break;
+                }
                 continue;
             }
             ESP_LOGE(TAG, "OTA: recv error %d at %d/%d bytes", received, received_total, total);
             failed = true;
             break;
         }
+        timeout_count = 0;
 
         err = esp_ota_write(ota_handle, buf, received);
         if (err != ESP_OK) {
@@ -315,8 +336,13 @@ esp_err_t ota_post_handler(httpd_req_t *req)
         esp_ota_abort(ota_handle);
         ota_remove_overlay();
         ota_restore_network();
-        httpd_resp_set_status(req, "500 Internal Server Error");
-        httpd_resp_sendstr(req, "{\"error\":\"OTA receive/write failed\"}");
+        if (timed_out) {
+            httpd_resp_set_status(req, "408 Request Timeout");
+            httpd_resp_sendstr(req, "{\"error\":\"OTA upload timed out\"}");
+        } else {
+            httpd_resp_set_status(req, "500 Internal Server Error");
+            httpd_resp_sendstr(req, "{\"error\":\"OTA receive/write failed\"}");
+        }
         return ESP_FAIL;
     }
 
@@ -390,6 +416,7 @@ esp_err_t version_get_handler(httpd_req_t *req)
 // Handler for checking GitHub OTA updates (returns JSON result to web UI)
 esp_err_t check_update_json_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     int update_channel = app_config_get()->update_channel;
     const char *cur_ver = ota_github_get_current_version();
 
@@ -457,6 +484,15 @@ esp_err_t ota_github_post_handler(httpd_req_t *req)
     if (ota_github_check(update_channel, cur_ver, rel) != OTA_CHECK_UPDATE_AVAILABLE) {
         heap_caps_free(rel);
         return send_400(req, "No update available");
+    }
+
+    /* Mutual exclusion: reject a second concurrent OTA without touching network state */
+    if (atomic_exchange(&ota_in_progress, true)) {
+        heap_caps_free(rel);
+        httpd_resp_set_status(req, "409 Conflict");
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_sendstr(req, "{\"error\":\"Update already in progress\"}");
+        return ESP_OK;
     }
 
     /* Stop network and show OTA overlay on device */

--- a/main/web_handlers_wifi.c
+++ b/main/web_handlers_wifi.c
@@ -69,6 +69,10 @@ esp_err_t wifi_scan_get_handler(httpd_req_t *req)
         cJSON_AddStringToObject(root, "error", "WiFi scan failed");
         cJSON_AddNumberToObject(root, "code", err);
         char *json = cJSON_PrintUnformatted(root);
+        if (!json) {
+            cJSON_Delete(root);
+            return httpd_resp_send_500(req);
+        }
         httpd_resp_set_type(req, "application/json");
         httpd_resp_set_status(req, "500 Internal Server Error");
         httpd_resp_sendstr(req, json);
@@ -90,6 +94,10 @@ esp_err_t wifi_scan_get_handler(httpd_req_t *req)
         cJSON_AddStringToObject(root, "error", "Out of memory for scan results");
         cJSON_AddNumberToObject(root, "code", ESP_ERR_NO_MEM);
         char *json = cJSON_PrintUnformatted(root);
+        if (!json) {
+            cJSON_Delete(root);
+            return httpd_resp_send_500(req);
+        }
         httpd_resp_set_type(req, "application/json");
         httpd_resp_set_status(req, "500 Internal Server Error");
         httpd_resp_sendstr(req, json);
@@ -144,6 +152,11 @@ esp_err_t wifi_scan_get_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "incompatible_count", incompatible_count);
 
     char *json = cJSON_PrintUnformatted(root);
+    if (!json) {
+        cJSON_Delete(root);
+        heap_caps_free(ap_records);
+        return httpd_resp_send_500(req);
+    }
     httpd_resp_set_type(req, "application/json");
     httpd_resp_sendstr(req, json);
 
@@ -174,18 +187,26 @@ esp_err_t wifi_setup_post_handler(httpd_req_t *req)
         return send_400(req, "SSID is required");
     }
 
-    /* Work on a mutex-protected snapshot copy; never field-write the live config. */
-    app_config_t cfg = app_config_get_snapshot();
-    strlcpy(cfg.wifi_networks[0].ssid, ssid_item->valuestring,
-            sizeof(cfg.wifi_networks[0].ssid));
+    /* Work on a mutex-protected snapshot copy; never field-write the live config.
+     * Heap-allocated in PSRAM (app_config_t is ~7.6 KB — too large for the httpd stack). */
+    app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+    if (!cfg) {
+        cJSON_Delete(root);
+        httpd_resp_send_500(req);
+        return ESP_OK;
+    }
+    *cfg = app_config_get_snapshot();
+    strlcpy(cfg->wifi_networks[0].ssid, ssid_item->valuestring,
+            sizeof(cfg->wifi_networks[0].ssid));
     if (cJSON_IsString(pass_item)) {
-        strlcpy(cfg.wifi_networks[0].password, pass_item->valuestring,
-                sizeof(cfg.wifi_networks[0].password));
+        strlcpy(cfg->wifi_networks[0].password, pass_item->valuestring,
+                sizeof(cfg->wifi_networks[0].password));
     } else {
-        cfg.wifi_networks[0].password[0] = '\0';
+        cfg->wifi_networks[0].password[0] = '\0';
     }
     /* Single atomic memcpy under mutex + NVS persist. */
-    app_config_save(&cfg);
+    app_config_save(cfg);
+    heap_caps_free(cfg);
 
     cJSON_Delete(root);
 
@@ -226,6 +247,10 @@ esp_err_t wifi_status_get_handler(httpd_req_t *req)
     cJSON_AddStringToObject(root, "ip", ip_str);
 
     char *json = cJSON_PrintUnformatted(root);
+    if (!json) {
+        cJSON_Delete(root);
+        return httpd_resp_send_500(req);
+    }
     httpd_resp_set_type(req, "application/json");
     httpd_resp_sendstr(req, json);
     free(json);


### PR DESCRIPTION
### Summary
This PR introduces the ability to restore the last set MQTT brightness level after a device reboot. It also includes numerous stability and reliability improvements across various system components, addressing potential issues in networking, configuration handling, over-the-air updates, and Spotify integration.

### Changes
*   The device now restores the last published MQTT brightness level from retained messages on boot, preventing reverts to default settings.
*   WebSocket operations are now serialized and protected by locks to prevent race conditions, improving overall system stability.
*   Configuration loading and saving are more robust, including NUL-termination of strings, validation on save, and protection against corrupted or future-version config blobs.
*   Over-the-Air (OTA) updates are more reliable with capped receive timeout retries, atomic mutual exclusion during updates, and blocking deep sleep during flashing.
*   Spotify token refresh no longer freezes the UI, and player handling is better integrated with OTA teardown procedures.
*   Album art is now freed on display-lock timeout to prevent memory leaks, and various NULL checks and guards prevent potential crashes.
*   WebSocket reconnect backoff logic is improved, and the weather client now handles HTTPS and redirects correctly.
*   Crash logs now include 64-bit uptime, and CPU statistics task caps are adjusted for better monitoring.

---
<sub>Analyzed **4** commit(s) | Updated: 2026-07-03T04:33:30.674Z | Generated by GitHub Actions</sub>