### PR TITLE
perf(ota): decide full-erase from CI-precomputed floor marker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -638,6 +638,38 @@ jobs:
           echo "pt_sha=$PT_SHA" >> $GITHUB_OUTPUT
           echo "bl_sha=$BL_SHA" >> $GITHUB_OUTPUT
 
+          # --- Full-erase floor (per-channel carry-forward) --------------------
+          # The floor is the newest release of THIS channel (stable vs
+          # pre-release) that required a full erase. It is carried forward in
+          # every release body so devices can decide erase-vs-OTA from the
+          # newest release alone. PREV_TAG above (git describe) is fine for the
+          # hash chain, but the floor must be read from the previous release of
+          # the SAME channel, so look that up explicitly. Soft-fail throughout:
+          # any lookup problem just means "no prior floor" — never fail the
+          # build over the floor computation.
+          THIS_TAG="${{ steps.tag.outputs.tag }}"
+          IS_PRERELEASE="${{ steps.tag.outputs.is_prerelease }}"
+          NEW_FLOOR=""
+          if [ "$REQUIRED" = "true" ]; then
+            NEW_FLOOR="$THIS_TAG"
+            echo "Full-erase floor: $NEW_FLOOR (new this release)"
+          else
+            # Latest release of the same channel, excluding the rolling
+            # snd-alpha tag and the tag being created by this run.
+            PREV_CHANNEL_TAG=$(gh release list --limit 50 --json tagName,isPrerelease \
+              -q "[.[] | select(.isPrerelease == ${IS_PRERELEASE}) | select(.tagName != \"snd-alpha\") | select(.tagName != \"${THIS_TAG}\")] | .[0].tagName" 2>/dev/null || true)
+            if [ -n "$PREV_CHANNEL_TAG" ] && [ "$PREV_CHANNEL_TAG" != "null" ]; then
+              PREV_CHANNEL_BODY=$(gh release view "$PREV_CHANNEL_TAG" --json body -q .body 2>/dev/null || true)
+              NEW_FLOOR=$(echo "$PREV_CHANNEL_BODY" | grep -oE 'nina:full_erase_floor=[A-Za-z0-9._-]+' | head -1 | sed 's/.*nina:full_erase_floor=//')
+            fi
+            if [ -n "$NEW_FLOOR" ]; then
+              echo "Full-erase floor: $NEW_FLOOR (carried forward from ${PREV_CHANNEL_TAG})"
+            else
+              echo "Full-erase floor: none (no prior floor found; marker omitted)"
+            fi
+          fi
+          echo "erase_floor=$NEW_FLOOR" >> $GITHUB_OUTPUT
+
           if [ "$REQUIRED" = "true" ]; then
             echo "required=true" >> $GITHUB_OUTPUT
             echo "reason<<EOFR" >> $GITHUB_OUTPUT
@@ -661,6 +693,7 @@ jobs:
           ERASE_REASON="${{ steps.erase_check.outputs.reason }}"
           PT_SHA="${{ steps.erase_check.outputs.pt_sha }}"
           BL_SHA="${{ steps.erase_check.outputs.bl_sha }}"
+          ERASE_FLOOR="${{ steps.erase_check.outputs.erase_floor }}"
 
           if [ -n "$PREV_TAG" ]; then
             COMPARE_URL="https://github.com/chvvkumar/ESP32-P4-NINA-Display/compare/${PREV_TAG}...${TAG}"
@@ -669,7 +702,7 @@ jobs:
           fi
 
           AI_AVAILABLE="${{ steps.release_summary.outputs.ai_available }}"
-          export TAG PREV_TAG VERSION BRANCH COMPARE_URL FACTORY_MB OTA_MB AI_AVAILABLE FULL_ERASE ERASE_REASON PT_SHA BL_SHA
+          export TAG PREV_TAG VERSION BRANCH COMPARE_URL FACTORY_MB OTA_MB AI_AVAILABLE FULL_ERASE ERASE_REASON PT_SHA BL_SHA ERASE_FLOOR
           python3 << 'PYEOF'
           import os, json
           tag = os.environ['TAG']
@@ -684,6 +717,7 @@ jobs:
           erase_reason = os.environ.get('ERASE_REASON', '').strip()
           pt_sha = os.environ.get('PT_SHA', '').strip()
           bl_sha = os.environ.get('BL_SHA', '').strip()
+          erase_floor = os.environ.get('ERASE_FLOOR', '').strip()
 
           # Load metrics if available
           try:
@@ -722,6 +756,13 @@ jobs:
               erase_marker,
               pt_marker,
               bl_marker,
+          ]
+          # Per-channel full-erase floor: newest release of this channel that
+          # required a full erase. Omitted entirely when no floor is known so
+          # devices fall back to their legacy release-history walk.
+          if erase_floor:
+              lines.append(f'<!-- nina:full_erase_floor={erase_floor} -->')
+          lines += [
               f'## NINA Display {tag}',
               '',
               f'**Branch:** {branch}',

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -123,6 +123,45 @@ static bool alpha_marker_indicates_update(const char *body_str) {
     return true;
 }
 
+/* ── Full-erase floor marker (fast-path erase decision) ───────────── */
+
+/*
+ * Parse the "nina:full_erase_floor=<tag>" hidden marker from a release body
+ * (same HTML-comment convention as the alpha "nina:sha" marker above). The tag
+ * is copied up to the next whitespace or the "-->" comment terminator, so
+ * pre-release tags containing '-' (e.g. "v2.0.0-dev.3") survive intact.
+ * Returns true when the marker is present with a non-empty value; no version
+ * validation is done here — the caller decides whether the tag is usable.
+ */
+static bool parse_full_erase_floor(const char *body_str, char *tag_out, size_t tag_out_size) {
+    if (!body_str || !tag_out || tag_out_size == 0) return false;
+    tag_out[0] = '\0';
+
+    const char *m = strstr(body_str, "nina:full_erase_floor=");
+    if (!m) return false;
+    m += strlen("nina:full_erase_floor=");
+
+    size_t n = 0;
+    while (m[n] && n < tag_out_size - 1) {
+        char c = m[n];
+        if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '>') break;
+        if (c == '-' && m[n + 1] == '-' && m[n + 2] == '>') break;
+        tag_out[n] = c;
+        n++;
+    }
+    tag_out[n] = '\0';
+
+    return tag_out[0] != '\0';
+}
+
+/* A floor tag is usable only when it parses as a full major.minor.patch
+ * version (optional 'v' prefix), mirroring compare_versions' parsing. */
+static bool floor_tag_parses_as_version(const char *tag) {
+    if (tag[0] == 'v' || tag[0] == 'V') tag++;
+    int maj = 0, min = 0, pat = 0;
+    return sscanf(tag, "%d.%d.%d", &maj, &min, &pat) == 3;
+}
+
 /* ── Strip markdown images ![alt](url) from a string in-place ─────── */
 
 static void strip_markdown_images(char *text) {
@@ -449,6 +488,9 @@ ota_check_result_t ota_github_check(int channel, const char *current_version, gi
     bool verify_error = false;          /* transient mid-path fetch failure (retry, not manual-flash) */
     bool fetch_failed_no_target = false;/* page-1 fetch failed before any target captured */
     char full_erase_tag_local[32] = {0};/* newest marked tag on the path (written once) */
+    bool floor_decided = false;         /* erase decision made via the target's floor marker */
+    bool floor_requires_erase = false;  /* fast-path result: installed < floor */
+    char floor_tag_local[32] = {0};     /* floor tag parsed from the target release body */
 
     for (int page = 1; page <= MAX_RELEASE_PAGES && !reached_installed; page++) {
         bool overflow = false;
@@ -556,6 +598,31 @@ ota_check_result_t ota_github_check(int channel, const char *current_version, gi
                     found_target = true;
                     ESP_LOGI(TAG, "Update target: %s (pre-release: %s)", out->tag, is_pre ? "yes" : "no");
 
+                    /* Fast path: the target release body may carry a precomputed
+                     * full-erase floor ("nina:full_erase_floor=<tag>"). When present
+                     * and parseable, the erase decision is installed < floor
+                     * (strictly less-than: installed == floor means the device
+                     * already went through that erase) and the history walk is
+                     * skipped entirely. Missing or malformed markers fall back to
+                     * the existing walk unchanged. The floor is also skipped during
+                     * a channel switch because cross-channel version tags are not
+                     * comparable, so the legacy path below decides. */
+                    if (!channel_switch &&
+                        parse_full_erase_floor(body_str, floor_tag_local, sizeof(floor_tag_local)) &&
+                        floor_tag_parses_as_version(floor_tag_local)) {
+                        floor_decided = true;
+                        floor_requires_erase =
+                            (compare_versions(current_version, floor_tag_local) < 0);
+                        ESP_LOGI(TAG, "Erase decision via floor marker: floor=%s installed=%s -> full_erase=%d",
+                                 floor_tag_local, current_version, (int)floor_requires_erase);
+                        reached_installed = true;   /* stop paging; walk not needed */
+                        break;
+                    }
+                    if (!channel_switch) {
+                        ESP_LOGW(TAG, "No usable full-erase floor marker on target %s, using history walk",
+                                 out->tag);
+                    }
+
                     /* Under channel_switch there is no installed-version boundary to
                      * reach, so the latest in-channel release is the whole path. */
                     if (channel_switch) {
@@ -591,13 +658,25 @@ ota_check_result_t ota_github_check(int channel, const char *current_version, gi
     }
 
     /* Populate the erase determination on the captured target. */
-    out->requires_full_erase = any_marker || fail_safe;
-    if (fail_safe) {
-        /* History-incomplete variant: empty tag signals "couldn't verify". */
-        out->full_erase_tag[0] = '\0';
+    if (floor_decided) {
+        /* Fast path: the target's floor marker decided; the OR walk did not run.
+         * The floor tag is only meaningful when an erase is actually required. */
+        out->requires_full_erase = floor_requires_erase;
+        if (floor_requires_erase) {
+            strncpy(out->full_erase_tag, floor_tag_local, sizeof(out->full_erase_tag) - 1);
+            out->full_erase_tag[sizeof(out->full_erase_tag) - 1] = '\0';
+        } else {
+            out->full_erase_tag[0] = '\0';
+        }
     } else {
-        strncpy(out->full_erase_tag, full_erase_tag_local, sizeof(out->full_erase_tag) - 1);
-        out->full_erase_tag[sizeof(out->full_erase_tag) - 1] = '\0';
+        out->requires_full_erase = any_marker || fail_safe;
+        if (fail_safe) {
+            /* History-incomplete variant: empty tag signals "couldn't verify". */
+            out->full_erase_tag[0] = '\0';
+        } else {
+            strncpy(out->full_erase_tag, full_erase_tag_local, sizeof(out->full_erase_tag) - 1);
+            out->full_erase_tag[sizeof(out->full_erase_tag) - 1] = '\0';
+        }
     }
 
     resolve_ota_download_url(out);


### PR DESCRIPTION
### Summary
This PR significantly speeds up the firmware update process by changing how the device determines if a full erase is needed. Instead of checking many release pages, it now uses a pre-computed marker from the target release, reducing boot time and update check delays.

### Changes
*   The device now determines if a full erase is required by checking a new `nina:full_erase_floor` marker in the target release body.
*   This new method avoids walking through multiple GitHub release pages, significantly speeding up the update check.
*   A full erase is triggered if the currently installed firmware version is older than the tag specified by the `full_erase_floor` marker.
*   The system falls back to the previous method of walking release history if the new marker is missing, malformed, or if the update involves a channel change.
*   The existing `nina:full_erase=1|0` marker is kept to ensure compatibility with older firmware versions.
*   The Alpha update channel continues to use the original method for determining full erase requirements.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-07-05T17:01:00.086Z | Generated by GitHub Actions</sub>