### PR TITLE
refactor: split config UI into lazily loaded fragments

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -1,0 +1,93 @@
+name: Host Tests
+
+on:
+  push:
+    branches: [main, dev, snd]
+    paths:
+      - 'main/**'
+      - 'test/**'
+      - '.github/workflows/host-tests.yml'
+  pull_request:
+    paths:
+      - 'main/**'
+      - 'test/**'
+      - '.github/workflows/host-tests.yml'
+
+jobs:
+  host-tests:
+    name: Host Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Configure host test project
+        run: cmake -S test/host -B build_host
+
+      - name: Build host tests
+        run: cmake --build build_host
+
+      - name: Run host tests
+        run: ctest --test-dir build_host --output-on-failure
+
+  cppcheck:
+    name: Static Analysis (cppcheck)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck against firmware sources
+        run: |
+          cppcheck \
+            --enable=warning,portability \
+            --error-exitcode=1 \
+            --inline-suppr \
+            --std=c11 \
+            -I main \
+            -I main/ui \
+            --suppress=missingIncludeSystem \
+            --suppress=missingInclude \
+            --suppress=unknownMacro \
+            --suppress=comparePointers \
+            --suppress=internalError:main/stb_image.h \
+            --suppress=zerodivcond:main/stb_image.h \
+            -i main/ui/lv_font_material_safety.c \
+            -i main/ui/lv_font_superscript_24.c \
+            -i main/ui/lv_font_overpass_16.c \
+            -i main/ui/lv_font_overpass_27.c \
+            -i main/ui/lv_font_playfair_228.c \
+            -i main/ui/lv_font_playfair_90.c \
+            -i main/stb_image.c \
+            -i main/stb_image.h \
+            main main/ui
+        # Suppression rationale (kept explicit and narrow; any new finding
+        # outside these exact classes/files still fails the job):
+        #   missingIncludeSystem / missingInclude - firmware headers pull in
+        #     ESP-IDF/FreeRTOS/LVGL headers that don't exist on this runner
+        #     (no IDF toolchain here); these are not real findings.
+        #   unknownMacro - ESP-IDF macros (ESP_LOGx, IRAM_ATTR, etc.) are
+        #     unresolvable without the IDF headers; not a real finding.
+        #   comparePointers - fires on the `xxx_end - xxx_start` idiom used
+        #     by every EMBED_FILES/EMBED_TXTFILES asset (config_ui.html,
+        #     login.html, setup_ui.html, favicon.png, logo.jpg,
+        #     spotify_logo.png, moon_texture.png, moon_equirect.jpg; verified
+        #     across main.c, moon_render.c, moon_sphere.cpp,
+        #     web_handlers_auth.c, web_handlers_config.c) because cppcheck
+        #     treats the two extern linker-symbol arrays as unrelated
+        #     objects. Confirmed false positive for this pattern, not a
+        #     first-party logic bug; suppressed by rule id only after
+        #     manual verification of every occurrence.
+        #   internalError / zerodivcond on main/stb_image.h - the -i excludes
+        #     above only skip stb_image.c/.h as standalone translation units;
+        #     cppcheck still analyzes stb_image.h's body when it is #included
+        #     (with STB_IMAGE_IMPLEMENTATION) by a non-excluded .c file, so
+        #     these need an explicit per-file suppression. stb_image.h is
+        #     vendored third-party code we do not maintain.
+        #   -i (excluded files) - generated LVGL bitmap font sources
+        #     (main/ui/lv_font_*.c) are machine-generated glyph tables, and
+        #     main/stb_image.* is a vendored third-party single-header
+        #     library; neither is firmware logic we maintain.

--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -2,7 +2,7 @@ name: Host Tests
 
 on:
   push:
-    branches: [main, dev, snd]
+    branches: [snd]
     paths:
       - 'main/**'
       - 'test/**'

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -3,10 +3,11 @@ file(GLOB_RECURSE LV_DEMOS_SOURCES ${LV_DEMO_DIR}/*.c)
 
 idf_component_register(
     SRCS main.c tasks.c axi_qos.c power_mgmt.c jpeg_utils.c stb_image.c image_red_remap.c perf_monitor.c ota_github.c
+         http_fetch.c poll_task.c time_parse.c
          nina_connection.c nina_client.c nina_api_fetchers.c nina_sequence.c nina_websocket.c
          allsky_client.c goes_client.c weather_client.c moon_ephemeris.c moon_render.c moon_sphere.cpp moon_interaction.c spotify_auth.c spotify_client.c demo_data.c
-         app_config.c control_registry.c web_server.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_image_display.c web_handlers_pages.c web_handlers_control.c web_handlers_auth.c web_handlers_wifi.c web_handlers_logs.c log_capture.c crash_log.c mqtt_ha.c
-         ui/page_registry.c ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_nav_arbiter.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_image_display.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
+         app_config.c settings_table.c control_registry.c web_server.c web_route_auth.c web_handlers_config.c web_handlers_display.c web_handlers_system.c web_handlers_allsky.c web_handlers_spotify.c web_handlers_image_display.c web_handlers_pages.c web_handlers_control.c web_handlers_auth.c web_handlers_wifi.c web_handlers_logs.c log_capture.c crash_log.c mqtt_ha.c
+         ui/page_registry.c ui/nina_dashboard.c ui/nina_dashboard_update.c ui/nina_nav_arbiter.c ui/nina_thumbnail.c ui/nina_graph_overlay.c ui/graph_downsample.c ui/nina_graph_controls.c ui/nina_sysinfo.c ui/nina_summary.c ui/nina_allsky.c ui/nina_image_display.c ui/nina_clock.c ui/nina_spotify.c ui/nina_settings_tabview.c ui/settings_tab_display.c ui/settings_tab_nodes.c ui/settings_tab_behavior.c ui/settings_tab_system.c ui/settings_color_picker.c ui/themes.c ui/ui_styles.c
          ui/nina_toast.c ui/nina_event_log.c ui/nina_alerts.c ui/nina_safety.c ui/nina_session_stats.c ui/lv_font_material_safety.c ui/lv_font_material_icons_idle.c ui/lv_font_warning_128.c ui/lv_font_superscript_24.c ui/lv_font_playfair_228.c ui/lv_font_playfair_90.c ui/lv_font_overpass_27.c ui/lv_font_overpass_16.c
          ui/nina_setup_screen.c ui/nina_idle_indicator.c
          ui/nina_info_overlay.c ui/nina_info_camera.c ui/nina_info_mount.c
@@ -16,7 +17,7 @@ idf_component_register(
          ui/nina_empty_state.c
          ${LV_DEMOS_SOURCES}
     INCLUDE_DIRS . ui ${LV_DEMO_DIR}
-    EMBED_TXTFILES config_ui.html login.html setup_ui.html
+    EMBED_TXTFILES config_ui.html login.html setup_ui.html fragment_logs.html fragment_backup.html fragment_api.html fragment_allsky.html fragment_clock.html fragment_spotify.html fragment_image_display.html fragment_nodes.html fragment_display.html fragment_behavior.html fragment_system.html
     EMBED_FILES favicon.png logo.jpg spotify_logo.png moon_texture.png moon_equirect.jpg)
 
 idf_component_get_property(LVGL_LIB lvgl__lvgl COMPONENT_LIB)

--- a/main/allsky_client.c
+++ b/main/allsky_client.c
@@ -2,12 +2,13 @@
  * @file allsky_client.c
  * @brief AllSky API HTTP client — polls /all endpoint and extracts configured field values.
  *
- * Uses esp_http_client in standalone mode (no keep-alive reuse) since AllSky
- * polling runs at low frequency (5-60 s) and only hits a single endpoint.
+ * Uses http_fetch's shared fetcher with a module-static keep-alive slot
+ * (s_conn). AllSky polling is single-owner (only allsky_poll_task ever
+ * calls allsky_client_poll), so the connection slot needs no locking.
  */
 
 #include "allsky_client.h"
-#include "esp_http_client.h"
+#include "http_fetch.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "esp_heap_caps.h"
@@ -26,6 +27,10 @@ static const char *TAG = "allsky_client";
 /* Cached parsed field_config_json — avoids re-parsing on every poll cycle */
 static cJSON *s_cached_field_config = NULL;
 static char  *s_cached_field_config_str = NULL;
+
+/* Persistent keep-alive slot, owned exclusively by allsky_poll_task; lazily
+ * created on first poll. */
+static http_fetch_conn_t *s_conn = NULL;
 
 // =============================================================================
 // Mutex Helpers
@@ -265,90 +270,41 @@ void allsky_client_poll(const char *hostname, const char *field_config_json, all
 
     ESP_LOGD(TAG, "Polling AllSky: %s", url);
 
-    /* Configure HTTP client — standalone mode (no keep-alive reuse) */
-    esp_http_client_config_t http_cfg = {
-        .url = url,
+    /* Lazily create the keep-alive slot on first poll. If allocation fails,
+     * fall through with conn == NULL -- http_fetch falls back to a one-shot
+     * client for this attempt, so a transient PSRAM shortage degrades
+     * gracefully instead of failing the poll outright. */
+    if (!s_conn) {
+        s_conn = http_fetch_conn_create();
+        if (!s_conn) {
+            ESP_LOGW(TAG, "Failed to allocate AllSky keep-alive connection slot");
+        }
+    }
+
+    http_fetch_opts_t opts = {
         .timeout_ms = ALLSKY_HTTP_TIMEOUT_MS,
-        .keep_alive_enable = true,
-        .keep_alive_idle = 15,
-        .keep_alive_interval = 5,
-        .keep_alive_count = 3,
+        .use_tls_bundle = false,
+        .max_redirects = 0,
+        .max_attempts = 1,
+        .max_response_bytes = ALLSKY_RESPONSE_BUF_SIZE,
+        .conn = s_conn,
     };
-    esp_http_client_handle_t client = esp_http_client_init(&http_cfg);
-    if (!client) {
-        ESP_LOGW(TAG, "Failed to init HTTP client for AllSky");
-        if (allsky_data_lock(data, 100)) {
-            data->connected = false;
-            allsky_data_unlock(data);
-        }
-        return;
-    }
 
-    esp_err_t err = esp_http_client_open(client, 0);
+    char *buffer = NULL;
+    size_t total_read = 0;
+    esp_err_t err = http_fetch_text(url, &opts, &buffer, &total_read);
     if (err != ESP_OK) {
-        ESP_LOGW(TAG, "AllSky HTTP open failed: %s", esp_err_to_name(err));
-        esp_http_client_cleanup(client);
+        ESP_LOGW(TAG, "AllSky HTTP fetch failed for %s: %s", url, esp_err_to_name(err));
         if (allsky_data_lock(data, 100)) {
             data->connected = false;
             allsky_data_unlock(data);
         }
         return;
     }
-
-    int content_length = esp_http_client_fetch_headers(client);
-    if (content_length < 0) {
-        ESP_LOGW(TAG, "AllSky HTTP fetch headers failed");
-        esp_http_client_cleanup(client);
-        if (allsky_data_lock(data, 100)) {
-            data->connected = false;
-            allsky_data_unlock(data);
-        }
-        return;
-    }
-
-    int status = esp_http_client_get_status_code(client);
-    if (status < 200 || status >= 300) {
-        ESP_LOGW(TAG, "AllSky HTTP %d for %s", status, url);
-        esp_http_client_cleanup(client);
-        if (allsky_data_lock(data, 100)) {
-            data->connected = false;
-            allsky_data_unlock(data);
-        }
-        return;
-    }
-
-    /* Determine buffer size: use content_length if available, else fixed max */
-    int buf_size = (content_length > 0) ? (content_length + 1) : ALLSKY_RESPONSE_BUF_SIZE;
-    if (buf_size > ALLSKY_RESPONSE_BUF_SIZE) {
-        buf_size = ALLSKY_RESPONSE_BUF_SIZE;
-    }
-
-    char *buffer = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
-    if (!buffer) {
-        ESP_LOGE(TAG, "Failed to allocate %d bytes for AllSky response", buf_size);
-        esp_http_client_cleanup(client);
-        if (allsky_data_lock(data, 100)) {
-            data->connected = false;
-            allsky_data_unlock(data);
-        }
-        return;
-    }
-
-    /* Read response body */
-    int total_read = 0, read_len;
-    int max_read = buf_size - 1;  /* Leave room for null terminator */
-    while (total_read < max_read) {
-        read_len = esp_http_client_read(client, buffer + total_read, max_read - total_read);
-        if (read_len <= 0) break;
-        total_read += read_len;
-    }
-    buffer[total_read] = '\0';
-
-    esp_http_client_cleanup(client);
 
     if (total_read == 0) {
         ESP_LOGW(TAG, "AllSky: empty response body");
-        free(buffer);
+        heap_caps_free(buffer);
         if (allsky_data_lock(data, 100)) {
             data->connected = false;
             allsky_data_unlock(data);
@@ -358,7 +314,7 @@ void allsky_client_poll(const char *hostname, const char *field_config_json, all
 
     /* Parse JSON response */
     cJSON *json = cJSON_Parse(buffer);
-    free(buffer);
+    heap_caps_free(buffer);
 
     if (!json) {
         ESP_LOGW(TAG, "AllSky: failed to parse JSON response");
@@ -396,7 +352,7 @@ void allsky_client_poll(const char *hostname, const char *field_config_json, all
         memcpy(data->field_values, local_data.field_values, sizeof(data->field_values));
         data->moon_illumination = local_data.moon_illumination;
         allsky_data_unlock(data);
-        ESP_LOGD(TAG, "AllSky poll OK — %d bytes parsed", total_read);
+        ESP_LOGD(TAG, "AllSky poll OK — %u bytes parsed", (unsigned)total_read);
     } else {
         ESP_LOGW(TAG, "AllSky: failed to acquire mutex for data update");
     }

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -1,4 +1,5 @@
 #include "app_config.h"
+#include "app_config_forward.h"
 #include "nvs_flash.h"
 #include "nvs.h"
 #include "esp_log.h"
@@ -10,6 +11,7 @@
 #include <stdlib.h>
 #include "esp_heap_caps.h"
 #include "perf_monitor.h"
+#include "settings_table.h"
 #include "themes.h"
 #include "ui/page_registry.h"
 
@@ -680,23 +682,16 @@ typedef struct {
 
 static void set_defaults(app_config_t *cfg) {
     memset(cfg, 0, sizeof(app_config_t));
+    settings_defaults_apply(cfg);   /* every "simple" field's default — see settings_table.h */
     cfg->config_version = APP_CONFIG_VERSION;
     strcpy(cfg->api_url[0], "http://astromele1.lan:1888/v2/api/");
     strcpy(cfg->api_url[1], "http://astromele2.lan:1888/v2/api/");
-    strcpy(cfg->ntp_server, "pool.ntp.org");
-    strcpy(cfg->tz_string, "CST6CDT,M3.2.0,M11.1.0");
     for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
         strcpy(cfg->filter_colors[i], "{}");
         strcpy(cfg->rms_thresholds[i], DEFAULT_RMS_THRESHOLDS);
         strcpy(cfg->hfr_thresholds[i], DEFAULT_HFR_THRESHOLDS);
     }
-    cfg->brightness = 50;
-    cfg->color_brightness = 100;
     cfg->active_page_override = PAGE_REF_SUMMARY;  /* Home Page = Summary (page_ref_t registry id) */
-    cfg->auto_rotate_enabled = false;
-    cfg->auto_rotate_interval_s = 30;
-    cfg->auto_rotate_effect = 0;
-    cfg->auto_rotate_skip_disconnected = true;
     cfg->auto_rotate_pages = 0x0E;  // Default: all NINA instances (bits 1-3)
     cfg->auto_rotate_pages_hi = 0;  // bits 8-15 off by default (Image Display opt-in, like AllSky/Spotify/Clock)
     /* Default rotation order: Summary, AllSky, Spotify, Clock, NINA1, NINA2, NINA3, SysInfo */
@@ -708,129 +703,43 @@ static void set_defaults(app_config_t *cfg) {
      * array, so set the explicit defaults and pad the tail (8..15) with 0xFF. */
     for (int i = 0; i < 8; i++) cfg->auto_rotate_order2[i] = (uint8_t)i;   // 0..7 (Clock is last)
     for (int i = 8; i < ARP_ORDER_CAPACITY; i++) cfg->auto_rotate_order2[i] = 0xFF;
+    /* update_rate_s / graph_update_interval_s: NOT table-driven — their
+     * validate_config() out-of-range reset target differs from this default
+     * (5->2 and 10->5 respectively), so one table row can't represent both
+     * constants without lying about one of them. See settings_table.h. */
     cfg->update_rate_s = 5;
     cfg->graph_update_interval_s = 10;
-    cfg->connection_timeout_s = 6;
-    cfg->toast_duration_s = 8;
-    cfg->debug_mode = false;
     for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
         cfg->instance_enabled[i] = true;
     }
-    cfg->screen_sleep_enabled = false;
-    cfg->screen_sleep_timeout_s = 60;
-    cfg->alert_flash_enabled = true;
-    cfg->idle_poll_interval_s = 30;
-    cfg->wifi_power_save = false;  /* mains-powered display: WIFI_PS_NONE cuts DTIM modem-sleep latency */
-    cfg->widget_style = 0;
-    cfg->auto_update_check = 1;
-    cfg->update_channel = 0;
-    cfg->deep_sleep_enabled = false;
-    cfg->deep_sleep_wake_timer_s = 28800;  // 8 hours
-    cfg->deep_sleep_on_idle = false;
-    cfg->screen_rotation = 0;
-    strcpy(cfg->hostname, "NINA-DISPLAY");
-    strcpy(cfg->mqtt_broker_url, "mqtt://192.168.1.250");
-    strcpy(cfg->mqtt_topic_prefix, "ninadisplay");
-    cfg->mqtt_port = 1883;
 
-    // AllSky defaults
-    strcpy(cfg->allsky_hostname, "allskypi5.lan");
-    cfg->allsky_update_interval_s = 5;
-    cfg->allsky_dew_offset = 5.0f;
+    // AllSky defaults (field_config/thresholds are JSON blobs, not table-driven)
     strncpy(cfg->allsky_field_config, DEFAULT_ALLSKY_FIELD_CONFIG, sizeof(cfg->allsky_field_config) - 1);
     cfg->allsky_field_config[sizeof(cfg->allsky_field_config) - 1] = '\0';
     strncpy(cfg->allsky_thresholds, DEFAULT_ALLSKY_THRESHOLDS, sizeof(cfg->allsky_thresholds) - 1);
     cfg->allsky_thresholds[sizeof(cfg->allsky_thresholds) - 1] = '\0';
-    cfg->allsky_enabled = false;
-    cfg->demo_mode = false;
 
-    // Spotify defaults
-    cfg->spotify_enabled = false;
+    // Spotify client ID: secret-like sentinel, not table-driven
     cfg->spotify_client_id[0] = '\0';
-    cfg->spotify_poll_interval_ms = 3000;
-    cfg->spotify_show_progress_bar = true;
-    cfg->spotify_minimal_mode = false;
-    cfg->spotify_overlay_timeout_s = 5;
-    cfg->spotify_scroll_text = true;
-    cfg->spotify_overlay_visible = false;
 
     memset(cfg->wifi_networks, 0, sizeof(cfg->wifi_networks));
 
-    // Toast notification overhaul defaults
-    cfg->toast_aggregation_window_s = 5;
+    // Toast notification overhaul defaults (mask/per-instance mute are not table-driven)
     cfg->toast_notify_mask = 0xFFFFFFFF;  // all categories enabled
     for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
         cfg->toast_instance_muted[i] = false;
     }
 
-    // Weather defaults
-    cfg->weather_provider = 0;
-    memset(cfg->weather_api_key, 0, sizeof(cfg->weather_api_key));
-    cfg->weather_lat = 0.0f;
-    cfg->weather_lon = 0.0f;
-    memset(cfg->weather_location_name, 0, sizeof(cfg->weather_location_name));
-    cfg->weather_poll_interval_s = 900;
-    cfg->weather_units = 0;
-    cfg->weather_time_format = 0;
-    cfg->idle_page_override_enabled = false;
     cfg->idle_page_override_target = PAGE_REF_SUMMARY;
-    cfg->idle_page_persistent = false;
-    cfg->idle_indicator_enabled = true;
-    cfg->nav_grace_s = 10;             // manual-nav grace window (10-300s, default 10)
-    cfg->home_page_lock = false;       // hold the Home Page regardless of connection state
+    cfg->home_page_lock = false;       // hold the Home Page regardless of connection state; explicit bool canonicalization in validate_config(), not table-driven
 
     // Admin password default — change via web UI on first boot
     strcpy(cfg->admin_password, "changeme123!");
 
-    // Image Display defaults
-    cfg->image_display_enabled = false;
-    cfg->image_display_show_overlay = true;
-    strcpy(cfg->goes_region, "umv");
-    cfg->goes_update_interval_s = 600;
-
-    // Moon phase defaults
-    cfg->image_display_source = 0;   // 0=GOES, 1=Moon
-    cfg->moon_bg_style = 0;          // 0=black, 1=stars, 2=glow
-    cfg->moon_lat = 0.0f;            // unset until configured / prefilled from weather
-    cfg->moon_lon = 0.0f;
-    cfg->solar_band = 0;             // SDO/AIA band index 0..9
-    cfg->image_display_crop = false; // crop/zoom image to fill & hide baked-in labels
+    /* moon_drag_light_mode: NOT table-driven — its validate_config()
+     * out-of-range reset target (0) differs from this default (2), so one
+     * table row can't represent both constants. See settings_table.h. */
     cfg->moon_drag_light_mode = 2;   // 0=true phase, 1=explore, 2=locked to surface (default) (moon drag-to-rotate lighting)
-
-    // Moon sphere orientation tuning defaults (tuned baseline from a reference device)
-    cfg->moon_flip_u = 0;            // mirror texture longitude E<->W
-    cfg->moon_flip_v = 0;            // flip texture latitude N<->S
-    cfg->moon_roll_offset = -7.0f;   // degrees, clamp [-180,180]
-    cfg->moon_yaw_offset = 0.0f;     // degrees, clamp [-180,180]
-    cfg->moon_pitch_offset = -5.0f;  // degrees, clamp [-90,90]
-    cfg->moon_north_up = 1;          // 0=true sky tilt, 1=always upright/north-up
-
-    // Moon touch-spin return behavior defaults
-    cfg->moon_spin_mode = 0;         // 0=rubber band snap-back (preserves existing behavior)
-    cfg->moon_spin_return_s = 3;     // free-spin hold before auto-return, clamp [3,60]
-
-    // Crash log defaults
-    cfg->crash_log_retention_days = 30;  // auto-purge crash records older than 30 days (0 = never)
-
-    // Per-source Image Display render rotation (0=0°,1=90°,2=180°,3=270° clockwise)
-    cfg->goes_orientation = 0;
-    cfg->solar_orientation = 0;
-
-    // Custom Image URL source (Image Display source index 3)
-    strcpy(cfg->custom_image_url, "https://picsum.photos/720");
-    cfg->custom_orientation = 0;          // 0=0°,1=90°,2=180°,3=270° clockwise
-    cfg->custom_update_interval_s = 60;   // poll interval (10-7200s)
-
-    // Per-source Image Display mirror flips (0=no flip = current behavior)
-    cfg->goes_vflip = 0;
-    cfg->goes_hflip = 0;
-    cfg->solar_vflip = 0;
-    cfg->solar_hflip = 0;
-    cfg->custom_vflip = 0;
-    cfg->custom_hflip = 0;
-
-    // Auth is on by default — protects device from open-LAN access
-    cfg->auth_enabled = true;
 }
 
 /* Convert the two page-target fields from their pre-v47 encodings
@@ -2868,29 +2777,7 @@ static bool validate_config(app_config_t *cfg) {
             fixed = true;
         }
     }
-    if (cfg->color_brightness < 0 || cfg->color_brightness > 100) {
-        cfg->color_brightness = 100;
-        fixed = true;
-    }
-    if (cfg->theme_index < 0 || cfg->theme_index >= themes_get_count()) {
-        cfg->theme_index = 0;
-        fixed = true;
-    }
-    if (cfg->brightness < 0 || cfg->brightness > 100) {
-        cfg->brightness = 50;
-        fixed = true;
-    }
-    /* Update channel: 0=Stable, 1=Pre-releases/Beta, 2=Alpha (snd). */
-    if (cfg->update_channel > 2) {
-        cfg->update_channel = 0;
-        fixed = true;
-    }
-    if (cfg->mqtt_topic_prefix[0] == '\0') {
-        strcpy(cfg->mqtt_topic_prefix, "ninadisplay");
-        fixed = true;
-    }
-    if (cfg->mqtt_port == 0) {
-        cfg->mqtt_port = 1883;
+    if (settings_clamp_apply(cfg)) {
         fixed = true;
     }
     /* Home Page stores a page_ref_t registry id (see ui/page_registry.h). Validate
@@ -2925,14 +2812,6 @@ static bool validate_config(app_config_t *cfg) {
             fixed = true;
         }
     }
-    if (cfg->auto_rotate_interval_s == 0 || cfg->auto_rotate_interval_s > 3600) {
-        cfg->auto_rotate_interval_s = 30;
-        fixed = true;
-    }
-    if (cfg->auto_rotate_effect > 3) {
-        cfg->auto_rotate_effect = 0;
-        fixed = true;
-    }
     if (cfg->auto_rotate_pages == 0) {
         cfg->auto_rotate_pages = 0x0E;  // Default: all NINA instances
         fixed = true;
@@ -2960,114 +2839,8 @@ static bool validate_config(app_config_t *cfg) {
         cfg->graph_update_interval_s = 5;
         fixed = true;
     }
-    if (cfg->connection_timeout_s < 2 || cfg->connection_timeout_s > 30) {
-        cfg->connection_timeout_s = 6;
-        fixed = true;
-    }
-    if (cfg->toast_duration_s < 3 || cfg->toast_duration_s > 30) {
-        cfg->toast_duration_s = 8;
-        fixed = true;
-    }
-    if (cfg->screen_sleep_timeout_s < 10 || cfg->screen_sleep_timeout_s > 3600) {
-        cfg->screen_sleep_timeout_s = 60;
-        fixed = true;
-    }
-    if (cfg->idle_poll_interval_s < 5 || cfg->idle_poll_interval_s > 120) {
-        cfg->idle_poll_interval_s = 30;
-        fixed = true;
-    }
-    if (cfg->widget_style >= WIDGET_STYLE_COUNT) {
-        cfg->widget_style = 0;
-        fixed = true;
-    }
-    if (cfg->screen_rotation > 3) {
-        cfg->screen_rotation = 0;
-        fixed = true;
-    }
-    if (cfg->allsky_update_interval_s < 1 || cfg->allsky_update_interval_s > 300) {
-        cfg->allsky_update_interval_s = 5;
-        fixed = true;
-    }
-    if (cfg->allsky_dew_offset < -50.0f || cfg->allsky_dew_offset > 50.0f) {
-        cfg->allsky_dew_offset = 5.0f;
-        fixed = true;
-    }
-    if (cfg->goes_update_interval_s < 300 || cfg->goes_update_interval_s > 7200) {
-        cfg->goes_update_interval_s = 600;
-        fixed = true;
-    }
-    cfg->goes_region[sizeof(cfg->goes_region) - 1] = '\0';
-    if (cfg->goes_region[0] == '\0') {
-        strcpy(cfg->goes_region, "umv");
-        fixed = true;
-    }
-    /* Custom Image URL source (Image Display source index 3) */
-    cfg->custom_image_url[sizeof(cfg->custom_image_url) - 1] = '\0';
-    if (cfg->custom_orientation > 3) {
-        cfg->custom_orientation = 0;
-        fixed = true;
-    }
-    if (cfg->custom_update_interval_s < 10 || cfg->custom_update_interval_s > 7200) {
-        cfg->custom_update_interval_s = 60;
-        fixed = true;
-    }
-    /* Per-source Image Display mirror flips — normalize each to 0/1. */
-    if (cfg->goes_vflip > 1)   { cfg->goes_vflip   = (cfg->goes_vflip   != 0) ? 1 : 0; fixed = true; }
-    if (cfg->goes_hflip > 1)   { cfg->goes_hflip   = (cfg->goes_hflip   != 0) ? 1 : 0; fixed = true; }
-    if (cfg->solar_vflip > 1)  { cfg->solar_vflip  = (cfg->solar_vflip  != 0) ? 1 : 0; fixed = true; }
-    if (cfg->solar_hflip > 1)  { cfg->solar_hflip  = (cfg->solar_hflip  != 0) ? 1 : 0; fixed = true; }
-    if (cfg->custom_vflip > 1) { cfg->custom_vflip = (cfg->custom_vflip != 0) ? 1 : 0; fixed = true; }
-    if (cfg->custom_hflip > 1) { cfg->custom_hflip = (cfg->custom_hflip != 0) ? 1 : 0; fixed = true; }
-    if (cfg->image_display_source > 3) {   /* 0=GOES, 1=Moon, 2=Solar, 3=Custom URL */
-        cfg->image_display_source = 0;
-        fixed = true;
-    }
-    if (cfg->moon_bg_style > 3) {
-        cfg->moon_bg_style = 0;
-        fixed = true;
-    }
-    if (cfg->solar_band > 17) {
-        cfg->solar_band = 0;
-        fixed = true;
-    }
     if (cfg->moon_drag_light_mode > 2) {
         cfg->moon_drag_light_mode = 0;
-        fixed = true;
-    }
-    if (cfg->moon_flip_u > 1) {
-        cfg->moon_flip_u = (cfg->moon_flip_u != 0) ? 1 : 0;
-        fixed = true;
-    }
-    if (cfg->moon_flip_v > 1) {
-        cfg->moon_flip_v = (cfg->moon_flip_v != 0) ? 1 : 0;
-        fixed = true;
-    }
-    if (cfg->moon_roll_offset < -180.0f || cfg->moon_roll_offset > 180.0f) {
-        if (cfg->moon_roll_offset < -180.0f) cfg->moon_roll_offset = -180.0f;
-        else cfg->moon_roll_offset = 180.0f;
-        fixed = true;
-    }
-    if (cfg->moon_yaw_offset < -180.0f || cfg->moon_yaw_offset > 180.0f) {
-        if (cfg->moon_yaw_offset < -180.0f) cfg->moon_yaw_offset = -180.0f;
-        else cfg->moon_yaw_offset = 180.0f;
-        fixed = true;
-    }
-    if (cfg->moon_pitch_offset < -90.0f || cfg->moon_pitch_offset > 90.0f) {
-        if (cfg->moon_pitch_offset < -90.0f) cfg->moon_pitch_offset = -90.0f;
-        else cfg->moon_pitch_offset = 90.0f;
-        fixed = true;
-    }
-    if (cfg->moon_spin_mode > 1) {
-        cfg->moon_spin_mode = 1;   /* only reached when value > 1 */
-        fixed = true;
-    }
-    if (cfg->moon_spin_return_s < 3 || cfg->moon_spin_return_s > 60) {
-        if (cfg->moon_spin_return_s < 3) cfg->moon_spin_return_s = 3;
-        else cfg->moon_spin_return_s = 60;
-        fixed = true;
-    }
-    if (cfg->moon_north_up > 1) {
-        cfg->moon_north_up = (cfg->moon_north_up != 0) ? 1 : 0;
         fixed = true;
     }
     if (cfg->allsky_thresholds[0] == '\0' ||
@@ -3077,14 +2850,8 @@ static bool validate_config(app_config_t *cfg) {
         cfg->allsky_thresholds[sizeof(cfg->allsky_thresholds) - 1] = '\0';
         fixed = true;
     }
-    if (cfg->nav_grace_s < 10)  { cfg->nav_grace_s = 10;  fixed = true; }
-    if (cfg->nav_grace_s > 300) { cfg->nav_grace_s = 300; fixed = true; }
     /* bool loaded from a raw NVS blob may hold any byte value; force canonical 0/1 */
     cfg->home_page_lock = cfg->home_page_lock ? true : false;
-    if (cfg->spotify_poll_interval_ms < 1000 || cfg->spotify_poll_interval_ms > 30000) {
-        cfg->spotify_poll_interval_ms = 3000;
-        fixed = true;
-    }
     /* spotify_overlay_timeout_s is uint8_t (0-255); 0 means never hide, all values valid */
 
     return fixed;
@@ -3501,7 +3268,7 @@ void app_config_init(void) {
          * version_check is either 0 (empty SSID) or a large printable-ASCII
          * value (>= 0x1000). A small integer just above APP_CONFIG_VERSION is a
          * future/unknown version (e.g. a firmware downgrade), not a v0 blob:
-         * let it fall through to the terminal defaults branch below instead of
+         * let it fall through to the forward-tolerant branch below instead of
          * mis-migrating it as v0. */
         app_config_v0_t old;
         memcpy(&old, raw, sizeof(app_config_v0_t));
@@ -3510,6 +3277,26 @@ void app_config_init(void) {
 
         nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
         nvs_commit(handle);
+    } else if (config_accept_forward(version_check, stored_size, APP_CONFIG_VERSION, sizeof(app_config_t))) {
+        /* Forward-tolerant load — firmware downgrade case. The stored blob was
+         * written by a NEWER firmware (version_check > APP_CONFIG_VERSION).
+         * Because app_config_t fields are strictly append-only, this
+         * firmware's entire struct layout is a known prefix of that blob, so
+         * read it directly rather than falling through to the terminal
+         * "unknown blob" branch, which would wipe the whole fleet's settings
+         * back to factory defaults on every downgrade.
+         *
+         * Deliberately do NOT nvs_set_blob() here: writing back would
+         * truncate the newer blob to this firmware's smaller struct size,
+         * discarding the fields added after APP_CONFIG_VERSION. Leaving NVS
+         * untouched means a subsequent re-upgrade finds the original newer
+         * blob still intact and loads it with no data loss. */
+        ESP_LOGW(TAG, "Config blob v%u is newer than firmware v%u; loading known prefix "
+                      "(fields added after v%u unavailable until re-upgrade)",
+                 (unsigned)version_check, (unsigned)APP_CONFIG_VERSION, (unsigned)APP_CONFIG_VERSION);
+        memcpy(&s_config, raw, sizeof(app_config_t));
+        s_config.config_version = APP_CONFIG_VERSION;
+        validate_config(&s_config);
     } else {
         ESP_LOGW(TAG, "Unknown config blob (size=%d, ver=0x%08x), using defaults",
                  (int)stored_size, (unsigned)version_check);

--- a/main/app_config_forward.h
+++ b/main/app_config_forward.h
@@ -1,0 +1,51 @@
+#pragma once
+
+/*
+ * Forward-tolerant config load — firmware downgrade case.
+ *
+ * app_config_t fields are append-only by protocol (CLAUDE.md "Configuration
+ * Persistence": never reorder/insert, always append + bump APP_CONFIG_VERSION).
+ * That means a config blob written by a NEWER firmware is always a strict
+ * superset of the CURRENT (older, post-downgrade) firmware's app_config_t
+ * layout: every field this firmware knows about sits at the same offset it
+ * always has, and the newer blob simply has more bytes tacked on the end.
+ *
+ * So when a downgraded device boots into a config blob whose version is
+ * newer than APP_CONFIG_VERSION, the safe move is to read the known prefix
+ * (memcpy sizeof(app_config_t) bytes from the front of the blob) rather than
+ * falling through to the terminal "unknown blob" branch, which wipes NVS
+ * back to factory defaults and would silently reset an entire fleet's
+ * settings on every downgrade.
+ *
+ * The 0x1000 ceiling on blob_version mirrors the existing legacy-v0 guard
+ * (app_config.c, version_check > APP_CONFIG_VERSION && version_check < 0x1000):
+ * a v0 blob's first four bytes are the wifi_ssid text, so version_check
+ * there is either 0 (empty SSID) or a large printable-ASCII value. Any small
+ * integer just above APP_CONFIG_VERSION is a plausible real future version
+ * number, not a v0 blob or other garbage — that's the case this function
+ * accepts.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
+
+/*
+ * Returns true iff the stored blob should be accepted as a forward
+ * (newer-than-firmware) config and read via its known prefix:
+ *   - blob_version is strictly newer than fw_version (otherwise this isn't
+ *     the downgrade case — exact match and older-version migrations are
+ *     handled by other branches).
+ *   - blob_version is below the legacy-blob heuristic ceiling (rules out
+ *     v0/garbage blobs whose first uint32_t happens to be a huge ASCII
+ *     value).
+ *   - blob_size is at least fw_size, so the known prefix is fully present
+ *     (a genuine newer blob is a superset; anything smaller is corrupt or
+ *     foreign data that merely happens to share a version-like first word).
+ */
+static inline bool config_accept_forward(uint32_t blob_version, size_t blob_size,
+                                          uint32_t fw_version, size_t fw_size) {
+    return blob_version > fw_version &&
+           blob_version < 0x1000 &&
+           blob_size >= fw_size;
+}

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -998,2184 +998,62 @@
   <main class="content">
 
     <!-- ==================== TAB 2: NODES & DATA ==================== -->
-    <div id="tab-nodes" class="tab-panel">
-
-      <div class="card" id="instance-overview">
-        <div class="card-title"><span class="card-title-label">Active N.I.N.A. Instances <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Active N.I.N.A. Instances</div><p>Selects which of the three N.I.N.A. instance slots the device polls and shows as pages. A disabled instance is not contacted and its page is skipped, but the slot keeps its fixed position so the other instances do not shift.</p><p>Each enabled instance gets its own dashboard page and a configuration card below. The device updates the page you are viewing in full and checks the other instances less often in the background.</p><p>Example: enable N.I.N.A. 1 and N.I.N.A. 2 for a two-instance setup and leave N.I.N.A. 3 off; only two node cards and two instance pages appear.</p></div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label" id="inst_lbl_0">N.I.N.A. 1</span>
-          <label class="toggle"><input type="checkbox" id="instance_enabled_0" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint">Polls this instance and shows its page; turn off to stop contacting it and hide its page.</div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label" id="inst_lbl_1">N.I.N.A. 2</span>
-          <label class="toggle"><input type="checkbox" id="instance_enabled_1" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint">Polls this instance and shows its page; turn off to stop contacting it and hide its page.</div>
-        <div class="toggle-row">
-          <span class="toggle-label" id="inst_lbl_2">N.I.N.A. 3</span>
-          <label class="toggle"><input type="checkbox" id="instance_enabled_2" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint">Polls this instance and shows its page; turn off to stop contacting it and hide its page.</div>
-      </div>
-
-      <div id="node-cards"></div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Polling &amp; Connectivity <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Polling and Connectivity</div><p>Sets how often the device contacts the NINA API and how patient it is before declaring an instance offline. Data update rate is the base polling interval for the active page; faster values refresh the display sooner but generate more API traffic. Graph update rate controls how often the RMS and HFR history graphs add a point.</p><p>Connection timeout is how long a request waits for a response before that instance is marked offline. Idle poll interval is the slower, occasional check used to re-test an offline instance while you are viewing a non-NINA page, which avoids contacting an instance that is not running too often.</p><p>Example: set Data update rate to 2 seconds for a responsive display, raise Connection timeout to 10 seconds on a slow or distant network, and leave Idle poll interval at 30 seconds.</p></div>
-        <div class="subsection">
-          <div class="subsection-title">Update Rates</div>
-          <div class="row stack-mobile">
-            <div class="field">
-              <label class="field-label">Data update rate (s)</label>
-              <input type="number" class="input" id="update_rate" min="1" max="10" value="2">
-              <div class="field-hint">Base polling interval for the active page, from 1 to 10 seconds; lower is more responsive but adds API traffic.</div>
-            </div>
-            <div class="field">
-              <label class="field-label">Graph update rate (s)</label>
-              <input type="number" class="input" id="graph_interval" min="2" max="30" value="5">
-              <div class="field-hint">How often the RMS and HFR history graphs record a new data point, from 2 to 30 seconds.</div>
-            </div>
-          </div>
-        </div>
-        <div class="subsection">
-          <div class="subsection-title">Connectivity</div>
-          <div class="row stack-mobile">
-            <div class="field">
-              <label class="field-label">Connection timeout (s)</label>
-              <input type="number" class="input" id="connection_timeout" min="2" max="30" value="6">
-              <div class="field-hint">Seconds without response before a NINA instance is offline</div>
-            </div>
-            <div class="field">
-              <label class="field-label">Idle poll interval (s)</label>
-              <input type="number" class="input" id="idle_poll_interval" min="5" max="120" value="30">
-              <div class="field-hint">How often an offline instance is re-checked while you are on a non-NINA page</div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+    <!-- Markup extracted to main/fragment_nodes.html (P6d); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=nodes and injected here. -->
+    <div id="tab-nodes" class="tab-panel"></div>
 
     <!-- ==================== TAB 5: ALLSKY ==================== -->
-    <div id="tab-allsky" class="tab-panel">
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Connection <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">AllSky Connection</div><p>Points the device at an AllSky camera's API and sets how often it reads data. AllSky updates run on their own schedule, independent of N.I.N.A. polling, so this interval does not affect N.I.N.A. updates.</p><p>The dew-point safety margin controls when the dew reading is colored as safe. The reading is treated as safe while the dew point sits below ambient temperature minus this margin.</p><p>Example: set the hostname to allskypi5.lan:8080, the interval to 5 seconds, and a 5 C margin so dew is flagged unsafe once the dew point rises to within 5 C of ambient.</p></div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Enable AllSky</span>
-          <label class="toggle"><input type="checkbox" id="allsky_enabled" onchange="updateAllSkyEnabledUI()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint">Turns on the AllSky page and starts reading AllSky data; off hides the page and stops reading.</div>
-        <div id="allskyConnectionFields">
-        <div class="subsection">
-          <div class="subsection-title">Server</div>
-          <div class="field">
-            <label class="field-label">AllSky Hostname</label>
-            <input type="text" class="input" id="allskyHostname" placeholder="allskypi5.lan:8080">
-            <div class="field-hint">Host:port of the AllSky API (e.g., allskypi5.lan:8080)</div>
-          </div>
-        </div>
-        <div class="subsection">
-          <div class="subsection-title">Reading</div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">Update Interval</label>
-            <select class="input" id="allskyInterval">
-              <option value="1">1 second</option>
-              <option value="2">2 seconds</option>
-              <option value="5" selected>5 seconds</option>
-              <option value="10">10 seconds</option>
-              <option value="30">30 seconds</option>
-              <option value="60">1 minute</option>
-              <option value="120">2 minutes</option>
-              <option value="300">5 minutes</option>
-            </select>
-            <div class="field-hint">How often the device reads the AllSky API; longer intervals reduce load on the AllSky host.</div>
-          </div>
-          <div class="field">
-            <label class="field-label">Dew Point Safety Margin (&deg;C)</label>
-            <input type="number" class="input" id="allskyDewOffset" step="0.5" min="-50" max="50" value="5.0">
-            <div class="field-hint">Dew point colored safe when below ambient &minus; this offset</div>
-          </div>
-        </div>
-        </div>
-        </div>
-      </div>
-
-      <div class="card" id="allskyFieldMappingsCard">
-        <div class="card-title"><span class="card-title-label">Field Mappings <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">AllSky Field Mappings</div><p>Maps values from the AllSky API JSON to the four display quadrants: Thermal, Sky Quality, Ambient, and Power. Each quadrant has a main value, two sub values, and two status dots, and each is filled by entering the JSON key path for that value.</p><p>Use Fetch JSON from AllSky to load the live response, click a Key Path input to make it active, then click Use on a value to copy its path in. Value fields that show a unit also have color controls that set the gradient range between their low and high bounds.</p><p>Example: map the Thermal main value to data.cpu_temp with a 0 to 80 range so the reading shifts from blue toward red as the camera warms.</p></div>
-        <div class="field-hint" style="margin-bottom:16px">Configure which AllSky API JSON values appear in each display quadrant. Click a value's path input, then click "Use" on a value to fill it. Use the color controls to set gradient ranges per field.</div>
-
-        <div class="subsection">
-          <div class="subsection-title">Import from AllSky</div>
-          <button onclick="fetchAllSkyJson()" class="btn btn-primary" id="fetchJsonBtn" style="width:100%;margin-bottom:16px">Fetch JSON from AllSky</button>
-
-          <div id="allskyJsonTree" style="display:none; max-height:300px; overflow-y:auto; margin:0; padding:12px; background:rgba(0,0,0,0.25); border-radius:var(--radius-sm); border:1px solid rgba(255,255,255,0.06); font-family:'SF Mono',Monaco,Consolas,monospace; font-size:0.75rem; line-height:1.6;"></div>
-        </div>
-
-        <div class="subsection">
-          <div class="subsection-title">Quadrant Mappings</div>
-          <div id="allskyFieldMappings"></div>
-        </div>
-      </div>
-
-    </div>
+    <!-- Markup extracted to main/fragment_allsky.html (P6c); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=allsky and injected here. -->
+    <div id="tab-allsky" class="tab-panel"></div>
 
     <!-- ==================== TAB 6: CLOCK & WEATHER ==================== -->
-    <div id="tab-clock" class="tab-panel">
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Weather <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Weather</div><p>Drives the weather overlay shown on the Clock page. Pick a provider and supply an API key if the provider needs one. Open-Meteo needs no key; OpenWeatherMap and Weather Underground each require a key. The forecast uses the device location set on the System tab.</p><p>The Time Format option switches the clock between 14:30 and 2:30 PM. Temperature Units switches all weather readings between degrees F and degrees C. Update Interval sets how often the device fetches new weather data.</p><p>Example: choose Open-Meteo, set units to degrees C, and the Clock page shows local conditions refreshed on the chosen interval.</p></div>
-        <div class="subsection">
-        <div class="subsection-title">Provider</div>
-        <div class="field">
-          <label class="field-label">Weather Provider</label>
-          <select class="input" id="weather_provider" onchange="toggleWeatherApiKey();checkDirty()">
-            <option value="0">OpenWeatherMap</option>
-            <option value="1">Open-Meteo (no key needed)</option>
-            <option value="2">Weather Underground</option>
-          </select>
-          <div class="field-hint">Open-Meteo works without a key; OpenWeatherMap and Weather Underground require an API key.</div>
-        </div>
-        <div class="field" id="weather_api_key_field">
-          <label class="field-label">API Key</label>
-          <input type="text" class="input" id="weather_api_key" placeholder="Enter API key">
-          <div class="field-hint" id="weather_api_key_hint">
-            <span id="owm_link">Get a free API key at <a href="https://home.openweathermap.org/api_keys" target="_blank" rel="noopener" style="color:#7eb8da">openweathermap.org</a></span>
-            <span id="wunderground_link" style="display:none">Get an API key at <a href="https://www.wunderground.com/member/api-keys" target="_blank" rel="noopener" style="color:#7eb8da">wunderground.com</a></span>
-          </div>
-        </div>
-        <div class="field" id="weather_location_name_field">
-          <label class="field-label">Location Name</label>
-          <input type="text" class="input" id="weather_location_name" readonly placeholder="Auto-filled by lookup" style="opacity:0.7">
-          <div class="field-hint">Read-only; set automatically by the city lookup on the System tab.</div>
-        </div>
-        <div class="field" id="weather_station_id_field" style="display:none">
-          <label class="field-label">Station ID</label>
-          <input type="text" class="input" id="weather_station_id" placeholder="e.g. KMOOFAL42">
-          <div class="field-hint">Personal Weather Station ID for Weather Underground</div>
-        </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Display Options</div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">Temperature Units</label>
-            <select class="input" id="weather_units">
-              <option value="0">&deg;F Imperial</option>
-              <option value="1">&deg;C Metric</option>
-            </select>
-            <div class="field-hint">Switches all weather temperatures between degrees F and degrees C.</div>
-          </div>
-          <div class="field">
-            <label class="field-label">Time Format</label>
-            <select class="input" id="weather_time_format">
-              <option value="0">12-hour (AM/PM)</option>
-              <option value="1">24-hour</option>
-            </select>
-            <div class="field-hint">Switches the clock between 12-hour (2:30 PM) and 24-hour (14:30) display.</div>
-          </div>
-        </div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">Update Interval</label>
-            <select class="input" id="weather_poll_interval_s">
-              <option value="900">15 minutes</option>
-              <option value="1200">20 minutes</option>
-              <option value="1800">30 minutes</option>
-              <option value="2700">45 minutes</option>
-              <option value="3600">60 minutes</option>
-            </select>
-            <div class="field-hint">How often the device fetches new weather data from the provider.</div>
-          </div>
-          <div class="field">
-            <div class="field-hint">The clock uses the time zone and NTP server configured on the System tab.</div>
-          </div>
-        </div>
-        </div>
-      </div>
-
-    </div>
+    <!-- Markup extracted to main/fragment_clock.html (P6c); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=clock and injected here. -->
+    <div id="tab-clock" class="tab-panel"></div>
 
     <!-- ==================== TAB 7: SPOTIFY ==================== -->
-    <div id="tab-spotify" class="tab-panel">
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Account Setup <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Account Setup</div><p>Connects the device to your Spotify account so the player page can show what is playing. Create a free app on the Spotify developer site, paste its Client ID here, then log in. The Client ID is saved to the device automatically when you select Login with Spotify, so no separate save is needed.</p><p>After you approve access, the browser lands on a page that cannot load. That is expected: copy the full address from that page, including the ?code= part, and paste it into the Redirect URL field. The device stores the resulting tokens, so login is a one-time step per account. Use Logout to clear the stored tokens.</p></div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Enable Spotify</span>
-          <label class="toggle"><input type="checkbox" id="spotify_enabled" onchange="updateSpotifyEnabledUI()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint">Turns the Spotify page on and starts checking your playback.</div>
-        <div id="spotifyConnectionFields">
-          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Step 1: Create a Spotify app</div>
-          <div class="field-hint">Go to <a href="https://developer.spotify.com" target="_blank" rel="noopener" style="color:rgba(var(--accent-rgb),1);text-decoration:underline">developer.spotify.com</a>, create a free app, and set its Redirect URI to <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;font-size:0.78rem">http://127.0.0.1:8000/callback</code></div>
-          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Step 2: Enter the Client ID</div>
-          <div class="field">
-            <label class="field-label">Client ID</label>
-            <input type="text" class="input" id="spotifyClientId" placeholder="e.g. a1b2c3d4e5f6...">
-            <div class="field-hint">Saved to the device automatically when you select Login with Spotify below. No separate save needed.</div>
-          </div>
-          <div id="spotifyAccountCard">
-            <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Step 3: Log in</div>
-            <div class="field">
-              <label class="field-label">Status</label>
-              <div id="spotifyStatus" style="font-size:0.875rem;color:var(--text-hint);margin-bottom:12px">Checking...</div>
-            </div>
-            <div style="display:flex;gap:10px;flex-wrap:wrap">
-              <button class="btn btn-primary" id="spotifyLoginBtn" onclick="spotifyLogin()" style="flex:1;min-width:120px">Login with Spotify</button>
-              <button class="btn btn-danger" id="spotifyLogoutBtn" onclick="spotifyLogout()" style="flex:1;min-width:120px;display:none">Logout</button>
-            </div>
-            <div id="spotifyPasteDiv" style="display:none;margin-top:16px">
-              <p style="font-size:0.82rem;color:#a1a1aa;margin:0 0 10px;line-height:1.5">After approving in Spotify, you'll see a "can't connect" page. Copy the <strong>full URL</strong> from the address bar and paste it below:</p>
-              <div class="field" style="margin-bottom:10px">
-                <label class="field-label">Redirect URL</label>
-                <input type="text" class="input" id="spotifyPasteUrl" placeholder="http://127.0.0.1:8000/callback?code=..." style="font-size:0.92rem;min-height:52px;border:1px solid rgba(var(--accent-rgb),0.35);background:rgba(0,0,0,0.45)">
-                <div class="field-hint">Paste the entire callback URL from the address bar; it must contain the ?code= portion.</div>
-              </div>
-              <button class="btn btn-primary" id="spotifySubmitBtn" onclick="spotifySubmitCallback()" style="width:100%">Submit</button>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card" id="spotifyPlayerCard">
-        <div class="card-title"><span class="card-title-label">Player Options <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Player Options</div><p>Controls how the Spotify player page looks and how often it refreshes. Poll Interval sets how often the device checks Spotify for the current track and playback position; lower values track changes faster but make more API calls.</p><p>Minimal Mode shows centered track text with the album art dimmed to a background and the transport controls hidden. Show Overlay keeps the playback overlay visible, the same as tapping the album art; Overlay Timeout sets how long it stays before auto-hiding, with 0 keeping it on permanently.</p></div>
-        <div id="spotifyPlayerOptionsFields">
-          <div class="field">
-            <label class="field-label">Poll Interval (ms)</label>
-            <input type="number" class="input" id="spotifyPollInterval" min="1000" max="30000" step="500" value="3000">
-            <div class="field-hint">How often to check playback state (1000 &ndash; 30000 ms)</div>
-          </div>
-          <div class="toggle-row">
-            <span class="toggle-label">Minimal Mode</span>
-            <label class="toggle"><input type="checkbox" id="spotify_minimal_mode"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Shows centered track text, with the album art dimmed to a background and the transport controls hidden.</div>
-          <div class="toggle-row">
-            <span class="toggle-label">Show Overlay</span>
-            <label class="toggle"><input type="checkbox" id="spotify_overlay_visible"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Force the minimal overlay visible (same as tapping album art)</div>
-          <div class="toggle-row">
-            <span class="toggle-label">Scroll Long Text</span>
-            <label class="toggle"><input type="checkbox" id="spotify_scroll_text" checked><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">When off, long text wraps to multiple lines</div>
-          <div class="toggle-row">
-            <span class="toggle-label">Show Progress Bar</span>
-            <label class="toggle"><input type="checkbox" id="spotify_show_progress_bar" checked><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Shows the track elapsed and remaining progress bar on the player.</div>
-          <div class="field">
-            <label class="field-label">Overlay Timeout (s)</label>
-            <input type="number" class="input" id="spotifyOverlayTimeout" min="0" max="60" step="1" value="5">
-            <div class="field-hint">Seconds before playback overlay auto-hides (0 = always visible)</div>
-          </div>
-        </div>
-      </div>
-
-    </div>
+    <!-- Markup extracted to main/fragment_spotify.html (P6c); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=spotify and injected here. -->
+    <div id="tab-spotify" class="tab-panel"></div>
 
     <!-- ==================== TAB: IMAGE DISPLAY ==================== -->
-    <div id="tab-image-display" class="tab-panel">
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">GOES Satellite Imagery <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Full-screen image page</div><p>Renders one full-screen image source on its own page: a GOES-19 GEOCOLOR satellite sector, a 3D-rendered moon phase, or SDO/SOHO solar imagery. Pick the source with the Source selector; the fields below change to match the chosen source. Show Overlay applies to all sources; the update interval applies to GOES and Solar (the moon is drawn on the device and has no fetch interval).</p><p>Fill (crop borders) zooms the disc to fill the 720x720 panel and cuts off the timestamp and label baked into the source image border. It applies to GOES and Solar; the Moon has no border text and is not cropped. Example: with Fill off, a GOES sector shows letterboxed with its caption; with Fill on, the disc fills the screen and the caption is hidden.</p><p>In some firmware versions the image may appear rotated, which is why each source has its own rotation control. If the satellite, moon, or sun appears upside down or sideways, set the matching rotation to correct it.</p></div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Enable Image Display</span>
-          <label class="toggle"><input type="checkbox" id="image_display_enabled" onchange="updateImageDisplayEnabledUI();applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint">Adds the full-screen image page and starts fetching the selected source.</div>
-        <div id="imageDisplayFields">
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Source</label>
-            <div class="pn-pill-grid">
-              <label class="pn-pill rotate-pill">
-                <input type="radio" name="imageSourceSel" id="imageSource0" value="0" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
-                <span class="pn-pill-visual">GOES Satellite</span>
-              </label>
-              <label class="pn-pill rotate-pill">
-                <input type="radio" name="imageSourceSel" id="imageSource1" value="1" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
-                <span class="pn-pill-visual">Moon Phase</span>
-              </label>
-              <label class="pn-pill rotate-pill">
-                <input type="radio" name="imageSourceSel" id="imageSource2" value="2" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
-                <span class="pn-pill-visual">Solar (SDO)</span>
-              </label>
-              <label class="pn-pill rotate-pill">
-                <input type="radio" name="imageSourceSel" id="imageSource3" value="3" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
-                <span class="pn-pill-visual">Custom URL</span>
-              </label>
-            </div>
-            <div class="field-hint">Chooses GOES satellite, Moon phase, Solar, or a custom image URL; the options below switch to match.</div>
-          </div>
-          <div class="toggle-row">
-            <span class="toggle-label">Show Overlay</span>
-            <label class="toggle"><input type="checkbox" id="image_display_show_overlay" onchange="applyImageDisplay();checkDirty()" checked><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Region/phase name and update time overlay on the display</div>
-          <div id="discOptions">
-          <div class="toggle-row">
-            <span class="toggle-label">Fill (crop borders)</span>
-            <label class="toggle"><input type="checkbox" id="image_display_crop" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Zoom the disc to fill the screen and hide the image's timestamp/label.</div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Update Interval</label>
-            <select class="input" id="goesInterval" onchange="applyImageDisplay();checkDirty()">
-              <option value="300">5 minutes</option>
-              <option value="600" selected>10 minutes</option>
-              <option value="900">15 minutes</option>
-              <option value="1800">30 minutes</option>
-              <option value="3600">1 hour</option>
-              <option value="7200">2 hours</option>
-            </select>
-            <div class="field-hint">How often the image refreshes.</div>
-          </div>
-          </div>
-          <div id="goesGroup">
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Region</label>
-            <select class="input" id="goesRegion" onchange="applyImageDisplay();checkDirty()">
-              <option value="umv">Upper Mississippi Valley</option>
-              <option value="cgl">Great Lakes</option>
-              <option value="ne">Northeast</option>
-              <option value="se">Southeast</option>
-              <option value="smv">Southern Mississippi Valley</option>
-              <option value="sp">Southern Plains</option>
-              <option value="nr">Northern Rockies</option>
-              <option value="sr">Southern Rockies</option>
-              <option value="pnw">Pacific Northwest</option>
-              <option value="psw">Pacific Southwest</option>
-              <option value="eus">U.S. Atlantic Coast</option>
-              <option value="pr">Puerto Rico</option>
-              <option value="mex">Mexico</option>
-              <option value="cam">Central America</option>
-              <option value="car">Caribbean</option>
-              <option value="ga">Gulf of America</option>
-              <option value="can">Canada</option>
-              <option value="na">Northern Atlantic</option>
-              <option value="taw">Tropical Atlantic</option>
-              <option value="eep">Eastern Pacific</option>
-              <option value="nsa">South America (North)</option>
-              <option value="ssa">South America (South)</option>
-            </select>
-            <div class="field-hint">GOES-19 GEOCOLOR sector for satellite imagery</div>
-          </div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">GOES Rotation</label>
-            <select class="input" id="goesOrientation" onchange="applyImageDisplay();checkDirty()">
-              <option value="0">0&deg;</option>
-              <option value="1">90&deg;</option>
-              <option value="2">180&deg;</option>
-              <option value="3">270&deg;</option>
-            </select>
-            <div class="field-hint">Rotate the satellite image clockwise.</div>
-          </div>
-          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
-            <span class="toggle-label">Flip vertical</span>
-            <label class="toggle"><input type="checkbox" id="goesVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the satellite image top-to-bottom.</div>
-          <div class="toggle-row">
-            <span class="toggle-label">Flip horizontal</span>
-            <label class="toggle"><input type="checkbox" id="goesHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the satellite image left-to-right.</div>
-          <div class="field" style="margin-top:16px">
-            <button onclick="fetchGoesPreview()" class="btn btn-primary" id="goesPreviewBtn" style="width:100%">Fetch Preview</button>
-          </div>
-          <div id="goesPreviewContainer" style="display:none;margin-top:12px;text-align:center">
-            <img id="goesPreviewImg" style="max-width:100%;border-radius:10px;border:1px solid rgba(255,255,255,0.1)" />
-          </div>
-          </div>
-          <div id="moonGroup" style="display:none">
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Background</label>
-            <select class="input" id="moonBg" onchange="applyImageDisplay();checkDirty()">
-              <option value="0">Plain black</option>
-              <option value="1">Starfield</option>
-              <option value="2">Soft glow</option>
-              <option value="3">Starfield + Glow</option>
-            </select>
-            <div class="field-hint">Sets what renders behind the moon disc (plain black, starfield, soft glow, or both).</div>
-          </div>
-          <div class="field-hint" style="margin-top:12px">The moon view uses the device location set on the System tab.</div>
-          <div class="field">
-            <label class="field-label">Moon drag lighting</label>
-            <select class="input" id="moonDragLight" onchange="applyImageDisplay();checkDirty()">
-              <option value="0">True phase</option>
-              <option value="1">Explore (full-lit)</option>
-              <option value="2">Locked to surface</option>
-            </select>
-            <div class="field-hint">How the Moon is lit while you drag to rotate it. True phase keeps the real terminator; Explore lights the whole surface.</div>
-          </div>
-          <div class="card">
-            <div class="card-title"><span class="card-title-label">Moon Orientation <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-          <div class="help-popover"><div class="help-popover-title">Moon appearance and orientation</div><p>Corrects how the rendered moon is oriented and how it responds to dragging. Keep Moon upright (north-up) holds the moon's north pole at the top like phone apps and NASA imagery; turning it off tilts the disc to match how the real moon sits in your local sky as it moves. The device location set on the System tab is used for an accurate sky-tilt and terminator.</p><p>Flip horizontal (U) and Flip vertical (V) mirror the image for displays or mounts that reverse it. The Roll, Yaw, and Pitch offset sliders nudge the moon from its standard orientation, and Reset orientation returns them to that standard view.</p><p>Free-spin mode changes drag behavior. Off, the disc rubber-bands back to the live sky as soon as you release it. On, the disc holds your spin and eases back after the Return to live view timeout (3 to 60 seconds). Example: enable Free-spin, set the return to 15s, drag to inspect the far limb, and the view holds for 15 seconds before returning to live.</p></div>
-          <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-            <span class="toggle-label">Keep Moon upright (north-up)</span>
-            <label class="toggle"><input type="checkbox" id="moon_north_up" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint" style="margin-bottom:12px">On: Moon's north pole stays up like apps/NASA. Off: tilts to match the real sky as the Moon moves.</div>
-          <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-            <span class="toggle-label">Flip horizontal (U)</span>
-            <label class="toggle"><input type="checkbox" id="moon_flip_u" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the moon left-to-right for reversed displays or mounts.</div>
-          <div class="toggle-row">
-            <span class="toggle-label">Flip vertical (V)</span>
-            <label class="toggle"><input type="checkbox" id="moon_flip_v" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the moon top-to-bottom.</div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Roll offset</label>
-            <div class="slider-group">
-              <input type="range" class="slider" id="moon_roll_offset" min="-180" max="180" step="1" value="0" oninput="updateMoonOrientReadout('moon_roll');applyImageDisplay();checkDirty()">
-              <span class="slider-val" id="moon_roll_val">0&deg;</span>
-            </div>
-            <div class="field-hint">Rotates the moon in the screen plane, -180 to 180 degrees from default.</div>
-          </div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Yaw offset</label>
-            <div class="slider-group">
-              <input type="range" class="slider" id="moon_yaw_offset" min="-180" max="180" step="1" value="0" oninput="updateMoonOrientReadout('moon_yaw');applyImageDisplay();checkDirty()">
-              <span class="slider-val" id="moon_yaw_val">0&deg;</span>
-            </div>
-            <div class="field-hint">Turns the moon left/right about its vertical axis, -180 to 180 degrees from default.</div>
-          </div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Pitch offset</label>
-            <div class="slider-group">
-              <input type="range" class="slider" id="moon_pitch_offset" min="-90" max="90" step="1" value="0" oninput="updateMoonOrientReadout('moon_pitch');applyImageDisplay();checkDirty()">
-              <span class="slider-val" id="moon_pitch_val">0&deg;</span>
-            </div>
-            <div class="field-hint">Tilts the moon up or down, from -90 to 90 degrees relative to its standard orientation.</div>
-          </div>
-          <hr class="divider">
-          <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-            <span class="toggle-label">Free-spin mode</span>
-            <label class="toggle"><input type="checkbox" id="moon_spin_mode" onchange="updateMoonSpinUI();applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint" style="margin-bottom:12px">Off: dragged disc snaps back to the live sky immediately (rubber band). On: the disc holds your spin, then eases back after the timeout below.</div>
-          <div class="field" style="margin-top:16px" id="moonSpinReturnField">
-            <label class="field-label">Return to live view after</label>
-            <div class="slider-group">
-              <input type="range" class="slider" id="moon_spin_return_s" min="3" max="60" step="1" value="3" oninput="updateMoonOrientReadout('moon_spin_return');applyImageDisplay();checkDirty()">
-              <span class="slider-val" id="moon_spin_return_val">3s</span>
-            </div>
-            <div class="field-hint">Only applies in free-spin mode.</div>
-          </div>
-          <div class="field" style="margin-top:16px">
-            <button onclick="resetMoonOrientation()" class="btn" id="moonOrientResetBtn" style="width:100%">Reset orientation</button>
-          </div>
-          </div>
-          </div>
-          <div id="solarGroup" style="display:none">
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Band</label>
-            <select class="input" id="solarBand" onchange="applyImageDisplay();checkDirty()">
-              <option value="0">AIA 94 (Fe XVIII)</option>
-              <option value="1">AIA 131 (Fe XX)</option>
-              <option value="2">AIA 171 (Fe IX/X)</option>
-              <option value="3">AIA 193 (Fe XII)</option>
-              <option value="4">AIA 211 (Fe XIV)</option>
-              <option value="5">AIA 304 (He II)</option>
-              <option value="6">AIA 335 (Fe XVI)</option>
-              <option value="7">AIA 1600 (C IV+cont)</option>
-              <option value="8">AIA 1700 (continuum)</option>
-              <option value="9">AIA 4500 (continuum)</option>
-              <option value="10">LASCO C2 (coronagraph)</option>
-              <option value="11">LASCO C3 (coronagraph)</option>
-              <option value="12">SOHO EIT 171</option>
-              <option value="13">SOHO EIT 195</option>
-              <option value="14">SOHO EIT 284</option>
-              <option value="15">SOHO EIT 304</option>
-              <option value="16">SDO/HMI Continuum</option>
-              <option value="17">SDO/HMI Magnetogram</option>
-            </select>
-            <div class="field-hint">NASA SDO/AIA and SOHO realtime (LASCO, EIT, HMI)</div>
-          </div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Solar Rotation</label>
-            <select class="input" id="solarOrientation" onchange="applyImageDisplay();checkDirty()">
-              <option value="0">0&deg;</option>
-              <option value="1">90&deg;</option>
-              <option value="2">180&deg;</option>
-              <option value="3">270&deg;</option>
-            </select>
-            <div class="field-hint">Rotate the solar image clockwise.</div>
-          </div>
-          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
-            <span class="toggle-label">Flip vertical</span>
-            <label class="toggle"><input type="checkbox" id="solarVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the solar image top-to-bottom.</div>
-          <div class="toggle-row">
-            <span class="toggle-label">Flip horizontal</span>
-            <label class="toggle"><input type="checkbox" id="solarHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the solar image left-to-right.</div>
-          </div>
-          <div id="customGroup" style="display:none">
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Image URL</label>
-            <input class="input" id="customImageUrl" type="url" placeholder="https://picsum.photos/720" onchange="applyImageDisplay();updateImgCustomPillHint();checkDirty()">
-            <div class="field-hint">JPEG only. Max 1024x1024 pixels, max 1 MB. PNG and WebP are not supported.</div>
-          </div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Custom Rotation</label>
-            <select class="input" id="customOrientation" onchange="applyImageDisplay();checkDirty()">
-              <option value="0">0&deg;</option>
-              <option value="1">90&deg;</option>
-              <option value="2">180&deg;</option>
-              <option value="3">270&deg;</option>
-            </select>
-            <div class="field-hint">Rotate the custom image clockwise.</div>
-          </div>
-          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
-            <span class="toggle-label">Flip vertical</span>
-            <label class="toggle"><input type="checkbox" id="customVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the custom image top-to-bottom.</div>
-          <div class="toggle-row">
-            <span class="toggle-label">Flip horizontal</span>
-            <label class="toggle"><input type="checkbox" id="customHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Mirrors the custom image left-to-right.</div>
-          <div class="field" style="margin-top:16px">
-            <label class="field-label">Update Interval</label>
-            <select class="input" id="customInterval" onchange="applyImageDisplay();checkDirty()">
-              <option value="10">10 seconds</option>
-              <option value="30">30 seconds</option>
-              <option value="60" selected>1 minute</option>
-              <option value="300">5 minutes</option>
-              <option value="600">10 minutes</option>
-              <option value="1800">30 minutes</option>
-              <option value="3600">1 hour</option>
-              <option value="7200">2 hours</option>
-            </select>
-            <div class="field-hint">How often the custom image refreshes.</div>
-          </div>
-          <div class="field" style="margin-top:16px">
-            <button onclick="fetchCustomPreview()" class="btn btn-primary" id="customPreviewBtn" style="width:100%">Refresh on Device</button>
-          </div>
-          </div>
-        </div>
-      </div>
-
-    </div>
+    <!-- Markup extracted to main/fragment_image_display.html (P6c); lazily
+         fetched by ensureTabLoaded() via GET /ui/fragment?tab=image-display
+         and injected here. Filename uses an underscore (tab name has a
+         hyphen) -- see s_ui_fragments[] in web_handlers_config.c for the
+         name->symbol mapping. -->
+    <div id="tab-image-display" class="tab-panel"></div>
 
     <!-- ==================== TAB 1: DISPLAY ==================== -->
-    <div id="tab-display" class="tab-panel">
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Appearance <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Appearance</div><p>Controls the look of the dashboard: the color theme, the visual style applied to widget panels, and the brightness of on-screen text. All three apply live as you change them and persist when you save.</p><p>Theme sets the color palette across every page. Widget Style changes only how the dashboard panels are drawn (borders, glass, inset, and similar). Text brightness scales the foreground text color, separate from the backlight in the Hardware card below.</p><p>Example: pick the Red Night theme to preserve dark adaptation at the telescope, then lower Text brightness to 50% if labels are still too bright.</p></div>
-        <div class="field">
-          <label class="field-label">Theme</label>
-          <select class="input" id="theme_select" onchange="setTheme(this.value)">
-            <option value="0">Default</option>
-            <option value="1">Red Night</option>
-            <option value="2">Cyber Dusk</option>
-            <option value="3">Stellar Ember</option>
-            <option value="4">Arctic Steel</option>
-            <option value="5">Oxidized Copper</option>
-            <option value="6">Solar Flare</option>
-            <option value="7">Phantom Green</option>
-            <option value="8">Bloodmoon</option>
-          </select>
-          <div class="field-hint">Color palette applied across all pages; changes preview immediately.</div>
-        </div>
-        <div class="field">
-          <label class="field-label">Widget Style</label>
-          <select class="input" id="widget_style_select" onchange="setWidgetStyle(this.value)">
-            <option value="0">Default</option>
-            <option value="1">Subtle Border</option>
-            <option value="2">Soft Inset</option>
-            <option value="3">Frosted Glass</option>
-            <option value="4">Chamfered</option>
-            <option value="5">Double Border</option>
-            <option value="6">Raised Slab</option>
-            <option value="7">Gradient Fade</option>
-            <option value="8">Scanline</option>
-            <option value="9">Pillar</option>
-            <option value="10">Stepped Edge</option>
-            <option value="11">Horizon Line</option>
-            <option value="12">Ember Ring</option>
-          </select>
-          <div class="field-hint">Visual treatment of the dashboard panels only, with no effect on colors or layout.</div>
-        </div>
-        <div class="field">
-          <label class="field-label">Text brightness</label>
-          <div class="slider-group">
-            <input type="range" class="slider" id="color_brightness" min="0" max="100" value="80" oninput="setColorBrightness(this.value)">
-            <span class="slider-val" id="color_brightness_val">80%</span>
-          </div>
-          <div class="field-hint">Scales on-screen text brightness, independent of the screen backlight below.</div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Hardware <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Hardware</div><p>Physical display controls: screen rotation, backlight level, and automatic screen off. All apply live and persist when you save.</p><p>Screen Rotation reorients the entire UI in 90-degree steps for sideways or upside-down mounting. Backlight sets the panel brightness, separate from the Text brightness control above. Turn off screen when idle blanks the backlight after a period with no touch; the firmware keeps running and the next touch wakes the screen.</p><p>Example: if the device is mounted with the USB port facing up, set Screen Rotation to 180 degrees so the dashboard reads right-side up.</p></div>
-        <div class="subsection">
-        <div class="subsection-title">Display</div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">Screen Rotation</label>
-            <select class="input" id="screen_rotation_select" onchange="setScreenRotation(this.value)">
-              <option value="0">0° (Default)</option>
-              <option value="1">90°</option>
-              <option value="2">180°</option>
-              <option value="3">270°</option>
-            </select>
-            <div class="field-hint">Rotates the whole UI in 90-degree steps to match the physical mounting.</div>
-          </div>
-          <div class="field">
-            <label class="field-label">Backlight</label>
-            <div class="slider-group">
-              <input type="range" class="slider" id="brightness" min="0" max="100" value="80" oninput="setBrightness(this.value)">
-              <span class="slider-val" id="brightness_val">80%</span>
-            </div>
-            <div class="field-hint">Panel backlight level, separate from Text brightness above.</div>
-          </div>
-        </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Screen Sleep</div>
-        <div class="toggle-row">
-          <span class="toggle-label">Turn off screen when idle</span>
-          <label class="toggle"><input type="checkbox" id="screen_sleep_enabled"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint" style="margin-top:4px">Blanks the backlight after the timeout while the firmware keeps running; touch wakes the screen.</div>
-        <div id="screen_sleep_details" style="margin-top:16px">
-          <div class="row stack-mobile">
-            <div class="field">
-              <label class="field-label">Timeout (seconds)</label>
-              <input type="number" class="input" id="screen_sleep_timeout" min="10" max="3600" value="60">
-              <div class="field-hint">Idle time with no touch before the screen blanks, from 10 to 3600 seconds.</div>
-            </div>
-          </div>
-        </div>
-        </div>
-      </div>
-    </div>
+    <!-- Markup extracted to main/fragment_display.html (P6d); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=display and injected here. -->
+    <div id="tab-display" class="tab-panel"></div>
 
     <!-- ==================== TAB 3: BEHAVIOR & ALERTS ==================== -->
-    <div id="tab-behavior" class="tab-panel">
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Page Navigation <span id="pm_summary" style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted);font-size:0.7rem"></span> <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Page Navigation</div><p>The display chooses a page automatically. Swipe or tap any time to take over; it returns to its automatic choice after the stay-on-page time. This table shows what appears in each situation.</p><table class="help-scenario"><thead><tr><th>In this situation</th><th>You'll see</th></tr></thead><tbody><tr><td>Always show the Home Page is on</td><td>Your Home Page, always (swipes return after the stay-on-page time)</td></tr><tr><td>You just swiped or tapped</td><td>That page, held briefly</td></tr><tr><td>Auto Cycle is on</td><td>Pages rotate in turn</td></tr><tr><td>One NINA instance online</td><td>That instance's dashboard</td></tr><tr><td>Several instances online</td><td>Your Home instance if it is one of them, otherwise the Summary page</td></tr><tr><td>All instances offline, "Switch when no connections" on</td><td>Your chosen fallback page</td></tr><tr><td>All instances offline, that option off</td><td>Your Home Page</td></tr><tr><td>Quiet, nothing happening</td><td>Your Home Page</td></tr></tbody></table></div>
-
-        <div class="subsection">
-        <div class="subsection-title">Home Page</div>
-        <div class="pn-pill-grid" id="start-page-pills"></div>
-        <div class="field-hint">The page the display settles on; when set to a NINA instance, the display also returns to that instance whenever it is online.</div>
-
-        <div class="toggle-row" style="margin-top:12px">
-          <div>
-            <span class="toggle-label">Always show the Home Page</span>
-            <div class="field-hint" style="margin-top:2px">Keeps the display on the Home Page at all times, even while instances are connected. You can still swipe to other pages; the display returns to the Home Page after the stay-on-page time.</div>
-          </div>
-          <label class="toggle"><input type="checkbox" id="home_page_lock" onchange="toggleHomeLock();checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        </div>
-
-        <div class="subsection">
-        <div class="subsection-title">Auto Cycle</div>
-        <div class="toggle-row">
-          <div>
-            <span class="toggle-label">Auto Cycle</span>
-            <div style="font-size:0.72rem;color:var(--text-muted);margin-top:2px;">Rotate through pages automatically</div>
-            <div class="field-hint" style="margin-top:2px">When enabled, overrides "Switch page when no connections" below</div>
-          </div>
-          <label class="toggle"><input type="checkbox" id="auto_cycle_toggle" onchange="toggleAutoCycle();checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-
-        <div class="pn-cycle-settings" id="pn_cycle_settings" style="display:none">
-          <div class="row stack-mobile">
-            <div class="field">
-              <label class="field-label">Interval (seconds)</label>
-              <input type="number" class="input" id="auto_rotate_interval" min="4" max="3600" value="30">
-              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600.</div>
-            </div>
-            <div class="field">
-              <label class="field-label">Transition</label>
-              <select class="input" id="auto_rotate_effect">
-                <option value="0">Instant</option>
-                <option value="1">Fade</option>
-                <option value="2">Slide Left</option>
-                <option value="3">Slide Right</option>
-              </select>
-              <div class="field-hint">Animation used when Auto Cycle changes pages.</div>
-            </div>
-          </div>
-          <div class="toggle-row">
-            <span class="toggle-label" style="font-size:0.82rem;color:var(--text-muted)">Skip disconnected nodes</span>
-            <label class="toggle"><input type="checkbox" id="auto_rotate_skip"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">During Auto Cycle, skip NINA instance pages that are not connected.</div>
-          <div class="pn-sub-divider"></div>
-          <div>
-            <div class="pn-section-label">Pages in Rotation</div>
-            <div style="font-size:0.72rem;color:var(--text-muted);margin:-8px 0 10px;opacity:0.7">Drag to reorder</div>
-            <div class="pn-pill-grid reorderable" id="arp-container"></div>
-            <div class="field-hint">Pick which pages and image sources rotate, and drag to set the order.</div>
-            <div class="field-hint">Note: Image pages (GOES, Solar, and Custom URL) download a fresh image from their source each time the rotation reaches them, even if their refresh interval has not elapsed yet. Shorter rotation intervals mean more frequent downloads from those image servers.</div>
-          </div>
-        </div>
-        </div>
-
-        <div class="subsection">
-        <div class="subsection-title">Manual Navigation</div>
-        <div class="field">
-          <label class="field-label">Stay on selected page (seconds)</label>
-          <input type="number" class="input" id="nav_grace_s" min="10" max="300" value="10">
-          <div class="field-hint" style="margin-top:2px">After you swipe or tap to a page, the display keeps showing it for this long, then returns on its own to the page it would normally show (the connected instance, or your Home page).</div>
-        </div>
-        </div>
-
-        <div class="subsection">
-        <div class="subsection-title">When Disconnected</div>
-        <div class="toggle-row">
-          <div>
-            <span class="toggle-label">Switch page when no connections</span>
-            <div class="field-hint" style="margin-top:2px">Automatically switches to the selected page when all NINA instances are disconnected, then resumes auto-rotate (if enabled) on reconnect.</div>
-          </div>
-          <label class="toggle"><input type="checkbox" id="idle_page_override_enabled" onchange="toggleIdleOverride();checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field" id="idle_target_field" style="display:none;margin-top:12px">
-          <label class="field-label">Target page</label>
-          <!-- Options populated dynamically from the device page registry (GET /api/pages) by populatePageControls(). -->
-          <select class="input" id="idle_page_override_target"></select>
-          <div class="field-hint">Page shown while every enabled NINA instance is confirmed disconnected.</div>
-          <div class="toggle-row" style="margin-top:12px">
-            <div>
-              <span class="toggle-label">Show idle indicator</span>
-              <div class="field-hint" style="margin-top:2px">Shows a small status dot on the idle page when all NINA instances are disconnected</div>
-            </div>
-            <label class="toggle"><input type="checkbox" id="idle_indicator_enabled" onchange="checkDirty()"><span class="toggle-track"></span></label>
-          </div>
-        </div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Notifications <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Notifications</div><p>Controls on-screen pop-up notifications, the border-flash alerts, and which event categories produce notifications. Notification duration sets how long a normal pop-up stays visible; error and warning pop-ups show for twice that time. Border flash alerts flash the screen edge when an RMS, HFR, or safety threshold is exceeded.</p><p>The aggregation window combines a burst of notifications that arrive close together into one, which reduces clutter during noisy events; set it to 0 to show every notification individually. The Event Categories toggles decide which kinds of events generate notifications at all; turning a category off suppresses its notifications.</p><p>Example: keep Error Events and Safety Events on, turn Focuser and Guider Events off to cut routine chatter, and set the aggregation window to 5 seconds so rapid sequence updates collapse into a single notification.</p></div>
-        <div class="subsection">
-        <div class="subsection-title">Alerts</div>
-        <div class="field" style="margin-bottom:16px">
-          <label class="field-label">Toast duration (s)</label>
-          <input type="number" class="input" id="toast_duration" min="3" max="30" value="8">
-          <div class="field-hint">Errors and warnings show for 2x this value</div>
-        </div>
-        <div class="toggle-row">
-          <span class="toggle-label">Border flash alerts</span>
-          <label class="toggle"><input type="checkbox" id="alert_flash_enabled" checked><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint" style="margin-top:4px">Flash the screen border when RMS, HFR, or safety thresholds are exceeded.</div>
-        <div class="field" style="margin-top:16px">
-          <label class="field-label">Aggregation Window</label>
-          <div class="slider-group">
-            <input type="range" class="slider" id="toast_aggregation_window" min="0" max="15" value="5" oninput="updateAggregationLabel(this.value);checkDirty()">
-            <span class="slider-val" id="toast_aggregation_val">5s</span>
-          </div>
-          <div class="field-hint">Combine rapid-fire notifications within this window. 0 = Off (show each individually).</div>
-        </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Event Categories</div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Error Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_8" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Equipment Connects</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_0" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Equipment Disconnects</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_1" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Sequence Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_2" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Focuser Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_3" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Mount Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_4" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Meridian Flip</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_5" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Guider Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_6" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Safety Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_7" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Profile Changes</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_9" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Dome Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_10" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        <div class="toggle-row">
-          <span class="toggle-label">Flat Device Events</span>
-          <label class="toggle"><input type="checkbox" id="notify_cat_11" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
-        </div>
-        </div>
-      </div>
-    </div>
+    <!-- Markup extracted to main/fragment_behavior.html (P6d); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=behavior and injected here. -->
+    <div id="tab-behavior" class="tab-panel"></div>
 
     <!-- ==================== TAB 4: SYSTEM ==================== -->
-    <div id="tab-system" class="tab-panel">
-
-      <div class="sys-metrics">
-          <div class="sys-metric m-temp">
-            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/></svg> Temperature</div>
-            <div class="sm-value"><span class="mv" id="mTemp">--</span></div>
-          </div>
-          <div class="sys-metric m-up">
-            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> Uptime</div>
-            <div class="sm-value"><span class="mv" id="mUptime">--</span></div>
-          </div>
-          <div class="sys-metric m-mem">
-            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="6" width="16" height="12" rx="2"/><path d="M8 6V4m4 2V4m4 2V4M8 18v2m4-2v2m4-2v2"/></svg> Internal Heap</div>
-            <div class="sm-value"><span class="mv" id="mMem">--</span></div>
-          </div>
-          <div class="sys-metric m-psram">
-            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3"/></svg> PSRAM</div>
-            <div class="sm-value"><span class="mv" id="mPsram">--</span></div>
-          </div>
-          <div class="sys-metric m-wifi">
-            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12.55a11 11 0 0 1 14.08 0M1.42 9a16 16 0 0 1 21.16 0M8.53 16.11a6 6 0 0 1 6.95 0M12 20h.01"/></svg> WiFi Signal</div>
-            <div class="sm-value"><span class="bars" id="mWifiBars"></span><span class="mv" id="mWifi">--</span></div>
-          </div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Network <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Network and time</div><p>The device connects to your WiFi and also broadcasts its own setup WiFi network at the same time. It joins one of the three configured networks to reach your NINA computers; its own setup network uses the device hostname as the network name with password 12345678, so you can reach the settings for first-time setup without a separate screen. The three networks are priority-ordered: Network 1 is tried first, then 2, then 3.</p><p>Hostname is used on your network, as the setup network name, and as the Home Assistant device name. NTP server and timezone set the clock used on the clock page and in timestamps; the timezone list carries the correct local-time and daylight-saving rules.</p><p>Example: hostname ninadash1 produces access point SSID ninadash1 and the device is reachable at ninadash1.lan. Changes here take effect after a reboot.</p></div>
-        <div class="wifi-scan-panel" id="wifiScanPanel">
-          <div class="wifi-scan-header" onclick="toggleScanPanel()">
-            <span class="wifi-scan-title"><span class="chevron collapsed" id="scanChevron">&#x25BC;</span> Available Networks</span>
-            <span class="wifi-scan-rescan" id="scanRescanBtn" onclick="event.stopPropagation();scanWifi()">&#x21bb; Rescan</span>
-          </div>
-          <div class="wifi-scan-list collapsed" id="wifiScanList">
-            <div class="wifi-scan-status" id="wifiScanStatus">Scanning for networks...</div>
-          </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Device Name</div>
-        <div class="field">
-          <label class="field-label">Device hostname</label>
-          <input type="text" class="input" id="hostname" placeholder="NINA-DISPLAY" maxlength="31" pattern="[A-Za-z0-9\-]+" style="max-width:320px">
-          <div class="field-hint">Used on your network, as the setup WiFi network name, and as the Home Assistant device name.</div>
-        </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">WiFi Networks</div>
-        <div class="field">
-          <div class="field-label" style="font-weight:600;color:var(--accent)">Network 1 (Primary)</div>
-          <label class="field-label">SSID</label>
-          <input type="text" class="input" id="ssid1" placeholder="Network name">
-          <div class="field-hint">Highest-priority network; the device connects to this one first when it is in range.</div>
-          <label class="field-label">Password</label>
-          <input type="password" class="input" id="pass1" placeholder="Enter new password to change">
-          <div class="hint">Password is stored in device config and not readable</div>
-
-          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Network 2</div>
-          <label class="field-label">SSID</label>
-          <input type="text" class="input" id="ssid2" placeholder="Network name">
-          <div class="field-hint">Fallback joined only when Network 1 is unavailable.</div>
-          <label class="field-label">Password</label>
-          <input type="password" class="input" id="pass2" placeholder="Enter new password to change">
-
-          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Network 3</div>
-          <label class="field-label">SSID</label>
-          <input type="text" class="input" id="ssid3" placeholder="Network name">
-          <div class="field-hint">Second fallback joined only when Networks 1 and 2 are unavailable.</div>
-          <label class="field-label">Password</label>
-          <input type="password" class="input" id="pass3" placeholder="Enter new password to change">
-        </div>
-        <div class="toggle-row">
-          <span class="toggle-label">WiFi power save</span>
-          <label class="toggle"><input type="checkbox" id="wifi_power_save" checked><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint">Lets the WiFi radio rest between updates to save power. The device stays connected, so there is no reconnect delay.</div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Time</div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">NTP server</label>
-            <input type="text" class="input" id="ntp" placeholder="pool.ntp.org">
-            <div class="field-hint">Hostname of the time server used to set the clock; pool.ntp.org works for most locations.</div>
-          </div>
-          <div class="field">
-            <label class="field-label">Timezone</label>
-            <select class="input" id="timezone">
-              <option value="">UTC (default)</option>
-              <option value="GMT0">GMT</option>
-              <option value="GMT0BST,M3.5.0/1,M10.5.0">UK (GMT/BST)</option>
-              <option value="CET-1CEST,M3.5.0,M10.5.0/3">Central Europe (CET/CEST)</option>
-              <option value="EET-2EEST,M3.5.0/3,M10.5.0/4">Eastern Europe (EET/EEST)</option>
-              <option value="EST5EDT,M3.2.0,M11.1.0">US Eastern (EST/EDT)</option>
-              <option value="CST6CDT,M3.2.0,M11.1.0">US Central (CST/CDT)</option>
-              <option value="MST7MDT,M3.2.0,M11.1.0">US Mountain (MST/MDT)</option>
-              <option value="MST7">US Arizona (MST, no DST)</option>
-              <option value="PST8PDT,M3.2.0,M11.1.0">US Pacific (PST/PDT)</option>
-              <option value="AKST9AKDT,M3.2.0,M11.1.0">US Alaska (AKST/AKDT)</option>
-              <option value="HST10">US Hawaii (HST, no DST)</option>
-              <option value="AEST-10AEDT,M10.1.0,M4.1.0/3">Australia Eastern (AEST/AEDT)</option>
-              <option value="ACST-9:30ACDT,M10.1.0,M4.1.0/3">Australia Central (ACST/ACDT)</option>
-              <option value="AWST-8">Australia Western (AWST, no DST)</option>
-              <option value="NZST-12NZDT,M9.5.0,M4.1.0/3">New Zealand (NZST/NZDT)</option>
-              <option value="JST-9">Japan (JST)</option>
-              <option value="CST-8">China (CST)</option>
-              <option value="IST-5:30">India (IST)</option>
-              <option value="<-03>3">Argentina (ART)</option>
-              <option value="<-03>3<-02>,M10.3.0/0,M2.3.0/0">Brazil (BRT/BRST)</option>
-              <option value="SAST-2">South Africa (SAST)</option>
-            </select>
-            <div class="field-hint">Select your region so local time and daylight-saving transitions are applied to displayed times.</div>
-          </div>
-        </div>
-        </div>
-        <div class="field-hint hint-center">Reboot required after changing hostname, WiFi, NTP, or timezone.</div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Location <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Location</div><p>Sets the device location used by location-based features: the weather forecast on the clock page and the moon phase view. Type a city name and select Look up to fill the coordinates automatically.</p><p>You can also enter latitude and longitude by hand, for example from a GPS reading or an online map.</p></div>
-        <div class="field-hint" style="margin-bottom:12px">This location is used by the weather forecast on the clock page and by the moon phase view.</div>
-        <div class="field" id="weather_city_lookup_field">
-          <label class="field-label">Location</label>
-          <div style="display:flex;gap:10px">
-            <input type="text" class="input" id="weather_location_search" placeholder="Search city name..." style="flex:1">
-            <button class="btn btn-outline" onclick="lookupCity()" type="button">Look up</button>
-          </div>
-          <div id="city_results" style="display:none;margin-top:6px;background:rgba(0,0,0,0.4);border:1px solid rgba(255,255,255,0.08);border-radius:10px;max-height:200px;overflow-y:auto"></div>
-          <div class="field-hint">Type a city name and select Look up to auto-fill latitude, longitude, and location name.</div>
-        </div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">Latitude</label>
-            <input type="number" class="input" id="weather_lat" step="0.0001" placeholder="0.0000">
-            <div class="field-hint">Decimal degrees, positive north (e.g. 39.7392); needed when not using city lookup.</div>
-          </div>
-          <div class="field">
-            <label class="field-label">Longitude</label>
-            <input type="number" class="input" id="weather_lon" step="0.0001" placeholder="0.0000">
-            <div class="field-hint">Decimal degrees, positive east, negative west (e.g. -104.9903).</div>
-          </div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Power Management <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Power Management</div><p>Controls deep sleep. Deep sleep powers the device down on a long-press of the BOOT button or, optionally, after extended disconnection from all NINA instances. While asleep the display is off and the device is not reachable over the network.</p><p>The wake timer sets how many hours pass before the device wakes itself from deep sleep. A value of 0 means it stays asleep until physically rebooted.</p><p>Example: leave deep sleep off for an always-mounted display so the dashboard stays reachable over the network at all times.</p></div>
-        <div class="toggle-row">
-          <span class="toggle-label">Enable deep sleep (long-press BOOT to power off)</span>
-          <label class="toggle"><input type="checkbox" id="deep_sleep_enabled"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint" style="margin-top:4px">Allows a long-press of the BOOT button to power the device into deep sleep.</div>
-        <div id="deep_sleep_details" style="margin-top:16px">
-          <div class="field">
-            <label class="field-label">Wake timer (hours)</label>
-            <input type="number" class="input" id="deep_sleep_wake_timer" min="0" max="72" step="1" value="0">
-            <div class="field-hint">Hours until auto-wake. 0 = stay asleep forever. Warning: with timer set to 0, the device must be physically rebooted to wake up; there is no manual wake from deep sleep.</div>
-          </div>
-          <div class="toggle-row">
-            <span class="toggle-label">Auto power off when idle</span>
-            <label class="toggle"><input type="checkbox" id="deep_sleep_on_idle"><span class="toggle-track"></span></label>
-          </div>
-          <div class="field-hint">Enter deep sleep after extended disconnection from all NINA instances. The device must be physically rebooted to wake up if the wake timer is set to 0.</div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">MQTT <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">MQTT publishing</div><p>Publishes this device's own state to an MQTT broker and exposes it in Home Assistant. It does not republish N.I.N.A. session data. Auto-discovery config messages are sent so Home Assistant creates the entities automatically, with no manual setup: screen brightness and text brightness (both controllable), a reboot button, and an uptime sensor.</p><p>Broker host and port point at your MQTT server. Topic prefix is added to the front of every topic the device sends, so multiple displays can share one broker without collision. Username and password are sent only if your broker requires authentication; leave them blank for anonymous brokers.</p><p>Example: broker host 192.168.1.250, port 1883, topic prefix ninadisplay publishes under ninadisplay/... and appears in Home Assistant as a device named after the hostname.</p></div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Enable MQTT</span>
-          <label class="toggle"><input type="checkbox" id="mqtt_enabled"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint" style="margin-top:4px">Turn on publishing of the device's own state and Home Assistant auto-discovery to the broker.</div>
-        <div class="subsection">
-        <div class="subsection-title">Broker</div>
-        <div class="field">
-          <label class="field-label">Broker host</label>
-          <input type="text" class="input" id="mqtt_broker" placeholder="192.168.1.250">
-          <div class="field-hint">IP address or hostname of your MQTT broker.</div>
-        </div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">Port</label>
-            <input type="text" class="input" id="mqtt_port" placeholder="1883">
-            <div class="field-hint">Broker TCP port; 1883 for plain MQTT is the common default.</div>
-          </div>
-          <div class="field">
-            <label class="field-label">Topic prefix</label>
-            <input type="text" class="input" id="mqtt_prefix" placeholder="ninadisplay">
-            <div class="field-hint">Added to the front of every topic the device sends; use a unique value per device.</div>
-          </div>
-        </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Authentication</div>
-        <div class="row stack-mobile">
-          <div class="field">
-            <label class="field-label">Username</label>
-            <input type="text" class="input" id="mqtt_user" placeholder="Username">
-            <div class="field-hint">Leave blank if the broker allows anonymous connections.</div>
-          </div>
-          <div class="field">
-            <label class="field-label">Password</label>
-            <input type="password" class="input" id="mqtt_pass" placeholder="Password">
-            <div class="field-hint">Leave blank if the broker allows anonymous connections.</div>
-          </div>
-        </div>
-        </div>
-        <div class="field-hint hint-center">Reboot required after changing MQTT settings.</div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Firmware <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Firmware and updates</div><p>The info grid is read-only build detail: running version and build date, the ESP-IDF version, and the exact release version. Updates are pulled from GitHub releases; the device keeps the previous firmware so a failed or bad update can roll back automatically.</p><p>Check for updates on boot queries GitHub at startup. Update channel selects which releases qualify: Stable only ignores pre-releases, Include pre-releases also offers beta builds. Check for Updates queries now and, if a newer build exists, shows release notes and an Install button. The file picker below it flashes a local .bin you supply instead of downloading from GitHub.</p><p>Example: set Update channel to Stable only and leave Check for updates on boot enabled to be notified of tagged releases without receiving test builds.</p></div>
-        <div class="fw-grid">
-          <div class="fw-item"><div class="fw-label">Version</div><div class="fw-value" id="fw_version">--</div></div>
-          <div class="fw-item"><div class="fw-label">Built</div><div class="fw-value" id="fw_date">--</div></div>
-          <div class="fw-item"><div class="fw-label">IDF</div><div class="fw-value" id="fw_idf">--</div></div>
-          <div class="fw-item"><div class="fw-label">Partition</div><div class="fw-value" id="fw_partition">--</div></div>
-          <div class="fw-item"><div class="fw-label">Release</div><div class="fw-value" id="fw_git_tag">--</div></div>
-          <div class="fw-item"><div class="fw-label">Commit</div><div class="fw-value" id="fw_git_sha">--</div></div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Automatic Updates</div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Check for updates on boot</span>
-          <label class="toggle"><input type="checkbox" id="auto_update_check" checked><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint" style="margin-top:4px">Automatically check GitHub for new firmware releases when the device boots.</div>
-        <div class="field" style="margin-top:12px">
-          <label class="field-label">Update channel</label>
-          <select class="input" id="update_channel">
-            <option value="0">Stable only</option>
-            <option value="1">Include pre-releases</option>
-            <option value="2">Alpha (snd)</option>
-          </select>
-          <div class="field-hint">Stable only skips pre-release builds; Include pre-releases also offers beta firmware. Alpha (snd) installs experimental snd-branch builds; expect frequent changes.</div>
-        </div>
-        <button class="btn btn-primary" style="margin-top:12px;width:100%" id="checkUpdateBtn" onclick="checkForUpdates()">Check for Updates</button>
-        <div id="updateResult" style="display:none;margin-top:12px;padding:12px;border-radius:10px;border:1px solid rgba(255,255,255,0.08);background:rgba(255,255,255,0.03)">
-          <div id="updateResultText" style="font-size:0.85rem;color:var(--text-secondary)"></div>
-          <div id="updateSummary" style="display:none;margin-top:8px;font-size:0.78rem;color:var(--text-muted);max-height:120px;overflow-y:auto;white-space:pre-wrap"></div>
-          <button class="btn btn-primary" id="otaGithubBtn" style="display:none;margin-top:12px;width:100%" onclick="startGithubOta()">Install Update</button>
-        </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Manual Update</div>
-        <div class="ota-bar">
-          <label class="ota-label" id="otaFileLabel">
-            Choose firmware .bin file
-            <input type="file" id="otaFile" accept=".bin" style="display:none" onchange="otaFileSelected(this)">
-          </label>
-          <button class="btn btn-primary" id="otaBtn" disabled onclick="startOta()">Update</button>
-        </div>
-        <div class="field-hint" style="margin-top:4px">Flash a firmware .bin you provide directly instead of downloading from GitHub.</div>
-        <div id="otaProgress" style="display:none;margin-top:16px">
-          <div class="progress-bg"><div id="otaProgressFill" class="progress-fill"></div></div>
-          <div id="otaStatus" class="progress-status"></div>
-        </div>
-        </div>
-      </div>
-
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Device <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Device actions and modes</div><p>Reboot restarts the device and applies pending reboot-required settings. Factory Reset erases all saved settings and returns every setting to defaults, including WiFi, so plan to reconnect over the device's own setup WiFi network afterward.</p><p>Debug Mode enables extra performance and diagnostic info; leave it off for normal use. Demo Mode generates simulated session data so the dashboard can be used with no live NINA connection. Reboot the device for the change to fully take effect. Capture Screenshot pulls a JPEG of the current display.</p><p>Example: enable Demo Mode to preview the dashboard layout before any N.I.N.A. instance is online, then disable it to return to live data.</p></div>
-        <div class="subsection danger-zone">
-        <div class="subsection-title">Device Actions</div>
-        <div class="row stack-mobile" style="margin-bottom:16px">
-          <button class="btn btn-outline" onclick="saveAndReboot()" style="flex:1">Reboot</button>
-          <button class="btn btn-danger" onclick="factoryReset()" style="flex:1">Factory Reset</button>
-        </div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Modes</div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Enable Debug Mode</span>
-          <label class="toggle"><input type="checkbox" id="debug_mode"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint" style="margin-top:4px;margin-bottom:16px">Shows extra performance and diagnostic info.</div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <span class="toggle-label">Enable Demo Mode</span>
-          <label class="toggle"><input type="checkbox" id="demo_mode"><span class="toggle-track"></span></label>
-        </div>
-        <div class="field-hint" style="margin-top:4px;margin-bottom:16px">Generates simulated astrophotography data. Reboot for the change to fully take effect.</div>
-        </div>
-        <button class="btn btn-outline" id="ssBtn" onclick="takeScreenshot()">Capture Screenshot</button>
-        <div id="ssContainer" style="display:none;margin-top:16px">
-          <img id="ssImage" style="width:100%;border-radius:var(--radius-sm);border:1px solid var(--border)">
-        </div>
-      </div>
-
-      <div class="card" id="adminPasswordCard">
-        <div class="card-title"><span class="card-title-label">Authentication <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Web UI access control</div><p>Require login asks for a username and password before the web settings will open, and is on by default. When it is off, anyone on the network can reboot, factory-reset, flash, or reconfigure the device; secrets such as passwords, API keys, and tokens stay redacted in API responses either way.</p><p>The admin password defaults to changeme123!. To change it, enter the current password, then the new password twice (4 to 32 characters). Sign out clears your current browser session.</p><p>Example: keep Require login enabled and change the password from the default before exposing the device beyond your local network.</p></div>
-        <div class="subsection">
-        <div class="subsection-title">Access Control</div>
-        <div class="toggle-row">
-          <span class="toggle-label">Require login to access the web UI</span>
-          <label class="toggle"><input type="checkbox" id="auth_enabled"><span class="toggle-track"></span></label>
-        </div>
-        <p style="color:#888;font-size:0.85em;margin:8px 0 0 0;">
-          When disabled, anyone on the network can control the device (reboot, factory reset, OTA, config change).
-          Secrets (passwords, API keys, tokens) remain redacted in API responses either way.
-        </p>
-        <button class="btn btn-primary" style="margin-top:12px" onclick="saveAuthEnabled()">Save</button>
-        <div id="auth_enabled_status" style="margin-top:10px;font-size:0.9em;"></div>
-        </div>
-        <div class="subsection">
-        <div class="subsection-title">Admin Password</div>
-        <p style="color:#888;font-size:0.85em;margin:2px 0 12px 0;">
-          Default password is <code>changeme123!</code>. Change it now to secure this device's web interface.
-        </p>
-        <div class="field">
-          <label for="admin_pw_current">Current password</label>
-          <input type="password" class="input" id="admin_pw_current" autocomplete="current-password">
-          <div class="field-hint">Enter the password in use now to authorize the change.</div>
-        </div>
-        <div class="field">
-          <label for="admin_pw_new">New password (4-32 chars)</label>
-          <input type="password" class="input" id="admin_pw_new" autocomplete="new-password">
-          <div class="field-hint">Choose a password 4 to 32 characters long.</div>
-        </div>
-        <div class="field">
-          <label for="admin_pw_confirm">Confirm new password</label>
-          <input type="password" class="input" id="admin_pw_confirm" autocomplete="new-password">
-          <div class="field-hint">Re-enter the new password exactly to confirm.</div>
-        </div>
-        <button class="btn btn-primary" onclick="changeAdminPassword()">Save Password</button>
-        <div id="admin_pw_status" style="margin-top:10px;font-size:0.9em;"></div>
-        </div>
-        <button class="btn" id="signOutBtn" onclick="signOut()">Sign out</button>
-      </div>
-    </div>
+    <!-- Markup extracted to main/fragment_system.html (P6d); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=system and injected here. -->
+    <div id="tab-system" class="tab-panel"></div>
 
     <!-- ==================== TAB: LOGS ==================== -->
-    <div id="tab-logs" class="tab-panel">
-
-      <div class="card nocollapse">
-        <div class="card-title"><span class="card-title-label">Logs <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Device and crash logs</div><p>Two sources share this card. Device shows console output captured since boot and kept in memory; only a limited amount is kept, so the oldest lines drop off as new ones arrive, and it is cleared on reboot. Crash shows saved crash history: the device records unexpected restarts and crashes, with details attached when available. Crash records survive reboots and power loss.</p><p>Refresh reloads the active source. Download saves the current source to a file. Clear empties it. For Device, Auto-refresh reloads on the chosen Interval. For Crash, Auto-clear after drops records older than the selected age, and Never keeps them indefinitely.</p><p>Example: switch to Crash and use Download to attach a crash record when reporting an unexpected reboot.</p></div>
-
-        <div class="logs-toolbar">
-          <div class="log-seg" role="tablist">
-            <button class="log-seg-btn active" id="logSegDevice" onclick="setLogSource('device')">Device</button>
-            <button class="log-seg-btn" id="logSegCrash" onclick="setLogSource('crash')">Crash</button>
-          </div>
-          <div class="logs-toolbar-actions">
-            <button class="btn btn-outline" id="logsRefreshBtn" onclick="logsRefreshActive()">Refresh</button>
-            <a class="btn btn-outline" id="logsDownloadLink" href="/api/logs" style="text-align:center">Download</a>
-            <button class="btn btn-outline" id="logsClearBtn" onclick="logsClearActive()">Clear</button>
-          </div>
-          <div class="logs-toolbar-slot">
-            <!-- Device source controls -->
-            <div id="logsDeviceCtl" style="display:flex;flex-wrap:wrap;align-items:center;gap:14px">
-              <div class="toggle-row" style="margin:0;border:0;padding:0">
-                <span class="toggle-label">Auto-refresh</span>
-                <label class="toggle"><input type="checkbox" id="logsAutoRefresh"><span class="toggle-track"></span></label>
-              </div>
-              <div style="display:flex;align-items:center;gap:8px">
-                <span class="field-hint" style="margin:0">Interval</span>
-                <select class="input" id="logsRefreshInterval" style="max-width:90px">
-                  <option value="2">2s</option>
-                  <option value="5" selected>5s</option>
-                  <option value="10">10s</option>
-                  <option value="30">30s</option>
-                </select>
-              </div>
-            </div>
-            <!-- Crash source controls -->
-            <div id="logsCrashCtl" style="display:none;align-items:center;gap:8px">
-              <span class="field-hint" style="margin:0">Auto-clear after</span>
-              <select class="input" id="crashlog_retention" style="max-width:110px">
-                <option value="0">Never</option>
-                <option value="7">7 days</option>
-                <option value="14">14 days</option>
-                <option value="30">30 days</option>
-                <option value="60">60 days</option>
-                <option value="90">90 days</option>
-              </select>
-            </div>
-          </div>
-        </div>
-
-        <div class="logs-meta">
-          <span class="field-hint" id="logsHint">Console output captured since boot (kept in memory; oldest lines drop off as new ones arrive).</span>
-          <span class="field-hint" id="logsStatus">Not loaded yet.</span>
-          <span class="field-hint" id="crashlogStatus" style="display:none">Not loaded yet.</span>
-        </div>
-
-        <pre id="logsView" class="logs-view"></pre>
-        <div id="crashlogView" class="logs-view hidden"></div>
-
-        <!-- Core dump diagnostics: hidden unless a crash dump is saved in flash -->
-        <div id="coredumpCard" class="logs-meta" style="display:none;margin-top:12px;align-items:center;gap:12px">
-          <span class="field-hint" id="coredumpInfo" style="margin:0">Crash dump present.</span>
-          <a class="btn btn-outline" id="coredumpDownloadLink" href="/api/coredump" style="text-align:center">Download dump</a>
-          <button type="button" class="btn btn-outline" id="coredumpClearBtn" onclick="clearCoredump()">Clear dump</button>
-        </div>
-      </div>
-    </div>
+    <!-- Markup extracted to main/fragment_logs.html (P6b); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=logs and injected here. -->
+    <div id="tab-logs" class="tab-panel"></div>
 
     <!-- ==================== TAB 7: BACKUP ==================== -->
-    <div id="tab-backup" class="tab-panel">
-      <!-- Export Card -->
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Export Configuration <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Export configuration</div><p>Downloads the device configuration as a JSON file for backup or for cloning settings to another unit. The header shows the configuration version and running firmware version embedded in the file; the restore screen uses these to flag version mismatches.</p><p>Include sensitive data controls whether secrets are written to the file. With it off, the export omits every secret: the weather API key, MQTT username, password, and broker URL, the Spotify Client ID, the hostname, your saved WiFi passwords, and the admin password. Turn it on only for a private full backup that can restore those values.</p><p>Example: leave Include sensitive data off when sharing a configuration as a template, and turn it on only for a private full backup of one device.</p></div>
-        <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;font-size:0.82rem;color:#a1a1aa">
-          <span>Config version: <strong style="color:#f4f4f5" id="backupCurrentVersion">--</strong></span>
-          <span>&middot;</span>
-          <span>Firmware: <strong style="color:#f4f4f5" id="backupFirmwareVersion">--</strong></span>
-        </div>
-        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-          <div>
-            <span class="toggle-label">Include sensitive data</span>
-            <div class="field-hint" style="margin-top:2px">Weather and MQTT credentials, Spotify Client ID, hostname, WiFi and admin passwords</div>
-          </div>
-          <label class="toggle"><input type="checkbox" id="backupIncludeSensitive"><span class="toggle-track"></span></label>
-        </div>
-        <button class="btn btn-primary" id="backupDownloadBtn" onclick="downloadBackup()" style="margin-top:16px;width:100%">Download Backup</button>
-      </div>
-
-      <!-- Import Card -->
-      <div class="card">
-        <div class="card-title"><span class="card-title-label">Restore Configuration <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Restore configuration</div><p>Loads a previously exported JSON file and previews the effect before applying it. The metadata header shows the source hostname and MAC, the firmware version the file came from, and the export date. A version warning appears when the backup's configuration version differs from this device.</p><p>The preview lists each setting that would change, plus notices for settings missing from the backup, settings this firmware does not recognize, sensitive values that were excluded from the file, and any validation issues. Nothing is written until you press Restore; Cancel discards the file.</p><p>Example: restoring a file exported without sensitive data leaves the current MQTT password and other secrets in place, shown as excluded in the preview.</p></div>
-        <div class="field">
-          <label class="ota-label" id="restoreFileLabel" style="display:block;text-align:center;cursor:pointer">
-            Choose backup .json file
-            <input type="file" id="restoreFileInput" accept=".json" onchange="restoreFileSelected(this)" style="display:none">
-          </label>
-        </div>
-
-        <!-- Preview Panel (hidden until file selected) -->
-        <div id="restorePreview" style="display:none;margin-top:16px">
-          <!-- Metadata Header -->
-          <div style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:10px;padding:14px 16px;margin-bottom:12px;font-size:0.82rem;color:#a1a1aa;line-height:1.8">
-            <div>Source: <strong style="color:#f4f4f5" id="restoreHostname">--</strong> (<span id="restoreMac">--</span>)</div>
-            <div>Firmware: <strong style="color:#f4f4f5" id="restoreFirmware">--</strong> &middot; Exported: <span id="restoreDate">--</span></div>
-          </div>
-
-          <!-- Version Warning Banner -->
-          <div id="restoreWarningBanner" style="border-radius:10px;padding:14px 16px;margin-bottom:12px;font-size:0.82rem;line-height:1.6;display:none"></div>
-
-          <!-- Changes Diff -->
-          <div id="restoreChanges" style="margin-bottom:12px"></div>
-
-          <!-- No Changes -->
-          <div id="restoreNoChanges" style="font-size:0.82rem;color:var(--text-hint);margin-bottom:12px"></div>
-
-          <!-- Missing Fields Notice -->
-          <div id="restoreMissing" style="display:none;background:rgba(245,158,11,0.06);border:1px solid rgba(245,158,11,0.15);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:#d4d4d8"></div>
-
-          <!-- Unknown Fields Notice -->
-          <div id="restoreUnknown" style="display:none;background:rgba(245,158,11,0.06);border:1px solid rgba(245,158,11,0.15);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:#d4d4d8"></div>
-
-          <!-- Sensitive Excluded Notice -->
-          <div id="restoreSensitive" style="display:none;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:var(--text-hint)"></div>
-
-          <!-- Validation Notes -->
-          <div id="restoreValidation" style="display:none;background:rgba(245,158,11,0.06);border:1px solid rgba(245,158,11,0.15);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:#d4d4d8"></div>
-
-          <!-- Action Buttons -->
-          <div style="display:flex;gap:10px;margin-top:16px">
-            <button class="btn btn-outline" onclick="cancelRestore()" style="flex:1">Cancel</button>
-            <button class="btn btn-primary" id="restoreConfirmBtn" onclick="confirmRestore()" style="flex:1">Restore</button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <!-- Markup extracted to main/fragment_backup.html (P6b); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=backup and injected here. -->
+    <div id="tab-backup" class="tab-panel"></div>
 
     <!-- ==================== TAB 8: API ==================== -->
-    <div id="tab-api" class="tab-panel">
-
-      <!-- Overview / Authentication -->
-      <div class="card nocollapse">
-        <div class="card-title"><span class="card-title-label">HTTP API</span></div>
-        <div class="api-intro">
-          <p>This page documents every HTTP endpoint the device serves. Examples use this device's address (<strong id="apiHostLabel">window.location.host</strong>). For protected endpoints, run the login command first to create cookies.txt.</p>
-          <p>Authentication uses a session cookie. <strong>POST /api/login</strong> with a JSON body <code>{"password":"..."}</code> sets a <code>session</code> cookie valid for 12 hours. Reuse the cookie on later requests. When <code>auth_enabled</code> is false, every endpoint is open and no cookie is required; secrets stay redacted in responses regardless.</p>
-          <p>Each endpoint carries a badge: <span class="api-badge public">Public</span> needs no session, <span class="api-badge auth">Auth</span> requires a valid session cookie when authentication is enabled.</p>
-          <p>Create the cookie once:</p>
-          <div class="api-snip" data-curl="curl -c cookies.txt -X POST http://HOST/api/login -d '{&quot;password&quot;:&quot;YOUR_PASSWORD&quot;}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -c cookies.txt -X POST http://<span class="api-host">HOST</span>/api/login -d '{"password":"YOUR_PASSWORD"}'</pre>
-          </div>
-          <p>Then pass <code>-b cookies.txt</code> on every protected request shown below.</p>
-        </div>
-      </div>
-
-      <!-- Authentication -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Authentication</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/login</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">Verify the admin password and set the session cookie.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -c cookies.txt -X POST http://HOST/api/login -d '{&quot;password&quot;:&quot;YOUR_PASSWORD&quot;}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -c cookies.txt -X POST http://<span class="api-host">HOST</span>/api/login -d '{"password":"YOUR_PASSWORD"}'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"status":"ok"}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/logout</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Destroy the current session.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/logout">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/logout</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/auth/status</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">Report whether the admin password is still the factory default.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl http://HOST/api/auth/status">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl http://<span class="api-host">HOST</span>/api/auth/status</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"default_password":true}</pre></div>
-        </div>
-      </div>
-
-      <!-- Config & Backup -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Config &amp; Backup</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the full configuration as JSON. Secrets (passwords, API keys, tokens) are redacted.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/config">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/config</pre>
-          </div>
-          <div class="api-snip-label">Response (truncated)</div>
-          <div class="api-snip"><pre>{"hostname":"NinaDash2","theme_index":0,"brightness":80,"update_rate_s":2,"api_url1":"http://astromele1.lan:1888/v2/api/","instance1_enabled":true,"admin_password":"********", ...}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Write the full configuration blob. Fields are validated and clamped before saving.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config -H 'Content-Type: application/json' -d @config.json">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config -H 'Content-Type: application/json' -d @config.json</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config/apply</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Apply staged configuration as a live preview without persisting it.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config/apply">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config/apply</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config/revert</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Discard the staged configuration and restore the saved values.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config/revert">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config/revert</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/config/backup</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Download the configuration as config.json. Add the query parameter include_sensitive=1 to include secrets.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -o config.json 'http://HOST/api/config/backup?include_sensitive=0'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -o config.json 'http://<span class="api-host">HOST</span>/api/config/backup?include_sensitive=0'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config/restore</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Upload a config.json. Send confirm:false first to preview the changes, then confirm:true to apply.</p>
-          <div class="api-snip-label">Request (preview)</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config/restore -H 'Content-Type: application/json' --data-binary @config.json">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config/restore -H 'Content-Type: application/json' --data-binary @config.json</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/admin-password</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Change the admin password.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/admin-password -d '{&quot;password&quot;:&quot;NEW_PASSWORD&quot;}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/admin-password -d '{"password":"NEW_PASSWORD"}'</pre>
-          </div>
-        </div>
-      </div>
-
-      <!-- Display -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Display</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/brightness</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Set the screen backlight (0 to 100).</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/brightness -d '{&quot;value&quot;:80}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/brightness -d '{"value":80}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/color-brightness</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Set the text and color brightness (0 to 100).</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/color-brightness -d '{&quot;value&quot;:70}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/color-brightness -d '{"value":70}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/theme</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Select a color theme by index.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/theme -d '{&quot;theme_index&quot;:2}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/theme -d '{"theme_index":2}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/widget-style</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Select the widget style by index.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/widget-style -d '{&quot;widget_style&quot;:1}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/widget-style -d '{"widget_style":1}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/screen-rotation</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Set the LVGL screen rotation by index.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/screen-rotation -d '{&quot;screen_rotation&quot;:0}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/screen-rotation -d '{"screen_rotation":0}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/screenshot</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Capture a JPEG of the current display.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -o screenshot.jpg http://HOST/api/screenshot">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -o screenshot.jpg http://<span class="api-host">HOST</span>/api/screenshot</pre>
-          </div>
-        </div>
-      </div>
-
-      <!-- Navigation -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Navigation</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/page</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Navigate to a page by legacy page index.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/page -d '{&quot;page&quot;:4}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/page -d '{"page":4}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/pages</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Enumerate the page registry. Returns id, slug, label, kind, category, targetable, and current availability for every page.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/pages">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/pages</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>[{"id":4,"slug":"summary","label":"Summary","kind":"page","category":"","targetable":true,"available":true}, ...]</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span> <span class="api-method">POST</span><span class="api-path">/api/navigate</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Navigate by page slug (?ref=) or page id (?id=). The page must be targetable and currently available.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt 'http://HOST/api/navigate?ref=summary'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt 'http://<span class="api-host">HOST</span>/api/navigate?ref=summary'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>OK</pre></div>
-        </div>
-      </div>
-
-      <!-- System & OTA -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">System &amp; OTA</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/status</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">Read a live device sample: uptime, heap, PSRAM, temperature, WiFi, and active page.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl http://HOST/api/status">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl http://<span class="api-host">HOST</span>/api/status</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"uptime_ms":36619476,"boot_count":145,"active_page":2,"instance_count":3,"heap_free":20355548,"heap_internal_free":198455,"heap_total":387867,"psram_free":20172872,"psram_total":29944064,"temperature_c":33.5,"wifi_rssi":-34,"wifi_ssid":"IoT"}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/version</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">Read firmware version, build, IDF version, partition, and git metadata.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl http://HOST/api/version">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl http://<span class="api-host">HOST</span>/api/version</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"version":"1.0.53","date":"","time":"","idf":"v5.5.2","partition":"ota_0","git_tag":"v1.0.53","git_sha":"598ab9a","git_branch":"HEAD"}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/check-update</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Trigger a firmware update check against GitHub releases.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/check-update">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/check-update</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/check-update-json</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the result of the last update check.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/check-update-json">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/check-update-json</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/ota-github</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Download and flash the latest GitHub release.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/ota-github">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/ota-github</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/ota</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Upload a firmware .bin for a manual OTA flash.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/ota --data-binary @firmware.bin">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/ota --data-binary @firmware.bin</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/perf</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read performance metrics. Available only when debug_mode is enabled in config.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/perf">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/perf</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/perf/reset</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Zero the performance counters.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/perf/reset">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/perf/reset</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/reboot</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Soft-reboot the device.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/reboot">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/reboot</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/factory-reset</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Erase NVS and reboot. All settings return to defaults.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/factory-reset">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/factory-reset</pre>
-          </div>
-        </div>
-      </div>
-
-      <!-- Logs & Diagnostics -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Logs &amp; Diagnostics</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/logs</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Download the serial-log ring buffer held in PSRAM since boot.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -o device.log http://HOST/api/logs">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -o device.log http://<span class="api-host">HOST</span>/api/logs</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/logs/clear</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Clear the serial log buffer.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/logs/clear">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/logs/clear</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/crashlog</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the reboot-reason history.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/crashlog">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/crashlog</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/crashlog/clear</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Erase the crash log.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/crashlog/clear">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/crashlog/clear</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/coredump</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Download the raw core dump (raw flash format). Decode with esp-coredump using the matching .elf.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -o coredump.bin http://HOST/api/coredump">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -o coredump.bin http://<span class="api-host">HOST</span>/api/coredump</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/coredump/info</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read core dump metadata (presence and size).</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/coredump/info">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/coredump/info</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/coredump/clear</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Erase the stored core dump.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/coredump/clear">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/coredump/clear</pre>
-          </div>
-        </div>
-      </div>
-
-      <!-- WiFi -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">WiFi</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/wifi/scan</span><span class="api-badge public">Public</span> <span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">List nearby networks with signal strength. Public during first-run setup, otherwise requires a session.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/wifi/scan">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/wifi/scan</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"networks":[{"ssid":"IoT","rssi":-34,"channel":6,"auth":"WPA2-PSK","compatible":true}],"count":1,"incompatible_count":0}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/wifi/status</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the current station connection state.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/wifi/status">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/wifi/status</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"connected":true,"ssid":"IoT","ip":"192.168.1.42"}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/wifi/setup</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Save network credentials (SSID and password).</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/wifi/setup -d '{&quot;ssid&quot;:&quot;IoT&quot;,&quot;password&quot;:&quot;WIFI_PASSWORD&quot;}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/wifi/setup -d '{"ssid":"IoT","password":"WIFI_PASSWORD"}'</pre>
-          </div>
-        </div>
-      </div>
-
-      <!-- NINA -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">NINA</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/nina/status</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">Read per-instance NINA connection state, WebSocket status, and poll counters.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl http://HOST/api/nina/status">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl http://<span class="api-host">HOST</span>/api/nina/status</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"instances":[{"index":0,"enabled":true,"url":"http://astromele1.lan:1888/v2/api/","connection_state":"disconnected","websocket_connected":false,"consecutive_failures":7275,"consecutive_successes":0,"last_successful_poll_ms":0}]}</pre></div>
-        </div>
-      </div>
-
-      <!-- Spotify -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Spotify</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/spotify/config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read Spotify settings.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/spotify/config">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/spotify/config</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"spotify_enabled":true,"spotify_client_id":"...","spotify_poll_interval_ms":3000,"spotify_show_progress_bar":true,"spotify_minimal_mode":false,"spotify_scroll_text":true,"spotify_overlay_timeout_s":10,"spotify_overlay_visible":true}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Update Spotify settings.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/config -d '{&quot;spotify_enabled&quot;:true}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/config -d '{"spotify_enabled":true}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/spotify/status</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the current authentication and playback state.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/spotify/status">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/spotify/status</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"auth_state":"authenticated","is_playing":true,"track":"Song Title","artist":"Artist Name"}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/control</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Send a playback command: play, pause, next, or previous.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/control -d '{&quot;action&quot;:&quot;next&quot;}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/control -d '{"action":"next"}'</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/spotify/callback</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">OAuth redirect target. Spotify calls this with the authorization code; not invoked manually.</p>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/token-exchange</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Complete the PKCE token exchange.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/token-exchange">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/token-exchange</pre>
-          </div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/logout</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Clear the stored Spotify token.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/logout">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/logout</pre>
-          </div>
-        </div>
-      </div>
-
-      <!-- AllSky -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">AllSky</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/allsky-config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read AllSky settings.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/allsky-config">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/allsky-config</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"hostname":"allsky.lan","update_interval_s":30,"dew_offset":2.0,"field_config":"{...}","thresholds":"{...}","allsky_enabled":true}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/allsky-proxy</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Proxy the remote AllSky /all endpoint to bypass CORS. Returns the upstream JSON payload.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/allsky-proxy">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/allsky-proxy</pre>
-          </div>
-        </div>
-      </div>
-
-      <!-- Image Display -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Image Display</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/image-display-config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the Image Display settings. Returns the full current value of every persisted parameter listed in the POST table below (force_fetch is not part of the output).</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/image-display-config">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/image-display-config</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"image_display_enabled":true,"image_display_show_overlay":true,"image_display_crop":false,"goes_region":"FD","goes_update_interval_s":600,"image_display_source":0,"moon_bg_style":0,"moon_lat":30,"moon_lon":-97,"solar_band":0,"goes_orientation":0,"solar_orientation":0,"custom_image_url":"","custom_orientation":0,"custom_update_interval_s":600,"moon_drag_light_mode":0,"moon_flip_u":0,"moon_flip_v":0,"moon_roll_offset":0,"moon_yaw_offset":0,"moon_pitch_offset":0,"moon_north_up":0,"moon_spin_mode":0,"moon_spin_return_s":10}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/image-display-config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Update Image Display settings. Each setting takes effect as a live preview and persists to NVS.</p>
-          <div class="api-note">
-            <strong>Partial merge.</strong> The handler loads the current full configuration, overwrites only the keys present in the request body, then saves. POST a single key to change one setting; any key you omit keeps its current value.
-          </div>
-          <div class="api-snip-label">Request (single key)</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/image-display-config -d '{&quot;image_display_source&quot;:1}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/image-display-config -d '{"image_display_source":1}'</pre>
-          </div>
-          <div class="api-snip-label">Request (force a refresh)</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/image-display-config -d '{&quot;force_fetch&quot;:true}'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/image-display-config -d '{"force_fetch":true}'</pre>
-          </div>
-          <div class="api-snip-label">Parameters</div>
-          <div class="api-table-wrap">
-            <table class="api-table">
-              <thead><tr><th>Param</th><th>Type</th><th>Range / Values</th><th>Notes</th></tr></thead>
-              <tbody>
-                <tr><td>image_display_enabled</td><td>bool</td><td>true / false</td><td>Master enable for the Image Display page.</td></tr>
-                <tr><td>image_display_show_overlay</td><td>bool</td><td>true / false</td><td>Show the info overlay.</td></tr>
-                <tr><td>image_display_crop</td><td>bool</td><td>true / false</td><td>Crop vs full-frame. Toggling re-renders the cached frame locally (no re-download).</td></tr>
-                <tr><td>image_display_source</td><td>int</td><td>0=GOES, 1=Moon, 2=Solar, 3=Custom</td><td>Active image source. An invalid value falls back to 0.</td></tr>
-                <tr><td>goes_region</td><td>string</td><td>region code</td><td>GOES region id.</td></tr>
-                <tr><td>goes_update_interval_s</td><td>int</td><td>300 to 7200 (clamped)</td><td>GOES refresh interval in seconds.</td></tr>
-                <tr><td>goes_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant (0/90/180/270 degrees).</td></tr>
-                <tr><td>goes_vflip</td><td>int</td><td>0 or 1</td><td>Flip GOES image vertically (top/bottom).</td></tr>
-                <tr><td>goes_hflip</td><td>int</td><td>0 or 1</td><td>Flip GOES image horizontally (left/right).</td></tr>
-                <tr><td>solar_band</td><td>int</td><td>0 to 17</td><td>Solar / SDO / SOHO band index. An invalid value falls back to 0.</td></tr>
-                <tr><td>solar_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant.</td></tr>
-                <tr><td>solar_vflip</td><td>int</td><td>0 or 1</td><td>Flip solar image vertically (top/bottom).</td></tr>
-                <tr><td>solar_hflip</td><td>int</td><td>0 or 1</td><td>Flip solar image horizontally (left/right).</td></tr>
-                <tr><td>custom_image_url</td><td>string (max 256)</td><td>must start with http:// or https:// (empty string clears it)</td><td>Custom image source URL. Validated server-side.</td></tr>
-                <tr><td>custom_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant.</td></tr>
-                <tr><td>custom_vflip</td><td>int</td><td>0 or 1</td><td>Flip custom image vertically (top/bottom).</td></tr>
-                <tr><td>custom_hflip</td><td>int</td><td>0 or 1</td><td>Flip custom image horizontally (left/right).</td></tr>
-                <tr><td>custom_update_interval_s</td><td>int</td><td>10 to 7200 (clamped)</td><td>Custom image refresh interval in seconds.</td></tr>
-                <tr><td>moon_bg_style</td><td>int</td><td>0 to 3</td><td>Moon page background style. An invalid value falls back to 0.</td></tr>
-                <tr><td>moon_lat</td><td>float</td><td>latitude</td><td>Observer latitude for moon libration.</td></tr>
-                <tr><td>moon_lon</td><td>float</td><td>longitude</td><td>Observer longitude.</td></tr>
-                <tr><td>moon_drag_light_mode</td><td>int</td><td>0 to 2</td><td>Drag lighting mode.</td></tr>
-                <tr><td>moon_flip_u</td><td>int</td><td>0 or 1</td><td>Flip texture horizontally.</td></tr>
-                <tr><td>moon_flip_v</td><td>int</td><td>0 or 1</td><td>Flip texture vertically.</td></tr>
-                <tr><td>moon_roll_offset</td><td>float</td><td>-180 to 180 (clamped)</td><td>Roll orientation offset in degrees.</td></tr>
-                <tr><td>moon_yaw_offset</td><td>float</td><td>-180 to 180 (clamped)</td><td>Yaw orientation offset in degrees.</td></tr>
-                <tr><td>moon_pitch_offset</td><td>float</td><td>-90 to 90 (clamped)</td><td>Pitch orientation offset in degrees.</td></tr>
-                <tr><td>moon_north_up</td><td>int</td><td>0 or 1</td><td>Force north-up.</td></tr>
-                <tr><td>moon_spin_mode</td><td>int</td><td>0 or 1</td><td>Enable spin interaction.</td></tr>
-                <tr><td>moon_spin_return_s</td><td>int</td><td>3 to 60 (clamped)</td><td>Seconds before spin returns to rest.</td></tr>
-                <tr><td>force_fetch</td><td>bool</td><td>true / false</td><td>Action only, not persisted. Forces an immediate re-fetch (used by the Preview / Refresh button). Forces a download only for the Custom source; for GOES and Solar a fetch happens automatically when source, band, or region changed.</td></tr>
-              </tbody>
-            </table>
-          </div>
-          <div class="api-note">
-            Changing source, band, or region triggers a re-download with a loading overlay. Crop-only or orientation-only changes re-render the cached frame locally without downloading.
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"success":true}</pre></div>
-          <p class="api-purpose" style="margin-top:8px">The response may also include "error_msg" carrying the reason of the last completed fetch failure, for example: {"success":true,"error_msg":"HTTP 404"}.</p>
-        </div>
-      </div>
-
-      <!-- Weather -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Weather</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/weather</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">Read the latest weather sample. Returns available:false when no data has been fetched yet. The hourly array always holds 10 entries.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl http://HOST/api/weather">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl http://<span class="api-host">HOST</span>/api/weather</pre>
-          </div>
-          <div class="api-snip-label">Response (no data)</div>
-          <div class="api-snip"><pre>{"available":false}</pre></div>
-          <div class="api-snip-label">Response (valid)</div>
-          <div class="api-snip"><pre>{"available":true,"temp_current":72.4,"temp_high":78.0,"temp_low":61.0,"humidity":54.0,"dew_point":55.2,"wind_speed":8.5,"wind_dir":"NW","uv_index":4.0,"condition":"Partly Cloudy","last_update_ts":1751049600,"units":"imperial","location_name":"Austin, TX","hourly":[{"hour":14,"temp":72.4},{"hour":15,"temp":73.1}]}</pre></div>
-        </div>
-      </div>
-
-      <!-- Events -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Events</span></div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/events</span><span class="api-badge public">Public</span></div>
-          <p class="api-purpose">Read the on-device UI event log. Newest first, maximum 100 entries. Severity is one of info, success, warning, error. timestamp_ms is boot-relative monotonic milliseconds.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl http://HOST/api/events">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl http://<span class="api-host">HOST</span>/api/events</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"count":2,"events":[{"severity":"warning","instance":0,"message":"Guider lost star","timestamp_ms":1234567},{"severity":"info","instance":1,"message":"Sequence started","timestamp_ms":1230000}]}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/events/clear</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Clear the UI event log.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/events/clear">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/events/clear</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"status":"ok"}</pre></div>
-        </div>
-      </div>
-
-      <!-- Control API -->
-      <div class="card collapsed">
-        <div class="card-title"><span class="card-title-label">Control API</span></div>
-
-        <div class="api-intro" style="margin-bottom:4px">
-          <p>A generic control surface for reading and changing device settings from single HTTP requests. Six control endpoints plus an image-refresh action, all backed by a live registry. Useful for any HTTP client, for example macro keypads, API Ninja, or Home Assistant.</p>
-          <p>This page does not hand-list every controllable item. Call <strong>GET /api/control/list</strong> for the full live catalog of items the device exposes.</p>
-        </div>
-
-        <div class="api-note">
-          <strong>Stateless authentication.</strong> Besides the session cookie, every auth-gated endpoint on the device (not only Control API) also accepts the admin password in the request header <code>X-Auth-Password: YOUR_PASSWORD</code>. This lets clients that cannot perform the cookie login flow authenticate on every request. It is rate-limited: it shares the login lockout, so repeated wrong passwords trigger a temporary lockout. Send it as a header, not a URL query, so it is not written to the device logs.
-        </div>
-        <div class="api-snip-label">Header authentication example</div>
-        <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' http://HOST/api/control/list">
-          <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-          <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' http://<span class="api-host">HOST</span>/api/control/list</pre>
-        </div>
-
-        <div class="api-note">
-          <strong>Item object shape.</strong> Every read and write returns a uniform item object: <code>name</code> (the config field name), <code>type</code> (bool, enum, or int), <code>value</code>, <code>label</code> (a human-readable string: an enum gets its name, a bool gets On or Off, an int gets the value), and <code>min</code>, <code>max</code>, <code>step</code>. An unknown name, an operation that does not match the item type, or a missing parameter returns HTTP 400.
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/control/list</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Enumerate every controllable item with its current value and range. This is the live catalog of available item names.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' http://HOST/api/control/list">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' http://<span class="api-host">HOST</span>/api/control/list</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>[{"name":"brightness","type":"int","value":80,"label":"80","min":0,"max":100,"step":5},{"name":"theme","type":"enum","value":2,"label":"Nord","min":0,"max":8,"step":1}]</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/control/get?name=&lt;name&gt;</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read one item by name.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' 'http://HOST/api/control/get?name=image_display_source'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' 'http://<span class="api-host">HOST</span>/api/control/get?name=image_display_source'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"name":"image_display_source","type":"enum","value":1,"label":"Moon","min":0,"max":3,"step":1}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/toggle?name=&lt;name&gt;</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Flip a bool item. Returns HTTP 400 for non-bool items.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/toggle?name=image_display_crop'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/toggle?name=image_display_crop'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"name":"image_display_crop","type":"bool","value":false,"label":"Off","min":0,"max":1,"step":1}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/cycle?name=&lt;name&gt;</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Advance an enum or int item by its step. Wraps from max back to min.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/cycle?name=image_display_source'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/cycle?name=image_display_source'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"name":"image_display_source","type":"enum","value":2,"label":"Solar","min":0,"max":3,"step":1}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/set?name=&lt;name&gt;&amp;value=&lt;v&gt;</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Set an exact value. The value is clamped to the item range.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/set?name=brightness&amp;value=50'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/set?name=brightness&amp;value=50'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"name":"brightness","type":"int","value":50,"label":"50","min":0,"max":100,"step":5}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/adjust?name=&lt;name&gt;&amp;delta=&lt;d&gt;</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Add a delta to the current value. The result is clamped to the item range and does not wrap.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/adjust?name=brightness&amp;delta=-10'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/adjust?name=brightness&amp;delta=-10'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"name":"brightness","type":"int","value":40,"label":"40","min":0,"max":100,"step":5}</pre></div>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/image-display/refresh</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Force an immediate re-fetch of the current image source. This works for all sources, unlike the force_fetch flag on /api/image-display-config which forces a download only for the Custom source.</p>
-          <div class="api-snip-label">Request</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://HOST/api/image-display/refresh">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://<span class="api-host">HOST</span>/api/image-display/refresh</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"success":true}</pre></div>
-          <p class="api-purpose" style="margin-top:8px">The response may include "error_msg" carrying the reason of the last completed fetch failure.</p>
-        </div>
-
-        <div class="api-ep">
-          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/nav/pin</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Pin the displayed page. While pinned, all automatic page changes are suspended (auto-rotate, session auto-follow, idle, and default re-home) and the current page is held until cleared. Manual navigation still works while pinned, and the chosen page persists. The pin is in-memory only and resets on reboot. It does not change the auto-rotate setting, it only suspends it while active.</p>
-          <div class="api-note">
-            Query parameters: <code>on</code> = 1 to pin, 0 to clear (required). Optional <code>id</code> = a page id from /api/pages to navigate to that page and pin it in one call.
-          </div>
-          <div class="api-snip-label">Request (pin current page)</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=1'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=1'</pre>
-          </div>
-          <div class="api-snip-label">Request (go to a page by id and pin)</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=1&amp;id=7'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=1&amp;id=7'</pre>
-          </div>
-          <div class="api-snip-label">Request (clear, resume automation)</div>
-          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=0'">
-            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=0'</pre>
-          </div>
-          <div class="api-snip-label">Response</div>
-          <div class="api-snip"><pre>{"pinned":true}</pre></div>
-          <p class="api-purpose" style="margin-top:8px">The same state is exposed as the <code>nav_pinned</code> Control item: GET /api/control/get?name=nav_pinned returns {"name":"nav_pinned","type":"bool","value":false,"label":"Off",...}. Toggle or set it like any bool (for example toggle?name=nav_pinned), so a macro key can show Pinned or Auto (On or Off) and flip it. The pin overrides auto-rotate while active.</p>
-        </div>
-
-        <div class="api-note">
-          <strong>Behavior notes.</strong> cycle wraps from max to min; set and adjust clamp to the range; toggle works on bool items only. The special item name <code>page</code> controls the current page and is the one item that navigates rather than saving config: cycle moves to the next available page, and set selects a page by id. Item names match the config field names used elsewhere in this documentation.
-        </div>
-
-        <div class="api-snip-label">Worked example: cycle the image source and read the label</div>
-        <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://HOST/api/control/cycle?name=image_display_source">
-          <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
-          <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://<span class="api-host">HOST</span>/api/control/cycle?name=image_display_source</pre>
-        </div>
-        <p class="api-purpose">Each call advances the source and returns the new item object. The response <code>label</code> (for example "Solar") can be shown on a key face so the keypad always reflects the current state.</p>
-      </div>
-
-    </div>
+    <!-- Markup extracted to main/fragment_api.html (P6b); lazily fetched by
+         ensureTabLoaded() via GET /ui/fragment?tab=api and injected here. -->
+    <div id="tab-api" class="tab-panel"></div>
 
   </main>
 
@@ -3296,10 +1174,19 @@
       }
     }
 
-    /* === Node Card Generation === */
-    (function(){
+    /* === Node Card Generation ===
+       P6d: tab-nodes is now a lazily-loaded fragment, so #node-cards does not
+       exist at script-parse time. Named (not a parse-time IIFE) and called
+       from populateTab_nodes(), which runs only after the fragment's markup
+       is present. Clears the container first so repeat calls (every config
+       reload, or a second lazy-populate race) rebuild cleanly instead of
+       appending duplicate cards -- the node cards use only inline on*=
+       handlers, never addEventListener, so a full rebuild carries no
+       duplicate-listener risk. */
+    function buildNodeCards(){
       const container=$('node-cards');
       if(!container) return;
+      container.innerHTML='';
       const placeholders=['192.168.1.100','192.168.1.101','192.168.1.102'];
       for(let i=0;i<3;i++){
         const urlId='url'+(i+1);
@@ -3363,10 +1250,24 @@
             '<input type="color" class="thresh-dot" id="'+pfx+'_bad_color_'+n+'" value="#ef4444">'+
           '</div></div>';
       }
-    })();
+    }
 
-    /* === Rotation Page Pill Generation === */
-    (function(){
+    /* === Rotation Page Pill Generation ===
+       P6d: tab-behavior is now a lazily-loaded fragment, so #arp-container
+       does not exist at script-parse time. Named (not a parse-time IIFE) and
+       called from populateTab_behavior(), which runs only after the
+       fragment's markup is present. Clears the container first so repeat
+       calls (every config reload) rebuild the pills cleanly instead of
+       appending duplicates. initPillDragReorder() attaches its
+       dragstart/dragover/dragleave/drop listeners directly on the container
+       element itself (which is NOT recreated by the innerHTML clear above,
+       only its children are) -- so it must run exactly once per container;
+       a `wired` data-attribute flag guards the repeat-call case. */
+    function buildArpPills(){
+      var c=$('arp-container');
+      if(!c) return;
+      var alreadyWired=c.dataset.wired==='1';
+      c.innerHTML='';
       var items=[
         ['arp_summary','Summary'],
         ['arp_nina1','NINA 1'],
@@ -3381,8 +1282,6 @@
         ['arp_img_solar','Img: Solar'],
         ['arp_img_custom','Img: Custom']
       ];
-      var c=$('arp-container');
-      if(!c) return;
       items.forEach(function(it,idx){
         c.insertAdjacentHTML('beforeend',
           '<label class="pn-pill rotate-pill" draggable="true" data-arp-idx="'+idx+'">'+
@@ -3392,8 +1291,11 @@
           '</label>'
         );
       });
-      initPillDragReorder(c);
-    })();
+      if(!alreadyWired){
+        initPillDragReorder(c);
+        c.dataset.wired='1';
+      }
+    }
 
     /* === Pill Drag-to-Reorder === */
     function initPillDragReorder(container){
@@ -3522,8 +1424,84 @@
       r.setProperty('--accent-rgb',a.rgb);
     }
 
+    /* === Tab Fragment Loader ===
+       Canonical tab list, in the same order the panels appear in the DOM.
+       P6a landed the loader machinery with every tab still pre-populated in
+       loadedTabs (no-op ensureTabLoaded() for all names). P6b extracted logs,
+       backup, and api. P6c extracted allsky, clock, spotify, and
+       image-display. P6d (final wave) extracts the remaining four -- nodes,
+       display, behavior, system -- so every tab now ships as
+       main/fragment_NAME.html (embedded, served by GET /ui/fragment?tab=NAME)
+       and loadedTabs starts empty: every tab, including the default ('nodes',
+       or whichever was restored from localStorage), is fetched lazily on
+       first activation. switchTab() already awaits ensureTabLoaded() before
+       marking a panel active (see below), so the initial switchTab() call at
+       boot -- which shows whichever tab was last active -- transparently
+       fetches that tab's fragment first; no separate boot-time special case
+       is needed for the default tab. */
+    const TAB_ORDER=['nodes','allsky','clock','spotify','image-display','display','behavior','system','logs','backup','api'];
+    const LAZY_TABS=new Set(TAB_ORDER);
+    const loadedTabs=new Set(TAB_ORDER.filter(n=>!LAZY_TABS.has(n)));
+
+    /* Serializes fragment fetches onto one chain so tabs never load in
+       parallel -- each GET /ui/fragment reuses the browser's kept-alive
+       connection to this device one request at a time, never a prefetch
+       burst. */
+    let _fragInFlight=Promise.resolve();
+
+    async function loadTabFragment(name){
+      var panel=$('tab-'+name);
+      if(!panel) return;
+      try{
+        var resp=await fetch('/ui/fragment?tab='+encodeURIComponent(name));
+        if(!resp.ok) throw new Error('HTTP '+resp.status);
+        panel.innerHTML=await resp.text();
+        loadedTabs.add(name);
+        /* Re-scan only the newly-injected subtree for collapsible cards --
+           re-scanning the whole document here would re-attach a second click
+           listener to every already-loaded tab's cards. */
+        if(typeof initCollapsibleCards==='function') initCollapsibleCards(panel);
+        if(_cfgCache && POPULATE_TAB_FNS[name]) POPULATE_TAB_FNS[name](_cfgCache);
+      }catch(e){
+        console.error('Failed to load tab fragment: '+name,e);
+      }
+    }
+
+    /* Await before showing/using a tab. Chains onto _fragInFlight so a rapid
+       double-tap (or programmatic switchTab calls) can never issue two
+       fragment fetches concurrently -- the socket budget only tolerates one
+       polite serial GET at a time (see CLAUDE.md connection ceiling). */
+    function ensureTabLoaded(name){
+      if(loadedTabs.has(name)) return _fragInFlight;
+      _fragInFlight=_fragInFlight.then(()=>loadTabFragment(name));
+      return _fragInFlight;
+    }
+
+    /* === Config Fetch Cache ===
+       Memoizes GET /api/config so the many readers of the whole-config blob
+       (populateConfig, per-tab lazy-populate on fragment load, getConfigData's
+       seed for not-yet-loaded tabs) share one fetch instead of each issuing
+       their own. Invalidated by any successful write to /api/config. */
+    let _cfgCache=null;
+    let _cfgFetchPromise=null;
+    function fetchConfig(force){
+      if(!force && _cfgCache) return Promise.resolve(_cfgCache);
+      if(_cfgFetchPromise) return _cfgFetchPromise;
+      _cfgFetchPromise=fetch('/api/config').then(r=>r.json()).then(function(data){
+        _cfgCache=data;
+        _cfgFetchPromise=null;
+        return data;
+      }).catch(function(e){
+        _cfgFetchPromise=null;
+        throw e;
+      });
+      return _cfgFetchPromise;
+    }
+    function invalidateConfigCache(){ _cfgCache=null; }
+
     /* === Tab Navigation === */
-    function switchTab(name){
+    async function switchTab(name){
+      await ensureTabLoaded(name);
       $$('.tab-panel').forEach(p=>p.classList.remove('active'));
       $$('.tab-btn, .nav-btn').forEach(b=>b.classList.remove('active'));
       var panel=$('tab-'+name);
@@ -3830,121 +1808,163 @@
     }
 
     /* === Config Data Assembly === */
-    function getConfigData(){
+    /* === Per-Tab Config Collectors ===
+       getConfigData() used to be one function reading every tab's DOM in a
+       single pass. Split here into one collector per tab (mutates the shared
+       `data` object) so getConfigData() can skip collectors for tabs that
+       were never loaded (see its TAB_ORDER.forEach loop below). As of P6d
+       every tab is a lazily-loaded fragment, so a tab the user never opened
+       has no collector call at all; getConfigData() seeds `data` from a
+       clone of the cached server config first (see getConfigData()), so an
+       unvisited tab's fields simply pass through untouched rather than being
+       dropped. Key order in the resulting object is irrelevant (JSON/cJSON
+       parsing does not care). */
+
+    function collectTab_nodes(data){
       var host1=$('url1').value.trim();
       var host2=$('url2').value.trim();
       var host3=$('url3').value.trim();
-      var mqttHost=$('mqtt_broker').value.trim();
       var mkUrl=h=>h?'http://'+h+':1888/v2/api/':'';
+      data.url1=mkUrl(host1);
+      data.url2=mkUrl(host2);
+      data.url3=mkUrl(host3);
+      data.filter_colors_1=JSON.stringify(filterColorsArr[0]);
+      data.filter_colors_2=JSON.stringify(filterColorsArr[1]);
+      data.filter_colors_3=JSON.stringify(filterColorsArr[2]);
+      data.rms_thresholds_1=JSON.stringify(getRmsObj(0));
+      data.rms_thresholds_2=JSON.stringify(getRmsObj(1));
+      data.rms_thresholds_3=JSON.stringify(getRmsObj(2));
+      data.hfr_thresholds_1=JSON.stringify(getHfrObj(0));
+      data.hfr_thresholds_2=JSON.stringify(getHfrObj(1));
+      data.hfr_thresholds_3=JSON.stringify(getHfrObj(2));
+      data.update_rate_s=parseInt($('update_rate').value)||2;
+      data.graph_update_interval_s=parseInt($('graph_interval').value)||5;
+      data.connection_timeout_s=parseInt($('connection_timeout').value)||6;
+      data.instance_enabled_1=!!$('instance_enabled_0').checked;
+      data.instance_enabled_2=!!$('instance_enabled_1').checked;
+      data.instance_enabled_3=!!$('instance_enabled_2').checked;
+      data.idle_poll_interval_s=parseInt($('idle_poll_interval').value)||30;
+      data.toast_instance_muted_1=!!$('toast_instance_muted_0').checked;
+      data.toast_instance_muted_2=!!$('toast_instance_muted_1').checked;
+      data.toast_instance_muted_3=!!$('toast_instance_muted_2').checked;
+    }
 
-      var data={
-        hostname:$('hostname').value.trim(),
-        url1:mkUrl(host1),url2:mkUrl(host2),url3:mkUrl(host3),
-        ntp:$('ntp').value.trim(),
-        timezone:$('timezone').value,
-        theme_index:parseInt($('theme_select').value),
-        widget_style:parseInt($('widget_style_select').value),
-        screen_rotation:parseInt($('screen_rotation_select').value),
-        brightness:parseInt($('brightness').value),
-        color_brightness:parseInt($('color_brightness').value),
-        filter_colors_1:JSON.stringify(filterColorsArr[0]),
-        filter_colors_2:JSON.stringify(filterColorsArr[1]),
-        filter_colors_3:JSON.stringify(filterColorsArr[2]),
-        rms_thresholds_1:JSON.stringify(getRmsObj(0)),
-        rms_thresholds_2:JSON.stringify(getRmsObj(1)),
-        rms_thresholds_3:JSON.stringify(getRmsObj(2)),
-        hfr_thresholds_1:JSON.stringify(getHfrObj(0)),
-        hfr_thresholds_2:JSON.stringify(getHfrObj(1)),
-        hfr_thresholds_3:JSON.stringify(getHfrObj(2)),
-        mqtt_enabled:!!$('mqtt_enabled').checked,
-        mqtt_broker_url:mqttHost?'mqtt://'+mqttHost:'',
-        mqtt_port:parseInt($('mqtt_port').value)||1883,
-        mqtt_username:$('mqtt_user').value,
-        mqtt_password:$('mqtt_pass').value,
-        mqtt_topic_prefix:$('mqtt_prefix').value.trim(),
-        active_page_override:getStartPageValue(),
-        auto_rotate_enabled:!!$('auto_cycle_toggle').checked,
-        auto_rotate_interval_s:parseInt($('auto_rotate_interval').value)||30,
-        auto_rotate_effect:parseInt($('auto_rotate_effect').value),
-        auto_rotate_skip_disconnected:!!$('auto_rotate_skip').checked,
-        auto_rotate_order2:getRotateOrder(),
-        nav_grace_s:parseInt($('nav_grace_s').value)||10,
-        home_page_lock:!!$('home_page_lock').checked,
-        update_rate_s:parseInt($('update_rate').value)||2,
-        graph_update_interval_s:parseInt($('graph_interval').value)||5,
-        connection_timeout_s:parseInt($('connection_timeout').value)||6,
-        toast_duration_s:parseInt($('toast_duration').value)||8,
-        debug_mode:!!$('debug_mode').checked,
-        demo_mode:!!$('demo_mode').checked,
-        instance_enabled_1:!!$('instance_enabled_0').checked,
-        instance_enabled_2:!!$('instance_enabled_1').checked,
-        instance_enabled_3:!!$('instance_enabled_2').checked,
-        screen_sleep_enabled:!!$('screen_sleep_enabled').checked,
-        screen_sleep_timeout_s:parseInt($('screen_sleep_timeout').value)||60,
-        idle_poll_interval_s:parseInt($('idle_poll_interval').value)||30,
-        wifi_power_save:!!$('wifi_power_save').checked,
-        deep_sleep_enabled:!!$('deep_sleep_enabled').checked,
-        deep_sleep_wake_timer_s:(parseInt($('deep_sleep_wake_timer').value)||0)*3600,
-        deep_sleep_on_idle:!!$('deep_sleep_on_idle').checked,
-        alert_flash_enabled:!!$('alert_flash_enabled').checked,
-        toast_aggregation_window_s:parseInt($('toast_aggregation_window').value)||0,
-        toast_notify_mask:(function(){var m=0;for(var i=0;i<12;i++){if($('notify_cat_'+i).checked) m|=(1<<i);}return m>>>0;})(),
-        toast_instance_muted_1:!!$('toast_instance_muted_0').checked,
-        toast_instance_muted_2:!!$('toast_instance_muted_1').checked,
-        toast_instance_muted_3:!!$('toast_instance_muted_2').checked,
-        auto_update_check:!!$('auto_update_check').checked,
-        update_channel:parseInt($('update_channel').value)||0,
-        allsky_enabled:!!$('allsky_enabled').checked,
-        allsky_hostname:$('allskyHostname').value.trim(),
-        allsky_update_interval_s:parseInt($('allskyInterval').value)||5,
-        allsky_dew_offset:parseFloat($('allskyDewOffset').value)||5.0,
-        allsky_field_config:JSON.stringify(gatherAllSkyFieldMappings()),
-        allsky_thresholds:JSON.stringify(gatherAllSkyThresholds()),
-        spotify_enabled:!!$('spotify_enabled').checked,
-        spotify_client_id:$('spotifyClientId').value.trim(),
-        spotify_poll_interval_ms:parseInt($('spotifyPollInterval').value)||3000,
-        spotify_show_progress_bar:!!$('spotify_show_progress_bar').checked,
-        spotify_minimal_mode:!!$('spotify_minimal_mode').checked,
-        spotify_overlay_visible:!!$('spotify_overlay_visible').checked,
-        spotify_scroll_text:!!$('spotify_scroll_text').checked,
-        spotify_overlay_timeout_s:parseInt($('spotifyOverlayTimeout').value)||0,
-        image_display_enabled:!!$('image_display_enabled').checked,
-        image_display_show_overlay:!!$('image_display_show_overlay').checked,
-        image_display_crop:!!$('image_display_crop').checked,
-        goes_region:$('goesRegion').value,
-        goes_update_interval_s:parseInt($('goesInterval').value)||600,
-        image_display_source:getImageSource(),
-        moon_bg_style:parseInt($('moonBg').value,10)||0,
-        moon_drag_light_mode:parseInt($('moonDragLight').value,10)||0,
-        solar_band:parseInt($('solarBand').value,10)||0,
-        goes_orientation:parseInt($('goesOrientation').value,10)||0,
-        solar_orientation:parseInt($('solarOrientation').value,10)||0,
-        custom_image_url:$('customImageUrl')?$('customImageUrl').value.trim():'',
-        custom_orientation:$('customOrientation')?parseInt($('customOrientation').value,10)||0:0,
-        custom_update_interval_s:$('customInterval')?parseInt($('customInterval').value,10)||60:60,
-        moon_lat:parseFloat($('weather_lat').value)||0,
-        moon_lon:parseFloat($('weather_lon').value)||0,
-        moon_north_up:$('moon_north_up').checked?1:0,
-        moon_flip_u:$('moon_flip_u').checked?1:0,
-        moon_flip_v:$('moon_flip_v').checked?1:0,
-        moon_roll_offset:parseFloat($('moon_roll_offset').value)||0,
-        moon_yaw_offset:parseFloat($('moon_yaw_offset').value)||0,
-        moon_pitch_offset:parseFloat($('moon_pitch_offset').value)||0,
-        moon_spin_mode:$('moon_spin_mode').checked?1:0,
-        moon_spin_return_s:parseInt($('moon_spin_return_s').value,10)||3,
-        weather_provider:parseInt($('weather_provider').value)||0,
-        weather_api_key:$('weather_api_key').value.trim(),
-        weather_lat:parseFloat($('weather_lat').value)||0,
-        weather_lon:parseFloat($('weather_lon').value)||0,
-        weather_location_name:($('weather_provider').value==='2'?$('weather_station_id').value.trim():$('weather_location_name').value.trim()),
-        weather_poll_interval_s:parseInt($('weather_poll_interval_s').value)||900,
-        weather_units:parseInt($('weather_units').value)||0,
-        weather_time_format:parseInt($('weather_time_format').value)||0,
-        idle_page_override_enabled:!!$('idle_page_override_enabled').checked,
-        idle_page_override_target:parseInt($('idle_page_override_target').value),
-        idle_indicator_enabled:!!$('idle_indicator_enabled').checked,
-        crash_log_retention_days:parseInt($('crashlog_retention').value,10)||0
-      };
+    function collectTab_allsky(data){
+      data.allsky_enabled=!!$('allsky_enabled').checked;
+      data.allsky_hostname=$('allskyHostname').value.trim();
+      data.allsky_update_interval_s=parseInt($('allskyInterval').value)||5;
+      data.allsky_dew_offset=parseFloat($('allskyDewOffset').value)||5.0;
+      data.allsky_field_config=JSON.stringify(gatherAllSkyFieldMappings());
+      data.allsky_thresholds=JSON.stringify(gatherAllSkyThresholds());
+    }
+
+    function collectTab_clock(data){
+      data.weather_provider=parseInt($('weather_provider').value)||0;
+      data.weather_api_key=$('weather_api_key').value.trim();
+      data.weather_location_name=($('weather_provider').value==='2'?$('weather_station_id').value.trim():$('weather_location_name').value.trim());
+      data.weather_poll_interval_s=parseInt($('weather_poll_interval_s').value)||900;
+      data.weather_units=parseInt($('weather_units').value)||0;
+      data.weather_time_format=parseInt($('weather_time_format').value)||0;
+    }
+
+    function collectTab_spotify(data){
+      data.spotify_enabled=!!$('spotify_enabled').checked;
+      data.spotify_client_id=$('spotifyClientId').value.trim();
+      data.spotify_poll_interval_ms=parseInt($('spotifyPollInterval').value)||3000;
+      data.spotify_show_progress_bar=!!$('spotify_show_progress_bar').checked;
+      data.spotify_minimal_mode=!!$('spotify_minimal_mode').checked;
+      data.spotify_overlay_visible=!!$('spotify_overlay_visible').checked;
+      data.spotify_scroll_text=!!$('spotify_scroll_text').checked;
+      data.spotify_overlay_timeout_s=parseInt($('spotifyOverlayTimeout').value)||0;
+    }
+
+    function collectTab_image_display(data){
+      data.image_display_enabled=!!$('image_display_enabled').checked;
+      data.image_display_show_overlay=!!$('image_display_show_overlay').checked;
+      data.image_display_crop=!!$('image_display_crop').checked;
+      data.goes_region=$('goesRegion').value;
+      data.goes_update_interval_s=parseInt($('goesInterval').value)||600;
+      data.image_display_source=getImageSource();
+      data.moon_bg_style=parseInt($('moonBg').value,10)||0;
+      data.moon_drag_light_mode=parseInt($('moonDragLight').value,10)||0;
+      data.solar_band=parseInt($('solarBand').value,10)||0;
+      data.goes_orientation=parseInt($('goesOrientation').value,10)||0;
+      data.solar_orientation=parseInt($('solarOrientation').value,10)||0;
+      data.custom_image_url=$('customImageUrl')?$('customImageUrl').value.trim():'';
+      data.custom_orientation=$('customOrientation')?parseInt($('customOrientation').value,10)||0:0;
+      data.custom_update_interval_s=$('customInterval')?parseInt($('customInterval').value,10)||60:60;
+      data.moon_north_up=$('moon_north_up').checked?1:0;
+      data.moon_flip_u=$('moon_flip_u').checked?1:0;
+      data.moon_flip_v=$('moon_flip_v').checked?1:0;
+      data.moon_roll_offset=parseFloat($('moon_roll_offset').value)||0;
+      data.moon_yaw_offset=parseFloat($('moon_yaw_offset').value)||0;
+      data.moon_pitch_offset=parseFloat($('moon_pitch_offset').value)||0;
+      data.moon_spin_mode=$('moon_spin_mode').checked?1:0;
+      data.moon_spin_return_s=parseInt($('moon_spin_return_s').value,10)||3;
+    }
+
+    function collectTab_display(data){
+      data.theme_index=parseInt($('theme_select').value);
+      data.widget_style=parseInt($('widget_style_select').value);
+      data.screen_rotation=parseInt($('screen_rotation_select').value);
+      data.brightness=parseInt($('brightness').value);
+      data.color_brightness=parseInt($('color_brightness').value);
+      data.screen_sleep_enabled=!!$('screen_sleep_enabled').checked;
+      data.screen_sleep_timeout_s=parseInt($('screen_sleep_timeout').value)||60;
+    }
+
+    function collectTab_behavior(data){
+      data.active_page_override=getStartPageValue();
+      data.auto_rotate_enabled=!!$('auto_cycle_toggle').checked;
+      data.auto_rotate_interval_s=parseInt($('auto_rotate_interval').value)||30;
+      data.auto_rotate_effect=parseInt($('auto_rotate_effect').value);
+      data.auto_rotate_skip_disconnected=!!$('auto_rotate_skip').checked;
+      data.auto_rotate_order2=getRotateOrder();
+      data.nav_grace_s=parseInt($('nav_grace_s').value)||10;
+      data.home_page_lock=!!$('home_page_lock').checked;
+      data.toast_duration_s=parseInt($('toast_duration').value)||8;
+      data.alert_flash_enabled=!!$('alert_flash_enabled').checked;
+      data.toast_aggregation_window_s=parseInt($('toast_aggregation_window').value)||0;
+      data.toast_notify_mask=(function(){var m=0;for(var i=0;i<12;i++){if($('notify_cat_'+i).checked) m|=(1<<i);}return m>>>0;})();
+      data.idle_page_override_enabled=!!$('idle_page_override_enabled').checked;
+      data.idle_page_override_target=parseInt($('idle_page_override_target').value);
+      data.idle_indicator_enabled=!!$('idle_indicator_enabled').checked;
+    }
+
+    function collectTab_system(data){
+      var mqttHost=$('mqtt_broker').value.trim();
+      data.hostname=$('hostname').value.trim();
+      data.ntp=$('ntp').value.trim();
+      data.timezone=$('timezone').value;
+      data.mqtt_enabled=!!$('mqtt_enabled').checked;
+      data.mqtt_broker_url=mqttHost?'mqtt://'+mqttHost:'';
+      data.mqtt_port=parseInt($('mqtt_port').value)||1883;
+      data.mqtt_username=$('mqtt_user').value;
+      data.mqtt_password=$('mqtt_pass').value;
+      data.mqtt_topic_prefix=$('mqtt_prefix').value.trim();
+      data.debug_mode=!!$('debug_mode').checked;
+      data.demo_mode=!!$('demo_mode').checked;
+      data.wifi_power_save=!!$('wifi_power_save').checked;
+      data.deep_sleep_enabled=!!$('deep_sleep_enabled').checked;
+      data.deep_sleep_wake_timer_s=(parseInt($('deep_sleep_wake_timer').value)||0)*3600;
+      data.deep_sleep_on_idle=!!$('deep_sleep_on_idle').checked;
+      data.auto_update_check=!!$('auto_update_check').checked;
+      data.update_channel=parseInt($('update_channel').value)||0;
+      /* weather_lat/weather_lon live on this tab's Location card and are
+         shared by the Image Display tab's moon widget -- there is no
+         separate moon_lat/moon_lon control, so both keys are derived from
+         the same two System-tab fields here. Both System and Image Display
+         are now lazily-loaded fragments (P6d), but this stays safe: this
+         collector only runs when System is in loadedTabs (see
+         getConfigData()'s TAB_ORDER.forEach gate), and getConfigData() seeds
+         `data` from a clone of the cached server config first, so if System
+         was never opened, moon_lat/moon_lon/weather_lat/weather_lon simply
+         pass through the last-saved server values untouched instead of
+         being dropped. */
+      data.moon_lat=parseFloat($('weather_lat').value)||0;
+      data.moon_lon=parseFloat($('weather_lon').value)||0;
+      data.weather_lat=parseFloat($('weather_lat').value)||0;
+      data.weather_lon=parseFloat($('weather_lon').value)||0;
 
       var nets=[];
       for(var i=1;i<=3;i++){
@@ -3955,6 +1975,40 @@
         nets.push(o);
       }
       data.wifi_networks=nets;
+    }
+
+    function collectTab_logs(data){
+      data.crash_log_retention_days=parseInt($('crashlog_retention').value,10)||0;
+    }
+
+    function collectTab_backup(data){
+      /* Backup tab is read-only (version display, download/restore buttons);
+         nothing it shows is fed back into the config payload. */
+    }
+
+    function collectTab_api(data){
+      /* API reference tab is documentation only; no form fields. */
+    }
+
+    const COLLECT_TAB_FNS={
+      nodes: collectTab_nodes,
+      allsky: collectTab_allsky,
+      clock: collectTab_clock,
+      spotify: collectTab_spotify,
+      'image-display': collectTab_image_display,
+      display: collectTab_display,
+      behavior: collectTab_behavior,
+      system: collectTab_system,
+      logs: collectTab_logs,
+      backup: collectTab_backup,
+      api: collectTab_api
+    };
+
+    function getConfigData(){
+      var data=_cfgCache?structuredClone(_cfgCache):{};
+      TAB_ORDER.forEach(function(name){
+        if(loadedTabs.has(name)) COLLECT_TAB_FNS[name](data);
+      });
       return data;
     }
 
@@ -3962,80 +2016,41 @@
     let loadedConfig='';
     let _populating=false;
 
-    async function populateConfig(data){
-      _populating=true;
-      /* Async ordering: load the page registry FIRST so the Home Page pills and
-         the idle target dropdown options exist before any value-set runs.
-         populateConfig is awaited by loadConfig(); every value-set below this
-         line (including the idle target and active_page_override pills near the
-         end) can safely assume the registry-driven controls are populated. */
-      await fetchPageRegistry();
-      populatePageControls();
-      $('hostname').value=data.hostname||'';
-      var hn=data.hostname||'NINA Display';
-      $('brandName').textContent=hn;
-      document.title=hn;
-      if(data.wifi_networks && data.wifi_networks.length) {
-        for(var i=0;i<3;i++) {
-          var n=data.wifi_networks[i]||{};
-          $('ssid'+(i+1)).value=n.ssid||'';
-          $('pass'+(i+1)).value='';
-        }
-      } else {
-        $('ssid1').value=data.ssid||'';
-        $('pass1').value='';
-        $('ssid2').value='';$('pass2').value='';
-        $('ssid3').value='';$('pass3').value='';
-      }
-      $('ntp').value=data.ntp||'';
-      $('timezone').value=data.timezone||'';
+    /* === Per-Tab Config Populators ===
+       Mirror image of the collectors above: one populate function per tab,
+       each setting only the DOM it owns. Split out of the old monolithic
+       populateConfig so a tab can be populated the moment its fragment
+       finishes loading (see loadTabFragment() above) instead of requiring
+       every tab's markup to already exist. As of P6d every tab is a lazily
+       loaded fragment: populateConfig()'s TAB_ORDER.forEach below only calls
+       a tab's populator once that tab is in loadedTabs, and loadTabFragment()
+       makes the matching direct call the moment a tab's fragment is
+       injected -- between the two, every tab still ends up populated exactly
+       once per fragment load / per config reload, whichever tab order the
+       user actually opens them in. */
 
+    function populateTab_nodes(data){
+      /* Build the per-instance node cards first (P6d: tab-nodes is now a
+         lazily-loaded fragment, so #node-cards is empty until this runs). */
+      buildNodeCards();
       function extractHost(url){
         if(!url) return '';
         var m=url.match(/^https?:\/\/([^:/]+)/);
         return m?m[1]:'';
       }
-
       $('url1').value=extractHost(data.url1);
       $('url2').value=extractHost(data.url2);
       $('url3').value=extractHost(data.url3);
-
-      $('theme_select').value=data.theme_index||0;
-      $('widget_style_select').value=data.widget_style||0;
-      $('screen_rotation_select').value=data.screen_rotation||0;
-      var br=data.brightness!=null?data.brightness:80;
-      $('brightness').value=br;
-      $('brightness_val').textContent=br+'%';
-      var cb=data.color_brightness!=null?data.color_brightness:80;
-      $('color_brightness').value=cb;
-      $('color_brightness_val').textContent=cb+'%';
       $('update_rate').value=data.update_rate_s||2;
       $('graph_interval').value=data.graph_update_interval_s||5;
       $('connection_timeout').value=data.connection_timeout_s||6;
-      $('toast_duration').value=data.toast_duration_s||8;
-      $('debug_mode').checked=!!data.debug_mode;
-      $('demo_mode').checked=!!data.demo_mode;
       $('instance_enabled_0').checked=data.instance_enabled_1!==false;
       $('instance_enabled_1').checked=data.instance_enabled_2!==false;
       $('instance_enabled_2').checked=data.instance_enabled_3!==false;
-      $('screen_sleep_enabled').checked=!!data.screen_sleep_enabled;
-      $('screen_sleep_timeout').value=data.screen_sleep_timeout_s||60;
       $('idle_poll_interval').value=data.idle_poll_interval_s||30;
-      $('wifi_power_save').checked=data.wifi_power_save!==false;
-      $('deep_sleep_enabled').checked=!!data.deep_sleep_enabled;
-      $('deep_sleep_wake_timer').value=Math.round((data.deep_sleep_wake_timer_s||0)/3600);
-      $('deep_sleep_on_idle').checked=!!data.deep_sleep_on_idle;
-      $('alert_flash_enabled').checked=data.alert_flash_enabled!==false;
-      var aggWin=data.toast_aggregation_window_s!=null?data.toast_aggregation_window_s:5;
-      $('toast_aggregation_window').value=aggWin;
-      updateAggregationLabel(aggWin);
-      var mask=data.toast_notify_mask!=null?data.toast_notify_mask:0xFFFFFFFF;
-      for(var i=0;i<12;i++){$('notify_cat_'+i).checked=!!(mask&(1<<i));}
       $('toast_instance_muted_0').checked=!!data.toast_instance_muted_1;
       $('toast_instance_muted_1').checked=!!data.toast_instance_muted_2;
       $('toast_instance_muted_2').checked=!!data.toast_instance_muted_3;
-      $('auto_update_check').checked=data.auto_update_check!==false;
-      $('update_channel').value=data.update_channel||0;
 
       for(var i=0;i<3;i++){
         var key='filter_colors_'+(i+1);
@@ -4047,30 +2062,19 @@
       loadThresholds(data,1,'rms_thresholds_2','hfr_thresholds_2');
       loadThresholds(data,2,'rms_thresholds_3','hfr_thresholds_3');
 
-      var mqttUrl=data.mqtt_broker_url||'';
-      var mqttMatch=mqttUrl.match(/^mqtt:\/\/(.+)/);
-      $('mqtt_broker').value=mqttMatch?mqttMatch[1]:'';
-      $('mqtt_port').value=data.mqtt_port||1883;
-      $('mqtt_user').value=data.mqtt_username||'';
-      $('mqtt_pass').value=data.mqtt_password||'';
-      $('mqtt_prefix').value=data.mqtt_topic_prefix||'';
-      $('mqtt_enabled').checked=!!data.mqtt_enabled;
-
-      $('auto_cycle_toggle').checked=!!data.auto_rotate_enabled;
-      toggleAutoCycle();
-
-      $('auto_rotate_interval').value=data.auto_rotate_interval_s||30;
-      $('auto_rotate_effect').value=data.auto_rotate_effect||0;
-      $('auto_rotate_skip').checked=!!data.auto_rotate_skip_disconnected;
-      if($('nav_grace_s')) $('nav_grace_s').value=(data.nav_grace_s||10);
-      if(data.auto_rotate_order2) setRotateOrder(data.auto_rotate_order2);
-      else if(data.auto_rotate_order) setRotateOrder(data.auto_rotate_order);
-
+      /* Cross-tab: rebuilds the Behavior tab's Home Page pills (via
+         updatePageSelectOptions -> buildStartPagePills) and the opacity of
+         its rotation-order checkboxes (via updateInstanceStates), using the
+         Nodes-tab fields just set above. populateTab_behavior() runs later
+         in TAB_ORDER and overwrites the Home Page pill selection with the
+         real server value, so this call's transient effect on that pill is
+         harmless -- matches the original monolith, which called
+         updateNodeLabels() at this same relative point, well before its
+         final setStartPageValue() call. */
       updateNodeLabels();
+    }
 
-      // passwords cleared in populateConfig wifi_networks block above
-
-      // AllSky fields
+    function populateTab_allsky(data){
       if($('allsky_enabled')) $('allsky_enabled').checked=!!data.allsky_enabled;
       if($('allskyHostname')) $('allskyHostname').value=data.allsky_hostname||'';
       if($('allskyInterval')) $('allskyInterval').value=data.allsky_update_interval_s||5;
@@ -4081,8 +2085,20 @@
       try{ asFields=JSON.parse(data.allsky_field_config||'{}'); }catch(e){}
       populateAllSkyFieldMappings(asFields,asThr);
       updateAllSkyEnabledUI();
+    }
 
-      // Spotify fields
+    function populateTab_clock(data){
+      if($('weather_provider')) $('weather_provider').value=data.weather_provider||0;
+      if($('weather_api_key')) $('weather_api_key').value=data.weather_api_key||'';
+      if($('weather_location_name')) $('weather_location_name').value=data.weather_location_name||'';
+      if($('weather_station_id')) $('weather_station_id').value=(data.weather_provider==2)?(data.weather_location_name||''):'';
+      if($('weather_poll_interval_s')) $('weather_poll_interval_s').value=data.weather_poll_interval_s||900;
+      if($('weather_units')) $('weather_units').value=data.weather_units||0;
+      if($('weather_time_format')) $('weather_time_format').value=data.weather_time_format||0;
+      toggleWeatherApiKey();
+    }
+
+    function populateTab_spotify(data){
       if($('spotify_enabled')) $('spotify_enabled').checked=!!data.spotify_enabled;
       if($('spotifyClientId')) $('spotifyClientId').value=data.spotify_client_id||'';
       if($('spotifyPollInterval')) $('spotifyPollInterval').value=data.spotify_poll_interval_ms||3000;
@@ -4092,8 +2108,9 @@
       if($('spotify_scroll_text')) $('spotify_scroll_text').checked=data.spotify_scroll_text!=null?!!data.spotify_scroll_text:true;
       if($('spotifyOverlayTimeout')) $('spotifyOverlayTimeout').value=data.spotify_overlay_timeout_s!=null?data.spotify_overlay_timeout_s:5;
       updateSpotifyEnabledUI();
+    }
 
-      // Image Display fields
+    function populateTab_image_display(data){
       if($('image_display_enabled')) $('image_display_enabled').checked=!!data.image_display_enabled;
       if($('image_display_show_overlay')) $('image_display_show_overlay').checked=data.image_display_show_overlay!=null?!!data.image_display_show_overlay:true;
       if($('image_display_crop')) $('image_display_crop').checked=!!data.image_display_crop;
@@ -4134,23 +2151,57 @@
       updateMoonSpinUI();
       updateImageDisplayEnabledUI();
       updateImageSourceUI();
+    }
 
-      // Clock & Weather fields
-      if($('weather_provider')) $('weather_provider').value=data.weather_provider||0;
-      if($('weather_api_key')) $('weather_api_key').value=data.weather_api_key||'';
-      var wlat=data.weather_lat, wlon=data.weather_lon;
-      // Fall back to a previously configured moon-only location
-      if((!wlat && !wlon) && (data.moon_lat || data.moon_lon)){ wlat=data.moon_lat; wlon=data.moon_lon; }
-      if($('weather_lat')) $('weather_lat').value=wlat||'';
-      if($('weather_lon')) $('weather_lon').value=wlon||'';
-      if($('weather_location_name')) $('weather_location_name').value=data.weather_location_name||'';
-      if($('weather_station_id')) $('weather_station_id').value=(data.weather_provider==2)?(data.weather_location_name||''):'';
-      if($('weather_poll_interval_s')) $('weather_poll_interval_s').value=data.weather_poll_interval_s||900;
-      if($('weather_units')) $('weather_units').value=data.weather_units||0;
-      if($('weather_time_format')) $('weather_time_format').value=data.weather_time_format||0;
-      toggleWeatherApiKey();
+    function populateTab_display(data){
+      $('theme_select').value=data.theme_index||0;
+      $('widget_style_select').value=data.widget_style||0;
+      $('screen_rotation_select').value=data.screen_rotation||0;
+      var br=data.brightness!=null?data.brightness:80;
+      $('brightness').value=br;
+      $('brightness_val').textContent=br+'%';
+      var cb=data.color_brightness!=null?data.color_brightness:80;
+      $('color_brightness').value=cb;
+      $('color_brightness_val').textContent=cb+'%';
+      $('screen_sleep_enabled').checked=!!data.screen_sleep_enabled;
+      $('screen_sleep_timeout').value=data.screen_sleep_timeout_s||60;
+    }
 
-      // Idle override fields
+    async function populateTab_behavior(data){
+      /* P6d: tab-behavior is now a lazily-loaded fragment. #arp-container's
+         rotation pills (buildArpPills) and #start-page-pills /
+         #idle_page_override_target (populatePageControls, page-registry
+         driven) must be (re)built here every time this tab populates --
+         populateConfig()'s unconditional populatePageControls() call at its
+         top only reaches these elements when this fragment is already
+         loaded by then. buildArpPills() has no registry dependency and runs
+         first so setRotateOrder() below always has pills to select from;
+         populatePageControls() awaits the (cached, near-instant after boot)
+         page registry fetch before building the Home Page pills and idle
+         target dropdown that setStartPageValue() needs. Both functions
+         clear-then-rebuild, so re-running them on every populate (including
+         a config reload) is safe. */
+      buildArpPills();
+      await fetchPageRegistry();
+      populatePageControls();
+      $('toast_duration').value=data.toast_duration_s||8;
+      $('alert_flash_enabled').checked=data.alert_flash_enabled!==false;
+      var aggWin=data.toast_aggregation_window_s!=null?data.toast_aggregation_window_s:5;
+      $('toast_aggregation_window').value=aggWin;
+      updateAggregationLabel(aggWin);
+      var mask=data.toast_notify_mask!=null?data.toast_notify_mask:0xFFFFFFFF;
+      for(var i=0;i<12;i++){$('notify_cat_'+i).checked=!!(mask&(1<<i));}
+
+      $('auto_cycle_toggle').checked=!!data.auto_rotate_enabled;
+      toggleAutoCycle();
+
+      $('auto_rotate_interval').value=data.auto_rotate_interval_s||30;
+      $('auto_rotate_effect').value=data.auto_rotate_effect||0;
+      $('auto_rotate_skip').checked=!!data.auto_rotate_skip_disconnected;
+      if($('nav_grace_s')) $('nav_grace_s').value=(data.nav_grace_s||10);
+      if(data.auto_rotate_order2) setRotateOrder(data.auto_rotate_order2);
+      else if(data.auto_rotate_order) setRotateOrder(data.auto_rotate_order);
+
       if($('idle_page_override_enabled')) $('idle_page_override_enabled').checked=!!data.idle_page_override_enabled;
       if($('idle_page_override_target')) $('idle_page_override_target').value=data.idle_page_override_target!=null?data.idle_page_override_target:0;
       if($('idle_indicator_enabled')) $('idle_indicator_enabled').checked=data.idle_indicator_enabled!==false;
@@ -4162,27 +2213,127 @@
       // needed here (the lock has no dependent controls to show/hide).
       if($('home_page_lock')) $('home_page_lock').checked=!!data.home_page_lock;
 
-      // Crash log retention (days; 0 = never). Default 30 when absent.
-      if($('crashlog_retention')) $('crashlog_retention').value=(data.crash_log_retention_days!=null?data.crash_log_retention_days:30);
+      // Home Page pills were just (re)built above by populatePageControls().
+      // active_page_override is a registry id after migration (never -1);
+      // default to 0 if absent.
+      setStartPageValue(data.active_page_override!=null?data.active_page_override:0);
+      updatePageNavSummary();
+    }
+
+    function populateTab_system(data){
+      /* P6d: tab-system is now a lazily-loaded fragment. The firmware/build
+         info grid (#fw_version etc.) is filled by loadVersion(), which is
+         normally kicked off once at boot (see the Init section at the
+         bottom of this file) -- but that first call races the System
+         fragment's own lazy load, and loadVersion() only ever runs that
+         once. Call it again here (guarded internally, safe to repeat) so
+         the grid is populated whenever this tab's fragment becomes present,
+         regardless of which happened first. */
+      if(typeof loadVersion==='function') loadVersion();
+      $('hostname').value=data.hostname||'';
+      if(data.wifi_networks && data.wifi_networks.length) {
+        for(var i=0;i<3;i++) {
+          var n=data.wifi_networks[i]||{};
+          $('ssid'+(i+1)).value=n.ssid||'';
+          $('pass'+(i+1)).value='';
+        }
+      } else {
+        $('ssid1').value=data.ssid||'';
+        $('pass1').value='';
+        $('ssid2').value='';$('pass2').value='';
+        $('ssid3').value='';$('pass3').value='';
+      }
+      $('ntp').value=data.ntp||'';
+      $('timezone').value=data.timezone||'';
+      // passwords cleared in the wifi_networks block above
+
+      $('debug_mode').checked=!!data.debug_mode;
+      $('demo_mode').checked=!!data.demo_mode;
+      $('wifi_power_save').checked=data.wifi_power_save!==false;
+      $('deep_sleep_enabled').checked=!!data.deep_sleep_enabled;
+      $('deep_sleep_wake_timer').value=Math.round((data.deep_sleep_wake_timer_s||0)/3600);
+      $('deep_sleep_on_idle').checked=!!data.deep_sleep_on_idle;
+      $('auto_update_check').checked=data.auto_update_check!==false;
+      $('update_channel').value=data.update_channel||0;
+
+      var mqttUrl=data.mqtt_broker_url||'';
+      var mqttMatch=mqttUrl.match(/^mqtt:\/\/(.+)/);
+      $('mqtt_broker').value=mqttMatch?mqttMatch[1]:'';
+      $('mqtt_port').value=data.mqtt_port||1883;
+      $('mqtt_user').value=data.mqtt_username||'';
+      $('mqtt_pass').value=data.mqtt_password||'';
+      $('mqtt_prefix').value=data.mqtt_topic_prefix||'';
+      $('mqtt_enabled').checked=!!data.mqtt_enabled;
+
+      /* weather_lat/weather_lon live on this tab's Location card and double
+         as the Image Display tab's moon widget coordinates -- there is no
+         separate moon_lat/moon_lon control (see the matching note in
+         collectTab_system). Falls back to a previously configured moon-only
+         location for devices upgraded from before the shared field existed. */
+      var wlat=data.weather_lat, wlon=data.weather_lon;
+      if((!wlat && !wlon) && (data.moon_lat || data.moon_lon)){ wlat=data.moon_lat; wlon=data.moon_lon; }
+      if($('weather_lat')) $('weather_lat').value=wlat||'';
+      if($('weather_lon')) $('weather_lon').value=wlon||'';
 
       // Authentication toggle — reflect in UI and hide sign-out button when off
       var authOn = (data.auth_enabled!==false);
       if($('auth_enabled')) $('auth_enabled').checked = authOn;
       if($('signOutBtn')) $('signOutBtn').style.display = authOn ? '' : 'none';
+    }
 
-      /* Backup tab version info */
+    function populateTab_logs(data){
+      // Crash log retention (days; 0 = never). Default 30 when absent.
+      if($('crashlog_retention')) $('crashlog_retention').value=(data.crash_log_retention_days!=null?data.crash_log_retention_days:30);
+      // Wire the tab's own change listeners now that its fragment is loaded
+      // (see wireLogsControls() for why this can't run at script-parse time).
+      if(typeof wireLogsControls==='function') wireLogsControls();
+    }
+
+    function populateTab_backup(data){
       if ($('backupCurrentVersion')) $('backupCurrentVersion').textContent = 'v' + (data.config_version || '?');
       if ($('backupFirmwareVersion')) {
         fetch('/api/version').then(function(r){return r.json()}).then(function(v){
           $('backupFirmwareVersion').textContent = v.git_tag || '--';
         }).catch(function(){});
       }
+    }
 
-      // Home Page pills are already built from the page registry (populatePageControls
-      // ran near the top). active_page_override is a registry id after migration
-      // (never -1); default to 0 if absent.
-      setStartPageValue(data.active_page_override!=null?data.active_page_override:0);
-      updatePageNavSummary();
+    function populateTab_api(data){
+      /* API reference tab is documentation only; nothing to populate from config. */
+    }
+
+    const POPULATE_TAB_FNS={
+      nodes: populateTab_nodes,
+      allsky: populateTab_allsky,
+      clock: populateTab_clock,
+      spotify: populateTab_spotify,
+      'image-display': populateTab_image_display,
+      display: populateTab_display,
+      behavior: populateTab_behavior,
+      system: populateTab_system,
+      logs: populateTab_logs,
+      backup: populateTab_backup,
+      api: populateTab_api
+    };
+
+    async function populateConfig(data){
+      _populating=true;
+      /* Async ordering: load the page registry FIRST so the Home Page pills and
+         the idle target dropdown options exist before any per-tab populate runs.
+         populateConfig is awaited by loadConfig(); every per-tab populate below
+         (including populateTab_nodes' updateNodeLabels() call and
+         populateTab_behavior's own pill/dropdown value-set) can safely assume
+         the registry-driven controls already exist. */
+      await fetchPageRegistry();
+      populatePageControls();
+
+      var hn=data.hostname||'NINA Display';
+      $('brandName').textContent=hn;
+      document.title=hn;
+
+      TAB_ORDER.forEach(function(name){
+        if(loadedTabs.has(name)) POPULATE_TAB_FNS[name](data);
+      });
 
       loadedConfig=JSON.stringify(getConfigData());
       _populating=false;
@@ -4216,7 +2367,10 @@
           div.onclick=function(){
             $('weather_lat').value=r.latitude.toFixed(4);
             $('weather_lon').value=r.longitude.toFixed(4);
-            $('weather_location_name').value=r.name+(r.admin1?', '+r.admin1:'');
+            /* weather_location_name lives on the (lazily-loaded) Clock tab
+               fragment -- guard the write since this button is on System
+               and Clock may never have been activated this session. */
+            if($('weather_location_name')) $('weather_location_name').value=r.name+(r.admin1?', '+r.admin1:'');
             resultsDiv.style.display='none';
             checkDirty();
           };
@@ -4356,42 +2510,54 @@
     function loadConfig(){
       /* Returns the chain so init can defer heavy startup work after populate.
          scanWifi() is no longer fired here; it runs lazily on first unfurl of the
-         "Available Networks" panel. */
-      return fetch('/api/config').then(r=>r.json()).then(populateConfig).catch(e=>console.error('Failed to load config',e));
+         "Available Networks" panel. Forces a fresh GET (bypassing _cfgCache) since
+         this is the authoritative load path -- initial page load and post-revert
+         reload both need the server's current state, not a stale cached copy. */
+      return fetchConfig(true).then(populateConfig).catch(e=>console.error('Failed to load config',e));
     }
 
     /* === Version Load === */
     function loadVersion(){
+      /* P6d: tab-system (where the whole #fw_* grid lives) is now a lazily
+         loaded fragment, so these elements may not exist yet the first time
+         this runs (boot fires it unconditionally -- see Init below -- before
+         the user has necessarily opened System). Every write is guarded;
+         populateTab_system() calls this again once the fragment is present
+         so the grid still ends up populated. */
       fetch('/api/version').then(r=>r.json()).then(data=>{
-        $('fw_version').textContent=data.version||'--';
-        $('fw_date').textContent=(data.date||'--')+' '+(data.time||'');
-        $('fw_idf').textContent=data.idf||'--';
-        $('fw_partition').textContent=data.partition||'--';
+        if($('fw_version')) $('fw_version').textContent=data.version||'--';
+        if($('fw_date')) $('fw_date').textContent=(data.date||'--')+' '+(data.time||'');
+        if($('fw_idf')) $('fw_idf').textContent=data.idf||'--';
+        if($('fw_partition')) $('fw_partition').textContent=data.partition||'--';
 
         var ghBase='https://github.com/chvvkumar/ESP32-P4-NINA-Display/';
         var tagEl=$('fw_git_tag');
-        tagEl.textContent='';
-        var releaseTag=data.version?'v'+data.version:data.git_tag;
-        if(releaseTag&&releaseTag!=='unknown'){
-          var a=document.createElement('a');
-          a.href=ghBase+'releases/tag/'+encodeURIComponent(releaseTag);
-          a.target='_blank'; a.rel='noopener'; a.className='accent-link';
-          a.textContent=releaseTag;
-          tagEl.appendChild(a);
-        }else{
-          tagEl.textContent=releaseTag||'--';
+        if(tagEl){
+          tagEl.textContent='';
+          var releaseTag=data.version?'v'+data.version:data.git_tag;
+          if(releaseTag&&releaseTag!=='unknown'){
+            var a=document.createElement('a');
+            a.href=ghBase+'releases/tag/'+encodeURIComponent(releaseTag);
+            a.target='_blank'; a.rel='noopener'; a.className='accent-link';
+            a.textContent=releaseTag;
+            tagEl.appendChild(a);
+          }else{
+            tagEl.textContent=releaseTag||'--';
+          }
         }
 
         var shaEl=$('fw_git_sha');
-        shaEl.textContent='';
-        if(data.git_sha&&data.git_sha!=='unknown'){
-          var a=document.createElement('a');
-          a.href=ghBase+'commit/'+encodeURIComponent(data.git_sha);
-          a.target='_blank'; a.rel='noopener'; a.className='mono-link';
-          a.textContent=data.git_sha.substring(0,8);
-          shaEl.appendChild(a);
-        }else{
-          shaEl.textContent=data.git_sha||'--';
+        if(shaEl){
+          shaEl.textContent='';
+          if(data.git_sha&&data.git_sha!=='unknown'){
+            var a=document.createElement('a');
+            a.href=ghBase+'commit/'+encodeURIComponent(data.git_sha);
+            a.target='_blank'; a.rel='noopener'; a.className='mono-link';
+            a.textContent=data.git_sha.substring(0,8);
+            shaEl.appendChild(a);
+          }else{
+            shaEl.textContent=data.git_sha||'--';
+          }
         }
       }).catch(e=>console.error('Failed to load version',e));
     }
@@ -4413,6 +2579,7 @@
         if(!r.ok) throw new Error('Save failed');
         return r.text();
       }).then(()=>{
+        invalidateConfigCache();
         showToast('Settings saved','success');
         loadedConfig=JSON.stringify(getConfigData());
         $('saveBar').classList.remove('visible');
@@ -4426,6 +2593,7 @@
     function reloadConfig(){
       fetch('/api/config/revert',{method:'POST'}).then(r=>{
         if(!r.ok) throw new Error('Revert failed');
+        invalidateConfigCache();
         loadConfig();
         $('saveBar').classList.remove('visible');
       }).catch(e=>showToast('Discard failed: '+e.message,'error'));
@@ -4435,6 +2603,7 @@
       if(!confirm('Apply changes and reboot now?')) return;
       postJson('/api/config',getConfigData()).then(r=>{
         if(!r.ok) throw new Error('Save failed');
+        invalidateConfigCache();
         return fetch('/api/reboot',{method:'POST'});
       }).then(()=>{
         showToast('Rebooting...','success');
@@ -4461,6 +2630,7 @@
         body:JSON.stringify({auth_enabled:want})
       }).then(function(r){
         if(!r.ok) throw new Error('HTTP '+r.status);
+        invalidateConfigCache();
         if(status){
           status.textContent = want ? 'Authentication enabled.' : 'Authentication disabled.';
           status.style.color = '#6c6';
@@ -4756,7 +2926,12 @@
     }
 
     function loadChangelog(){
-      var channel=parseInt($('update_channel').value)||0;
+      /* update_channel is a System-tab field. openChangelogModal() (this
+         function's only caller) is reachable from the global updatePill
+         badge in the top nav, which is wired at parse time and visible on
+         any tab (see checkUpdateBadge()) -- so System may never have been
+         opened this session. Fall back to the cached server config. */
+      var channel=$('update_channel')?(parseInt($('update_channel').value)||0):(_cfgCache&&_cfgCache.update_channel!=null?_cfgCache.update_channel:0);
       fetch('https://api.github.com/repos/chvvkumar/ESP32-P4-NINA-Display/releases?per_page=30')
         .then(function(r){return r.json();})
         .then(function(releases){
@@ -5345,6 +3520,33 @@
       if($('customGroup')) $('customGroup').style.display=(s===3)?'':'none';
     }
 
+    /* weather_lat/weather_lon are System-tab fields (Location card) reused as
+       the moon widget's coordinates -- see the matching note in
+       collectTab_system/populateTab_system. Both Image Display and System
+       are lazily-loaded fragments (P6c, P6d), and applyImageDisplay() is
+       called from Image-Display-tab-only buttons (resetMoonOrientation,
+       fetchCustomPreview), so System may never have been opened this
+       session. Fall back to the cached server config (whichever of
+       weather_lat/lon or the older moon_lat/lon key is present) instead of
+       silently reading null.value and throwing, or resetting the moon
+       position to 0,0 on every apply. */
+    function currentMoonLat(){
+      if($('weather_lat')) return parseFloat($('weather_lat').value)||0;
+      if(_cfgCache){
+        if(_cfgCache.weather_lat!=null) return _cfgCache.weather_lat;
+        if(_cfgCache.moon_lat!=null) return _cfgCache.moon_lat;
+      }
+      return 0;
+    }
+    function currentMoonLon(){
+      if($('weather_lon')) return parseFloat($('weather_lon').value)||0;
+      if(_cfgCache){
+        if(_cfgCache.weather_lon!=null) return _cfgCache.weather_lon;
+        if(_cfgCache.moon_lon!=null) return _cfgCache.moon_lon;
+      }
+      return 0;
+    }
+
     function applyImageDisplay(force){
       return postJson('/api/image-display-config', {
         force_fetch: !!force,
@@ -5356,8 +3558,8 @@
         image_display_source: getImageSource(),
         moon_bg_style: parseInt($('moonBg').value,10)||0,
         moon_drag_light_mode: parseInt($('moonDragLight').value,10)||0,
-        moon_lat: parseFloat($('weather_lat').value)||0,
-        moon_lon: parseFloat($('weather_lon').value)||0,
+        moon_lat: currentMoonLat(),
+        moon_lon: currentMoonLon(),
         moon_north_up: $('moon_north_up').checked?1:0,
         moon_flip_u: $('moon_flip_u').checked?1:0,
         moon_flip_v: $('moon_flip_v').checked?1:0,
@@ -5545,10 +3747,15 @@
       if(pop && pop.classList.contains('help-popover')) pop.classList.toggle('open');
     }
 
-    function initCollapsibleCards(){
+    function initCollapsibleCards(root){
+      /* root scopes the scan to one just-injected fragment (see
+         loadTabFragment) so re-running this after a lazy tab loads does not
+         re-attach a second click listener to cards from tabs already wired
+         at initial page load. Defaults to the whole document for the
+         original startup call below. */
       var saved={};
       try{ saved=JSON.parse(localStorage.getItem('nina_collapse_state')||'{}'); }catch(e){}
-      document.querySelectorAll('.card').forEach(function(card){
+      (root||document).querySelectorAll('.card').forEach(function(card){
         var title=card.querySelector('.card-title');
         if(!title) return;
         if(card.classList.contains('nocollapse')) return;  // always-expanded cards (e.g. Logs)
@@ -5740,20 +3947,30 @@
       else stopLogsAutoRefresh();
     }
 
-    (function(){
+    /* Attaches the Logs tab's checkbox/select change listeners. Named (not a
+       parse-time IIFE) because tab-logs is now a lazily-loaded fragment
+       (P6b): the elements don't exist at script-parse time unless Logs is
+       the tab restored from localStorage, and even then the fragment fetch
+       is async. Called from populateTab_logs(), which already runs once the
+       fragment's markup is guaranteed present (either via loadTabFragment's
+       direct post-injection call, or via populateConfig()'s loadedTabs-gated
+       loop) -- so this may run more than once across a session (e.g. every
+       config reload); addEventListener with the same function reference is
+       idempotent, so repeat calls do not attach duplicate listeners. */
+    function wireLogsControls(){
       var cb=$('logsAutoRefresh');
       var sel=$('logsRefreshInterval');
+      if(!cb && !sel) return;  // fragment not loaded yet
       if(cb) cb.addEventListener('change',syncLogsAutoRefresh);
       if(sel) sel.addEventListener('change',function(){
         /* Restart with the new interval only if auto-refresh is on. */
         if(cb && cb.checked) startLogsAutoRefresh();
       });
-      /* If Logs is the restored active tab on page load, the early switchTab()
-         ran before these functions existed (guarded by typeof), so populate now.
-         setLogSource('device') wires up the default source and refreshes it; crash
-         data loads lazily the first time the user switches to the crash source. */
+      /* If Logs is the active tab when this first runs, populate the default
+         source now; switchTab() also does this on every Logs activation, so
+         this is a harmless re-trigger when both fire close together. */
       if(logsTabActive()){ setLogSource('device'); }
-    })();
+    }
 
     /* Pause auto-refresh when the page is hidden; resume when visible on Logs tab. */
     document.addEventListener('visibilitychange',function(){

--- a/main/fragment_allsky.html
+++ b/main/fragment_allsky.html
@@ -1,0 +1,63 @@
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Connection <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">AllSky Connection</div><p>Points the device at an AllSky camera's API and sets how often it reads data. AllSky updates run on their own schedule, independent of N.I.N.A. polling, so this interval does not affect N.I.N.A. updates.</p><p>The dew-point safety margin controls when the dew reading is colored as safe. The reading is treated as safe while the dew point sits below ambient temperature minus this margin.</p><p>Example: set the hostname to allskypi5.lan:8080, the interval to 5 seconds, and a 5 C margin so dew is flagged unsafe once the dew point rises to within 5 C of ambient.</p></div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable AllSky</span>
+          <label class="toggle"><input type="checkbox" id="allsky_enabled" onchange="updateAllSkyEnabledUI()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint">Turns on the AllSky page and starts reading AllSky data; off hides the page and stops reading.</div>
+        <div id="allskyConnectionFields">
+        <div class="subsection">
+          <div class="subsection-title">Server</div>
+          <div class="field">
+            <label class="field-label">AllSky Hostname</label>
+            <input type="text" class="input" id="allskyHostname" placeholder="allskypi5.lan:8080">
+            <div class="field-hint">Host:port of the AllSky API (e.g., allskypi5.lan:8080)</div>
+          </div>
+        </div>
+        <div class="subsection">
+          <div class="subsection-title">Reading</div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">Update Interval</label>
+            <select class="input" id="allskyInterval">
+              <option value="1">1 second</option>
+              <option value="2">2 seconds</option>
+              <option value="5" selected>5 seconds</option>
+              <option value="10">10 seconds</option>
+              <option value="30">30 seconds</option>
+              <option value="60">1 minute</option>
+              <option value="120">2 minutes</option>
+              <option value="300">5 minutes</option>
+            </select>
+            <div class="field-hint">How often the device reads the AllSky API; longer intervals reduce load on the AllSky host.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Dew Point Safety Margin (&deg;C)</label>
+            <input type="number" class="input" id="allskyDewOffset" step="0.5" min="-50" max="50" value="5.0">
+            <div class="field-hint">Dew point colored safe when below ambient &minus; this offset</div>
+          </div>
+        </div>
+        </div>
+        </div>
+      </div>
+
+      <div class="card" id="allskyFieldMappingsCard">
+        <div class="card-title"><span class="card-title-label">Field Mappings <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">AllSky Field Mappings</div><p>Maps values from the AllSky API JSON to the four display quadrants: Thermal, Sky Quality, Ambient, and Power. Each quadrant has a main value, two sub values, and two status dots, and each is filled by entering the JSON key path for that value.</p><p>Use Fetch JSON from AllSky to load the live response, click a Key Path input to make it active, then click Use on a value to copy its path in. Value fields that show a unit also have color controls that set the gradient range between their low and high bounds.</p><p>Example: map the Thermal main value to data.cpu_temp with a 0 to 80 range so the reading shifts from blue toward red as the camera warms.</p></div>
+        <div class="field-hint" style="margin-bottom:16px">Configure which AllSky API JSON values appear in each display quadrant. Click a value's path input, then click "Use" on a value to fill it. Use the color controls to set gradient ranges per field.</div>
+
+        <div class="subsection">
+          <div class="subsection-title">Import from AllSky</div>
+          <button onclick="fetchAllSkyJson()" class="btn btn-primary" id="fetchJsonBtn" style="width:100%;margin-bottom:16px">Fetch JSON from AllSky</button>
+
+          <div id="allskyJsonTree" style="display:none; max-height:300px; overflow-y:auto; margin:0; padding:12px; background:rgba(0,0,0,0.25); border-radius:var(--radius-sm); border:1px solid rgba(255,255,255,0.06); font-family:'SF Mono',Monaco,Consolas,monospace; font-size:0.75rem; line-height:1.6;"></div>
+        </div>
+
+        <div class="subsection">
+          <div class="subsection-title">Quadrant Mappings</div>
+          <div id="allskyFieldMappings"></div>
+        </div>
+      </div>
+

--- a/main/fragment_api.html
+++ b/main/fragment_api.html
@@ -1,0 +1,851 @@
+
+      <!-- Overview / Authentication -->
+      <div class="card nocollapse">
+        <div class="card-title"><span class="card-title-label">HTTP API</span></div>
+        <div class="api-intro">
+          <p>This page documents every HTTP endpoint the device serves. Examples use this device's address (<strong id="apiHostLabel">window.location.host</strong>). For protected endpoints, run the login command first to create cookies.txt.</p>
+          <p>Authentication uses a session cookie. <strong>POST /api/login</strong> with a JSON body <code>{"password":"..."}</code> sets a <code>session</code> cookie valid for 12 hours. Reuse the cookie on later requests. When <code>auth_enabled</code> is false, every endpoint is open and no cookie is required; secrets stay redacted in responses regardless.</p>
+          <p>Each endpoint carries a badge: <span class="api-badge public">Public</span> needs no session, <span class="api-badge auth">Auth</span> requires a valid session cookie when authentication is enabled.</p>
+          <p>Create the cookie once:</p>
+          <div class="api-snip" data-curl="curl -c cookies.txt -X POST http://HOST/api/login -d '{&quot;password&quot;:&quot;YOUR_PASSWORD&quot;}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -c cookies.txt -X POST http://<span class="api-host">HOST</span>/api/login -d '{"password":"YOUR_PASSWORD"}'</pre>
+          </div>
+          <p>Then pass <code>-b cookies.txt</code> on every protected request shown below.</p>
+        </div>
+      </div>
+
+      <!-- Authentication -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Authentication</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/login</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">Verify the admin password and set the session cookie.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -c cookies.txt -X POST http://HOST/api/login -d '{&quot;password&quot;:&quot;YOUR_PASSWORD&quot;}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -c cookies.txt -X POST http://<span class="api-host">HOST</span>/api/login -d '{"password":"YOUR_PASSWORD"}'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"status":"ok"}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/logout</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Destroy the current session.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/logout">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/logout</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/auth/status</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">Report whether the admin password is still the factory default.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl http://HOST/api/auth/status">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl http://<span class="api-host">HOST</span>/api/auth/status</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"default_password":true}</pre></div>
+        </div>
+      </div>
+
+      <!-- Config & Backup -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Config &amp; Backup</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/config</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read the full configuration as JSON. Secrets (passwords, API keys, tokens) are redacted.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/config">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/config</pre>
+          </div>
+          <div class="api-snip-label">Response (truncated)</div>
+          <div class="api-snip"><pre>{"hostname":"NinaDash2","theme_index":0,"brightness":80,"update_rate_s":2,"api_url1":"http://astromele1.lan:1888/v2/api/","instance1_enabled":true,"admin_password":"********", ...}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Write the full configuration blob. Fields are validated and clamped before saving.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config -H 'Content-Type: application/json' -d @config.json">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config -H 'Content-Type: application/json' -d @config.json</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config/apply</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Apply staged configuration as a live preview without persisting it.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config/apply">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config/apply</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config/revert</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Discard the staged configuration and restore the saved values.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config/revert">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config/revert</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/config/backup</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Download the configuration as config.json. Add the query parameter include_sensitive=1 to include secrets.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -o config.json 'http://HOST/api/config/backup?include_sensitive=0'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -o config.json 'http://<span class="api-host">HOST</span>/api/config/backup?include_sensitive=0'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/config/restore</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Upload a config.json. Send confirm:false first to preview the changes, then confirm:true to apply.</p>
+          <div class="api-snip-label">Request (preview)</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/config/restore -H 'Content-Type: application/json' --data-binary @config.json">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/config/restore -H 'Content-Type: application/json' --data-binary @config.json</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/admin-password</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Change the admin password.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/admin-password -d '{&quot;password&quot;:&quot;NEW_PASSWORD&quot;}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/admin-password -d '{"password":"NEW_PASSWORD"}'</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- Display -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Display</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/brightness</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Set the screen backlight (0 to 100).</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/brightness -d '{&quot;value&quot;:80}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/brightness -d '{"value":80}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/color-brightness</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Set the text and color brightness (0 to 100).</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/color-brightness -d '{&quot;value&quot;:70}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/color-brightness -d '{"value":70}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/theme</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Select a color theme by index.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/theme -d '{&quot;theme_index&quot;:2}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/theme -d '{"theme_index":2}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/widget-style</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Select the widget style by index.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/widget-style -d '{&quot;widget_style&quot;:1}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/widget-style -d '{"widget_style":1}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/screen-rotation</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Set the LVGL screen rotation by index.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/screen-rotation -d '{&quot;screen_rotation&quot;:0}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/screen-rotation -d '{"screen_rotation":0}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/screenshot</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Capture a JPEG of the current display.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -o screenshot.jpg http://HOST/api/screenshot">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -o screenshot.jpg http://<span class="api-host">HOST</span>/api/screenshot</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- Navigation -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Navigation</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/page</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Navigate to a page by legacy page index.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/page -d '{&quot;page&quot;:4}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/page -d '{"page":4}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/pages</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Enumerate the page registry. Returns id, slug, label, kind, category, targetable, and current availability for every page.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/pages">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/pages</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>[{"id":4,"slug":"summary","label":"Summary","kind":"page","category":"","targetable":true,"available":true}, ...]</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span> <span class="api-method">POST</span><span class="api-path">/api/navigate</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Navigate by page slug (?ref=) or page id (?id=). The page must be targetable and currently available.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt 'http://HOST/api/navigate?ref=summary'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt 'http://<span class="api-host">HOST</span>/api/navigate?ref=summary'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>OK</pre></div>
+        </div>
+      </div>
+
+      <!-- System & OTA -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">System &amp; OTA</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/status</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">Read a live device sample: uptime, heap, PSRAM, temperature, WiFi, and active page.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl http://HOST/api/status">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl http://<span class="api-host">HOST</span>/api/status</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"uptime_ms":36619476,"boot_count":145,"active_page":2,"instance_count":3,"heap_free":20355548,"heap_internal_free":198455,"heap_total":387867,"psram_free":20172872,"psram_total":29944064,"temperature_c":33.5,"wifi_rssi":-34,"wifi_ssid":"IoT"}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/version</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">Read firmware version, build, IDF version, partition, and git metadata.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl http://HOST/api/version">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl http://<span class="api-host">HOST</span>/api/version</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"version":"1.0.53","date":"","time":"","idf":"v5.5.2","partition":"ota_0","git_tag":"v1.0.53","git_sha":"598ab9a","git_branch":"HEAD"}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/check-update</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Trigger a firmware update check against GitHub releases.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/check-update">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/check-update</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/check-update-json</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read the result of the last update check.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/check-update-json">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/check-update-json</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/ota-github</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Download and flash the latest GitHub release.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/ota-github">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/ota-github</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/ota</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Upload a firmware .bin for a manual OTA flash.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/ota --data-binary @firmware.bin">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/ota --data-binary @firmware.bin</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/perf</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read performance metrics. Available only when debug_mode is enabled in config.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/perf">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/perf</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/perf/reset</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Zero the performance counters.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/perf/reset">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/perf/reset</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/reboot</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Soft-reboot the device.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/reboot">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/reboot</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/factory-reset</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Erase NVS and reboot. All settings return to defaults.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/factory-reset">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/factory-reset</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- Logs & Diagnostics -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Logs &amp; Diagnostics</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/logs</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Download the serial-log ring buffer held in PSRAM since boot.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -o device.log http://HOST/api/logs">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -o device.log http://<span class="api-host">HOST</span>/api/logs</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/logs/clear</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Clear the serial log buffer.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/logs/clear">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/logs/clear</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/crashlog</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read the reboot-reason history.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/crashlog">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/crashlog</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/crashlog/clear</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Erase the crash log.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/crashlog/clear">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/crashlog/clear</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/coredump</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Download the raw core dump (raw flash format). Decode with esp-coredump using the matching .elf.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -o coredump.bin http://HOST/api/coredump">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -o coredump.bin http://<span class="api-host">HOST</span>/api/coredump</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/coredump/info</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read core dump metadata (presence and size).</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/coredump/info">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/coredump/info</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/coredump/clear</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Erase the stored core dump.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/coredump/clear">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/coredump/clear</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- WiFi -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">WiFi</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/wifi/scan</span><span class="api-badge public">Public</span> <span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">List nearby networks with signal strength. Public during first-run setup, otherwise requires a session.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/wifi/scan">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/wifi/scan</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"networks":[{"ssid":"IoT","rssi":-34,"channel":6,"auth":"WPA2-PSK","compatible":true}],"count":1,"incompatible_count":0}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/wifi/status</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read the current station connection state.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/wifi/status">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/wifi/status</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"connected":true,"ssid":"IoT","ip":"192.168.1.42"}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/wifi/setup</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Save network credentials (SSID and password).</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/wifi/setup -d '{&quot;ssid&quot;:&quot;IoT&quot;,&quot;password&quot;:&quot;WIFI_PASSWORD&quot;}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/wifi/setup -d '{"ssid":"IoT","password":"WIFI_PASSWORD"}'</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- NINA -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">NINA</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/nina/status</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">Read per-instance NINA connection state, WebSocket status, and poll counters.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl http://HOST/api/nina/status">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl http://<span class="api-host">HOST</span>/api/nina/status</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"instances":[{"index":0,"enabled":true,"url":"http://astromele1.lan:1888/v2/api/","connection_state":"disconnected","websocket_connected":false,"consecutive_failures":7275,"consecutive_successes":0,"last_successful_poll_ms":0}]}</pre></div>
+        </div>
+      </div>
+
+      <!-- Spotify -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Spotify</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/spotify/config</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read Spotify settings.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/spotify/config">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/spotify/config</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"spotify_enabled":true,"spotify_client_id":"...","spotify_poll_interval_ms":3000,"spotify_show_progress_bar":true,"spotify_minimal_mode":false,"spotify_scroll_text":true,"spotify_overlay_timeout_s":10,"spotify_overlay_visible":true}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/config</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Update Spotify settings.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/config -d '{&quot;spotify_enabled&quot;:true}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/config -d '{"spotify_enabled":true}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/spotify/status</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read the current authentication and playback state.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/spotify/status">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/spotify/status</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"auth_state":"authenticated","is_playing":true,"track":"Song Title","artist":"Artist Name"}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/control</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Send a playback command: play, pause, next, or previous.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/control -d '{&quot;action&quot;:&quot;next&quot;}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/control -d '{"action":"next"}'</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/spotify/callback</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">OAuth redirect target. Spotify calls this with the authorization code; not invoked manually.</p>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/token-exchange</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Complete the PKCE token exchange.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/token-exchange">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/token-exchange</pre>
+          </div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/spotify/logout</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Clear the stored Spotify token.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/spotify/logout">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/spotify/logout</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- AllSky -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">AllSky</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/allsky-config</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read AllSky settings.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/allsky-config">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/allsky-config</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"hostname":"allsky.lan","update_interval_s":30,"dew_offset":2.0,"field_config":"{...}","thresholds":"{...}","allsky_enabled":true}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/allsky-proxy</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Proxy the remote AllSky /all endpoint to bypass CORS. Returns the upstream JSON payload.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/allsky-proxy">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/allsky-proxy</pre>
+          </div>
+        </div>
+      </div>
+
+      <!-- Image Display -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Image Display</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/image-display-config</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read the Image Display settings. Returns the full current value of every persisted parameter listed in the POST table below (force_fetch is not part of the output).</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/image-display-config">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt http://<span class="api-host">HOST</span>/api/image-display-config</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"image_display_enabled":true,"image_display_show_overlay":true,"image_display_crop":false,"goes_region":"FD","goes_update_interval_s":600,"image_display_source":0,"moon_bg_style":0,"moon_lat":30,"moon_lon":-97,"solar_band":0,"goes_orientation":0,"solar_orientation":0,"custom_image_url":"","custom_orientation":0,"custom_update_interval_s":600,"moon_drag_light_mode":0,"moon_flip_u":0,"moon_flip_v":0,"moon_roll_offset":0,"moon_yaw_offset":0,"moon_pitch_offset":0,"moon_north_up":0,"moon_spin_mode":0,"moon_spin_return_s":10}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/image-display-config</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Update Image Display settings. Each setting takes effect as a live preview and persists to NVS.</p>
+          <div class="api-note">
+            <strong>Partial merge.</strong> The handler loads the current full configuration, overwrites only the keys present in the request body, then saves. POST a single key to change one setting; any key you omit keeps its current value.
+          </div>
+          <div class="api-snip-label">Request (single key)</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/image-display-config -d '{&quot;image_display_source&quot;:1}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/image-display-config -d '{"image_display_source":1}'</pre>
+          </div>
+          <div class="api-snip-label">Request (force a refresh)</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/image-display-config -d '{&quot;force_fetch&quot;:true}'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/image-display-config -d '{"force_fetch":true}'</pre>
+          </div>
+          <div class="api-snip-label">Parameters</div>
+          <div class="api-table-wrap">
+            <table class="api-table">
+              <thead><tr><th>Param</th><th>Type</th><th>Range / Values</th><th>Notes</th></tr></thead>
+              <tbody>
+                <tr><td>image_display_enabled</td><td>bool</td><td>true / false</td><td>Master enable for the Image Display page.</td></tr>
+                <tr><td>image_display_show_overlay</td><td>bool</td><td>true / false</td><td>Show the info overlay.</td></tr>
+                <tr><td>image_display_crop</td><td>bool</td><td>true / false</td><td>Crop vs full-frame. Toggling re-renders the cached frame locally (no re-download).</td></tr>
+                <tr><td>image_display_source</td><td>int</td><td>0=GOES, 1=Moon, 2=Solar, 3=Custom</td><td>Active image source. An invalid value falls back to 0.</td></tr>
+                <tr><td>goes_region</td><td>string</td><td>region code</td><td>GOES region id.</td></tr>
+                <tr><td>goes_update_interval_s</td><td>int</td><td>300 to 7200 (clamped)</td><td>GOES refresh interval in seconds.</td></tr>
+                <tr><td>goes_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant (0/90/180/270 degrees).</td></tr>
+                <tr><td>goes_vflip</td><td>int</td><td>0 or 1</td><td>Flip GOES image vertically (top/bottom).</td></tr>
+                <tr><td>goes_hflip</td><td>int</td><td>0 or 1</td><td>Flip GOES image horizontally (left/right).</td></tr>
+                <tr><td>solar_band</td><td>int</td><td>0 to 17</td><td>Solar / SDO / SOHO band index. An invalid value falls back to 0.</td></tr>
+                <tr><td>solar_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant.</td></tr>
+                <tr><td>solar_vflip</td><td>int</td><td>0 or 1</td><td>Flip solar image vertically (top/bottom).</td></tr>
+                <tr><td>solar_hflip</td><td>int</td><td>0 or 1</td><td>Flip solar image horizontally (left/right).</td></tr>
+                <tr><td>custom_image_url</td><td>string (max 256)</td><td>must start with http:// or https:// (empty string clears it)</td><td>Custom image source URL. Validated server-side.</td></tr>
+                <tr><td>custom_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant.</td></tr>
+                <tr><td>custom_vflip</td><td>int</td><td>0 or 1</td><td>Flip custom image vertically (top/bottom).</td></tr>
+                <tr><td>custom_hflip</td><td>int</td><td>0 or 1</td><td>Flip custom image horizontally (left/right).</td></tr>
+                <tr><td>custom_update_interval_s</td><td>int</td><td>10 to 7200 (clamped)</td><td>Custom image refresh interval in seconds.</td></tr>
+                <tr><td>moon_bg_style</td><td>int</td><td>0 to 3</td><td>Moon page background style. An invalid value falls back to 0.</td></tr>
+                <tr><td>moon_lat</td><td>float</td><td>latitude</td><td>Observer latitude for moon libration.</td></tr>
+                <tr><td>moon_lon</td><td>float</td><td>longitude</td><td>Observer longitude.</td></tr>
+                <tr><td>moon_drag_light_mode</td><td>int</td><td>0 to 2</td><td>Drag lighting mode.</td></tr>
+                <tr><td>moon_flip_u</td><td>int</td><td>0 or 1</td><td>Flip texture horizontally.</td></tr>
+                <tr><td>moon_flip_v</td><td>int</td><td>0 or 1</td><td>Flip texture vertically.</td></tr>
+                <tr><td>moon_roll_offset</td><td>float</td><td>-180 to 180 (clamped)</td><td>Roll orientation offset in degrees.</td></tr>
+                <tr><td>moon_yaw_offset</td><td>float</td><td>-180 to 180 (clamped)</td><td>Yaw orientation offset in degrees.</td></tr>
+                <tr><td>moon_pitch_offset</td><td>float</td><td>-90 to 90 (clamped)</td><td>Pitch orientation offset in degrees.</td></tr>
+                <tr><td>moon_north_up</td><td>int</td><td>0 or 1</td><td>Force north-up.</td></tr>
+                <tr><td>moon_spin_mode</td><td>int</td><td>0 or 1</td><td>Enable spin interaction.</td></tr>
+                <tr><td>moon_spin_return_s</td><td>int</td><td>3 to 60 (clamped)</td><td>Seconds before spin returns to rest.</td></tr>
+                <tr><td>force_fetch</td><td>bool</td><td>true / false</td><td>Action only, not persisted. Forces an immediate re-fetch (used by the Preview / Refresh button). Forces a download only for the Custom source; for GOES and Solar a fetch happens automatically when source, band, or region changed.</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="api-note">
+            Changing source, band, or region triggers a re-download with a loading overlay. Crop-only or orientation-only changes re-render the cached frame locally without downloading.
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"success":true}</pre></div>
+          <p class="api-purpose" style="margin-top:8px">The response may also include "error_msg" carrying the reason of the last completed fetch failure, for example: {"success":true,"error_msg":"HTTP 404"}.</p>
+        </div>
+      </div>
+
+      <!-- Weather -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Weather</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/weather</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">Read the latest weather sample. Returns available:false when no data has been fetched yet. The hourly array always holds 10 entries.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl http://HOST/api/weather">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl http://<span class="api-host">HOST</span>/api/weather</pre>
+          </div>
+          <div class="api-snip-label">Response (no data)</div>
+          <div class="api-snip"><pre>{"available":false}</pre></div>
+          <div class="api-snip-label">Response (valid)</div>
+          <div class="api-snip"><pre>{"available":true,"temp_current":72.4,"temp_high":78.0,"temp_low":61.0,"humidity":54.0,"dew_point":55.2,"wind_speed":8.5,"wind_dir":"NW","uv_index":4.0,"condition":"Partly Cloudy","last_update_ts":1751049600,"units":"imperial","location_name":"Austin, TX","hourly":[{"hour":14,"temp":72.4},{"hour":15,"temp":73.1}]}</pre></div>
+        </div>
+      </div>
+
+      <!-- Events -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Events</span></div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/events</span><span class="api-badge public">Public</span></div>
+          <p class="api-purpose">Read the on-device UI event log. Newest first, maximum 100 entries. Severity is one of info, success, warning, error. timestamp_ms is boot-relative monotonic milliseconds.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl http://HOST/api/events">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl http://<span class="api-host">HOST</span>/api/events</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"count":2,"events":[{"severity":"warning","instance":0,"message":"Guider lost star","timestamp_ms":1234567},{"severity":"info","instance":1,"message":"Sequence started","timestamp_ms":1230000}]}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/events/clear</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Clear the UI event log.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/events/clear">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/events/clear</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"status":"ok"}</pre></div>
+        </div>
+      </div>
+
+      <!-- Control API -->
+      <div class="card collapsed">
+        <div class="card-title"><span class="card-title-label">Control API</span></div>
+
+        <div class="api-intro" style="margin-bottom:4px">
+          <p>A generic control surface for reading and changing device settings from single HTTP requests. Six control endpoints plus an image-refresh action, all backed by a live registry. Useful for any HTTP client, for example macro keypads, API Ninja, or Home Assistant.</p>
+          <p>This page does not hand-list every controllable item. Call <strong>GET /api/control/list</strong> for the full live catalog of items the device exposes.</p>
+        </div>
+
+        <div class="api-note">
+          <strong>Stateless authentication.</strong> Besides the session cookie, every auth-gated endpoint on the device (not only Control API) also accepts the admin password in the request header <code>X-Auth-Password: YOUR_PASSWORD</code>. This lets clients that cannot perform the cookie login flow authenticate on every request. It is rate-limited: it shares the login lockout, so repeated wrong passwords trigger a temporary lockout. Send it as a header, not a URL query, so it is not written to the device logs.
+        </div>
+        <div class="api-snip-label">Header authentication example</div>
+        <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' http://HOST/api/control/list">
+          <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+          <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' http://<span class="api-host">HOST</span>/api/control/list</pre>
+        </div>
+
+        <div class="api-note">
+          <strong>Item object shape.</strong> Every read and write returns a uniform item object: <code>name</code> (the config field name), <code>type</code> (bool, enum, or int), <code>value</code>, <code>label</code> (a human-readable string: an enum gets its name, a bool gets On or Off, an int gets the value), and <code>min</code>, <code>max</code>, <code>step</code>. An unknown name, an operation that does not match the item type, or a missing parameter returns HTTP 400.
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/control/list</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Enumerate every controllable item with its current value and range. This is the live catalog of available item names.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' http://HOST/api/control/list">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' http://<span class="api-host">HOST</span>/api/control/list</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>[{"name":"brightness","type":"int","value":80,"label":"80","min":0,"max":100,"step":5},{"name":"theme","type":"enum","value":2,"label":"Nord","min":0,"max":8,"step":1}]</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/control/get?name=&lt;name&gt;</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Read one item by name.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' 'http://HOST/api/control/get?name=image_display_source'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' 'http://<span class="api-host">HOST</span>/api/control/get?name=image_display_source'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"name":"image_display_source","type":"enum","value":1,"label":"Moon","min":0,"max":3,"step":1}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/toggle?name=&lt;name&gt;</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Flip a bool item. Returns HTTP 400 for non-bool items.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/toggle?name=image_display_crop'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/toggle?name=image_display_crop'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"name":"image_display_crop","type":"bool","value":false,"label":"Off","min":0,"max":1,"step":1}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/cycle?name=&lt;name&gt;</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Advance an enum or int item by its step. Wraps from max back to min.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/cycle?name=image_display_source'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/cycle?name=image_display_source'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"name":"image_display_source","type":"enum","value":2,"label":"Solar","min":0,"max":3,"step":1}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/set?name=&lt;name&gt;&amp;value=&lt;v&gt;</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Set an exact value. The value is clamped to the item range.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/set?name=brightness&amp;value=50'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/set?name=brightness&amp;value=50'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"name":"brightness","type":"int","value":50,"label":"50","min":0,"max":100,"step":5}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/control/adjust?name=&lt;name&gt;&amp;delta=&lt;d&gt;</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Add a delta to the current value. The result is clamped to the item range and does not wrap.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/control/adjust?name=brightness&amp;delta=-10'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/control/adjust?name=brightness&amp;delta=-10'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"name":"brightness","type":"int","value":40,"label":"40","min":0,"max":100,"step":5}</pre></div>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/image-display/refresh</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Force an immediate re-fetch of the current image source. This works for all sources, unlike the force_fetch flag on /api/image-display-config which forces a download only for the Custom source.</p>
+          <div class="api-snip-label">Request</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://HOST/api/image-display/refresh">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://<span class="api-host">HOST</span>/api/image-display/refresh</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"success":true}</pre></div>
+          <p class="api-purpose" style="margin-top:8px">The response may include "error_msg" carrying the reason of the last completed fetch failure.</p>
+        </div>
+
+        <div class="api-ep">
+          <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/nav/pin</span><span class="api-badge auth">Auth</span></div>
+          <p class="api-purpose">Pin the displayed page. While pinned, all automatic page changes are suspended (auto-rotate, session auto-follow, idle, and default re-home) and the current page is held until cleared. Manual navigation still works while pinned, and the chosen page persists. The pin is in-memory only and resets on reboot. It does not change the auto-rotate setting, it only suspends it while active.</p>
+          <div class="api-note">
+            Query parameters: <code>on</code> = 1 to pin, 0 to clear (required). Optional <code>id</code> = a page id from /api/pages to navigate to that page and pin it in one call.
+          </div>
+          <div class="api-snip-label">Request (pin current page)</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=1'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=1'</pre>
+          </div>
+          <div class="api-snip-label">Request (go to a page by id and pin)</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=1&amp;id=7'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=1&amp;id=7'</pre>
+          </div>
+          <div class="api-snip-label">Request (clear, resume automation)</div>
+          <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://HOST/api/nav/pin?on=0'">
+            <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+            <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST 'http://<span class="api-host">HOST</span>/api/nav/pin?on=0'</pre>
+          </div>
+          <div class="api-snip-label">Response</div>
+          <div class="api-snip"><pre>{"pinned":true}</pre></div>
+          <p class="api-purpose" style="margin-top:8px">The same state is exposed as the <code>nav_pinned</code> Control item: GET /api/control/get?name=nav_pinned returns {"name":"nav_pinned","type":"bool","value":false,"label":"Off",...}. Toggle or set it like any bool (for example toggle?name=nav_pinned), so a macro key can show Pinned or Auto (On or Off) and flip it. The pin overrides auto-rotate while active.</p>
+        </div>
+
+        <div class="api-note">
+          <strong>Behavior notes.</strong> cycle wraps from max to min; set and adjust clamp to the range; toggle works on bool items only. The special item name <code>page</code> controls the current page and is the one item that navigates rather than saving config: cycle moves to the next available page, and set selects a page by id. Item names match the config field names used elsewhere in this documentation.
+        </div>
+
+        <div class="api-snip-label">Worked example: cycle the image source and read the label</div>
+        <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://HOST/api/control/cycle?name=image_display_source">
+          <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
+          <pre>curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://<span class="api-host">HOST</span>/api/control/cycle?name=image_display_source</pre>
+        </div>
+        <p class="api-purpose">Each call advances the source and returns the new item object. The response <code>label</code> (for example "Solar") can be shown on a key face so the keypad always reflects the current state.</p>
+      </div>
+

--- a/main/fragment_backup.html
+++ b/main/fragment_backup.html
@@ -1,0 +1,66 @@
+      <!-- Export Card -->
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Export Configuration <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Export configuration</div><p>Downloads the device configuration as a JSON file for backup or for cloning settings to another unit. The header shows the configuration version and running firmware version embedded in the file; the restore screen uses these to flag version mismatches.</p><p>Include sensitive data controls whether secrets are written to the file. With it off, the export omits every secret: the weather API key, MQTT username, password, and broker URL, the Spotify Client ID, the hostname, your saved WiFi passwords, and the admin password. Turn it on only for a private full backup that can restore those values.</p><p>Example: leave Include sensitive data off when sharing a configuration as a template, and turn it on only for a private full backup of one device.</p></div>
+        <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;font-size:0.82rem;color:#a1a1aa">
+          <span>Config version: <strong style="color:#f4f4f5" id="backupCurrentVersion">--</strong></span>
+          <span>&middot;</span>
+          <span>Firmware: <strong style="color:#f4f4f5" id="backupFirmwareVersion">--</strong></span>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <div>
+            <span class="toggle-label">Include sensitive data</span>
+            <div class="field-hint" style="margin-top:2px">Weather and MQTT credentials, Spotify Client ID, hostname, WiFi and admin passwords</div>
+          </div>
+          <label class="toggle"><input type="checkbox" id="backupIncludeSensitive"><span class="toggle-track"></span></label>
+        </div>
+        <button class="btn btn-primary" id="backupDownloadBtn" onclick="downloadBackup()" style="margin-top:16px;width:100%">Download Backup</button>
+      </div>
+
+      <!-- Import Card -->
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Restore Configuration <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Restore configuration</div><p>Loads a previously exported JSON file and previews the effect before applying it. The metadata header shows the source hostname and MAC, the firmware version the file came from, and the export date. A version warning appears when the backup's configuration version differs from this device.</p><p>The preview lists each setting that would change, plus notices for settings missing from the backup, settings this firmware does not recognize, sensitive values that were excluded from the file, and any validation issues. Nothing is written until you press Restore; Cancel discards the file.</p><p>Example: restoring a file exported without sensitive data leaves the current MQTT password and other secrets in place, shown as excluded in the preview.</p></div>
+        <div class="field">
+          <label class="ota-label" id="restoreFileLabel" style="display:block;text-align:center;cursor:pointer">
+            Choose backup .json file
+            <input type="file" id="restoreFileInput" accept=".json" onchange="restoreFileSelected(this)" style="display:none">
+          </label>
+        </div>
+
+        <!-- Preview Panel (hidden until file selected) -->
+        <div id="restorePreview" style="display:none;margin-top:16px">
+          <!-- Metadata Header -->
+          <div style="background:rgba(255,255,255,0.04);border:1px solid rgba(255,255,255,0.08);border-radius:10px;padding:14px 16px;margin-bottom:12px;font-size:0.82rem;color:#a1a1aa;line-height:1.8">
+            <div>Source: <strong style="color:#f4f4f5" id="restoreHostname">--</strong> (<span id="restoreMac">--</span>)</div>
+            <div>Firmware: <strong style="color:#f4f4f5" id="restoreFirmware">--</strong> &middot; Exported: <span id="restoreDate">--</span></div>
+          </div>
+
+          <!-- Version Warning Banner -->
+          <div id="restoreWarningBanner" style="border-radius:10px;padding:14px 16px;margin-bottom:12px;font-size:0.82rem;line-height:1.6;display:none"></div>
+
+          <!-- Changes Diff -->
+          <div id="restoreChanges" style="margin-bottom:12px"></div>
+
+          <!-- No Changes -->
+          <div id="restoreNoChanges" style="font-size:0.82rem;color:var(--text-hint);margin-bottom:12px"></div>
+
+          <!-- Missing Fields Notice -->
+          <div id="restoreMissing" style="display:none;background:rgba(245,158,11,0.06);border:1px solid rgba(245,158,11,0.15);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:#d4d4d8"></div>
+
+          <!-- Unknown Fields Notice -->
+          <div id="restoreUnknown" style="display:none;background:rgba(245,158,11,0.06);border:1px solid rgba(245,158,11,0.15);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:#d4d4d8"></div>
+
+          <!-- Sensitive Excluded Notice -->
+          <div id="restoreSensitive" style="display:none;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:var(--text-hint)"></div>
+
+          <!-- Validation Notes -->
+          <div id="restoreValidation" style="display:none;background:rgba(245,158,11,0.06);border:1px solid rgba(245,158,11,0.15);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:#d4d4d8"></div>
+
+          <!-- Action Buttons -->
+          <div style="display:flex;gap:10px;margin-top:16px">
+            <button class="btn btn-outline" onclick="cancelRestore()" style="flex:1">Cancel</button>
+            <button class="btn btn-primary" id="restoreConfirmBtn" onclick="confirmRestore()" style="flex:1">Restore</button>
+          </div>
+        </div>
+      </div>

--- a/main/fragment_behavior.html
+++ b/main/fragment_behavior.html
@@ -1,0 +1,174 @@
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Page Navigation <span id="pm_summary" style="font-weight:400;text-transform:none;letter-spacing:0;color:var(--text-muted);font-size:0.7rem"></span> <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Page Navigation</div><p>The display chooses a page automatically. Swipe or tap any time to take over; it returns to its automatic choice after the stay-on-page time. This table shows what appears in each situation.</p><table class="help-scenario"><thead><tr><th>In this situation</th><th>You'll see</th></tr></thead><tbody><tr><td>Always show the Home Page is on</td><td>Your Home Page, always (swipes return after the stay-on-page time)</td></tr><tr><td>You just swiped or tapped</td><td>That page, held briefly</td></tr><tr><td>Auto Cycle is on</td><td>Pages rotate in turn</td></tr><tr><td>One NINA instance online</td><td>That instance's dashboard</td></tr><tr><td>Several instances online</td><td>Your Home instance if it is one of them, otherwise the Summary page</td></tr><tr><td>All instances offline, "Switch when no connections" on</td><td>Your chosen fallback page</td></tr><tr><td>All instances offline, that option off</td><td>Your Home Page</td></tr><tr><td>Quiet, nothing happening</td><td>Your Home Page</td></tr></tbody></table></div>
+
+        <div class="subsection">
+        <div class="subsection-title">Home Page</div>
+        <div class="pn-pill-grid" id="start-page-pills"></div>
+        <div class="field-hint">The page the display settles on; when set to a NINA instance, the display also returns to that instance whenever it is online.</div>
+
+        <div class="toggle-row" style="margin-top:12px">
+          <div>
+            <span class="toggle-label">Always show the Home Page</span>
+            <div class="field-hint" style="margin-top:2px">Keeps the display on the Home Page at all times, even while instances are connected. You can still swipe to other pages; the display returns to the Home Page after the stay-on-page time.</div>
+          </div>
+          <label class="toggle"><input type="checkbox" id="home_page_lock" onchange="toggleHomeLock();checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        </div>
+
+        <div class="subsection">
+        <div class="subsection-title">Auto Cycle</div>
+        <div class="toggle-row">
+          <div>
+            <span class="toggle-label">Auto Cycle</span>
+            <div style="font-size:0.72rem;color:var(--text-muted);margin-top:2px;">Rotate through pages automatically</div>
+            <div class="field-hint" style="margin-top:2px">When enabled, overrides "Switch page when no connections" below</div>
+          </div>
+          <label class="toggle"><input type="checkbox" id="auto_cycle_toggle" onchange="toggleAutoCycle();checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+
+        <div class="pn-cycle-settings" id="pn_cycle_settings" style="display:none">
+          <div class="row stack-mobile">
+            <div class="field">
+              <label class="field-label">Interval (seconds)</label>
+              <input type="number" class="input" id="auto_rotate_interval" min="4" max="3600" value="30">
+              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600.</div>
+            </div>
+            <div class="field">
+              <label class="field-label">Transition</label>
+              <select class="input" id="auto_rotate_effect">
+                <option value="0">Instant</option>
+                <option value="1">Fade</option>
+                <option value="2">Slide Left</option>
+                <option value="3">Slide Right</option>
+              </select>
+              <div class="field-hint">Animation used when Auto Cycle changes pages.</div>
+            </div>
+          </div>
+          <div class="toggle-row">
+            <span class="toggle-label" style="font-size:0.82rem;color:var(--text-muted)">Skip disconnected nodes</span>
+            <label class="toggle"><input type="checkbox" id="auto_rotate_skip"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">During Auto Cycle, skip NINA instance pages that are not connected.</div>
+          <div class="pn-sub-divider"></div>
+          <div>
+            <div class="pn-section-label">Pages in Rotation</div>
+            <div style="font-size:0.72rem;color:var(--text-muted);margin:-8px 0 10px;opacity:0.7">Drag to reorder</div>
+            <div class="pn-pill-grid reorderable" id="arp-container"></div>
+            <div class="field-hint">Pick which pages and image sources rotate, and drag to set the order.</div>
+            <div class="field-hint">Note: Image pages (GOES, Solar, and Custom URL) download a fresh image from their source each time the rotation reaches them, even if their refresh interval has not elapsed yet. Shorter rotation intervals mean more frequent downloads from those image servers.</div>
+          </div>
+        </div>
+        </div>
+
+        <div class="subsection">
+        <div class="subsection-title">Manual Navigation</div>
+        <div class="field">
+          <label class="field-label">Stay on selected page (seconds)</label>
+          <input type="number" class="input" id="nav_grace_s" min="10" max="300" value="10">
+          <div class="field-hint" style="margin-top:2px">After you swipe or tap to a page, the display keeps showing it for this long, then returns on its own to the page it would normally show (the connected instance, or your Home page).</div>
+        </div>
+        </div>
+
+        <div class="subsection">
+        <div class="subsection-title">When Disconnected</div>
+        <div class="toggle-row">
+          <div>
+            <span class="toggle-label">Switch page when no connections</span>
+            <div class="field-hint" style="margin-top:2px">Automatically switches to the selected page when all NINA instances are disconnected, then resumes auto-rotate (if enabled) on reconnect.</div>
+          </div>
+          <label class="toggle"><input type="checkbox" id="idle_page_override_enabled" onchange="toggleIdleOverride();checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field" id="idle_target_field" style="display:none;margin-top:12px">
+          <label class="field-label">Target page</label>
+          <!-- Options populated dynamically from the device page registry (GET /api/pages) by populatePageControls(). -->
+          <select class="input" id="idle_page_override_target"></select>
+          <div class="field-hint">Page shown while every enabled NINA instance is confirmed disconnected.</div>
+          <div class="toggle-row" style="margin-top:12px">
+            <div>
+              <span class="toggle-label">Show idle indicator</span>
+              <div class="field-hint" style="margin-top:2px">Shows a small status dot on the idle page when all NINA instances are disconnected</div>
+            </div>
+            <label class="toggle"><input type="checkbox" id="idle_indicator_enabled" onchange="checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+        </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Notifications <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Notifications</div><p>Controls on-screen pop-up notifications, the border-flash alerts, and which event categories produce notifications. Notification duration sets how long a normal pop-up stays visible; error and warning pop-ups show for twice that time. Border flash alerts flash the screen edge when an RMS, HFR, or safety threshold is exceeded.</p><p>The aggregation window combines a burst of notifications that arrive close together into one, which reduces clutter during noisy events; set it to 0 to show every notification individually. The Event Categories toggles decide which kinds of events generate notifications at all; turning a category off suppresses its notifications.</p><p>Example: keep Error Events and Safety Events on, turn Focuser and Guider Events off to cut routine chatter, and set the aggregation window to 5 seconds so rapid sequence updates collapse into a single notification.</p></div>
+        <div class="subsection">
+        <div class="subsection-title">Alerts</div>
+        <div class="field" style="margin-bottom:16px">
+          <label class="field-label">Toast duration (s)</label>
+          <input type="number" class="input" id="toast_duration" min="3" max="30" value="8">
+          <div class="field-hint">Errors and warnings show for 2x this value</div>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-label">Border flash alerts</span>
+          <label class="toggle"><input type="checkbox" id="alert_flash_enabled" checked><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px">Flash the screen border when RMS, HFR, or safety thresholds are exceeded.</div>
+        <div class="field" style="margin-top:16px">
+          <label class="field-label">Aggregation Window</label>
+          <div class="slider-group">
+            <input type="range" class="slider" id="toast_aggregation_window" min="0" max="15" value="5" oninput="updateAggregationLabel(this.value);checkDirty()">
+            <span class="slider-val" id="toast_aggregation_val">5s</span>
+          </div>
+          <div class="field-hint">Combine rapid-fire notifications within this window. 0 = Off (show each individually).</div>
+        </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Event Categories</div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Error Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_8" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Equipment Connects</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_0" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Equipment Disconnects</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_1" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Sequence Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_2" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Focuser Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_3" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Mount Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_4" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Meridian Flip</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_5" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Guider Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_6" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Safety Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_7" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Profile Changes</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_9" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Dome Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_10" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-label">Flat Device Events</span>
+          <label class="toggle"><input type="checkbox" id="notify_cat_11" checked onchange="checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        </div>
+      </div>

--- a/main/fragment_clock.html
+++ b/main/fragment_clock.html
@@ -1,0 +1,73 @@
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Weather <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Weather</div><p>Drives the weather overlay shown on the Clock page. Pick a provider and supply an API key if the provider needs one. Open-Meteo needs no key; OpenWeatherMap and Weather Underground each require a key. The forecast uses the device location set on the System tab.</p><p>The Time Format option switches the clock between 14:30 and 2:30 PM. Temperature Units switches all weather readings between degrees F and degrees C. Update Interval sets how often the device fetches new weather data.</p><p>Example: choose Open-Meteo, set units to degrees C, and the Clock page shows local conditions refreshed on the chosen interval.</p></div>
+        <div class="subsection">
+        <div class="subsection-title">Provider</div>
+        <div class="field">
+          <label class="field-label">Weather Provider</label>
+          <select class="input" id="weather_provider" onchange="toggleWeatherApiKey();checkDirty()">
+            <option value="0">OpenWeatherMap</option>
+            <option value="1">Open-Meteo (no key needed)</option>
+            <option value="2">Weather Underground</option>
+          </select>
+          <div class="field-hint">Open-Meteo works without a key; OpenWeatherMap and Weather Underground require an API key.</div>
+        </div>
+        <div class="field" id="weather_api_key_field">
+          <label class="field-label">API Key</label>
+          <input type="text" class="input" id="weather_api_key" placeholder="Enter API key">
+          <div class="field-hint" id="weather_api_key_hint">
+            <span id="owm_link">Get a free API key at <a href="https://home.openweathermap.org/api_keys" target="_blank" rel="noopener" style="color:#7eb8da">openweathermap.org</a></span>
+            <span id="wunderground_link" style="display:none">Get an API key at <a href="https://www.wunderground.com/member/api-keys" target="_blank" rel="noopener" style="color:#7eb8da">wunderground.com</a></span>
+          </div>
+        </div>
+        <div class="field" id="weather_location_name_field">
+          <label class="field-label">Location Name</label>
+          <input type="text" class="input" id="weather_location_name" readonly placeholder="Auto-filled by lookup" style="opacity:0.7">
+          <div class="field-hint">Read-only; set automatically by the city lookup on the System tab.</div>
+        </div>
+        <div class="field" id="weather_station_id_field" style="display:none">
+          <label class="field-label">Station ID</label>
+          <input type="text" class="input" id="weather_station_id" placeholder="e.g. KMOOFAL42">
+          <div class="field-hint">Personal Weather Station ID for Weather Underground</div>
+        </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Display Options</div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">Temperature Units</label>
+            <select class="input" id="weather_units">
+              <option value="0">&deg;F Imperial</option>
+              <option value="1">&deg;C Metric</option>
+            </select>
+            <div class="field-hint">Switches all weather temperatures between degrees F and degrees C.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Time Format</label>
+            <select class="input" id="weather_time_format">
+              <option value="0">12-hour (AM/PM)</option>
+              <option value="1">24-hour</option>
+            </select>
+            <div class="field-hint">Switches the clock between 12-hour (2:30 PM) and 24-hour (14:30) display.</div>
+          </div>
+        </div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">Update Interval</label>
+            <select class="input" id="weather_poll_interval_s">
+              <option value="900">15 minutes</option>
+              <option value="1200">20 minutes</option>
+              <option value="1800">30 minutes</option>
+              <option value="2700">45 minutes</option>
+              <option value="3600">60 minutes</option>
+            </select>
+            <div class="field-hint">How often the device fetches new weather data from the provider.</div>
+          </div>
+          <div class="field">
+            <div class="field-hint">The clock uses the time zone and NTP server configured on the System tab.</div>
+          </div>
+        </div>
+        </div>
+      </div>
+

--- a/main/fragment_display.html
+++ b/main/fragment_display.html
@@ -1,0 +1,92 @@
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Appearance <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Appearance</div><p>Controls the look of the dashboard: the color theme, the visual style applied to widget panels, and the brightness of on-screen text. All three apply live as you change them and persist when you save.</p><p>Theme sets the color palette across every page. Widget Style changes only how the dashboard panels are drawn (borders, glass, inset, and similar). Text brightness scales the foreground text color, separate from the backlight in the Hardware card below.</p><p>Example: pick the Red Night theme to preserve dark adaptation at the telescope, then lower Text brightness to 50% if labels are still too bright.</p></div>
+        <div class="field">
+          <label class="field-label">Theme</label>
+          <select class="input" id="theme_select" onchange="setTheme(this.value)">
+            <option value="0">Default</option>
+            <option value="1">Red Night</option>
+            <option value="2">Cyber Dusk</option>
+            <option value="3">Stellar Ember</option>
+            <option value="4">Arctic Steel</option>
+            <option value="5">Oxidized Copper</option>
+            <option value="6">Solar Flare</option>
+            <option value="7">Phantom Green</option>
+            <option value="8">Bloodmoon</option>
+          </select>
+          <div class="field-hint">Color palette applied across all pages; changes preview immediately.</div>
+        </div>
+        <div class="field">
+          <label class="field-label">Widget Style</label>
+          <select class="input" id="widget_style_select" onchange="setWidgetStyle(this.value)">
+            <option value="0">Default</option>
+            <option value="1">Subtle Border</option>
+            <option value="2">Soft Inset</option>
+            <option value="3">Frosted Glass</option>
+            <option value="4">Chamfered</option>
+            <option value="5">Double Border</option>
+            <option value="6">Raised Slab</option>
+            <option value="7">Gradient Fade</option>
+            <option value="8">Scanline</option>
+            <option value="9">Pillar</option>
+            <option value="10">Stepped Edge</option>
+            <option value="11">Horizon Line</option>
+            <option value="12">Ember Ring</option>
+          </select>
+          <div class="field-hint">Visual treatment of the dashboard panels only, with no effect on colors or layout.</div>
+        </div>
+        <div class="field">
+          <label class="field-label">Text brightness</label>
+          <div class="slider-group">
+            <input type="range" class="slider" id="color_brightness" min="0" max="100" value="80" oninput="setColorBrightness(this.value)">
+            <span class="slider-val" id="color_brightness_val">80%</span>
+          </div>
+          <div class="field-hint">Scales on-screen text brightness, independent of the screen backlight below.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Hardware <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Hardware</div><p>Physical display controls: screen rotation, backlight level, and automatic screen off. All apply live and persist when you save.</p><p>Screen Rotation reorients the entire UI in 90-degree steps for sideways or upside-down mounting. Backlight sets the panel brightness, separate from the Text brightness control above. Turn off screen when idle blanks the backlight after a period with no touch; the firmware keeps running and the next touch wakes the screen.</p><p>Example: if the device is mounted with the USB port facing up, set Screen Rotation to 180 degrees so the dashboard reads right-side up.</p></div>
+        <div class="subsection">
+        <div class="subsection-title">Display</div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">Screen Rotation</label>
+            <select class="input" id="screen_rotation_select" onchange="setScreenRotation(this.value)">
+              <option value="0">0° (Default)</option>
+              <option value="1">90°</option>
+              <option value="2">180°</option>
+              <option value="3">270°</option>
+            </select>
+            <div class="field-hint">Rotates the whole UI in 90-degree steps to match the physical mounting.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Backlight</label>
+            <div class="slider-group">
+              <input type="range" class="slider" id="brightness" min="0" max="100" value="80" oninput="setBrightness(this.value)">
+              <span class="slider-val" id="brightness_val">80%</span>
+            </div>
+            <div class="field-hint">Panel backlight level, separate from Text brightness above.</div>
+          </div>
+        </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Screen Sleep</div>
+        <div class="toggle-row">
+          <span class="toggle-label">Turn off screen when idle</span>
+          <label class="toggle"><input type="checkbox" id="screen_sleep_enabled"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px">Blanks the backlight after the timeout while the firmware keeps running; touch wakes the screen.</div>
+        <div id="screen_sleep_details" style="margin-top:16px">
+          <div class="row stack-mobile">
+            <div class="field">
+              <label class="field-label">Timeout (seconds)</label>
+              <input type="number" class="input" id="screen_sleep_timeout" min="10" max="3600" value="60">
+              <div class="field-hint">Idle time with no touch before the screen blanks, from 10 to 3600 seconds.</div>
+            </div>
+          </div>
+        </div>
+        </div>
+      </div>

--- a/main/fragment_image_display.html
+++ b/main/fragment_image_display.html
@@ -1,0 +1,287 @@
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">GOES Satellite Imagery <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Full-screen image page</div><p>Renders one full-screen image source on its own page: a GOES-19 GEOCOLOR satellite sector, a 3D-rendered moon phase, or SDO/SOHO solar imagery. Pick the source with the Source selector; the fields below change to match the chosen source. Show Overlay applies to all sources; the update interval applies to GOES and Solar (the moon is drawn on the device and has no fetch interval).</p><p>Fill (crop borders) zooms the disc to fill the 720x720 panel and cuts off the timestamp and label baked into the source image border. It applies to GOES and Solar; the Moon has no border text and is not cropped. Example: with Fill off, a GOES sector shows letterboxed with its caption; with Fill on, the disc fills the screen and the caption is hidden.</p><p>In some firmware versions the image may appear rotated, which is why each source has its own rotation control. If the satellite, moon, or sun appears upside down or sideways, set the matching rotation to correct it.</p></div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable Image Display</span>
+          <label class="toggle"><input type="checkbox" id="image_display_enabled" onchange="updateImageDisplayEnabledUI();applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint">Adds the full-screen image page and starts fetching the selected source.</div>
+        <div id="imageDisplayFields">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Source</label>
+            <div class="pn-pill-grid">
+              <label class="pn-pill rotate-pill">
+                <input type="radio" name="imageSourceSel" id="imageSource0" value="0" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
+                <span class="pn-pill-visual">GOES Satellite</span>
+              </label>
+              <label class="pn-pill rotate-pill">
+                <input type="radio" name="imageSourceSel" id="imageSource1" value="1" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
+                <span class="pn-pill-visual">Moon Phase</span>
+              </label>
+              <label class="pn-pill rotate-pill">
+                <input type="radio" name="imageSourceSel" id="imageSource2" value="2" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
+                <span class="pn-pill-visual">Solar (SDO)</span>
+              </label>
+              <label class="pn-pill rotate-pill">
+                <input type="radio" name="imageSourceSel" id="imageSource3" value="3" onchange="updateImageSourceUI();applyImageDisplay();checkDirty()">
+                <span class="pn-pill-visual">Custom URL</span>
+              </label>
+            </div>
+            <div class="field-hint">Chooses GOES satellite, Moon phase, Solar, or a custom image URL; the options below switch to match.</div>
+          </div>
+          <div class="toggle-row">
+            <span class="toggle-label">Show Overlay</span>
+            <label class="toggle"><input type="checkbox" id="image_display_show_overlay" onchange="applyImageDisplay();checkDirty()" checked><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Region/phase name and update time overlay on the display</div>
+          <div id="discOptions">
+          <div class="toggle-row">
+            <span class="toggle-label">Fill (crop borders)</span>
+            <label class="toggle"><input type="checkbox" id="image_display_crop" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Zoom the disc to fill the screen and hide the image's timestamp/label.</div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Update Interval</label>
+            <select class="input" id="goesInterval" onchange="applyImageDisplay();checkDirty()">
+              <option value="300">5 minutes</option>
+              <option value="600" selected>10 minutes</option>
+              <option value="900">15 minutes</option>
+              <option value="1800">30 minutes</option>
+              <option value="3600">1 hour</option>
+              <option value="7200">2 hours</option>
+            </select>
+            <div class="field-hint">How often the image refreshes.</div>
+          </div>
+          </div>
+          <div id="goesGroup">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Region</label>
+            <select class="input" id="goesRegion" onchange="applyImageDisplay();checkDirty()">
+              <option value="umv">Upper Mississippi Valley</option>
+              <option value="cgl">Great Lakes</option>
+              <option value="ne">Northeast</option>
+              <option value="se">Southeast</option>
+              <option value="smv">Southern Mississippi Valley</option>
+              <option value="sp">Southern Plains</option>
+              <option value="nr">Northern Rockies</option>
+              <option value="sr">Southern Rockies</option>
+              <option value="pnw">Pacific Northwest</option>
+              <option value="psw">Pacific Southwest</option>
+              <option value="eus">U.S. Atlantic Coast</option>
+              <option value="pr">Puerto Rico</option>
+              <option value="mex">Mexico</option>
+              <option value="cam">Central America</option>
+              <option value="car">Caribbean</option>
+              <option value="ga">Gulf of America</option>
+              <option value="can">Canada</option>
+              <option value="na">Northern Atlantic</option>
+              <option value="taw">Tropical Atlantic</option>
+              <option value="eep">Eastern Pacific</option>
+              <option value="nsa">South America (North)</option>
+              <option value="ssa">South America (South)</option>
+            </select>
+            <div class="field-hint">GOES-19 GEOCOLOR sector for satellite imagery</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">GOES Rotation</label>
+            <select class="input" id="goesOrientation" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">0&deg;</option>
+              <option value="1">90&deg;</option>
+              <option value="2">180&deg;</option>
+              <option value="3">270&deg;</option>
+            </select>
+            <div class="field-hint">Rotate the satellite image clockwise.</div>
+          </div>
+          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Flip vertical</span>
+            <label class="toggle"><input type="checkbox" id="goesVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the satellite image top-to-bottom.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Flip horizontal</span>
+            <label class="toggle"><input type="checkbox" id="goesHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the satellite image left-to-right.</div>
+          <div class="field" style="margin-top:16px">
+            <button onclick="fetchGoesPreview()" class="btn btn-primary" id="goesPreviewBtn" style="width:100%">Fetch Preview</button>
+          </div>
+          <div id="goesPreviewContainer" style="display:none;margin-top:12px;text-align:center">
+            <img id="goesPreviewImg" style="max-width:100%;border-radius:10px;border:1px solid rgba(255,255,255,0.1)" />
+          </div>
+          </div>
+          <div id="moonGroup" style="display:none">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Background</label>
+            <select class="input" id="moonBg" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">Plain black</option>
+              <option value="1">Starfield</option>
+              <option value="2">Soft glow</option>
+              <option value="3">Starfield + Glow</option>
+            </select>
+            <div class="field-hint">Sets what renders behind the moon disc (plain black, starfield, soft glow, or both).</div>
+          </div>
+          <div class="field-hint" style="margin-top:12px">The moon view uses the device location set on the System tab.</div>
+          <div class="field">
+            <label class="field-label">Moon drag lighting</label>
+            <select class="input" id="moonDragLight" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">True phase</option>
+              <option value="1">Explore (full-lit)</option>
+              <option value="2">Locked to surface</option>
+            </select>
+            <div class="field-hint">How the Moon is lit while you drag to rotate it. True phase keeps the real terminator; Explore lights the whole surface.</div>
+          </div>
+          <div class="card">
+            <div class="card-title"><span class="card-title-label">Moon Orientation <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+          <div class="help-popover"><div class="help-popover-title">Moon appearance and orientation</div><p>Corrects how the rendered moon is oriented and how it responds to dragging. Keep Moon upright (north-up) holds the moon's north pole at the top like phone apps and NASA imagery; turning it off tilts the disc to match how the real moon sits in your local sky as it moves. The device location set on the System tab is used for an accurate sky-tilt and terminator.</p><p>Flip horizontal (U) and Flip vertical (V) mirror the image for displays or mounts that reverse it. The Roll, Yaw, and Pitch offset sliders nudge the moon from its standard orientation, and Reset orientation returns them to that standard view.</p><p>Free-spin mode changes drag behavior. Off, the disc rubber-bands back to the live sky as soon as you release it. On, the disc holds your spin and eases back after the Return to live view timeout (3 to 60 seconds). Example: enable Free-spin, set the return to 15s, drag to inspect the far limb, and the view holds for 15 seconds before returning to live.</p></div>
+          <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Keep Moon upright (north-up)</span>
+            <label class="toggle"><input type="checkbox" id="moon_north_up" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint" style="margin-bottom:12px">On: Moon's north pole stays up like apps/NASA. Off: tilts to match the real sky as the Moon moves.</div>
+          <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Flip horizontal (U)</span>
+            <label class="toggle"><input type="checkbox" id="moon_flip_u" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the moon left-to-right for reversed displays or mounts.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Flip vertical (V)</span>
+            <label class="toggle"><input type="checkbox" id="moon_flip_v" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the moon top-to-bottom.</div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Roll offset</label>
+            <div class="slider-group">
+              <input type="range" class="slider" id="moon_roll_offset" min="-180" max="180" step="1" value="0" oninput="updateMoonOrientReadout('moon_roll');applyImageDisplay();checkDirty()">
+              <span class="slider-val" id="moon_roll_val">0&deg;</span>
+            </div>
+            <div class="field-hint">Rotates the moon in the screen plane, -180 to 180 degrees from default.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Yaw offset</label>
+            <div class="slider-group">
+              <input type="range" class="slider" id="moon_yaw_offset" min="-180" max="180" step="1" value="0" oninput="updateMoonOrientReadout('moon_yaw');applyImageDisplay();checkDirty()">
+              <span class="slider-val" id="moon_yaw_val">0&deg;</span>
+            </div>
+            <div class="field-hint">Turns the moon left/right about its vertical axis, -180 to 180 degrees from default.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Pitch offset</label>
+            <div class="slider-group">
+              <input type="range" class="slider" id="moon_pitch_offset" min="-90" max="90" step="1" value="0" oninput="updateMoonOrientReadout('moon_pitch');applyImageDisplay();checkDirty()">
+              <span class="slider-val" id="moon_pitch_val">0&deg;</span>
+            </div>
+            <div class="field-hint">Tilts the moon up or down, from -90 to 90 degrees relative to its standard orientation.</div>
+          </div>
+          <hr class="divider">
+          <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Free-spin mode</span>
+            <label class="toggle"><input type="checkbox" id="moon_spin_mode" onchange="updateMoonSpinUI();applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint" style="margin-bottom:12px">Off: dragged disc snaps back to the live sky immediately (rubber band). On: the disc holds your spin, then eases back after the timeout below.</div>
+          <div class="field" style="margin-top:16px" id="moonSpinReturnField">
+            <label class="field-label">Return to live view after</label>
+            <div class="slider-group">
+              <input type="range" class="slider" id="moon_spin_return_s" min="3" max="60" step="1" value="3" oninput="updateMoonOrientReadout('moon_spin_return');applyImageDisplay();checkDirty()">
+              <span class="slider-val" id="moon_spin_return_val">3s</span>
+            </div>
+            <div class="field-hint">Only applies in free-spin mode.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <button onclick="resetMoonOrientation()" class="btn" id="moonOrientResetBtn" style="width:100%">Reset orientation</button>
+          </div>
+          </div>
+          </div>
+          <div id="solarGroup" style="display:none">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Band</label>
+            <select class="input" id="solarBand" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">AIA 94 (Fe XVIII)</option>
+              <option value="1">AIA 131 (Fe XX)</option>
+              <option value="2">AIA 171 (Fe IX/X)</option>
+              <option value="3">AIA 193 (Fe XII)</option>
+              <option value="4">AIA 211 (Fe XIV)</option>
+              <option value="5">AIA 304 (He II)</option>
+              <option value="6">AIA 335 (Fe XVI)</option>
+              <option value="7">AIA 1600 (C IV+cont)</option>
+              <option value="8">AIA 1700 (continuum)</option>
+              <option value="9">AIA 4500 (continuum)</option>
+              <option value="10">LASCO C2 (coronagraph)</option>
+              <option value="11">LASCO C3 (coronagraph)</option>
+              <option value="12">SOHO EIT 171</option>
+              <option value="13">SOHO EIT 195</option>
+              <option value="14">SOHO EIT 284</option>
+              <option value="15">SOHO EIT 304</option>
+              <option value="16">SDO/HMI Continuum</option>
+              <option value="17">SDO/HMI Magnetogram</option>
+            </select>
+            <div class="field-hint">NASA SDO/AIA and SOHO realtime (LASCO, EIT, HMI)</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Solar Rotation</label>
+            <select class="input" id="solarOrientation" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">0&deg;</option>
+              <option value="1">90&deg;</option>
+              <option value="2">180&deg;</option>
+              <option value="3">270&deg;</option>
+            </select>
+            <div class="field-hint">Rotate the solar image clockwise.</div>
+          </div>
+          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Flip vertical</span>
+            <label class="toggle"><input type="checkbox" id="solarVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the solar image top-to-bottom.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Flip horizontal</span>
+            <label class="toggle"><input type="checkbox" id="solarHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the solar image left-to-right.</div>
+          </div>
+          <div id="customGroup" style="display:none">
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Image URL</label>
+            <input class="input" id="customImageUrl" type="url" placeholder="https://picsum.photos/720" onchange="applyImageDisplay();updateImgCustomPillHint();checkDirty()">
+            <div class="field-hint">JPEG only. Max 1024x1024 pixels, max 1 MB. PNG and WebP are not supported.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Custom Rotation</label>
+            <select class="input" id="customOrientation" onchange="applyImageDisplay();checkDirty()">
+              <option value="0">0&deg;</option>
+              <option value="1">90&deg;</option>
+              <option value="2">180&deg;</option>
+              <option value="3">270&deg;</option>
+            </select>
+            <div class="field-hint">Rotate the custom image clockwise.</div>
+          </div>
+          <div class="toggle-row" style="margin-top:16px;border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Flip vertical</span>
+            <label class="toggle"><input type="checkbox" id="customVflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the custom image top-to-bottom.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Flip horizontal</span>
+            <label class="toggle"><input type="checkbox" id="customHflip" onchange="applyImageDisplay();checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Mirrors the custom image left-to-right.</div>
+          <div class="field" style="margin-top:16px">
+            <label class="field-label">Update Interval</label>
+            <select class="input" id="customInterval" onchange="applyImageDisplay();checkDirty()">
+              <option value="10">10 seconds</option>
+              <option value="30">30 seconds</option>
+              <option value="60" selected>1 minute</option>
+              <option value="300">5 minutes</option>
+              <option value="600">10 minutes</option>
+              <option value="1800">30 minutes</option>
+              <option value="3600">1 hour</option>
+              <option value="7200">2 hours</option>
+            </select>
+            <div class="field-hint">How often the custom image refreshes.</div>
+          </div>
+          <div class="field" style="margin-top:16px">
+            <button onclick="fetchCustomPreview()" class="btn btn-primary" id="customPreviewBtn" style="width:100%">Refresh on Device</button>
+          </div>
+          </div>
+        </div>
+      </div>
+

--- a/main/fragment_logs.html
+++ b/main/fragment_logs.html
@@ -1,0 +1,63 @@
+
+      <div class="card nocollapse">
+        <div class="card-title"><span class="card-title-label">Logs <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Device and crash logs</div><p>Two sources share this card. Device shows console output captured since boot and kept in memory; only a limited amount is kept, so the oldest lines drop off as new ones arrive, and it is cleared on reboot. Crash shows saved crash history: the device records unexpected restarts and crashes, with details attached when available. Crash records survive reboots and power loss.</p><p>Refresh reloads the active source. Download saves the current source to a file. Clear empties it. For Device, Auto-refresh reloads on the chosen Interval. For Crash, Auto-clear after drops records older than the selected age, and Never keeps them indefinitely.</p><p>Example: switch to Crash and use Download to attach a crash record when reporting an unexpected reboot.</p></div>
+
+        <div class="logs-toolbar">
+          <div class="log-seg" role="tablist">
+            <button class="log-seg-btn active" id="logSegDevice" onclick="setLogSource('device')">Device</button>
+            <button class="log-seg-btn" id="logSegCrash" onclick="setLogSource('crash')">Crash</button>
+          </div>
+          <div class="logs-toolbar-actions">
+            <button class="btn btn-outline" id="logsRefreshBtn" onclick="logsRefreshActive()">Refresh</button>
+            <a class="btn btn-outline" id="logsDownloadLink" href="/api/logs" style="text-align:center">Download</a>
+            <button class="btn btn-outline" id="logsClearBtn" onclick="logsClearActive()">Clear</button>
+          </div>
+          <div class="logs-toolbar-slot">
+            <!-- Device source controls -->
+            <div id="logsDeviceCtl" style="display:flex;flex-wrap:wrap;align-items:center;gap:14px">
+              <div class="toggle-row" style="margin:0;border:0;padding:0">
+                <span class="toggle-label">Auto-refresh</span>
+                <label class="toggle"><input type="checkbox" id="logsAutoRefresh"><span class="toggle-track"></span></label>
+              </div>
+              <div style="display:flex;align-items:center;gap:8px">
+                <span class="field-hint" style="margin:0">Interval</span>
+                <select class="input" id="logsRefreshInterval" style="max-width:90px">
+                  <option value="2">2s</option>
+                  <option value="5" selected>5s</option>
+                  <option value="10">10s</option>
+                  <option value="30">30s</option>
+                </select>
+              </div>
+            </div>
+            <!-- Crash source controls -->
+            <div id="logsCrashCtl" style="display:none;align-items:center;gap:8px">
+              <span class="field-hint" style="margin:0">Auto-clear after</span>
+              <select class="input" id="crashlog_retention" style="max-width:110px">
+                <option value="0">Never</option>
+                <option value="7">7 days</option>
+                <option value="14">14 days</option>
+                <option value="30">30 days</option>
+                <option value="60">60 days</option>
+                <option value="90">90 days</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        <div class="logs-meta">
+          <span class="field-hint" id="logsHint">Console output captured since boot (kept in memory; oldest lines drop off as new ones arrive).</span>
+          <span class="field-hint" id="logsStatus">Not loaded yet.</span>
+          <span class="field-hint" id="crashlogStatus" style="display:none">Not loaded yet.</span>
+        </div>
+
+        <pre id="logsView" class="logs-view"></pre>
+        <div id="crashlogView" class="logs-view hidden"></div>
+
+        <!-- Core dump diagnostics: hidden unless a crash dump is saved in flash -->
+        <div id="coredumpCard" class="logs-meta" style="display:none;margin-top:12px;align-items:center;gap:12px">
+          <span class="field-hint" id="coredumpInfo" style="margin:0">Crash dump present.</span>
+          <a class="btn btn-outline" id="coredumpDownloadLink" href="/api/coredump" style="text-align:center">Download dump</a>
+          <button type="button" class="btn btn-outline" id="coredumpClearBtn" onclick="clearCoredump()">Clear dump</button>
+        </div>
+      </div>

--- a/main/fragment_nodes.html
+++ b/main/fragment_nodes.html
@@ -1,0 +1,57 @@
+
+      <div class="card" id="instance-overview">
+        <div class="card-title"><span class="card-title-label">Active N.I.N.A. Instances <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Active N.I.N.A. Instances</div><p>Selects which of the three N.I.N.A. instance slots the device polls and shows as pages. A disabled instance is not contacted and its page is skipped, but the slot keeps its fixed position so the other instances do not shift.</p><p>Each enabled instance gets its own dashboard page and a configuration card below. The device updates the page you are viewing in full and checks the other instances less often in the background.</p><p>Example: enable N.I.N.A. 1 and N.I.N.A. 2 for a two-instance setup and leave N.I.N.A. 3 off; only two node cards and two instance pages appear.</p></div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label" id="inst_lbl_0">N.I.N.A. 1</span>
+          <label class="toggle"><input type="checkbox" id="instance_enabled_0" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint">Polls this instance and shows its page; turn off to stop contacting it and hide its page.</div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label" id="inst_lbl_1">N.I.N.A. 2</span>
+          <label class="toggle"><input type="checkbox" id="instance_enabled_1" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint">Polls this instance and shows its page; turn off to stop contacting it and hide its page.</div>
+        <div class="toggle-row">
+          <span class="toggle-label" id="inst_lbl_2">N.I.N.A. 3</span>
+          <label class="toggle"><input type="checkbox" id="instance_enabled_2" onchange="updateInstanceStates();checkDirty()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint">Polls this instance and shows its page; turn off to stop contacting it and hide its page.</div>
+      </div>
+
+      <div id="node-cards"></div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Polling &amp; Connectivity <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Polling and Connectivity</div><p>Sets how often the device contacts the NINA API and how patient it is before declaring an instance offline. Data update rate is the base polling interval for the active page; faster values refresh the display sooner but generate more API traffic. Graph update rate controls how often the RMS and HFR history graphs add a point.</p><p>Connection timeout is how long a request waits for a response before that instance is marked offline. Idle poll interval is the slower, occasional check used to re-test an offline instance while you are viewing a non-NINA page, which avoids contacting an instance that is not running too often.</p><p>Example: set Data update rate to 2 seconds for a responsive display, raise Connection timeout to 10 seconds on a slow or distant network, and leave Idle poll interval at 30 seconds.</p></div>
+        <div class="subsection">
+          <div class="subsection-title">Update Rates</div>
+          <div class="row stack-mobile">
+            <div class="field">
+              <label class="field-label">Data update rate (s)</label>
+              <input type="number" class="input" id="update_rate" min="1" max="10" value="2">
+              <div class="field-hint">Base polling interval for the active page, from 1 to 10 seconds; lower is more responsive but adds API traffic.</div>
+            </div>
+            <div class="field">
+              <label class="field-label">Graph update rate (s)</label>
+              <input type="number" class="input" id="graph_interval" min="2" max="30" value="5">
+              <div class="field-hint">How often the RMS and HFR history graphs record a new data point, from 2 to 30 seconds.</div>
+            </div>
+          </div>
+        </div>
+        <div class="subsection">
+          <div class="subsection-title">Connectivity</div>
+          <div class="row stack-mobile">
+            <div class="field">
+              <label class="field-label">Connection timeout (s)</label>
+              <input type="number" class="input" id="connection_timeout" min="2" max="30" value="6">
+              <div class="field-hint">Seconds without response before a NINA instance is offline</div>
+            </div>
+            <div class="field">
+              <label class="field-label">Idle poll interval (s)</label>
+              <input type="number" class="input" id="idle_poll_interval" min="5" max="120" value="30">
+              <div class="field-hint">How often an offline instance is re-checked while you are on a non-NINA page</div>
+            </div>
+          </div>
+        </div>
+      </div>

--- a/main/fragment_spotify.html
+++ b/main/fragment_spotify.html
@@ -1,0 +1,78 @@
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Account Setup <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Account Setup</div><p>Connects the device to your Spotify account so the player page can show what is playing. Create a free app on the Spotify developer site, paste its Client ID here, then log in. The Client ID is saved to the device automatically when you select Login with Spotify, so no separate save is needed.</p><p>After you approve access, the browser lands on a page that cannot load. That is expected: copy the full address from that page, including the ?code= part, and paste it into the Redirect URL field. The device stores the resulting tokens, so login is a one-time step per account. Use Logout to clear the stored tokens.</p></div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable Spotify</span>
+          <label class="toggle"><input type="checkbox" id="spotify_enabled" onchange="updateSpotifyEnabledUI()"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint">Turns the Spotify page on and starts checking your playback.</div>
+        <div id="spotifyConnectionFields">
+          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Step 1: Create a Spotify app</div>
+          <div class="field-hint">Go to <a href="https://developer.spotify.com" target="_blank" rel="noopener" style="color:rgba(var(--accent-rgb),1);text-decoration:underline">developer.spotify.com</a>, create a free app, and set its Redirect URI to <code style="background:rgba(0,0,0,0.3);padding:2px 6px;border-radius:4px;font-size:0.78rem">http://127.0.0.1:8000/callback</code></div>
+          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Step 2: Enter the Client ID</div>
+          <div class="field">
+            <label class="field-label">Client ID</label>
+            <input type="text" class="input" id="spotifyClientId" placeholder="e.g. a1b2c3d4e5f6...">
+            <div class="field-hint">Saved to the device automatically when you select Login with Spotify below. No separate save needed.</div>
+          </div>
+          <div id="spotifyAccountCard">
+            <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Step 3: Log in</div>
+            <div class="field">
+              <label class="field-label">Status</label>
+              <div id="spotifyStatus" style="font-size:0.875rem;color:var(--text-hint);margin-bottom:12px">Checking...</div>
+            </div>
+            <div style="display:flex;gap:10px;flex-wrap:wrap">
+              <button class="btn btn-primary" id="spotifyLoginBtn" onclick="spotifyLogin()" style="flex:1;min-width:120px">Login with Spotify</button>
+              <button class="btn btn-danger" id="spotifyLogoutBtn" onclick="spotifyLogout()" style="flex:1;min-width:120px;display:none">Logout</button>
+            </div>
+            <div id="spotifyPasteDiv" style="display:none;margin-top:16px">
+              <p style="font-size:0.82rem;color:#a1a1aa;margin:0 0 10px;line-height:1.5">After approving in Spotify, you'll see a "can't connect" page. Copy the <strong>full URL</strong> from the address bar and paste it below:</p>
+              <div class="field" style="margin-bottom:10px">
+                <label class="field-label">Redirect URL</label>
+                <input type="text" class="input" id="spotifyPasteUrl" placeholder="http://127.0.0.1:8000/callback?code=..." style="font-size:0.92rem;min-height:52px;border:1px solid rgba(var(--accent-rgb),0.35);background:rgba(0,0,0,0.45)">
+                <div class="field-hint">Paste the entire callback URL from the address bar; it must contain the ?code= portion.</div>
+              </div>
+              <button class="btn btn-primary" id="spotifySubmitBtn" onclick="spotifySubmitCallback()" style="width:100%">Submit</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card" id="spotifyPlayerCard">
+        <div class="card-title"><span class="card-title-label">Player Options <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Player Options</div><p>Controls how the Spotify player page looks and how often it refreshes. Poll Interval sets how often the device checks Spotify for the current track and playback position; lower values track changes faster but make more API calls.</p><p>Minimal Mode shows centered track text with the album art dimmed to a background and the transport controls hidden. Show Overlay keeps the playback overlay visible, the same as tapping the album art; Overlay Timeout sets how long it stays before auto-hiding, with 0 keeping it on permanently.</p></div>
+        <div id="spotifyPlayerOptionsFields">
+          <div class="field">
+            <label class="field-label">Poll Interval (ms)</label>
+            <input type="number" class="input" id="spotifyPollInterval" min="1000" max="30000" step="500" value="3000">
+            <div class="field-hint">How often to check playback state (1000 &ndash; 30000 ms)</div>
+          </div>
+          <div class="toggle-row">
+            <span class="toggle-label">Minimal Mode</span>
+            <label class="toggle"><input type="checkbox" id="spotify_minimal_mode"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Shows centered track text, with the album art dimmed to a background and the transport controls hidden.</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Show Overlay</span>
+            <label class="toggle"><input type="checkbox" id="spotify_overlay_visible"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Force the minimal overlay visible (same as tapping album art)</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Scroll Long Text</span>
+            <label class="toggle"><input type="checkbox" id="spotify_scroll_text" checked><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">When off, long text wraps to multiple lines</div>
+          <div class="toggle-row">
+            <span class="toggle-label">Show Progress Bar</span>
+            <label class="toggle"><input type="checkbox" id="spotify_show_progress_bar" checked><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Shows the track elapsed and remaining progress bar on the player.</div>
+          <div class="field">
+            <label class="field-label">Overlay Timeout (s)</label>
+            <input type="number" class="input" id="spotifyOverlayTimeout" min="0" max="60" step="1" value="5">
+            <div class="field-hint">Seconds before playback overlay auto-hides (0 = always visible)</div>
+          </div>
+        </div>
+      </div>
+

--- a/main/fragment_system.html
+++ b/main/fragment_system.html
@@ -1,0 +1,332 @@
+
+      <div class="sys-metrics">
+          <div class="sys-metric m-temp">
+            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/></svg> Temperature</div>
+            <div class="sm-value"><span class="mv" id="mTemp">--</span></div>
+          </div>
+          <div class="sys-metric m-up">
+            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg> Uptime</div>
+            <div class="sm-value"><span class="mv" id="mUptime">--</span></div>
+          </div>
+          <div class="sys-metric m-mem">
+            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="4" y="6" width="16" height="12" rx="2"/><path d="M8 6V4m4 2V4m4 2V4M8 18v2m4-2v2m4-2v2"/></svg> Internal Heap</div>
+            <div class="sm-value"><span class="mv" id="mMem">--</span></div>
+          </div>
+          <div class="sys-metric m-psram">
+            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><ellipse cx="12" cy="5" rx="8" ry="3"/><path d="M4 5v14c0 1.66 3.58 3 8 3s8-1.34 8-3V5M4 12c0 1.66 3.58 3 8 3s8-1.34 8-3"/></svg> PSRAM</div>
+            <div class="sm-value"><span class="mv" id="mPsram">--</span></div>
+          </div>
+          <div class="sys-metric m-wifi">
+            <div class="sm-label"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 12.55a11 11 0 0 1 14.08 0M1.42 9a16 16 0 0 1 21.16 0M8.53 16.11a6 6 0 0 1 6.95 0M12 20h.01"/></svg> WiFi Signal</div>
+            <div class="sm-value"><span class="bars" id="mWifiBars"></span><span class="mv" id="mWifi">--</span></div>
+          </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Network <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Network and time</div><p>The device connects to your WiFi and also broadcasts its own setup WiFi network at the same time. It joins one of the three configured networks to reach your NINA computers; its own setup network uses the device hostname as the network name with password 12345678, so you can reach the settings for first-time setup without a separate screen. The three networks are priority-ordered: Network 1 is tried first, then 2, then 3.</p><p>Hostname is used on your network, as the setup network name, and as the Home Assistant device name. NTP server and timezone set the clock used on the clock page and in timestamps; the timezone list carries the correct local-time and daylight-saving rules.</p><p>Example: hostname ninadash1 produces access point SSID ninadash1 and the device is reachable at ninadash1.lan. Changes here take effect after a reboot.</p></div>
+        <div class="wifi-scan-panel" id="wifiScanPanel">
+          <div class="wifi-scan-header" onclick="toggleScanPanel()">
+            <span class="wifi-scan-title"><span class="chevron collapsed" id="scanChevron">&#x25BC;</span> Available Networks</span>
+            <span class="wifi-scan-rescan" id="scanRescanBtn" onclick="event.stopPropagation();scanWifi()">&#x21bb; Rescan</span>
+          </div>
+          <div class="wifi-scan-list collapsed" id="wifiScanList">
+            <div class="wifi-scan-status" id="wifiScanStatus">Scanning for networks...</div>
+          </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Device Name</div>
+        <div class="field">
+          <label class="field-label">Device hostname</label>
+          <input type="text" class="input" id="hostname" placeholder="NINA-DISPLAY" maxlength="31" pattern="[A-Za-z0-9\-]+" style="max-width:320px">
+          <div class="field-hint">Used on your network, as the setup WiFi network name, and as the Home Assistant device name.</div>
+        </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">WiFi Networks</div>
+        <div class="field">
+          <div class="field-label" style="font-weight:600;color:var(--accent)">Network 1 (Primary)</div>
+          <label class="field-label">SSID</label>
+          <input type="text" class="input" id="ssid1" placeholder="Network name">
+          <div class="field-hint">Highest-priority network; the device connects to this one first when it is in range.</div>
+          <label class="field-label">Password</label>
+          <input type="password" class="input" id="pass1" placeholder="Enter new password to change">
+          <div class="hint">Password is stored in device config and not readable</div>
+
+          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Network 2</div>
+          <label class="field-label">SSID</label>
+          <input type="text" class="input" id="ssid2" placeholder="Network name">
+          <div class="field-hint">Fallback joined only when Network 1 is unavailable.</div>
+          <label class="field-label">Password</label>
+          <input type="password" class="input" id="pass2" placeholder="Enter new password to change">
+
+          <div class="field-label" style="margin-top:16px;font-weight:600;color:var(--accent)">Network 3</div>
+          <label class="field-label">SSID</label>
+          <input type="text" class="input" id="ssid3" placeholder="Network name">
+          <div class="field-hint">Second fallback joined only when Networks 1 and 2 are unavailable.</div>
+          <label class="field-label">Password</label>
+          <input type="password" class="input" id="pass3" placeholder="Enter new password to change">
+        </div>
+        <div class="toggle-row">
+          <span class="toggle-label">WiFi power save</span>
+          <label class="toggle"><input type="checkbox" id="wifi_power_save" checked><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint">Lets the WiFi radio rest between updates to save power. The device stays connected, so there is no reconnect delay.</div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Time</div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">NTP server</label>
+            <input type="text" class="input" id="ntp" placeholder="pool.ntp.org">
+            <div class="field-hint">Hostname of the time server used to set the clock; pool.ntp.org works for most locations.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Timezone</label>
+            <select class="input" id="timezone">
+              <option value="">UTC (default)</option>
+              <option value="GMT0">GMT</option>
+              <option value="GMT0BST,M3.5.0/1,M10.5.0">UK (GMT/BST)</option>
+              <option value="CET-1CEST,M3.5.0,M10.5.0/3">Central Europe (CET/CEST)</option>
+              <option value="EET-2EEST,M3.5.0/3,M10.5.0/4">Eastern Europe (EET/EEST)</option>
+              <option value="EST5EDT,M3.2.0,M11.1.0">US Eastern (EST/EDT)</option>
+              <option value="CST6CDT,M3.2.0,M11.1.0">US Central (CST/CDT)</option>
+              <option value="MST7MDT,M3.2.0,M11.1.0">US Mountain (MST/MDT)</option>
+              <option value="MST7">US Arizona (MST, no DST)</option>
+              <option value="PST8PDT,M3.2.0,M11.1.0">US Pacific (PST/PDT)</option>
+              <option value="AKST9AKDT,M3.2.0,M11.1.0">US Alaska (AKST/AKDT)</option>
+              <option value="HST10">US Hawaii (HST, no DST)</option>
+              <option value="AEST-10AEDT,M10.1.0,M4.1.0/3">Australia Eastern (AEST/AEDT)</option>
+              <option value="ACST-9:30ACDT,M10.1.0,M4.1.0/3">Australia Central (ACST/ACDT)</option>
+              <option value="AWST-8">Australia Western (AWST, no DST)</option>
+              <option value="NZST-12NZDT,M9.5.0,M4.1.0/3">New Zealand (NZST/NZDT)</option>
+              <option value="JST-9">Japan (JST)</option>
+              <option value="CST-8">China (CST)</option>
+              <option value="IST-5:30">India (IST)</option>
+              <option value="<-03>3">Argentina (ART)</option>
+              <option value="<-03>3<-02>,M10.3.0/0,M2.3.0/0">Brazil (BRT/BRST)</option>
+              <option value="SAST-2">South Africa (SAST)</option>
+            </select>
+            <div class="field-hint">Select your region so local time and daylight-saving transitions are applied to displayed times.</div>
+          </div>
+        </div>
+        </div>
+        <div class="field-hint hint-center">Reboot required after changing hostname, WiFi, NTP, or timezone.</div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Location <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Location</div><p>Sets the device location used by location-based features: the weather forecast on the clock page and the moon phase view. Type a city name and select Look up to fill the coordinates automatically.</p><p>You can also enter latitude and longitude by hand, for example from a GPS reading or an online map.</p></div>
+        <div class="field-hint" style="margin-bottom:12px">This location is used by the weather forecast on the clock page and by the moon phase view.</div>
+        <div class="field" id="weather_city_lookup_field">
+          <label class="field-label">Location</label>
+          <div style="display:flex;gap:10px">
+            <input type="text" class="input" id="weather_location_search" placeholder="Search city name..." style="flex:1">
+            <button class="btn btn-outline" onclick="lookupCity()" type="button">Look up</button>
+          </div>
+          <div id="city_results" style="display:none;margin-top:6px;background:rgba(0,0,0,0.4);border:1px solid rgba(255,255,255,0.08);border-radius:10px;max-height:200px;overflow-y:auto"></div>
+          <div class="field-hint">Type a city name and select Look up to auto-fill latitude, longitude, and location name.</div>
+        </div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">Latitude</label>
+            <input type="number" class="input" id="weather_lat" step="0.0001" placeholder="0.0000">
+            <div class="field-hint">Decimal degrees, positive north (e.g. 39.7392); needed when not using city lookup.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Longitude</label>
+            <input type="number" class="input" id="weather_lon" step="0.0001" placeholder="0.0000">
+            <div class="field-hint">Decimal degrees, positive east, negative west (e.g. -104.9903).</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Power Management <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Power Management</div><p>Controls deep sleep. Deep sleep powers the device down on a long-press of the BOOT button or, optionally, after extended disconnection from all NINA instances. While asleep the display is off and the device is not reachable over the network.</p><p>The wake timer sets how many hours pass before the device wakes itself from deep sleep. A value of 0 means it stays asleep until physically rebooted.</p><p>Example: leave deep sleep off for an always-mounted display so the dashboard stays reachable over the network at all times.</p></div>
+        <div class="toggle-row">
+          <span class="toggle-label">Enable deep sleep (long-press BOOT to power off)</span>
+          <label class="toggle"><input type="checkbox" id="deep_sleep_enabled"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px">Allows a long-press of the BOOT button to power the device into deep sleep.</div>
+        <div id="deep_sleep_details" style="margin-top:16px">
+          <div class="field">
+            <label class="field-label">Wake timer (hours)</label>
+            <input type="number" class="input" id="deep_sleep_wake_timer" min="0" max="72" step="1" value="0">
+            <div class="field-hint">Hours until auto-wake. 0 = stay asleep forever. Warning: with timer set to 0, the device must be physically rebooted to wake up; there is no manual wake from deep sleep.</div>
+          </div>
+          <div class="toggle-row">
+            <span class="toggle-label">Auto power off when idle</span>
+            <label class="toggle"><input type="checkbox" id="deep_sleep_on_idle"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Enter deep sleep after extended disconnection from all NINA instances. The device must be physically rebooted to wake up if the wake timer is set to 0.</div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">MQTT <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">MQTT publishing</div><p>Publishes this device's own state to an MQTT broker and exposes it in Home Assistant. It does not republish N.I.N.A. session data. Auto-discovery config messages are sent so Home Assistant creates the entities automatically, with no manual setup: screen brightness and text brightness (both controllable), a reboot button, and an uptime sensor.</p><p>Broker host and port point at your MQTT server. Topic prefix is added to the front of every topic the device sends, so multiple displays can share one broker without collision. Username and password are sent only if your broker requires authentication; leave them blank for anonymous brokers.</p><p>Example: broker host 192.168.1.250, port 1883, topic prefix ninadisplay publishes under ninadisplay/... and appears in Home Assistant as a device named after the hostname.</p></div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable MQTT</span>
+          <label class="toggle"><input type="checkbox" id="mqtt_enabled"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px">Turn on publishing of the device's own state and Home Assistant auto-discovery to the broker.</div>
+        <div class="subsection">
+        <div class="subsection-title">Broker</div>
+        <div class="field">
+          <label class="field-label">Broker host</label>
+          <input type="text" class="input" id="mqtt_broker" placeholder="192.168.1.250">
+          <div class="field-hint">IP address or hostname of your MQTT broker.</div>
+        </div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">Port</label>
+            <input type="text" class="input" id="mqtt_port" placeholder="1883">
+            <div class="field-hint">Broker TCP port; 1883 for plain MQTT is the common default.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Topic prefix</label>
+            <input type="text" class="input" id="mqtt_prefix" placeholder="ninadisplay">
+            <div class="field-hint">Added to the front of every topic the device sends; use a unique value per device.</div>
+          </div>
+        </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Authentication</div>
+        <div class="row stack-mobile">
+          <div class="field">
+            <label class="field-label">Username</label>
+            <input type="text" class="input" id="mqtt_user" placeholder="Username">
+            <div class="field-hint">Leave blank if the broker allows anonymous connections.</div>
+          </div>
+          <div class="field">
+            <label class="field-label">Password</label>
+            <input type="password" class="input" id="mqtt_pass" placeholder="Password">
+            <div class="field-hint">Leave blank if the broker allows anonymous connections.</div>
+          </div>
+        </div>
+        </div>
+        <div class="field-hint hint-center">Reboot required after changing MQTT settings.</div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Firmware <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Firmware and updates</div><p>The info grid is read-only build detail: running version and build date, the ESP-IDF version, and the exact release version. Updates are pulled from GitHub releases; the device keeps the previous firmware so a failed or bad update can roll back automatically.</p><p>Check for updates on boot queries GitHub at startup. Update channel selects which releases qualify: Stable only ignores pre-releases, Include pre-releases also offers beta builds. Check for Updates queries now and, if a newer build exists, shows release notes and an Install button. The file picker below it flashes a local .bin you supply instead of downloading from GitHub.</p><p>Example: set Update channel to Stable only and leave Check for updates on boot enabled to be notified of tagged releases without receiving test builds.</p></div>
+        <div class="fw-grid">
+          <div class="fw-item"><div class="fw-label">Version</div><div class="fw-value" id="fw_version">--</div></div>
+          <div class="fw-item"><div class="fw-label">Built</div><div class="fw-value" id="fw_date">--</div></div>
+          <div class="fw-item"><div class="fw-label">IDF</div><div class="fw-value" id="fw_idf">--</div></div>
+          <div class="fw-item"><div class="fw-label">Partition</div><div class="fw-value" id="fw_partition">--</div></div>
+          <div class="fw-item"><div class="fw-label">Release</div><div class="fw-value" id="fw_git_tag">--</div></div>
+          <div class="fw-item"><div class="fw-label">Commit</div><div class="fw-value" id="fw_git_sha">--</div></div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Automatic Updates</div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Check for updates on boot</span>
+          <label class="toggle"><input type="checkbox" id="auto_update_check" checked><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px">Automatically check GitHub for new firmware releases when the device boots.</div>
+        <div class="field" style="margin-top:12px">
+          <label class="field-label">Update channel</label>
+          <select class="input" id="update_channel">
+            <option value="0">Stable only</option>
+            <option value="1">Include pre-releases</option>
+            <option value="2">Alpha (snd)</option>
+          </select>
+          <div class="field-hint">Stable only skips pre-release builds; Include pre-releases also offers beta firmware. Alpha (snd) installs experimental snd-branch builds; expect frequent changes.</div>
+        </div>
+        <button class="btn btn-primary" style="margin-top:12px;width:100%" id="checkUpdateBtn" onclick="checkForUpdates()">Check for Updates</button>
+        <div id="updateResult" style="display:none;margin-top:12px;padding:12px;border-radius:10px;border:1px solid rgba(255,255,255,0.08);background:rgba(255,255,255,0.03)">
+          <div id="updateResultText" style="font-size:0.85rem;color:var(--text-secondary)"></div>
+          <div id="updateSummary" style="display:none;margin-top:8px;font-size:0.78rem;color:var(--text-muted);max-height:120px;overflow-y:auto;white-space:pre-wrap"></div>
+          <button class="btn btn-primary" id="otaGithubBtn" style="display:none;margin-top:12px;width:100%" onclick="startGithubOta()">Install Update</button>
+        </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Manual Update</div>
+        <div class="ota-bar">
+          <label class="ota-label" id="otaFileLabel">
+            Choose firmware .bin file
+            <input type="file" id="otaFile" accept=".bin" style="display:none" onchange="otaFileSelected(this)">
+          </label>
+          <button class="btn btn-primary" id="otaBtn" disabled onclick="startOta()">Update</button>
+        </div>
+        <div class="field-hint" style="margin-top:4px">Flash a firmware .bin you provide directly instead of downloading from GitHub.</div>
+        <div id="otaProgress" style="display:none;margin-top:16px">
+          <div class="progress-bg"><div id="otaProgressFill" class="progress-fill"></div></div>
+          <div id="otaStatus" class="progress-status"></div>
+        </div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Device <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Device actions and modes</div><p>Reboot restarts the device and applies pending reboot-required settings. Factory Reset erases all saved settings and returns every setting to defaults, including WiFi, so plan to reconnect over the device's own setup WiFi network afterward.</p><p>Debug Mode enables extra performance and diagnostic info; leave it off for normal use. Demo Mode generates simulated session data so the dashboard can be used with no live NINA connection. Reboot the device for the change to fully take effect. Capture Screenshot pulls a JPEG of the current display.</p><p>Example: enable Demo Mode to preview the dashboard layout before any N.I.N.A. instance is online, then disable it to return to live data.</p></div>
+        <div class="subsection danger-zone">
+        <div class="subsection-title">Device Actions</div>
+        <div class="row stack-mobile" style="margin-bottom:16px">
+          <button class="btn btn-outline" onclick="saveAndReboot()" style="flex:1">Reboot</button>
+          <button class="btn btn-danger" onclick="factoryReset()" style="flex:1">Factory Reset</button>
+        </div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Modes</div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable Debug Mode</span>
+          <label class="toggle"><input type="checkbox" id="debug_mode"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px;margin-bottom:16px">Shows extra performance and diagnostic info.</div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <span class="toggle-label">Enable Demo Mode</span>
+          <label class="toggle"><input type="checkbox" id="demo_mode"><span class="toggle-track"></span></label>
+        </div>
+        <div class="field-hint" style="margin-top:4px;margin-bottom:16px">Generates simulated astrophotography data. Reboot for the change to fully take effect.</div>
+        </div>
+        <button class="btn btn-outline" id="ssBtn" onclick="takeScreenshot()">Capture Screenshot</button>
+        <div id="ssContainer" style="display:none;margin-top:16px">
+          <img id="ssImage" style="width:100%;border-radius:var(--radius-sm);border:1px solid var(--border)">
+        </div>
+      </div>
+
+      <div class="card" id="adminPasswordCard">
+        <div class="card-title"><span class="card-title-label">Authentication <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Web UI access control</div><p>Require login asks for a username and password before the web settings will open, and is on by default. When it is off, anyone on the network can reboot, factory-reset, flash, or reconfigure the device; secrets such as passwords, API keys, and tokens stay redacted in API responses either way.</p><p>The admin password defaults to changeme123!. To change it, enter the current password, then the new password twice (4 to 32 characters). Sign out clears your current browser session.</p><p>Example: keep Require login enabled and change the password from the default before exposing the device beyond your local network.</p></div>
+        <div class="subsection">
+        <div class="subsection-title">Access Control</div>
+        <div class="toggle-row">
+          <span class="toggle-label">Require login to access the web UI</span>
+          <label class="toggle"><input type="checkbox" id="auth_enabled"><span class="toggle-track"></span></label>
+        </div>
+        <p style="color:#888;font-size:0.85em;margin:8px 0 0 0;">
+          When disabled, anyone on the network can control the device (reboot, factory reset, OTA, config change).
+          Secrets (passwords, API keys, tokens) remain redacted in API responses either way.
+        </p>
+        <button class="btn btn-primary" style="margin-top:12px" onclick="saveAuthEnabled()">Save</button>
+        <div id="auth_enabled_status" style="margin-top:10px;font-size:0.9em;"></div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">Admin Password</div>
+        <p style="color:#888;font-size:0.85em;margin:2px 0 12px 0;">
+          Default password is <code>changeme123!</code>. Change it now to secure this device's web interface.
+        </p>
+        <div class="field">
+          <label for="admin_pw_current">Current password</label>
+          <input type="password" class="input" id="admin_pw_current" autocomplete="current-password">
+          <div class="field-hint">Enter the password in use now to authorize the change.</div>
+        </div>
+        <div class="field">
+          <label for="admin_pw_new">New password (4-32 chars)</label>
+          <input type="password" class="input" id="admin_pw_new" autocomplete="new-password">
+          <div class="field-hint">Choose a password 4 to 32 characters long.</div>
+        </div>
+        <div class="field">
+          <label for="admin_pw_confirm">Confirm new password</label>
+          <input type="password" class="input" id="admin_pw_confirm" autocomplete="new-password">
+          <div class="field-hint">Re-enter the new password exactly to confirm.</div>
+        </div>
+        <button class="btn btn-primary" onclick="changeAdminPassword()">Save Password</button>
+        <div id="admin_pw_status" style="margin-top:10px;font-size:0.9em;"></div>
+        </div>
+        <button class="btn" id="signOutBtn" onclick="signOut()">Sign out</button>
+      </div>

--- a/main/fragment_system.html
+++ b/main/fragment_system.html
@@ -283,7 +283,7 @@
         </div>
         <div class="field-hint" style="margin-top:4px;margin-bottom:16px">Generates simulated astrophotography data. Reboot for the change to fully take effect.</div>
         </div>
-        <button class="btn btn-outline" id="ssBtn" onclick="takeScreenshot()">Capture Screenshot</button>
+        <button class="btn btn-outline" id="ssBtn" onclick="takeScreenshot()" style="margin-top:16px">Capture Screenshot</button>
         <div id="ssContainer" style="display:none;margin-top:16px">
           <img id="ssImage" style="width:100%;border-radius:var(--radius-sm);border:1px solid var(--border)">
         </div>

--- a/main/http_fetch.c
+++ b/main/http_fetch.c
@@ -1,0 +1,380 @@
+/**
+ * @file http_fetch.c
+ * @brief Shared JSON/text HTTP GET fetcher. See http_fetch.h for scope.
+ */
+
+#include "http_fetch.h"
+#include "http_fetch_policy.h"
+
+#include <string.h>
+#include <strings.h>
+
+#include "esp_http_client.h"
+#include "esp_crt_bundle.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "esp_timer.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
+static const char *TAG = "http_fetch";
+
+struct http_fetch_conn {
+    esp_http_client_handle_t client; /* NULL until first successful fetch */
+};
+
+/**
+ * Clear the caller's capture buffer (if provided). Called before every
+ * response-header fetch -- including each redirect re-open -- so that only
+ * the FINAL response's header value survives; each hop re-fetches headers
+ * and would otherwise leave a stale value from an intermediate response.
+ */
+static void capture_reset(const http_fetch_opts_t *opts) {
+    if (opts->capture_header_out && opts->capture_header_out_len > 0) {
+        opts->capture_header_out[0] = '\0';
+    }
+}
+
+/**
+ * esp_http_client event callback registered on every client this module
+ * creates (including reused keep-alive handles). Arbitrary response headers
+ * are only observable via HTTP_EVENT_ON_HEADER -- they are not queryable
+ * after esp_http_client_fetch_headers(). evt->user_data is read from the
+ * client's user_data at dispatch time, so attempt_once() can re-point it at
+ * the current request's opts even though the client handle persists across
+ * requests.
+ */
+static esp_err_t header_capture_event_cb(esp_http_client_event_t *evt) {
+    if (evt->event_id != HTTP_EVENT_ON_HEADER) return ESP_OK;
+
+    const http_fetch_opts_t *opts = (const http_fetch_opts_t *)evt->user_data;
+    if (!opts || !opts->capture_header ||
+        !opts->capture_header_out || opts->capture_header_out_len == 0) {
+        return ESP_OK;
+    }
+    if (!evt->header_key || !evt->header_value) return ESP_OK;
+    if (strcasecmp(evt->header_key, opts->capture_header) != 0) return ESP_OK;
+
+    /* Copy with an explicit length clamp: the event's value string is freed
+     * by esp_http_client immediately after dispatch. */
+    size_t n = strnlen(evt->header_value, opts->capture_header_out_len - 1);
+    memcpy(opts->capture_header_out, evt->header_value, n);
+    opts->capture_header_out[n] = '\0';
+    return ESP_OK;
+}
+
+/** Fill in defaults for any unset (zero/negative) field. */
+static void normalize_opts(http_fetch_opts_t *o) {
+    if (o->timeout_ms <= 0) o->timeout_ms = 8000;
+    if (o->max_attempts <= 0) o->max_attempts = 1;
+    if (o->retry_delay_ms <= 0) o->retry_delay_ms = 500;
+    if (o->max_response_bytes == 0) o->max_response_bytes = 65536;
+}
+
+/** Allocate a fresh esp_http_client for @p url per @p opts. */
+static esp_http_client_handle_t make_client(const char *url,
+                                             const http_fetch_opts_t *opts,
+                                             bool keep_alive) {
+    esp_http_client_config_t cfg = {
+        .url = url,
+        .timeout_ms = opts->timeout_ms,
+        .keep_alive_enable = keep_alive,
+        .crt_bundle_attach = opts->use_tls_bundle ? esp_crt_bundle_attach : NULL,
+        .event_handler = header_capture_event_cb,
+        /* user_data intentionally NULL here: the capture target is attached
+         * per request in attempt_once() via esp_http_client_set_user_data(),
+         * because a keep-alive client outlives any single opts. */
+    };
+    return esp_http_client_init(&cfg);
+}
+
+/** Apply the optional headers from @p opts to @p client. */
+static void apply_headers(esp_http_client_handle_t client, const http_fetch_opts_t *opts) {
+    if (opts->host_header) {
+        /* Re-assert on every call: a reused keep-alive handle may have served
+         * a different Host on a prior request, and esp_http_client_set_url()
+         * does not update an already-set Host header. */
+        esp_http_client_set_header(client, "Host", opts->host_header);
+    }
+    if (opts->bearer_token) {
+        /* 1200 bytes: real-world bearer tokens (e.g. Spotify OAuth access
+         * tokens) can run several hundred characters -- 256 silently dropped
+         * the header (snprintf truncation check below) for long tokens. */
+        char hdr[1200];
+        int n = snprintf(hdr, sizeof(hdr), "Bearer %s", opts->bearer_token);
+        if (n > 0 && n < (int)sizeof(hdr)) {
+            esp_http_client_set_header(client, "Authorization", hdr);
+        }
+    }
+    if (opts->user_agent) {
+        esp_http_client_set_header(client, "User-Agent", opts->user_agent);
+    }
+    if (opts->accept) {
+        esp_http_client_set_header(client, "Accept", opts->accept);
+    }
+}
+
+/**
+ * Open @p client, fetch headers, and follow any redirect chain (streaming
+ * open()/read() does not auto-follow -- must be done manually per hop).
+ * On success fills *status_out / *content_length_out and returns ESP_OK.
+ * On transport failure returns the esp_http_client error.
+ *
+ * @param opened_out    set true as soon as the FIRST esp_http_client_open()
+ *                       call (before any redirect hop) succeeds, regardless
+ *                       of what happens afterward -- mirrors the "ever
+ *                       connected" latch callers use to distinguish an
+ *                       unreachable host from a reachable one that failed.
+ * @param connect_us_out cumulative esp_http_client_open() duration across
+ *                       the initial open and any redirect re-opens.
+ * @param headers_us_out cumulative esp_http_client_fetch_headers() duration.
+ * All three out-params may be NULL when the caller doesn't need them.
+ */
+static esp_err_t open_and_follow_redirects(esp_http_client_handle_t client,
+                                            const http_fetch_opts_t *opts,
+                                            int *status_out, int *content_length_out,
+                                            bool *opened_out, int64_t *connect_us_out,
+                                            int64_t *headers_us_out) {
+    capture_reset(opts);
+    int64_t t0 = esp_timer_get_time();
+    esp_err_t err = esp_http_client_open(client, 0);
+    if (connect_us_out) *connect_us_out += esp_timer_get_time() - t0;
+    if (err != ESP_OK) return err;
+    if (opened_out) *opened_out = true;
+
+    int64_t t1 = esp_timer_get_time();
+    int content_length = esp_http_client_fetch_headers(client);
+    if (headers_us_out) *headers_us_out += esp_timer_get_time() - t1;
+    int status = esp_http_client_get_status_code(client);
+
+    int redirects = 0;
+    while (http_status_is_redirect(status) && redirects < opts->max_redirects) {
+        err = esp_http_client_set_redirection(client);
+        if (err != ESP_OK) break; /* no Location header or similar -- stop following */
+
+        esp_http_client_close(client);
+        capture_reset(opts); /* only the final hop's header value may survive */
+        t0 = esp_timer_get_time();
+        err = esp_http_client_open(client, 0);
+        if (connect_us_out) *connect_us_out += esp_timer_get_time() - t0;
+        if (err != ESP_OK) return err;
+
+        t1 = esp_timer_get_time();
+        content_length = esp_http_client_fetch_headers(client);
+        if (headers_us_out) *headers_us_out += esp_timer_get_time() - t1;
+        status = esp_http_client_get_status_code(client);
+        redirects++;
+    }
+
+    *status_out = status;
+    *content_length_out = content_length;
+    return ESP_OK;
+}
+
+/** Close (keep-alive) or cleanup @p client depending on whether @p conn is set. */
+static void finish_client(esp_http_client_handle_t client, http_fetch_conn_t *conn) {
+    if (conn) {
+        /* Detach the capture context before parking the handle: it points at
+         * this request's opts (stack of http_fetch_text) and would dangle. */
+        esp_http_client_set_user_data(client, NULL);
+        esp_http_client_close(client);
+        conn->client = client;
+    } else {
+        esp_http_client_cleanup(client);
+    }
+}
+
+/**
+ * Perform a single fetch attempt (no retry-loop delay here -- that lives in
+ * http_fetch_text()). Sets *retryable to tell the caller whether another
+ * attempt is worth trying on failure. @p info accumulates per-phase timing /
+ * status for opts->on_attempt; caller pre-zeroes it and sets attempt_index.
+ */
+static esp_err_t attempt_once(const char *url, const http_fetch_opts_t *opts,
+                               char **out_body, size_t *out_len, bool *retryable,
+                               http_fetch_attempt_info_t *info) {
+    *retryable = true;
+    http_fetch_conn_t *conn = opts->conn;
+    bool reused = (conn && conn->client != NULL);
+
+    esp_http_client_handle_t client;
+    if (reused) {
+        client = conn->client;
+        esp_http_client_set_url(client, url);
+    } else {
+        client = make_client(url, opts, conn != NULL);
+        if (!client) return ESP_ERR_NO_MEM;
+    }
+    apply_headers(client, opts);
+    /* Point the header-capture event handler at this request's opts (const
+     * cast: the handler only writes through opts->capture_header_out). */
+    esp_http_client_set_user_data(client, (void *)opts);
+
+    int status = 0;
+    int content_length = 0;
+    esp_err_t err = open_and_follow_redirects(client, opts, &status, &content_length,
+                                               &info->ever_connected, &info->connect_us,
+                                               &info->headers_us);
+
+    if ((err != ESP_OK || status == -1) && reused) {
+        /* Stale/dead keep-alive connection (status -1 = server closed it
+         * silently) -- destroy and retry once within this attempt, mirroring
+         * spotify_client.c's player_client reconnect pattern. */
+        ESP_LOGD(TAG, "Stale keep-alive for %s -- reconnecting", url);
+        esp_http_client_cleanup(client);
+        conn->client = NULL;
+
+        client = make_client(url, opts, true);
+        if (!client) return ESP_ERR_NO_MEM;
+        apply_headers(client, opts);
+        esp_http_client_set_user_data(client, (void *)opts);
+        err = open_and_follow_redirects(client, opts, &status, &content_length,
+                                         &info->ever_connected, &info->connect_us,
+                                         &info->headers_us);
+    }
+
+    info->status = status;
+
+    if (err != ESP_OK) {
+        /* Transport-level failure (connect/DNS/etc.) -- retryable. */
+        esp_http_client_cleanup(client);
+        return err;
+    }
+
+    if (status < 200 || status >= 300) {
+        ESP_LOGW(TAG, "HTTP %d for %s", status, url);
+        finish_client(client, conn);
+        *retryable = (status >= 500);
+        return ESP_FAIL;
+    }
+
+    size_t cap = opts->max_response_bytes;
+
+    if (content_length > 0 && (size_t)content_length + 1 > cap) {
+        ESP_LOGW(TAG, "response too large (%d bytes, cap %u) for %s",
+                 content_length, (unsigned)cap, url);
+        finish_client(client, conn);
+        *retryable = false;
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    size_t bufsize = http_buf_initial(content_length, cap);
+    if (bufsize == 0) {
+        finish_client(client, conn);
+        *retryable = false;
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    char *buf = heap_caps_malloc(bufsize, MALLOC_CAP_SPIRAM);
+    if (!buf) {
+        finish_client(client, conn);
+        *retryable = false;
+        return ESP_ERR_NO_MEM;
+    }
+
+    size_t total = 0;
+    bool truncated = false;
+    int64_t body_start_us = esp_timer_get_time();
+    while (total + 1 < bufsize) {
+        int n = esp_http_client_read(client, buf + total, (int)(bufsize - 1 - total));
+        if (n <= 0) break;
+        total += (size_t)n;
+
+        if (total + 1 >= bufsize) {
+            size_t grown = http_buf_grow(bufsize, cap);
+            if (grown == 0) {
+                /* Cap reached. For a known content_length this just means we
+                 * read exactly up to it -- not truncation. For an unknown-
+                 * length stream it genuinely is truncation. */
+                truncated = (content_length <= 0);
+                break;
+            }
+            char *nb = heap_caps_realloc(buf, grown, MALLOC_CAP_SPIRAM);
+            if (!nb) {
+                info->body_us = esp_timer_get_time() - body_start_us;
+                heap_caps_free(buf);
+                finish_client(client, conn);
+                *retryable = false;
+                return ESP_ERR_NO_MEM;
+            }
+            buf = nb;
+            bufsize = grown;
+        }
+    }
+    info->body_us = esp_timer_get_time() - body_start_us;
+    buf[total] = '\0';
+
+    if (content_length > 0 && total < (size_t)content_length) {
+        ESP_LOGW(TAG, "Partial HTTP read: %u/%d bytes for %s",
+                 (unsigned)total, content_length, url);
+        heap_caps_free(buf);
+        finish_client(client, conn);
+        return ESP_FAIL; /* retryable stays true */
+    }
+
+    if (truncated) {
+        ESP_LOGW(TAG, "Response truncated at cap (%u bytes) for %s", (unsigned)cap, url);
+    }
+
+    finish_client(client, conn);
+    *out_body = buf;
+    *out_len = total;
+    info->ok = true;
+    return ESP_OK;
+}
+
+esp_err_t http_fetch_text(const char *url, const http_fetch_opts_t *opts_in,
+                           char **out_body, size_t *out_len) {
+    if (!url || !out_body || !out_len) return ESP_ERR_INVALID_ARG;
+
+    http_fetch_opts_t opts = opts_in ? *opts_in : (http_fetch_opts_t){0};
+    normalize_opts(&opts);
+
+    esp_err_t last_err = ESP_FAIL;
+    for (int attempt = 0; attempt < opts.max_attempts; attempt++) {
+        if (attempt > 0) {
+            vTaskDelay(pdMS_TO_TICKS(opts.retry_delay_ms));
+        }
+
+        bool retryable = true;
+        http_fetch_attempt_info_t info = { .attempt_index = attempt };
+        esp_err_t err = attempt_once(url, &opts, out_body, out_len, &retryable, &info);
+        if (opts.on_attempt) opts.on_attempt(&info, opts.hook_ctx);
+        if (opts.status_out && info.status != 0) *opts.status_out = info.status;
+        if (err == ESP_OK) return ESP_OK;
+
+        last_err = err;
+        if (!retryable) break;
+        if (!http_should_retry(attempt, opts.max_attempts)) break;
+    }
+
+    ESP_LOGW(TAG, "%s unreachable (%s)", url, esp_err_to_name(last_err));
+    return last_err;
+}
+
+cJSON *http_fetch_json(const char *url, const http_fetch_opts_t *opts) {
+    char *body = NULL;
+    size_t len = 0;
+    if (http_fetch_text(url, opts, &body, &len) != ESP_OK) {
+        return NULL;
+    }
+
+    cJSON *json = cJSON_Parse(body);
+    heap_caps_free(body);
+    if (!json) {
+        ESP_LOGW(TAG, "JSON parse failed for %s", url);
+    }
+    return json;
+}
+
+http_fetch_conn_t *http_fetch_conn_create(void) {
+    return heap_caps_calloc(1, sizeof(http_fetch_conn_t), MALLOC_CAP_SPIRAM);
+}
+
+void http_fetch_conn_destroy(http_fetch_conn_t *conn) {
+    if (!conn) return;
+    if (conn->client) {
+        esp_http_client_cleanup(conn->client);
+    }
+    heap_caps_free(conn);
+}

--- a/main/http_fetch.h
+++ b/main/http_fetch.h
@@ -1,0 +1,126 @@
+#pragma once
+
+/**
+ * @file http_fetch.h
+ * @brief Shared JSON/text HTTP GET fetcher -- the common case only.
+ *
+ * Scope: a plain text/JSON HTTP GET with retry, manual redirect-following
+ * (esp_http_client's streaming open()/read() path does NOT auto-follow
+ * redirects -- only the one-shot perform() variant does), status checking,
+ * and a PSRAM-backed response buffer, with optional persistent keep-alive
+ * reuse across calls from the same task.
+ *
+ * NOT for: image streaming (GOES tiles, Spotify album art -- those decode
+ * progressively into caller-managed buffers) or OTA binary download (goes
+ * through esp_https_ota / ota_github.c's own 4KB chunked writer). Those
+ * stay on their own hand-rolled paths.
+ *
+ * v3 seam note: NINA-specific URL building (/v2/api/ vs /v3/api/ path
+ * prefixes), the response-envelope unwrap ({"Response":...,"Success":bool}),
+ * and any NINA-specific auth scheme deliberately stay in nina_client.c, NOT
+ * here. This module is protocol-agnostic on purpose so a future v2/v3
+ * dual-client can sit on top of it unchanged. See
+ * .claude memory: reference_ninaapi_v3_migration_delta.
+ *
+ * Thread-safety: an http_fetch_opts_t / http_fetch_conn_t pair is NOT safe
+ * to share across tasks concurrently. Each task that wants keep-alive reuse
+ * owns its own http_fetch_conn_t and passes only its own opts, mirroring the
+ * per-task poll-context registry pattern in nina_client_internal.h.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include "esp_err.h"
+#include "cJSON.h"
+
+/** Opaque persistent keep-alive slot; one per task that wants reuse. */
+typedef struct http_fetch_conn http_fetch_conn_t;
+
+/**
+ * Optional per-attempt diagnostics, reported via http_fetch_opts_t.on_attempt
+ * once per attempt (success or failure). Lets a caller with its own latency
+ * instrumentation (e.g. NINA's perf_monitor connect/TTFB/body timers) rebuild
+ * per-phase timing and retry/failure counters without this module depending
+ * on any specific metrics framework.
+ */
+typedef struct {
+    int     attempt_index;    /**< 0-based */
+    bool    ok;               /**< true if this attempt produced the final result */
+    bool    ever_connected;   /**< true if esp_http_client_open() succeeded this attempt */
+    int     status;           /**< HTTP status code; 0 if headers were never reached */
+    int64_t connect_us;       /**< esp_http_client_open() duration (0 if not reached) */
+    int64_t headers_us;       /**< fetch_headers (TTFB) duration (0 if not reached) */
+    int64_t body_us;          /**< body read loop duration (0 if not reached) */
+} http_fetch_attempt_info_t;
+
+typedef struct {
+    int timeout_ms;             /**< 0 -> 8000 */
+    bool use_tls_bundle;        /**< true -> esp_crt_bundle_attach (HTTPS cert validation) */
+    int max_redirects;          /**< 0 = don't follow redirects */
+    int max_attempts;           /**< 0 -> 1 (no retry) */
+    int retry_delay_ms;         /**< flat delay between attempts; 0 -> 500 */
+    size_t max_response_bytes;  /**< 0 -> 65536; hard cap, includes the NUL terminator */
+    const char *bearer_token;   /**< optional: adds "Authorization: Bearer <token>" */
+    const char *user_agent;     /**< optional: adds a "User-Agent" header */
+    const char *accept;         /**< optional: adds an "Accept" header */
+    const char *host_header;    /**< optional: explicit "Host" header, re-applied on every
+                                  * attempt (including a reused keep-alive connection).
+                                  * For mDNS-bypass callers that rewrite the request URL's
+                                  * host to a numeric IP so esp_http_client skips
+                                  * getaddrinfo(): pass the original hostname here so the
+                                  * server still sees the intended Host. Applied before
+                                  * esp_http_client_open(), same as any other header. */
+    void (*on_attempt)(const http_fetch_attempt_info_t *info, void *hook_ctx);
+                                 /**< optional: NULL disables. See http_fetch_attempt_info_t. */
+    void *hook_ctx;              /**< passed through unchanged to on_attempt */
+    http_fetch_conn_t *conn;    /**< optional: NULL = one-shot client (no reuse) */
+    int *status_out;            /**< optional: written with the FINAL attempt's HTTP
+                                  * status code whenever a status was received --
+                                  * including non-2xx failure returns (e.g. 204, 401,
+                                  * 500). Left untouched if no response ever arrived
+                                  * (transport failure -- DNS/connect/timeout). Caller
+                                  * should pre-set to 0 to distinguish "no response"
+                                  * from a real status of 0. */
+    const char *capture_header;  /**< optional: name of ONE response header to capture
+                                  * as a raw string (case-insensitive match); NULL = off.
+                                  * No parsing happens here -- this layer stays
+                                  * protocol-agnostic. */
+    char *capture_header_out;    /**< caller buffer for the captured value. On a
+                                  * successful fetch, holds the header value from the
+                                  * FINAL response (after redirects), NUL-terminated
+                                  * (truncated to fit). If the header was absent, or
+                                  * capture is disabled, the buffer is set to "" (when
+                                  * provided). */
+    size_t capture_header_out_len; /**< size of capture_header_out incl. NUL */
+} http_fetch_opts_t;
+
+/**
+ * Fetch @p url via HTTP GET.
+ *
+ * On success returns ESP_OK, and *out_body is a NUL-terminated PSRAM
+ * buffer the caller must release with heap_caps_free(); *out_len is the
+ * body length excluding the NUL. On failure returns an esp_err_t != ESP_OK
+ * and leaves *out_body / *out_len untouched.
+ *
+ * @param opts  May be NULL to use all defaults (one-shot, no retry, 8s
+ *              timeout, 64KB cap, no TLS bundle).
+ */
+esp_err_t http_fetch_text(const char *url, const http_fetch_opts_t *opts,
+                           char **out_body, size_t *out_len);
+
+/**
+ * Convenience wrapper: http_fetch_text() + cJSON_Parse(). Returns NULL on
+ * any failure (transport, HTTP status, or JSON parse). Caller must
+ * cJSON_Delete() the result.
+ */
+cJSON *http_fetch_json(const char *url, const http_fetch_opts_t *opts);
+
+/**
+ * Create a persistent keep-alive slot for the calling task's poll loop.
+ * Returns NULL on allocation failure. Free with http_fetch_conn_destroy().
+ */
+http_fetch_conn_t *http_fetch_conn_create(void);
+
+/** Destroy a keep-alive slot, cleaning up any live client handle it holds. */
+void http_fetch_conn_destroy(http_fetch_conn_t *conn);

--- a/main/http_fetch_policy.h
+++ b/main/http_fetch_policy.h
@@ -1,0 +1,71 @@
+#pragma once
+
+/**
+ * @file http_fetch_policy.h
+ * @brief Pure decision functions for http_fetch.c -- redirect classification,
+ * retry-loop continuation, and response-buffer sizing.
+ *
+ * Header-only, no ESP-IDF/FreeRTOS includes on purpose: these are the parts
+ * of the fetcher's control flow worth pinning with a host-side truth table
+ * (test/host/test_http_policy.c) without dragging in esp_http_client.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/** True for the HTTP redirect status codes esp_http_client_set_redirection()
+ * knows how to follow (301/302/303/307/308). */
+static inline bool http_status_is_redirect(int status) {
+    switch (status) {
+        case 301:
+        case 302:
+        case 303:
+        case 307:
+        case 308:
+            return true;
+        default:
+            return false;
+    }
+}
+
+/** True if a retry attempt should follow @p attempt (0-indexed: attempt 0 is
+ * the first try). False once @p attempt is the last of @p max_attempts. */
+static inline bool http_should_retry(int attempt, int max_attempts) {
+    if (max_attempts <= 0) return false;
+    return (attempt + 1) < max_attempts;
+}
+
+/**
+ * Initial response-buffer size (bytes, including 1 for the NUL terminator).
+ *
+ * @param content_length  Server-reported Content-Length, or <= 0 when
+ *                         unknown/chunked (unknown-length streaming case).
+ * @param cap              Hard ceiling on total buffer size; 0 means no room
+ *                         at all (caller should treat as failure).
+ */
+static inline size_t http_buf_initial(int64_t content_length, size_t cap) {
+    if (cap == 0) return 0;
+    if (content_length > 0) {
+        size_t want = (size_t)content_length + 1; /* +1 for NUL */
+        return (want > cap) ? cap : want;
+    }
+    /* Unknown length: start small and grow via http_buf_grow(). */
+    size_t start = 4096;
+    return (start > cap) ? cap : start;
+}
+
+/**
+ * Next buffer size when the current buffer filled up (doubling growth).
+ * Returns 0 when @p cur has already reached @p cap (cannot grow further --
+ * caller must stop reading and, for unknown-length responses, treat the
+ * body as truncated at the cap).
+ */
+static inline size_t http_buf_grow(size_t cur, size_t cap) {
+    if (cur == 0 || cur >= cap) return 0;
+    size_t next = cur * 2;
+    if (next < cur) next = cap;   /* overflow guard */
+    if (next > cap) next = cap;
+    if (next <= cur) return 0;    /* already at cap */
+    return next;
+}

--- a/main/nina_api_fetchers.c
+++ b/main/nina_api_fetchers.c
@@ -9,6 +9,7 @@
 #include "nina_api_fetchers.h"
 #include "nina_client_internal.h"
 #include "esp_log.h"
+#include "esp_timer.h"
 #include "cJSON.h"
 #include <string.h>
 #include <stdio.h>
@@ -37,7 +38,12 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
     char url[256];
     snprintf(url, sizeof(url), "%sequipment/camera/info", base_url);
 
-    cJSON *json = http_get_json(url);
+    /* Capture the NINA PC's own clock from the HTTP Date header, and stamp
+     * the device monotonic clock ONCE right after the fetch returns so the
+     * (epoch, mono) pair describes the same instant. */
+    int64_t date_epoch = 0;
+    cJSON *json = http_get_json_dated(url, &date_epoch);
+    int64_t fetch_mono_us = esp_timer_get_time();
     if (!json) {
         // Transport failure / non-2xx / empty body — API unreachable.
         nina_fetch_set_offline(data);
@@ -66,6 +72,10 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
         return;
     }
     data->connected = true;
+    if (date_epoch > 0) {
+        data->nina_clock_epoch = date_epoch;
+        data->nina_clock_mono_us = fetch_mono_us;
+    }
     {
         // Camera name
         cJSON *cam_name = cJSON_GetObjectItem(response, "Name");
@@ -100,17 +110,21 @@ void fetch_camera_info_robust(const char *base_url, nina_client_t *data) {
 
         if (data->is_exposing && exp_end && exp_end->valuestring) {
             time_t end_time = parse_iso8601(exp_end->valuestring);
-            time_t now = time(NULL);
+            /* Do the remaining-time math in the NINA clock domain: Date-derived
+             * "now" needs no boot-clock sanity guard; the time(NULL) fallback
+             * keeps the >2020 guard against an unset SNTP clock. */
+            int64_t now_nina = (date_epoch > 0) ? date_epoch : (int64_t)time(NULL);
+            bool now_valid = (date_epoch > 0) || (now_nina > 1577836800);
 
-            if (now > 1577836800 && end_time > 0) {
-                double remaining = difftime(end_time, now);
+            if (now_valid && end_time > 0) {
+                int64_t remaining = (int64_t)end_time - now_nina;
                 if (remaining >= 0 && remaining <= 7200) {
-                    data->exposure_current = -remaining;
+                    data->exposure_current = -(float)remaining;
                     data->exposure_end_epoch = (int64_t)end_time;
-                    if (data->exposure_total == 0 && remaining > 0.5) {
+                    if (data->exposure_total == 0 && remaining > 0) {
                         data->exposure_total = (float)remaining;
                     }
-                    ESP_LOGI(TAG, "Camera exposing: %.1fs remaining", remaining);
+                    ESP_LOGI(TAG, "Camera exposing: %llds remaining", (long long)remaining);
                 }
             }
         }
@@ -558,7 +572,12 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
     char url[256];
     snprintf(url, sizeof(url), "%sequipment/info", base_url);
 
-    cJSON *json = http_get_json(url);
+    /* Capture NINA's own clock (HTTP Date header) + a device monotonic stamp
+     * taken ONCE right after the fetch returns (same pattern as
+     * fetch_camera_info_robust). */
+    int64_t date_epoch = 0;
+    cJSON *json = http_get_json_dated(url, &date_epoch);
+    int64_t fetch_mono_us = esp_timer_get_time();
     if (!json) {
         // Transport failure / non-2xx / empty body — API unreachable.
         nina_fetch_set_offline(data);
@@ -589,6 +608,10 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
         return 0;
     }
     data->connected = true;
+    if (date_epoch > 0) {
+        data->nina_clock_epoch = date_epoch;
+        data->nina_clock_mono_us = fetch_mono_us;
+    }
 
     // ── Camera ──
     cJSON *camera = cJSON_GetObjectItem(response, "Camera");
@@ -621,13 +644,16 @@ int fetch_equipment_info_bundled(const char *base_url, nina_client_t *data, bool
 
         if (data->is_exposing && exp_end && exp_end->valuestring) {
             time_t end_time = parse_iso8601(exp_end->valuestring);
-            time_t now = time(NULL);
-            if (now > 1577836800 && end_time > 0) {
-                double remaining = difftime(end_time, now);
+            /* NINA-domain "now": Date-derived needs no boot-clock guard; the
+             * time(NULL) fallback keeps the >2020 unset-SNTP guard. */
+            int64_t now_nina = (date_epoch > 0) ? date_epoch : (int64_t)time(NULL);
+            bool now_valid = (date_epoch > 0) || (now_nina > 1577836800);
+            if (now_valid && end_time > 0) {
+                int64_t remaining = (int64_t)end_time - now_nina;
                 if (remaining >= 0 && remaining <= 7200) {
-                    data->exposure_current = -remaining;
+                    data->exposure_current = -(float)remaining;
                     data->exposure_end_epoch = (int64_t)end_time;
-                    if (data->exposure_total == 0 && remaining > 0.5) {
+                    if (data->exposure_total == 0 && remaining > 0) {
                         data->exposure_total = (float)remaining;
                     }
                 }

--- a/main/nina_client.c
+++ b/main/nina_client.c
@@ -13,6 +13,8 @@
 #include "nina_sequence.h"
 #include "nina_websocket.h"
 #include "nina_connection.h"
+#include "http_fetch.h"
+#include "time_parse.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "freertos/semphr.h"
@@ -80,9 +82,8 @@ http_poll_ctx_t *http_poll_ctx_get(void) {
 
 static SemaphoreHandle_t s_dns_mutex = NULL;
 
-// Retry delays between attempts (ms). Index 0 = delay before 2nd attempt, etc.
-static const int http_retry_delays_ms[] = {500};
-#define HTTP_MAX_ATTEMPTS  2
+#define HTTP_MAX_ATTEMPTS    2      // Total attempts: 1 initial + 1 retry
+#define HTTP_RETRY_DELAY_MS  500    // Flat delay before the retry
 #define HTTP_JSON_MAX_SIZE (1024 * 1024)  // 1 MB cap for JSON API responses
 
 // =============================================================================
@@ -179,12 +180,51 @@ time_t parse_iso8601(const char *str) {
     return 0;
 }
 
-cJSON *http_get_json(const char *url) {
-    /* Read per-task HTTP context from TLS (set by poll tasks).
-     * If no context is set, use standalone mode (no reuse, no keep-alive). */
+/* ── Per-attempt perf instrumentation bridge for http_get_json() ──
+ * http_fetch.c (main/http_fetch.h/.c) is deliberately protocol- and
+ * metrics-agnostic, so it reports diagnostics per attempt via an optional
+ * callback instead of calling into perf_monitor directly. This adapter
+ * reconstructs the exact connect/TTFB/body timing and retry/failure
+ * counters the old hand-rolled loop recorded inline. */
+typedef struct {
+    bool ever_connected;   /* true if ANY attempt's esp_http_client_open() succeeded */
+    bool succeeded_late;   /* true if the attempt that finally produced the result was > 0 */
+} http_get_json_perf_ctx_t;
+
+static void http_get_json_on_attempt(const http_fetch_attempt_info_t *info, void *hook_ctx) {
+    http_get_json_perf_ctx_t *pctx = (http_get_json_perf_ctx_t *)hook_ctx;
+
+    if (info->attempt_index > 0) {
+        perf_counter_increment(&g_perf.http_retry_count);
+    }
+
+    /* http_connect times esp_http_client_open() itself, so it's meaningful
+     * whether or not the open succeeded (matches the original timer, which
+     * wrapped open() unconditionally). http_ttfb (fetch_headers) and
+     * http_body (read loop) are only ever attempted once open succeeded. */
+    perf_timer_record(&g_perf.http_connect, info->connect_us);
+    if (info->ever_connected) {
+        pctx->ever_connected = true;
+        perf_timer_record(&g_perf.http_ttfb, info->headers_us);
+    }
+    if (info->body_us > 0) {
+        perf_timer_record(&g_perf.http_body, info->body_us);
+    }
+
+    if (info->ok && info->attempt_index > 0) {
+        pctx->succeeded_late = true;
+    }
+}
+
+cJSON *http_get_json_dated(const char *url, int64_t *date_epoch_out) {
+    if (date_epoch_out) *date_epoch_out = 0;
+
+    /* Read per-task HTTP context (set by poll tasks) for keep-alive reuse via
+     * the shared fetcher (main/http_fetch.h). If no context is registered,
+     * or its conn slot is unset, http_fetch treats a NULL conn as a one-shot
+     * client (no reuse, no keep-alive) -- same fallback as before. */
     http_poll_ctx_t *tls_ctx = http_poll_ctx_get();
-    bool poll_mode = tls_ctx ? tls_ctx->poll_mode : false;
-    esp_http_client_handle_t *reuse_slot = tls_ctx ? tls_ctx->client_handle : NULL;
+    http_fetch_conn_t *reuse_conn = tls_ctx ? tls_ctx->conn : NULL;
 
     /* ── mDNS-bypass URL rewrite ──
      * NINA hostnames are typically .lan (mDNS), and esp_http_client does a fresh
@@ -234,166 +274,102 @@ cJSON *http_get_json(const char *url) {
 
     perf_timer_start(&g_perf.http_request);
     perf_counter_increment(&g_perf.http_request_count);
-    bool ever_connected = false;
-    for (int attempt = 0; attempt < HTTP_MAX_ATTEMPTS; attempt++) {
-        if (attempt > 0) {
-            perf_counter_increment(&g_perf.http_retry_count);
-            ESP_LOGD(TAG, "HTTP retry %d/%d for %s (delay %d ms)",
-                     attempt + 1, HTTP_MAX_ATTEMPTS, url,
-                     http_retry_delays_ms[attempt - 1]);
-            vTaskDelay(pdMS_TO_TICKS(http_retry_delays_ms[attempt - 1]));
-        }
 
-        esp_http_client_handle_t client;
-        bool reusing = (poll_mode && reuse_slot && *reuse_slot != NULL);
+    /* Optional response-Date capture (NINA-PC clock domain). RFC-1123 dates
+     * are 29 chars ("Mon, 06 Jul 2026 19:06:19 GMT"); 48 leaves headroom. */
+    char date_buf[48];
+    date_buf[0] = '\0';
 
-        if (reusing) {
-            client = *reuse_slot;
-            esp_http_client_set_url(client, req_url);
+    http_get_json_perf_ctx_t pctx = { 0 };
+    http_fetch_opts_t opts = {
+        .timeout_ms = 3000,
+        .max_attempts = HTTP_MAX_ATTEMPTS,
+        .retry_delay_ms = HTTP_RETRY_DELAY_MS,
+        /* +1 for the NUL terminator: http_fetch's cap check rejects when
+         * content_length+1 exceeds it, matching the original's
+         * "content_length > HTTP_JSON_MAX_SIZE" boundary (content_length ==
+         * HTTP_JSON_MAX_SIZE exactly was allowed). */
+        .max_response_bytes = HTTP_JSON_MAX_SIZE + 1,
+        .host_header = host_hdr,
+        .on_attempt = http_get_json_on_attempt,
+        .hook_ctx = &pctx,
+        .conn = reuse_conn,
+        .capture_header = date_epoch_out ? "Date" : NULL,
+        .capture_header_out = date_epoch_out ? date_buf : NULL,
+        .capture_header_out_len = date_epoch_out ? sizeof(date_buf) : 0,
+    };
+
+    char *body = NULL;
+    size_t body_len = 0;
+    esp_err_t err = http_fetch_text(req_url, &opts, &body, &body_len);
+
+    if (err != ESP_OK) {
+        /* Extract host from URL for a clean log message. (http_fetch.c also
+         * logs its own generic failure line under the "http_fetch" tag; this
+         * host-only line is kept for parity with the previous log format.) */
+        const char *host = url;
+        const char *scheme_end = strstr(url, "://");
+        if (scheme_end) host = scheme_end + 3;
+        const char *host_end = strchr(host, ':');
+        if (!host_end) host_end = strchr(host, '/');
+        int host_len = host_end ? (int)(host_end - host) : (int)strlen(host);
+        ESP_LOGW(TAG, "%.*s unreachable", host_len, host);
+
+        if (pctx.ever_connected) {
+            perf_counter_increment(&g_perf.http_failure_count);
         } else {
-            esp_http_client_config_t cfg = {
-                .url = req_url,
-                .timeout_ms = 3000,
-                .keep_alive_enable = poll_mode,
-            };
-            client = esp_http_client_init(&cfg);
-            if (!client) continue;
+            perf_counter_increment(&g_perf.http_unreachable_count);
         }
-
-        /* When the URL carries a numeric IP (mDNS bypass), the Host header must
-         * always carry the original hostname so NINA routes correctly. Re-set it
-         * every request: a reused handle may have served a different host, and
-         * set_url() does not update an explicitly-set Host header. When no rewrite
-         * happened (host_hdr == NULL) leave esp_http_client to derive Host from the
-         * URL as usual. */
-        if (host_hdr) {
-            esp_http_client_set_header(client, "Host", host_hdr);
-        }
-
-        perf_timer_start(&g_perf.http_connect);
-        esp_err_t err = esp_http_client_open(client, 0);
-        perf_timer_stop(&g_perf.http_connect);
-        if (err != ESP_OK) {
-            esp_http_client_cleanup(client);
-            if (reusing && reuse_slot) *reuse_slot = NULL;
-            continue;  // Transport error — retryable
-        }
-        ever_connected = true;
-
-        perf_timer_start(&g_perf.http_ttfb);
-        int content_length = esp_http_client_fetch_headers(client);
-        perf_timer_stop(&g_perf.http_ttfb);
-        if (content_length < 0) {
-            esp_http_client_cleanup(client);
-            if (reusing && reuse_slot) *reuse_slot = NULL;
-            continue;  // Transport error — retryable
-        }
-
-        int status = esp_http_client_get_status_code(client);
-        if (status < 200 || status >= 300) {
-            ESP_LOGW(TAG, "HTTP %d for %s", status, url);
-            if (reusing) {
-                esp_http_client_close(client);
-            } else {
-                esp_http_client_cleanup(client);
-            }
-            if (status >= 500) continue;  // 5xx — retryable
-            perf_timer_stop(&g_perf.http_request);
-            return NULL;  // 4xx — not retryable
-        }
-
-        // Guard against chunked transfer encoding or missing Content-Length.
-        // NINA API always sends Content-Length; if absent, treat as error.
-        if (content_length == 0) {
-            ESP_LOGW(TAG, "No Content-Length for %s (chunked?), skipping", url);
-            if (reusing) {
-                esp_http_client_close(client);
-            } else {
-                esp_http_client_cleanup(client);
-            }
-            perf_timer_stop(&g_perf.http_request);
-            return NULL;
-        }
-
-        if (content_length > HTTP_JSON_MAX_SIZE) {
-            ESP_LOGW(TAG, "JSON response too large (%d bytes, max %d) for %s",
-                     content_length, HTTP_JSON_MAX_SIZE, url);
-            if (reusing) {
-                esp_http_client_close(client);
-            } else {
-                esp_http_client_cleanup(client);
-            }
-            perf_timer_stop(&g_perf.http_request);
-            return NULL;
-        }
-
-        char *buffer = heap_caps_malloc(content_length + 1, MALLOC_CAP_SPIRAM);
-        if (!buffer) {
-            if (reusing) esp_http_client_close(client);
-            else esp_http_client_cleanup(client);
-            perf_timer_stop(&g_perf.http_request);
-            return NULL;  // OOM — not retryable
-        }
-
-        int total_read_len = 0, read_len;
-        perf_timer_start(&g_perf.http_body);
-        while (total_read_len < content_length) {
-            read_len = esp_http_client_read(client, buffer + total_read_len,
-                                            content_length - total_read_len);
-            if (read_len <= 0) break;
-            total_read_len += read_len;
-        }
-        perf_timer_stop(&g_perf.http_body);
-        /* Check for partial read — truncated JSON could parse into
-         * a valid but incomplete tree, causing silent data loss. */
-        if (total_read_len < content_length) {
-            ESP_LOGW(TAG, "Partial HTTP read: %d/%d bytes for %s",
-                     total_read_len, content_length, url);
-            free(buffer);
-            if (poll_mode && reuse_slot) {
-                esp_http_client_close(client);
-                *reuse_slot = client;
-            } else {
-                esp_http_client_cleanup(client);
-            }
-            continue;  /* retry */
-        }
-        buffer[total_read_len] = '\0';
-
-        // Keep connection alive for reuse in poll mode; cleanup otherwise
-        if (poll_mode && reuse_slot) {
-            esp_http_client_close(client);
-            *reuse_slot = client;
-        } else {
-            esp_http_client_cleanup(client);
-        }
-
-        perf_timer_start(&g_perf.json_parse);
-        cJSON *json = cJSON_Parse(buffer);
-        perf_timer_stop(&g_perf.json_parse);
-        perf_counter_increment(&g_perf.json_parse_count);
-        free(buffer);
         perf_timer_stop(&g_perf.http_request);
-        if (attempt > 0) perf_counter_increment(&g_perf.http_attempt0_fail_count);
-        return json;
+        return NULL;  // All attempts exhausted
     }
 
-    /* Extract host from URL for a clean log message */
-    const char *host = url;
-    const char *scheme_end = strstr(url, "://");
-    if (scheme_end) host = scheme_end + 3;
-    const char *host_end = strchr(host, ':');
-    if (!host_end) host_end = strchr(host, '/');
-    int host_len = host_end ? (int)(host_end - host) : (int)strlen(host);
-    ESP_LOGW(TAG, "%.*s unreachable", host_len, host);
-
-    if (ever_connected) {
-        perf_counter_increment(&g_perf.http_failure_count);
-    } else {
-        perf_counter_increment(&g_perf.http_unreachable_count);
+    if (pctx.succeeded_late) {
+        perf_counter_increment(&g_perf.http_attempt0_fail_count);
     }
+
+    /* Parse the captured Date header (empty string when absent). 0 stays in
+     * *date_epoch_out on any parse failure. */
+    if (date_epoch_out && date_buf[0] != '\0') {
+        *date_epoch_out = (int64_t)time_parse_rfc1123(date_buf);
+    }
+
+    /* Guard against chunked transfer encoding or missing Content-Length.
+     * NINA API always sends Content-Length; an empty body is treated as
+     * error, matching the original manual-client behavior. */
+    if (body_len == 0) {
+        ESP_LOGW(TAG, "No Content-Length for %s (chunked?), skipping", url);
+        heap_caps_free(body);
+        perf_timer_stop(&g_perf.http_request);
+        return NULL;
+    }
+
+    perf_timer_start(&g_perf.json_parse);
+    cJSON *json = cJSON_Parse(body);
+    perf_timer_stop(&g_perf.json_parse);
+    perf_counter_increment(&g_perf.json_parse_count);
+    heap_caps_free(body);
     perf_timer_stop(&g_perf.http_request);
-    return NULL;  // All attempts exhausted
+    return json;
+}
+
+/* Thin wrapper — the common no-Date-capture case used by ~17 call sites. */
+cJSON *http_get_json(const char *url) {
+    return http_get_json_dated(url, NULL);
+}
+
+/* Current time in the NINA-PC clock domain. See nina_client.h for the
+ * locking contract: nina_clock_epoch/nina_clock_mono_us are written under
+ * the client mutex (camera-info fetchers only); callers should hold the
+ * mutex or tolerate a rare torn int64 read on RV32 — lock-free UI timers
+ * use a cached pair copied under the lock instead. All math is int64
+ * (P4 FPU is single-precision; no double). */
+int64_t nina_client_now_epoch(const nina_client_t *client) {
+    if (client && client->nina_clock_epoch != 0) {
+        return client->nina_clock_epoch +
+               (esp_timer_get_time() - client->nina_clock_mono_us) / 1000000;
+    }
+    return (int64_t)time(NULL);
 }
 
 /* ── NINA API envelope helpers ──
@@ -488,16 +464,23 @@ void nina_client_get_data(const char *base_url, nina_client_t *data) {
 
 void nina_poll_state_init(nina_poll_state_t *state) {
     if (state->http_client) {
-        esp_http_client_cleanup((esp_http_client_handle_t)state->http_client);
+        http_fetch_conn_destroy((http_fetch_conn_t *)state->http_client);
     }
     memset(state, 0, sizeof(nina_poll_state_t));
     state->cached_image_count = -1;  // Force initial full fetch
 }
 
 void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state_t *state, int instance) {
-    // Set per-task HTTP context for client reuse during this poll cycle
-    esp_http_client_handle_t reuse_handle = (esp_http_client_handle_t)state->http_client;
-    http_poll_ctx_t poll_ctx = { .client_handle = &reuse_handle, .poll_mode = true };
+    // Set per-task HTTP context for client reuse during this poll cycle.
+    // Lazily create the persistent keep-alive slot on first use (mirrors the
+    // previous lazy esp_http_client_handle_t allocation inside http_get_json).
+    // state->http_client holds the http_fetch_conn_t* directly and persists
+    // across calls, so — unlike the old reuse_handle round-trip — there is
+    // nothing to write back at the end of this function.
+    if (!state->http_client) {
+        state->http_client = http_fetch_conn_create();
+    }
+    http_poll_ctx_t poll_ctx = { .conn = (http_fetch_conn_t *)state->http_client };
     http_poll_ctx_set(&poll_ctx);
 
     int64_t now_ms = esp_timer_get_time() / 1000;
@@ -556,7 +539,6 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
             data->prev_target_container[0] = '\0';
             nina_client_unlock(data);
         }
-        state->http_client = (void *)reuse_handle;
         http_poll_ctx_set(NULL);
         return;
     }
@@ -701,8 +683,6 @@ void nina_client_poll(const char *base_url, nina_client_t *data, nina_poll_state
         nina_client_unlock(data);
     }
 
-    // Save persistent HTTP client for next poll cycle
-    state->http_client = (void *)reuse_handle;
     http_poll_ctx_set(NULL);
 
     ESP_LOGI(TAG, "=== Poll Summary ===");
@@ -725,9 +705,14 @@ void nina_client_poll_heartbeat(const char *base_url, nina_client_t *data, int i
 }
 
 void nina_client_poll_background(const char *base_url, nina_client_t *data, nina_poll_state_t *state, int instance) {
-    // Set per-task HTTP context for client reuse during this poll cycle
-    esp_http_client_handle_t reuse_handle = (esp_http_client_handle_t)state->http_client;
-    http_poll_ctx_t poll_ctx = { .client_handle = &reuse_handle, .poll_mode = true };
+    // Set per-task HTTP context for client reuse during this poll cycle.
+    // Lazily create the persistent keep-alive slot on first use; state->http_client
+    // holds the http_fetch_conn_t* directly and persists across calls (see
+    // nina_client_poll() above for the full rationale).
+    if (!state->http_client) {
+        state->http_client = http_fetch_conn_create();
+    }
+    http_poll_ctx_t poll_ctx = { .conn = (http_fetch_conn_t *)state->http_client };
     http_poll_ctx_set(&poll_ctx);
 
     int64_t now_ms = esp_timer_get_time() / 1000;
@@ -764,7 +749,6 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
         state->static_fetched = false;
         state->cached_image_count = -1;
         nina_connection_set_static_data_ready(instance, false);
-        state->http_client = (void *)reuse_handle;
         http_poll_ctx_set(NULL);
         return;
     }
@@ -829,8 +813,6 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
         state->last_sequence_poll_ms = now_ms;
     }
 
-    // Save persistent HTTP client for next poll cycle
-    state->http_client = (void *)reuse_handle;
     http_poll_ctx_set(NULL);
 
     ESP_LOGD(TAG, "Background poll: connected=%d, profile=%s, target=%s",

--- a/main/nina_client.h
+++ b/main/nina_client.h
@@ -62,6 +62,15 @@ typedef struct {
     bool is_waiting;              // Sequence is in a wait state (TS-WAITSTART)
     int64_t wait_start_epoch;     // Wait start time (Unix epoch seconds)
 
+    // NINA-PC clock domain anchor. NINA timestamps (ExposureEndTime, sequence
+    // ExpectedDateTime, WaitStartTime) are stamped by the NINA PC's clock,
+    // which can be several seconds skewed from the device's SNTP clock. The
+    // camera-info fetchers capture NINA's own clock from the HTTP Date
+    // response header; all NINA-timestamp math should use this pair (via
+    // nina_client_now_epoch()) instead of time(NULL).
+    int64_t nina_clock_epoch;    /* NINA-domain UTC epoch from HTTP Date header, 0 = unknown */
+    int64_t nina_clock_mono_us;  /* esp_timer_get_time() at capture */
+
     // Image stats
     float hfr;
     int stars;
@@ -151,6 +160,14 @@ void nina_client_init_mutex(nina_client_t *client);
 bool nina_client_lock(nina_client_t *client, uint32_t timeout_ms);
 void nina_client_unlock(nina_client_t *client);
 
+// Current time in the NINA-PC clock domain (Unix epoch seconds).
+// Returns nina_clock_epoch advanced by the device's monotonic esp_timer since
+// capture, or falls back to (int64_t)time(NULL) while the pair is unknown.
+// The pair is written under the client mutex; callers should hold it or
+// tolerate a rare torn read (int64 on RV32) — lock-free UI paths use a cached
+// pair instead (see dashboard_page_t.cached_nina_epoch).
+int64_t nina_client_now_epoch(const nina_client_t *client);
+
 // Polling intervals (ms)
 #define NINA_POLL_SLOW_MS     30000   // Focuser, mount, switch
 #define NINA_POLL_SEQUENCE_MS 15000   // Sequence counts (supplemented by event-driven sequence_poll_needed)
@@ -170,7 +187,9 @@ typedef struct {
     nina_filter_t cached_filters[MAX_FILTERS];
     int cached_filter_count;
 
-    // Persistent HTTP client handle for keep-alive reuse (esp_http_client_handle_t)
+    // Persistent keep-alive slot for the shared HTTP fetcher (http_fetch_conn_t*,
+    // see main/http_fetch.h). Opaque here to avoid a header dependency; owned
+    // and destroyed via nina_poll_state_init()/http_fetch_conn_destroy().
     void *http_client;
 
     // Cached image count for change-detection gating of /image-history.

--- a/main/nina_client_internal.h
+++ b/main/nina_client_internal.h
@@ -11,23 +11,25 @@
 #include "cJSON.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
-#include "esp_http_client.h"
+#include "http_fetch.h"
 #include <time.h>
 
 /* ── Per-task HTTP client context ──
  *
  * Each instance_poll_task registers its context before calling poll functions.
  * http_get_json() looks up the context for the current task to enable
- * keep-alive client reuse.  When no context is registered (e.g., UI
- * coordinator fetching thumbnails/graphs), http_get_json() falls back to
- * standalone mode (no reuse, no keep-alive).
+ * keep-alive client reuse via the shared fetcher (main/http_fetch.h). When no
+ * context is registered (e.g., UI coordinator fetching thumbnails/graphs),
+ * http_get_json() falls back to standalone mode (one-shot, no reuse, no
+ * keep-alive).
  *
  * Implementation uses a small fixed-size registry indexed by instance,
  * avoiding FreeRTOS TLS (whose index 0 is claimed by LWIP/pthread).
  */
 typedef struct {
-    esp_http_client_handle_t *client_handle;  /* Points to local reuse_handle */
-    bool poll_mode;                           /* true = keep-alive + client reuse */
+    http_fetch_conn_t *conn;  /* Persistent keep-alive slot, owned by the caller's
+                               * nina_poll_state_t.http_client. NULL = standalone/
+                               * one-shot mode (no reuse, no keep-alive). */
 } http_poll_ctx_t;
 
 /**
@@ -45,6 +47,12 @@ http_poll_ctx_t *http_poll_ctx_get(void);
 /* HTTP GET and parse JSON response. Caller must cJSON_Delete() the result.
  * Uses per-task poll context for client reuse when available. */
 cJSON *http_get_json(const char *url);
+
+/* Variant of http_get_json() that also captures the response "Date" header
+ * (the NINA PC's own clock) parsed to a UTC epoch. Writes 0 to *date_epoch_out
+ * when the header is missing/unparseable or the fetch fails; date_epoch_out
+ * may be NULL (behaves exactly like http_get_json()). */
+cJSON *http_get_json_dated(const char *url, int64_t *date_epoch_out);
 
 /* Resolve an IPv4 hostname to its dotted-quad string using the app-level
  * DNS cache (60s TTL, stale fallback). On a hit, copies the cached IP into

--- a/main/nina_sequence.c
+++ b/main/nina_sequence.c
@@ -42,6 +42,10 @@ typedef struct {
     int min_seconds;          // Smallest RemainingTime found so far (-1 = none)
     const char *reason;       // Header label for the binding constraint
     int condition_count;      // Total conditions found (including those without time)
+    int64_t now_epoch;        // "Now" in the NINA clock domain (from
+                              // nina_client_now_epoch); ExpectedDateTime is a
+                              // NINA-PC timestamp, so the subtraction must not
+                              // use the device SNTP clock. 0 = unknown.
 } earliest_condition_t;
 
 // Recursively scan all conditions with RemainingTime or ExpectedDateTime in a
@@ -72,9 +76,9 @@ static void find_earliest_condition(cJSON *container, earliest_condition_t *out)
                     time_t expected = parse_iso8601(edt->valuestring);
                     // Ignore sentinel values (year 1 / parse failure)
                     if (expected > 86400) {
-                        time_t now = time(NULL);
-                        if (now > 0 && expected > now) {
-                            secs = (int)(expected - now);
+                        int64_t now_nina = out->now_epoch;
+                        if (now_nina > 0 && (int64_t)expected > now_nina) {
+                            secs = (int)((int64_t)expected - now_nina);
                         }
                     }
                 }
@@ -310,7 +314,13 @@ void fetch_sequence_counts_optional(const char *base_url, nina_client_t *data) {
                 // Find the earliest binding condition (time, horizon, dawn, etc.)
                 data->target_time_remaining[0] = '\0';
                 data->target_time_reason[0] = '\0';
-                earliest_condition_t earliest = { .min_seconds = -1, .reason = "TIME LIMIT", .condition_count = 0 };
+                /* now_epoch: NINA clock domain (falls back to time(NULL) while
+                 * unknown). This runs on the instance's poll task — the same
+                 * task that writes the clock pair in the camera-info fetcher —
+                 * so the unlocked read cannot tear. */
+                earliest_condition_t earliest = { .min_seconds = -1, .reason = "TIME LIMIT",
+                                                  .condition_count = 0,
+                                                  .now_epoch = nina_client_now_epoch(data) };
                 find_earliest_condition(target_container, &earliest);
                 data->target_condition_count = earliest.condition_count;
                 if (earliest.min_seconds >= 0) {

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -1,5 +1,6 @@
 #include "ota_github.h"
 #include "build_version.h"
+#include "http_fetch.h"
 #include "esp_log.h"
 #include "esp_http_client.h"
 #include "esp_ota_ops.h"
@@ -98,6 +99,11 @@ static bool alpha_marker_indicates_update(const char *body_str) {
     /* Copy the hex sha up to the next whitespace or end-of-marker. */
     char marker_sha[64] = {0};
     size_t n = 0;
+    /* cppcheck-suppress arrayIndexThenCheck
+     * m[n] indexes into the null-terminated body_str buffer (via strstr),
+     * not into marker_sha; it is safe to read at any n up to and including
+     * the string's terminating '\0', independent of the marker_sha bound
+     * checked here. */
     while (m[n] && n < sizeof(marker_sha) - 1) {
         char c = m[n];
         if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '-' || c == '>') break;
@@ -142,6 +148,11 @@ static bool parse_full_erase_floor(const char *body_str, char *tag_out, size_t t
     m += strlen("nina:full_erase_floor=");
 
     size_t n = 0;
+    /* cppcheck-suppress arrayIndexThenCheck
+     * m[n] indexes into the null-terminated body_str buffer (via strstr),
+     * not into tag_out; it is safe to read at any n up to and including the
+     * string's terminating '\0', independent of the tag_out_size bound
+     * checked here. */
     while (m[n] && n < tag_out_size - 1) {
         char c = m[n];
         if (c == ' ' || c == '\t' || c == '\r' || c == '\n' || c == '>') break;
@@ -233,37 +244,6 @@ static void extract_summary(const char *body, char *out, size_t out_size) {
     strip_markdown_images(out);
 }
 
-/* ── HTTP event handler for reading response into buffer ──────────── */
-
-typedef struct {
-    char *buffer;
-    int   buffer_len;
-    int   buffer_size;
-    bool  overflow;
-} http_response_t;
-
-static esp_err_t http_event_handler(esp_http_client_event_t *evt) {
-    http_response_t *resp = (http_response_t *)evt->user_data;
-    if (!resp) return ESP_OK;
-
-    switch (evt->event_id) {
-    case HTTP_EVENT_ON_DATA:
-        if (resp->buffer_len + evt->data_len < resp->buffer_size) {
-            memcpy(resp->buffer + resp->buffer_len, evt->data, evt->data_len);
-            resp->buffer_len += evt->data_len;
-            resp->buffer[resp->buffer_len] = '\0';
-        } else if (!resp->overflow) {
-            resp->overflow = true;
-            ESP_LOGW(TAG, "Response buffer overflow: %d + %d >= %d",
-                     resp->buffer_len, evt->data_len, resp->buffer_size);
-        }
-        break;
-    default:
-        break;
-    }
-    return ESP_OK;
-}
-
 /* ── Redirect resolver — captures Location header from 3xx ────────── */
 
 typedef struct {
@@ -295,63 +275,40 @@ static esp_err_t redirect_event_handler(esp_http_client_event_t *evt) {
  * it is left untouched on other failures. The helper frees its own response buffer.
  */
 static cJSON *fetch_releases_page(int page, bool *overflow_out) {
-    http_response_t resp = {0};
-    resp.buffer_size = MAX_RESPONSE_SIZE;
-    resp.buffer = heap_caps_malloc(resp.buffer_size, MALLOC_CAP_SPIRAM);
-    if (!resp.buffer) {
-        ESP_LOGE(TAG, "Failed to allocate response buffer (page %d)", page);
-        return NULL;
-    }
-    resp.buffer[0] = '\0';
-
     char url[RELEASE_URL_BUF];
     snprintf(url, sizeof(url), "%s&page=%d", GITHUB_API_URL, page);
 
-    esp_http_client_config_t config = {
-        .url = url,
-        .event_handler = http_event_handler,
-        .user_data = &resp,
+    http_fetch_opts_t opts = {
         .timeout_ms = 10000,
-        .crt_bundle_attach = esp_crt_bundle_attach,
-        .buffer_size = 2048,
-        .buffer_size_tx = 512,
+        .use_tls_bundle = true,
+        .max_redirects = 3,
+        .max_attempts = 1,
+        .max_response_bytes = MAX_RESPONSE_SIZE,
+        .user_agent = "ESP32-NINA-Display",
+        .accept = "application/vnd.github.v3+json",
     };
 
-    esp_http_client_handle_t client = esp_http_client_init(&config);
-    if (!client) {
-        ESP_LOGE(TAG, "Failed to init HTTP client (page %d)", page);
-        free(resp.buffer);
-        return NULL;
-    }
-
-    esp_http_client_set_header(client, "User-Agent", "ESP32-NINA-Display");
-    esp_http_client_set_header(client, "Accept", "application/vnd.github.v3+json");
-
-    esp_err_t err = esp_http_client_perform(client);
-    int status = esp_http_client_get_status_code(client);
-    esp_http_client_cleanup(client);
-
-    if (err != ESP_OK || status != 200) {
-        ESP_LOGW(TAG, "GitHub API request failed (page %d, err=%s, status=%d)",
-                 page, esp_err_to_name(err), status);
-        free(resp.buffer);
-        return NULL;
-    }
-
-    ESP_LOGI(TAG, "GitHub API response (page %d): %d bytes", page, resp.buffer_len);
-
-    if (resp.overflow) {
-        ESP_LOGE(TAG, "Response was truncated (page %d, buffer %d bytes too small)",
-                 page, resp.buffer_size);
-        if (overflow_out) {
-            *overflow_out = true;
+    char *body = NULL;
+    size_t body_len = 0;
+    esp_err_t err = http_fetch_text(url, &opts, &body, &body_len);
+    if (err != ESP_OK) {
+        if (err == ESP_ERR_INVALID_SIZE) {
+            ESP_LOGE(TAG, "Response was truncated (page %d, buffer %d bytes too small)",
+                     page, MAX_RESPONSE_SIZE);
+            if (overflow_out) {
+                *overflow_out = true;
+            }
+        } else {
+            ESP_LOGW(TAG, "GitHub API request failed (page %d, err=%s)",
+                     page, esp_err_to_name(err));
         }
-        free(resp.buffer);
         return NULL;
     }
 
-    cJSON *releases = cJSON_Parse(resp.buffer);
-    free(resp.buffer);
+    ESP_LOGI(TAG, "GitHub API response (page %d): %u bytes", page, (unsigned)body_len);
+
+    cJSON *releases = cJSON_Parse(body);
+    heap_caps_free(body);
     if (!releases || !cJSON_IsArray(releases)) {
         ESP_LOGW(TAG, "Failed to parse GitHub releases JSON (page %d)", page);
         if (releases) {

--- a/main/poll_backoff.h
+++ b/main/poll_backoff.h
@@ -1,0 +1,39 @@
+#pragma once
+
+/**
+ * @file poll_backoff.h
+ * @brief Pure exponential-backoff step function for poll_task.c.
+ *
+ * Header-only, no ESP-IDF/FreeRTOS includes -- host-testable in isolation
+ * (test/host/test_poll_backoff.c).
+ *
+ * Reset-on-success is intentionally NOT encoded here: the caller (poll_task.c)
+ * simply assigns its backoff-state variable back to 0 after a successful
+ * poll_once(). That is a one-line caller responsibility, not policy worth a
+ * pure function of its own.
+ */
+
+#include <stdint.h>
+
+/**
+ * Compute the next backoff delay (ms) after a failed poll.
+ *
+ * @param cur      Current backoff delay in ms; 0 means "no failure yet"
+ *                  (first failure since the last success or task start).
+ * @param initial  Delay to use on the first failure. 0 disables backoff
+ *                  entirely -- always returns 0, telling the caller to fall
+ *                  back to its normal poll interval instead.
+ * @param max      Ceiling the doubling saturates at. 0 means unbounded.
+ */
+static inline uint32_t poll_backoff_next(uint32_t cur, uint32_t initial, uint32_t max) {
+    if (initial == 0) return 0; /* backoff disabled */
+
+    if (cur == 0) {
+        return (max != 0 && initial > max) ? max : initial;
+    }
+
+    uint32_t next = cur * 2;
+    if (next < cur) next = (max != 0) ? max : cur; /* overflow guard */
+    if (max != 0 && next > max) next = max;
+    return next;
+}

--- a/main/poll_task.c
+++ b/main/poll_task.c
@@ -1,0 +1,54 @@
+/**
+ * @file poll_task.c
+ * @brief Shared poll-loop skeleton. See poll_task.h for scope.
+ */
+
+#include "poll_task.h"
+#include "poll_backoff.h"
+#include "tasks.h"
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+
+static const char *TAG = "poll_task";
+
+void poll_loop_run(const poll_loop_spec_t *spec, void *arg) {
+    if (!spec || !spec->poll_once || !spec->interval_ms) {
+        ESP_LOGE(TAG, "poll_loop_run: invalid spec");
+        return;
+    }
+
+    if (spec->wifi_group) {
+        xEventGroupWaitBits(spec->wifi_group, spec->wifi_bits, pdFALSE, pdFALSE, portMAX_DELAY);
+    }
+    ESP_LOGI(TAG, "%s: WiFi connected, starting poll loop", spec->name);
+
+    uint32_t backoff_ms = 0; /* 0 = not currently backing off */
+
+    while (1) {
+        /* Suspend during OTA updates or while gated inactive (page not visible). */
+        while (ota_in_progress || (spec->page_active && !*spec->page_active)) {
+            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000));
+        }
+
+        bool ok = spec->poll_once(arg);
+
+        uint32_t wait_ms;
+        if (ok) {
+            backoff_ms = 0;
+            wait_ms = spec->interval_ms(arg);
+        } else if (spec->backoff_initial_ms == 0) {
+            /* Backoff disabled -- just retry at the normal interval. */
+            wait_ms = spec->interval_ms(arg);
+        } else {
+            backoff_ms = poll_backoff_next(backoff_ms, spec->backoff_initial_ms, spec->backoff_max_ms);
+            wait_ms = backoff_ms;
+            ESP_LOGW(TAG, "%s: poll failed, retrying in %u ms", spec->name, (unsigned)wait_ms);
+        }
+
+        /* A pending task notify (e.g. WebSocket wake, config change) wakes
+         * this early instead of sleeping the full interval. */
+        ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(wait_ms));
+    }
+}

--- a/main/poll_task.h
+++ b/main/poll_task.h
@@ -1,0 +1,49 @@
+#pragma once
+
+/**
+ * @file poll_task.h
+ * @brief Shared poll-loop skeleton for independent background pollers.
+ *
+ * Expresses the shape common to allsky_poll_task (main/tasks.c) and
+ * weather_poll_task (main/weather_client.c): wait for WiFi once, then loop
+ * suspending while OTA is in progress or (optionally) while some page-active
+ * flag is false, call a poll function, and sleep for a live-config interval
+ * -- with exponential backoff on failure if the caller opts in.
+ *
+ * The pure backoff step lives in poll_backoff.h (host-testable). This header
+ * + poll_task.c own the FreeRTOS wait/notify plumbing around it.
+ */
+
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdint.h>
+
+typedef struct {
+    const char *name;              /**< Log tag for this poll loop. */
+    EventGroupHandle_t wifi_group; /**< Waited on once before the first poll. */
+    EventBits_t wifi_bits;         /**< Bits to wait for (e.g. WIFI_CONNECTED_BIT). */
+
+    /** Optional gate; NULL = always active. Matches the `_Atomic bool
+     * xxx_page_active` flags declared in tasks.h (e.g. allsky_page_active,
+     * clock_page_active). */
+    _Atomic bool *page_active;
+
+    /** Perform one fetch. Return false on failure (triggers backoff, if
+     * configured). @p arg is the opaque pointer passed to poll_loop_run(). */
+    bool (*poll_once)(void *arg);
+
+    /** Live-config poll interval in ms, re-read every cycle so a config
+     * change takes effect on the very next sleep. */
+    uint32_t (*interval_ms)(void *arg);
+
+    uint32_t backoff_initial_ms; /**< 0 = no failure backoff (retry at interval_ms()). */
+    uint32_t backoff_max_ms;     /**< Ceiling the doubling saturates at; 0 = unbounded. */
+} poll_loop_spec_t;
+
+/**
+ * Run the poll loop described by @p spec. Never returns -- call this as (or
+ * from) a FreeRTOS task entry point.
+ */
+void poll_loop_run(const poll_loop_spec_t *spec, void *arg);

--- a/main/settings_table.c
+++ b/main/settings_table.c
@@ -1,0 +1,235 @@
+#include "settings_table.h"
+#include "app_config.h"
+#include "themes.h"
+#include "cJSON.h"
+#include <string.h>
+
+/* -- settings_defaults_apply() ------------------------------------------- */
+
+#define DEF_BOOL(field, json_key, def) \
+    cfg->field = (def);
+#define DEF_INT(field, json_key, def, min, max) \
+    cfg->field = (def);
+#define DEF_INT_RESET(field, json_key, def, min, max) \
+    cfg->field = (def);
+#define DEF_FLT(field, json_key, def, min, max) \
+    cfg->field = (def);
+#define DEF_FLT_RESET(field, json_key, def, min, max) \
+    cfg->field = (def);
+#define DEF_ENUM(field, json_key, def, count_expr) \
+    cfg->field = (def);
+#define DEF_STR(field, json_key, def) \
+    do { \
+        strncpy(cfg->field, (def), sizeof(cfg->field) - 1); \
+        cfg->field[sizeof(cfg->field) - 1] = '\0'; \
+    } while (0);
+#define DEF_STR_RESET(field, json_key, def) \
+    do { \
+        strncpy(cfg->field, (def), sizeof(cfg->field) - 1); \
+        cfg->field[sizeof(cfg->field) - 1] = '\0'; \
+    } while (0);
+
+void settings_defaults_apply(app_config_t *cfg) {
+    SETTINGS_TABLE(DEF_BOOL, DEF_INT, DEF_INT_RESET, DEF_FLT, DEF_FLT_RESET,
+                   DEF_ENUM, DEF_STR, DEF_STR_RESET)
+}
+
+#undef DEF_BOOL
+#undef DEF_INT
+#undef DEF_INT_RESET
+#undef DEF_FLT
+#undef DEF_FLT_RESET
+#undef DEF_ENUM
+#undef DEF_STR
+#undef DEF_STR_RESET
+
+/* -- Shared CLAMP_* macros -------------------------------------------------
+ * Single source of the bound/reset code text for each row kind. Used by
+ * BOTH settings_clamp_apply() (below) and settings_json_parse() (further
+ * down, via the PARSE_* macros) so the bound-check logic for a given kind
+ * exists exactly once in this file. Each macro references a local `fixed`
+ * bool in its caller's scope; settings_clamp_apply() threads it through as
+ * its return value, while settings_json_parse()'s PARSE_* wrappers declare
+ * a throwaway per-field `fixed` (the parse path doesn't need to report
+ * "was anything out of range", only settings_clamp_apply() does).
+ *
+ * Cast to `long` before comparing against `min`/`max`: several rows use an
+ * unsigned field type with a literal min of 0 (e.g. deep_sleep_wake_timer_s,
+ * uint32_t), where `cfg->field < 0` is always false and would otherwise trip
+ * -Wtype-limits. All table values fit comfortably in a (32-bit) long. */
+#define CLAMP_BOOL(field, json_key, def) \
+    /* deliberate no-op: see settings_table.h kind comment */
+#define CLAMP_INT(field, json_key, def, min, max) \
+    if ((long)cfg->field < (long)(min)) { cfg->field = (min); fixed = true; } \
+    else if ((long)cfg->field > (long)(max)) { cfg->field = (max); fixed = true; }
+#define CLAMP_INT_RESET(field, json_key, def, min, max) \
+    if ((long)cfg->field < (long)(min) || (long)cfg->field > (long)(max)) { cfg->field = (def); fixed = true; }
+#define CLAMP_FLT(field, json_key, def, min, max) \
+    if (cfg->field < (min)) { cfg->field = (min); fixed = true; } \
+    else if (cfg->field > (max)) { cfg->field = (max); fixed = true; }
+#define CLAMP_FLT_RESET(field, json_key, def, min, max) \
+    if (cfg->field < (min) || cfg->field > (max)) { cfg->field = (def); fixed = true; }
+#define CLAMP_ENUM(field, json_key, def, count_expr) \
+    if ((int)cfg->field < 0 || (int)cfg->field >= (count_expr)) { cfg->field = (def); fixed = true; }
+#define CLAMP_STR(field, json_key, def) \
+    cfg->field[sizeof(cfg->field) - 1] = '\0';
+#define CLAMP_STR_RESET(field, json_key, def) \
+    cfg->field[sizeof(cfg->field) - 1] = '\0'; \
+    if (cfg->field[0] == '\0') { \
+        strncpy(cfg->field, (def), sizeof(cfg->field) - 1); \
+        cfg->field[sizeof(cfg->field) - 1] = '\0'; \
+        fixed = true; \
+    }
+
+/* -- settings_clamp_apply() ----------------------------------------------
+ * `fixed` (declared below) accumulates whether any row's value was out of
+ * range and got changed, mirroring the `fixed` bool that validate_config()
+ * already threads through the rest of its per-field checks. */
+bool settings_clamp_apply(app_config_t *cfg) {
+    bool fixed = false;
+    SETTINGS_TABLE(CLAMP_BOOL, CLAMP_INT, CLAMP_INT_RESET, CLAMP_FLT, CLAMP_FLT_RESET,
+                   CLAMP_ENUM, CLAMP_STR, CLAMP_STR_RESET)
+    return fixed;
+}
+
+/* -- settings_json_serialize() -------------------------------------------
+ * One cJSON_Add*ToObject call per row, keyed by json_key. */
+
+#define SER_BOOL(field, json_key, def) \
+    cJSON_AddBoolToObject(root, json_key, cfg->field);
+#define SER_INT(field, json_key, def, min, max) \
+    cJSON_AddNumberToObject(root, json_key, (double)cfg->field);
+#define SER_INT_RESET(field, json_key, def, min, max) \
+    cJSON_AddNumberToObject(root, json_key, (double)cfg->field);
+#define SER_FLT(field, json_key, def, min, max) \
+    cJSON_AddNumberToObject(root, json_key, (double)cfg->field);
+#define SER_FLT_RESET(field, json_key, def, min, max) \
+    cJSON_AddNumberToObject(root, json_key, (double)cfg->field);
+#define SER_ENUM(field, json_key, def, count_expr) \
+    cJSON_AddNumberToObject(root, json_key, (double)cfg->field);
+#define SER_STR(field, json_key, def) \
+    cJSON_AddStringToObject(root, json_key, cfg->field);
+#define SER_STR_RESET(field, json_key, def) \
+    cJSON_AddStringToObject(root, json_key, cfg->field);
+
+void settings_json_serialize(const app_config_t *cfg, cJSON *root) {
+    SETTINGS_TABLE(SER_BOOL, SER_INT, SER_INT_RESET, SER_FLT, SER_FLT_RESET,
+                   SER_ENUM, SER_STR, SER_STR_RESET)
+}
+
+#undef SER_BOOL
+#undef SER_INT
+#undef SER_INT_RESET
+#undef SER_FLT
+#undef SER_FLT_RESET
+#undef SER_ENUM
+#undef SER_STR
+#undef SER_STR_RESET
+
+/* -- settings_json_parse() ------------------------------------------------
+ * For each row: look up json_key in `root`; if present and its JSON type
+ * matches the row's kind, assign into cfg->field and then apply the same
+ * clamp/reset rule as settings_clamp_apply() by invoking the CLAMP_* macro
+ * for that kind (still in scope from above — this is the "reuse the
+ * existing CLAMP_* macros directly inside PARSE_*" approach, so the
+ * bound-check code text is not duplicated). If the key is absent or the
+ * wrong JSON type, cfg->field is left completely untouched — the clamp is
+ * only ever applied to a value that was actually just assigned from JSON. */
+
+#define PARSE_BOOL(field, json_key, def) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsBool(_it)) { \
+            bool fixed = false; (void)fixed; \
+            cfg->field = cJSON_IsTrue(_it); \
+            CLAMP_BOOL(field, json_key, def) \
+        } \
+    } while (0);
+#define PARSE_INT(field, json_key, def, min, max) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsNumber(_it)) { \
+            bool fixed = false; (void)fixed; \
+            cfg->field = (__typeof__(cfg->field))_it->valueint; \
+            CLAMP_INT(field, json_key, def, min, max) \
+        } \
+    } while (0);
+#define PARSE_INT_RESET(field, json_key, def, min, max) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsNumber(_it)) { \
+            bool fixed = false; (void)fixed; \
+            cfg->field = (__typeof__(cfg->field))_it->valueint; \
+            CLAMP_INT_RESET(field, json_key, def, min, max) \
+        } \
+    } while (0);
+#define PARSE_FLT(field, json_key, def, min, max) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsNumber(_it)) { \
+            bool fixed = false; (void)fixed; \
+            cfg->field = (float)_it->valuedouble; \
+            CLAMP_FLT(field, json_key, def, min, max) \
+        } \
+    } while (0);
+#define PARSE_FLT_RESET(field, json_key, def, min, max) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsNumber(_it)) { \
+            bool fixed = false; (void)fixed; \
+            cfg->field = (float)_it->valuedouble; \
+            CLAMP_FLT_RESET(field, json_key, def, min, max) \
+        } \
+    } while (0);
+#define PARSE_ENUM(field, json_key, def, count_expr) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsNumber(_it)) { \
+            bool fixed = false; (void)fixed; \
+            cfg->field = (__typeof__(cfg->field))_it->valueint; \
+            CLAMP_ENUM(field, json_key, def, count_expr) \
+        } \
+    } while (0);
+#define PARSE_STR(field, json_key, def) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsString(_it)) { \
+            bool fixed = false; (void)fixed; \
+            strncpy(cfg->field, _it->valuestring, sizeof(cfg->field) - 1); \
+            cfg->field[sizeof(cfg->field) - 1] = '\0'; \
+            CLAMP_STR(field, json_key, def) \
+        } \
+    } while (0);
+#define PARSE_STR_RESET(field, json_key, def) \
+    do { \
+        cJSON *_it = cJSON_GetObjectItem(root, json_key); \
+        if (cJSON_IsString(_it)) { \
+            bool fixed = false; (void)fixed; \
+            strncpy(cfg->field, _it->valuestring, sizeof(cfg->field) - 1); \
+            cfg->field[sizeof(cfg->field) - 1] = '\0'; \
+            CLAMP_STR_RESET(field, json_key, def) \
+        } \
+    } while (0);
+
+void settings_json_parse(const cJSON *root, app_config_t *cfg) {
+    SETTINGS_TABLE(PARSE_BOOL, PARSE_INT, PARSE_INT_RESET, PARSE_FLT, PARSE_FLT_RESET,
+                   PARSE_ENUM, PARSE_STR, PARSE_STR_RESET)
+}
+
+#undef PARSE_BOOL
+#undef PARSE_INT
+#undef PARSE_INT_RESET
+#undef PARSE_FLT
+#undef PARSE_FLT_RESET
+#undef PARSE_ENUM
+#undef PARSE_STR
+#undef PARSE_STR_RESET
+
+#undef CLAMP_BOOL
+#undef CLAMP_INT
+#undef CLAMP_INT_RESET
+#undef CLAMP_FLT
+#undef CLAMP_FLT_RESET
+#undef CLAMP_ENUM
+#undef CLAMP_STR
+#undef CLAMP_STR_RESET

--- a/main/settings_table.h
+++ b/main/settings_table.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include "app_config.h"   /* app_config_t */
+#include "cJSON.h"        /* cJSON, used by settings_json_serialize/parse */
+
+/* X-macro table of "simple" app_config_t settings: one row per field that has
+ * a plain 1:1 default value and (optionally) a range check. Driven by
+ * settings_defaults_apply() / settings_clamp_apply() in settings_table.c,
+ * which are called from set_defaults() / validate_config() in app_config.c.
+ *
+ * Ranges below are transcribed VERBATIM from the pre-existing per-field
+ * checks in validate_config() (or, where noted "no prior clamp", from the
+ * nearest existing bound already enforced elsewhere, e.g. the web POST
+ * handler in web_handlers_config.c). Do not "improve" a range without
+ * updating both the firmware behavior and this comment.
+ *
+ * Kinds:
+ *   SETTING_BOOL      (field, json_key, def)
+ *       Default only. Clamp is a deliberate no-op: apart from
+ *       home_page_lock (excluded below — see app_config.c), no bool field in
+ *       the live struct is canonicalized in validate_config() today, so a
+ *       blanket "make every bool literally 0/1" clamp would be new behavior.
+ *
+ *   SETTING_INT       (field, json_key, def, min, max)
+ *       True two-sided clamp-to-bound: value < min -> min; value > max -> max.
+ *       Works for any integer width (uint8/16/32_t, int8_t, int).
+ *
+ *   SETTING_INT_RESET (field, json_key, def, min, max)
+ *       RESET semantics: value < min OR value > max -> def (NOT the nearest
+ *       bound). Use only where the existing code assigns one fixed constant
+ *       regardless of which side was violated, and that constant equals
+ *       `def`. If the reset-target differs from the set_defaults() default,
+ *       the field must NOT be migrated (see exclusions in app_config.c) —
+ *       one table row cannot carry two different constants without lying
+ *       about one of them.
+ *
+ *   SETTING_FLOAT       (field, json_key, def, min, max)      -- true clamp
+ *   SETTING_FLOAT_RESET (field, json_key, def, min, max)      -- reset semantics
+ *       Float analogues of SETTING_INT / SETTING_INT_RESET.
+ *
+ *   SETTING_ENUM      (field, json_key, def, count_expr)
+ *       value < 0 OR value >= count_expr -> def. count_expr may be a runtime
+ *       call (themes_get_count()) or a compile-time constant
+ *       (WIDGET_STYLE_COUNT). This is itself reset-to-def semantics (matches
+ *       the existing theme_index / widget_style checks, which reset to 0
+ *       rather than clamping to count_expr-1).
+ *
+ *   SETTING_STR       (field, json_key, def)
+ *       Default = safe bounded copy of `def` into cfg->field. Clamp = force
+ *       cfg->field[sizeof(cfg->field)-1] = '\0'. This duplicates the
+ *       existing top-of-validate_config() NUL-termination block for the
+ *       same field; that block is intentionally left untouched (it covers
+ *       many fields, including ones NOT migrated here), so the duplication
+ *       is harmless (idempotent) rather than deleted.
+ *
+ *   SETTING_STR_RESET (field, json_key, def)
+ *       Same as SETTING_STR, plus: if cfg->field[0] == '\0' after
+ *       NUL-termination, reset to `def`. Matches the existing
+ *       "reset to default if empty" checks for mqtt_topic_prefix and
+ *       goes_region.
+ */
+#define SETTINGS_TABLE(BOOL, INT, INT_RESET, FLT, FLT_RESET, ENUM, STR, STR_RESET) \
+    /* -- MQTT -- */ \
+    BOOL      (mqtt_enabled,                 "mqtt_enabled",                 false) \
+    STR       (mqtt_broker_url,              "mqtt_broker_url",              "mqtt://192.168.1.250") \
+    STR       (mqtt_username,                "mqtt_username",                "") \
+    STR_RESET (mqtt_topic_prefix,            "mqtt_topic_prefix",            "ninadisplay") \
+    INT_RESET (mqtt_port,                    "mqtt_port",                    1883,  1,     65535) \
+    /* -- Display / theme -- */ \
+    ENUM      (theme_index,                  "theme_index",                  0,     themes_get_count()) \
+    INT_RESET (brightness,                   "brightness",                   50,    0,     100) \
+    INT_RESET (color_brightness,             "color_brightness",             100,   0,     100) \
+    ENUM      (widget_style,                 "widget_style",                 0,     WIDGET_STYLE_COUNT) \
+    INT_RESET (screen_rotation,              "screen_rotation",              0,     0,     3) \
+    /* -- Auto-rotate (scalars only; arrays/bitmask excluded — see app_config.c) -- */ \
+    BOOL      (auto_rotate_enabled,          "auto_rotate_enabled",          false) \
+    INT_RESET (auto_rotate_interval_s,       "auto_rotate_interval_s",       30,    1,     3600) \
+    INT_RESET (auto_rotate_effect,           "auto_rotate_effect",           0,     0,     3) \
+    BOOL      (auto_rotate_skip_disconnected,"auto_rotate_skip_disconnected",true) \
+    /* -- Polling / timing -- */ \
+    INT_RESET (connection_timeout_s,         "connection_timeout_s",         6,     2,     30) \
+    INT_RESET (toast_duration_s,             "toast_duration_s",             8,     3,     30) \
+    INT_RESET (screen_sleep_timeout_s,       "screen_sleep_timeout_s",       60,    10,    3600) \
+    INT_RESET (idle_poll_interval_s,         "idle_poll_interval_s",         30,    5,     120) \
+    /* -- Misc toggles -- */ \
+    BOOL      (debug_mode,                   "debug_mode",                   false) \
+    BOOL      (screen_sleep_enabled,         "screen_sleep_enabled",         false) \
+    BOOL      (alert_flash_enabled,          "alert_flash_enabled",          true) \
+    BOOL      (wifi_power_save,              "wifi_power_save",              false) \
+    BOOL      (auto_update_check,            "auto_update_check",            1) \
+    INT_RESET (update_channel,               "update_channel",               0,     0,     2) \
+    /* -- Deep sleep -- */ \
+    BOOL      (deep_sleep_enabled,           "deep_sleep_enabled",           false) \
+    INT       (deep_sleep_wake_timer_s,      "deep_sleep_wake_timer_s",      28800, 0,     259200) /* no prior clamp; bound sourced from POST handler */ \
+    BOOL      (deep_sleep_on_idle,           "deep_sleep_on_idle",           false) \
+    /* -- Hostname / NTP / TZ -- */ \
+    STR       (hostname,                     "hostname",                    "NINA-DISPLAY") \
+    STR       (ntp_server,                   "ntp",                          "pool.ntp.org") \
+    STR       (tz_string,                    "timezone",                     "CST6CDT,M3.2.0,M11.1.0") \
+    /* -- AllSky -- */ \
+    STR       (allsky_hostname,              "allsky_hostname",              "allskypi5.lan") \
+    INT_RESET (allsky_update_interval_s,     "allsky_update_interval_s",     5,     1,     300) \
+    FLT_RESET (allsky_dew_offset,            "allsky_dew_offset",            5.0f,  -50.0f,50.0f) \
+    BOOL      (allsky_enabled,               "allsky_enabled",               false) \
+    BOOL      (demo_mode,                    "demo_mode",                    false) \
+    /* -- Spotify -- */ \
+    BOOL      (spotify_enabled,              "spotify_enabled",              false) \
+    INT_RESET (spotify_poll_interval_ms,     "spotify_poll_interval_ms",     3000,  1000,  30000) \
+    BOOL      (spotify_show_progress_bar,    "spotify_show_progress_bar",    true) \
+    INT       (spotify_overlay_timeout_s,    "spotify_overlay_timeout_s",    5,     0,     255)   /* whole uint8 domain valid; clamp is a documented no-op */ \
+    BOOL      (spotify_minimal_mode,         "spotify_minimal_mode",         false) \
+    BOOL      (spotify_scroll_text,          "spotify_scroll_text",          true) \
+    BOOL      (spotify_overlay_visible,      "spotify_overlay_visible",      false) \
+    /* -- Toast (scalar only; mask/array excluded — see app_config.c) -- */ \
+    INT       (toast_aggregation_window_s,   "toast_aggregation_window_s",   5,     0,     15)    /* no prior clamp; bound sourced from POST handler */ \
+    /* -- Weather -- */ \
+    INT_RESET (weather_provider,             "weather_provider",             0,     0,     2) \
+    STR       (weather_api_key,              "weather_api_key",              "") \
+    FLT       (weather_lat,                  "weather_lat",                  0.0f,  -90.0f, 90.0f)  /* no prior clamp; obviously-correct latitude bound */ \
+    FLT       (weather_lon,                  "weather_lon",                  0.0f,  -180.0f,180.0f) /* no prior clamp; obviously-correct longitude bound */ \
+    STR       (weather_location_name,        "weather_location_name",        "") \
+    INT       (weather_poll_interval_s,      "weather_poll_interval_s",      900,   900,   3600)  /* no prior clamp in validate_config; bound sourced from POST handler */ \
+    INT       (weather_units,                "weather_units",                0,     0,     1) \
+    INT       (weather_time_format,          "weather_time_format",          0,     0,     1) \
+    /* -- Idle page override (target excluded — cross-field page-registry semantics) -- */ \
+    BOOL      (idle_page_override_enabled,   "idle_page_override_enabled",   false) \
+    BOOL      (idle_page_persistent,         "idle_page_persistent",         false) /* retired/unread; not currently serialized */ \
+    BOOL      (idle_indicator_enabled,       "idle_indicator_enabled",       true) \
+    /* -- Auth (admin_password excluded — secret) -- */ \
+    BOOL      (auth_enabled,                 "auth_enabled",                 true) \
+    /* -- Image Display / GOES -- */ \
+    BOOL      (image_display_enabled,        "image_display_enabled",        false) \
+    BOOL      (image_display_show_overlay,   "image_display_show_overlay",   true) \
+    STR_RESET (goes_region,                  "goes_region",                  "umv") \
+    INT_RESET (goes_update_interval_s,       "goes_update_interval_s",       600,   300,   7200) \
+    INT_RESET (image_display_source,         "image_display_source",         0,     0,     3) \
+    BOOL      (image_display_crop,           "image_display_crop",           false) \
+    INT       (goes_orientation,             "goes_orientation",             0,     0,     3)     /* no prior clamp; web UI already reads/writes this key but the firmware previously ignored it both directions (dead field) — now wired */ \
+    INT       (solar_orientation,            "solar_orientation",            0,     0,     3)     /* no prior clamp; web UI already reads/writes this key but the firmware previously ignored it both directions (dead field) — now wired */ \
+    INT       (goes_vflip,                   "goes_vflip",                   0,     0,     1) \
+    INT       (goes_hflip,                   "goes_hflip",                   0,     0,     1) \
+    INT       (solar_vflip,                  "solar_vflip",                  0,     0,     1) \
+    INT       (solar_hflip,                  "solar_hflip",                  0,     0,     1) \
+    INT       (custom_vflip,                 "custom_vflip",                 0,     0,     1) \
+    INT       (custom_hflip,                 "custom_hflip",                 0,     0,     1) \
+    /* -- Moon phase -- */ \
+    INT_RESET (moon_bg_style,                "moon_bg_style",                0,     0,     3) \
+    FLT       (moon_lat,                     "moon_lat",                     0.0f,  -90.0f, 90.0f)  /* no prior clamp; obviously-correct latitude bound */ \
+    FLT       (moon_lon,                     "moon_lon",                     0.0f,  -180.0f,180.0f) /* no prior clamp; obviously-correct longitude bound */ \
+    INT_RESET (solar_band,                   "solar_band",                   0,     0,     17) \
+    INT       (moon_flip_u,                  "moon_flip_u",                  0,     0,     1) \
+    INT       (moon_flip_v,                  "moon_flip_v",                  0,     0,     1) \
+    FLT       (moon_roll_offset,             "moon_roll_offset",             -7.0f, -180.0f,180.0f) \
+    FLT       (moon_yaw_offset,              "moon_yaw_offset",              0.0f,  -180.0f,180.0f) \
+    FLT       (moon_pitch_offset,            "moon_pitch_offset",            -5.0f, -90.0f, 90.0f) \
+    INT       (moon_north_up,                "moon_north_up",                1,     0,     1) \
+    INT       (moon_spin_mode,               "moon_spin_mode",               0,     0,     1) \
+    INT       (moon_spin_return_s,           "moon_spin_return_s",           3,     3,     60) \
+    /* -- Crash log -- */ \
+    INT       (crash_log_retention_days,     "crash_log_retention_days",     30,    0,     255)   /* no prior clamp; bound sourced from POST handler */ \
+    /* -- Navigation -- */ \
+    INT       (nav_grace_s,                  "nav_grace_s",                  10,    10,    300) \
+    /* -- Custom Image URL source -- */ \
+    STR       (custom_image_url,             "custom_image_url",             "https://picsum.photos/720") \
+    INT_RESET (custom_orientation,           "custom_orientation",           0,     0,     3) \
+    INT_RESET (custom_update_interval_s,     "custom_update_interval_s",     60,    10,    7200)
+
+/* Apply every row's default value to *cfg. Called from set_defaults()
+ * immediately after the memset(). Does not touch excluded/complex fields
+ * (arrays, JSON blobs, secrets, cross-field page targets) — those keep their
+ * existing hand-written assignments in app_config.c. */
+void settings_defaults_apply(app_config_t *cfg);
+
+/* Apply every row's range/reset check to *cfg in place. Called from
+ * validate_config() in place of the equivalent per-field checks it replaces.
+ * Returns true if any field was changed (out of range), matching the
+ * `fixed` accumulation pattern used by the rest of validate_config(). */
+bool settings_clamp_apply(app_config_t *cfg);
+
+/* Serialize every row's current value into `root` under its json_key, one
+ * cJSON_Add*ToObject call per row (bool->AddBool, string kinds->AddString,
+ * everything else->AddNumber). Does not touch excluded/complex fields
+ * (arrays, JSON blobs, secrets, cross-field page targets, idle_page_persistent) —
+ * callers that need those keep their existing hand-written cJSON_Add*
+ * calls in web_handlers_config.c. */
+void settings_json_serialize(const app_config_t *cfg, cJSON *root);
+
+/* For every row: look up json_key in `root`. If present and its JSON type
+ * matches the row's kind (number for INT/INT_RESET/FLT/FLT_RESET/ENUM, bool
+ * for BOOL, string for STR/STR_RESET), assign into cfg->field and then apply
+ * that row's clamp/reset rule (identical bound-check code to
+ * settings_clamp_apply(), reused via the shared CLAMP_* macros in
+ * settings_table.c). If the key is absent, or present with the wrong JSON
+ * type, cfg->field is left completely untouched. */
+void settings_json_parse(const cJSON *root, app_config_t *cfg);

--- a/main/spotify_client.c
+++ b/main/spotify_client.c
@@ -9,6 +9,7 @@
 
 #include "spotify_client.h"
 #include "spotify_auth.h"
+#include "http_fetch.h"
 #include "esp_http_client.h"
 #include "esp_crt_bundle.h"
 #include "esp_log.h"
@@ -143,7 +144,7 @@ static esp_err_t send_control_request(const char *url, esp_http_client_method_t 
 // Public API — Init
 // =============================================================================
 
-/* Guards s_player_client and s_player_shutdown. Held for the full lifetime of
+/* Guards s_player_conn and s_player_shutdown. Held for the full lifetime of
  * any player/album-art HTTP request so spotify_client_prepare_shutdown can
  * guarantee no request is in flight before it destroys the handle. */
 static SemaphoreHandle_t s_player_mutex;
@@ -162,37 +163,25 @@ void spotify_client_init(void)
 // Public API — Get Currently Playing (persistent keep-alive connection)
 // =============================================================================
 
-/* Persistent HTTP client for the currently-playing endpoint.
- * Reusing the TLS session avoids a 2-5 second handshake on every poll. */
-static esp_http_client_handle_t s_player_client = NULL;
+/* Persistent keep-alive slot for the currently-playing endpoint. http_fetch's
+ * conn owns the underlying esp_http_client handle and its own stale/dead
+ * keep-alive reconnect-once logic (mirrors the hand-rolled retry this used
+ * to do here directly). */
+static http_fetch_conn_t *s_player_conn = NULL;
+
+/* PSRAM buffer for the raw access token passed to http_fetch's bearer_token
+ * option (http_fetch prepends "Bearer " itself, so no prefix room needed
+ * here, unlike s_auth_header_buf above). Lazy-allocated on first use. */
+static char *s_player_token_buf = NULL;
+#define SPOTIFY_TOKEN_BUF_SIZE AUTH_HEADER_BUF_SIZE
 
 /* Caller must hold s_player_mutex. */
-static void player_client_destroy(void)
+static void player_conn_destroy(void)
 {
-    if (s_player_client) {
-        esp_http_client_cleanup(s_player_client);
-        s_player_client = NULL;
+    if (s_player_conn) {
+        http_fetch_conn_destroy(s_player_conn);
+        s_player_conn = NULL;
     }
-}
-
-/* Caller must hold s_player_mutex. */
-static esp_http_client_handle_t player_client_get(void)
-{
-    if (s_player_shutdown) return NULL;
-    if (s_player_client) return s_player_client;
-
-    esp_http_client_config_t http_cfg = {
-        .url = SPOTIFY_API_BASE "/currently-playing",
-        .timeout_ms = SPOTIFY_HTTP_TIMEOUT_MS,
-        .crt_bundle_attach = esp_crt_bundle_attach,
-        .keep_alive_enable = true,
-    };
-
-    s_player_client = esp_http_client_init(&http_cfg);
-    if (s_player_client) {
-        ESP_LOGI(TAG, "Created persistent HTTP client for currently-playing");
-    }
-    return s_player_client;
 }
 
 esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
@@ -210,68 +199,52 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
 
     esp_err_t ret = ESP_FAIL;
 
-    esp_http_client_handle_t client = player_client_get();
-    if (!client) {
-        ESP_LOGE(TAG, "Failed to init HTTP client for currently-playing");
+    if (!s_player_conn) {
+        s_player_conn = http_fetch_conn_create();
+        if (!s_player_conn) {
+            ESP_LOGE(TAG, "Failed to create http_fetch conn for currently-playing");
+            ret = ESP_FAIL;
+            goto unlock;
+        }
+    }
+
+    if (!s_player_token_buf) {
+        s_player_token_buf = heap_caps_malloc(SPOTIFY_TOKEN_BUF_SIZE, MALLOC_CAP_SPIRAM);
+        if (!s_player_token_buf) {
+            ESP_LOGE(TAG, "Failed to allocate token buffer from PSRAM");
+            ret = ESP_FAIL;
+            goto unlock;
+        }
+    }
+    if (spotify_auth_get_access_token(s_player_token_buf, SPOTIFY_TOKEN_BUF_SIZE) != ESP_OK) {
+        ESP_LOGW(TAG, "No valid access token available");
         ret = ESP_FAIL;
         goto unlock;
     }
 
-    if (set_auth_header(client) != ESP_OK) {
-        ret = ESP_FAIL;
-        goto unlock;
-    }
+    int status = 0;
+    char *body = NULL;
+    size_t body_len = 0;
+    http_fetch_opts_t opts = {
+        .use_tls_bundle = true,
+        .timeout_ms = SPOTIFY_HTTP_TIMEOUT_MS,
+        .max_attempts = 1,        /* conn's internal stale-reconnect covers the
+                                    * hand-rolled retry this call used to do */
+        .max_response_bytes = SPOTIFY_RESPONSE_BUF_SIZE,
+        .bearer_token = s_player_token_buf,
+        .conn = s_player_conn,
+        .status_out = &status,
+    };
 
-    esp_err_t err = esp_http_client_open(client, 0);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "HTTP open failed: %s — reconnecting", esp_err_to_name(err));
-        /* Connection stale or dropped — destroy and retry once */
-        player_client_destroy();
-        client = player_client_get();
-        if (!client) { ret = ESP_FAIL; goto unlock; }
-        if (set_auth_header(client) != ESP_OK) { ret = ESP_FAIL; goto unlock; }
-        err = esp_http_client_open(client, 0);
-        if (err != ESP_OK) {
-            ESP_LOGW(TAG, "HTTP open retry failed: %s", esp_err_to_name(err));
-            player_client_destroy();
-            ret = ESP_FAIL;
-            goto unlock;
-        }
-    }
+    esp_err_t err = http_fetch_text(SPOTIFY_API_BASE "/currently-playing", &opts,
+                                     &body, &body_len);
 
-    int content_length = esp_http_client_fetch_headers(client);
-    int status = esp_http_client_get_status_code(client);
-
-    /* Status -1 means the server closed the keep-alive connection silently.
-     * Reconnect and retry once instead of wasting a poll cycle. */
-    if (status == -1) {
-        ESP_LOGW(TAG, "Stale keep-alive connection — reconnecting");
-        player_client_destroy();
-        client = player_client_get();
-        if (!client) { ret = ESP_FAIL; goto unlock; }
-        if (set_auth_header(client) != ESP_OK) { ret = ESP_FAIL; goto unlock; }
-        err = esp_http_client_open(client, 0);
-        if (err != ESP_OK) {
-            ESP_LOGW(TAG, "HTTP open retry failed: %s", esp_err_to_name(err));
-            player_client_destroy();
-            ret = ESP_FAIL;
-            goto unlock;
-        }
-        content_length = esp_http_client_fetch_headers(client);
-        status = esp_http_client_get_status_code(client);
-        if (status == -1) {
-            player_client_destroy();
-            ret = ESP_FAIL;
-            goto unlock;
-        }
-    }
-
-    /* 204 = nothing currently playing — drain and keep connection alive */
+    /* 204 = nothing currently playing. Any 2xx (including 204) is success to
+     * http_fetch, so this arrives as err == ESP_OK with an empty body; keep
+     * the connection alive, same as before. */
     if (status == 204) {
         ESP_LOGD(TAG, "No active playback (204)");
-        /* Drain any residual body to keep the connection clean */
-        char drain[64];
-        while (esp_http_client_read(client, drain, sizeof(drain)) > 0) {}
+        if (body) heap_caps_free(body);
 
         /* Update cached state to reflect nothing playing */
         if (xSemaphoreTake(s_mutex, pdMS_TO_TICKS(200)) == pdTRUE) {
@@ -288,69 +261,37 @@ esp_err_t spotify_client_get_currently_playing(spotify_playback_t *out)
     if (status == 401) {
         ESP_LOGW(TAG, "HTTP 401 from currently-playing — invalidating token");
         spotify_auth_invalidate_token();
-        player_client_destroy();
+        if (body) heap_caps_free(body);
+        player_conn_destroy();
         ret = ESP_FAIL;
         goto unlock;
     }
 
-    if (status != 200) {
-        ESP_LOGW(TAG, "Unexpected HTTP %d from currently-playing", status);
-        player_client_destroy();
+    if (err != ESP_OK || status != 200) {
+        ESP_LOGW(TAG, "currently-playing failed: %s (HTTP %d)",
+                 esp_err_to_name(err), status);
+        if (body) heap_caps_free(body);
+        player_conn_destroy();
         ret = ESP_FAIL;
         goto unlock;
     }
 
-    /* A body larger than the cap cannot be parsed. Destroy the connection so
-     * the next poll starts clean rather than reading a truncated JSON. */
-    if (content_length > 0 && (content_length + 1) > SPOTIFY_RESPONSE_BUF_SIZE) {
-        ESP_LOGW(TAG, "currently-playing response too large: %d bytes", content_length);
-        player_client_destroy();
-        ret = ESP_FAIL;
-        goto unlock;
-    }
-
-    /* Allocate response buffer from SPIRAM */
-    int buf_size = (content_length > 0) ? (content_length + 1) : SPOTIFY_RESPONSE_BUF_SIZE;
-    if (buf_size > SPOTIFY_RESPONSE_BUF_SIZE) {
-        buf_size = SPOTIFY_RESPONSE_BUF_SIZE;
-    }
-
-    char *buffer = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
-    if (!buffer) {
-        ESP_LOGE(TAG, "Failed to allocate %d bytes for response", buf_size);
-        player_client_destroy();
-        ret = ESP_FAIL;
-        goto unlock;
-    }
-
-    /* Read response body */
-    int total_read = 0, read_len;
-    int max_read = buf_size - 1;
-    while (total_read < max_read) {
-        read_len = esp_http_client_read(client, buffer + total_read, max_read - total_read);
-        if (read_len <= 0) break;
-        total_read += read_len;
-    }
-    buffer[total_read] = '\0';
-
-    /* Don't cleanup — keep connection alive for next poll */
-
-    if (total_read == 0) {
+    if (body_len == 0) {
         ESP_LOGW(TAG, "Empty response body from currently-playing");
-        free(buffer);
+        if (body) heap_caps_free(body);
         ret = ESP_FAIL;
         goto unlock;
     }
 
     /* Parse JSON */
-    cJSON *json = cJSON_Parse(buffer);
-    free(buffer);
+    cJSON *json = cJSON_Parse(body);
+    heap_caps_free(body);
 
     if (!json) {
         /* Likely a truncated/partial body on a reused connection — destroy so
          * the next poll starts on a clean connection. */
         ESP_LOGW(TAG, "Failed to parse currently-playing JSON");
-        player_client_destroy();
+        player_conn_destroy();
         ret = ESP_FAIL;
         goto unlock;
     }
@@ -622,10 +563,10 @@ esp_err_t spotify_client_fetch_album_art(const char *url, uint8_t **out_buf,
 void spotify_client_destroy_connection(void)
 {
     if (s_player_mutex && xSemaphoreTake(s_player_mutex, portMAX_DELAY) == pdTRUE) {
-        player_client_destroy();
+        player_conn_destroy();
         xSemaphoreGive(s_player_mutex);
     } else {
-        player_client_destroy();
+        player_conn_destroy();
     }
 }
 
@@ -639,12 +580,12 @@ void spotify_client_prepare_shutdown(void)
      * so 15s is long enough for it to finish. */
     if (xSemaphoreTake(s_player_mutex, pdMS_TO_TICKS(15000)) == pdTRUE) {
         s_player_shutdown = true;
-        player_client_destroy();
+        player_conn_destroy();
         xSemaphoreGive(s_player_mutex);
     } else {
         /* Contract requires the handle destroyed on return; force it. */
         ESP_LOGW(TAG, "prepare_shutdown: mutex wait timed out — forcing teardown");
         s_player_shutdown = true;
-        player_client_destroy();
+        player_conn_destroy();
     }
 }

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -58,6 +58,7 @@
 #include "driver/jpeg_decode.h"
 #include "freertos/queue.h"
 #include "ui/nina_thumbnail.h"
+#include "poll_task.h"
 
 static const char *TAG = "tasks";
 
@@ -564,32 +565,47 @@ static void ota_progress_cb(int percent) {
 // AllSky Poll Task — independent poller pinned to Core 0
 // =============================================================================
 
+static bool allsky_poll_once(void *arg) {
+    (void)arg;
+
+    /* Read fields directly from config pointer — avoids copying the full
+     * ~6.7 KB app_config_t onto this task's small stack. */
+    const app_config_t *cfg = app_config_get();
+
+    /* Only poll when hostname is configured */
+    if (cfg->allsky_hostname[0] != '\0') {
+        allsky_client_poll(cfg->allsky_hostname, cfg->allsky_field_config, &allsky_data);
+    }
+    return true; /* no failure signal — matches original unconditional-retry-at-interval behavior */
+}
+
+static uint32_t allsky_interval_ms(void *arg) {
+    (void)arg;
+
+    const app_config_t *cfg = app_config_get();
+
+    /* Sleep for the configured interval (clamped 1-300s at config-validate time; floor here too) */
+    uint32_t interval_ms = (uint32_t)cfg->allsky_update_interval_s * 1000;
+    if (interval_ms < 1000) interval_ms = 1000;
+    return interval_ms;
+}
+
 void allsky_poll_task(void *arg) {
+    (void)arg;
     ESP_LOGI(TAG, "AllSky poll task started");
 
-    // Wait for WiFi before attempting any HTTP requests
-    xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT, pdFALSE, pdFALSE, portMAX_DELAY);
+    poll_loop_spec_t spec = {
+        .name = "allsky",
+        .wifi_group = s_wifi_event_group,
+        .wifi_bits = WIFI_CONNECTED_BIT,
+        .page_active = &allsky_page_active,
+        .poll_once = allsky_poll_once,
+        .interval_ms = allsky_interval_ms,
+        .backoff_initial_ms = 0,
+        .backoff_max_ms = 0,
+    };
 
-    while (1) {
-        /* Suspend during OTA or when AllSky page is not visible */
-        while (ota_in_progress || !allsky_page_active) {
-            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000));
-        }
-
-        /* Read fields directly from config pointer — avoids copying the full
-         * ~6.7 KB app_config_t onto this task's small stack. */
-        const app_config_t *cfg = app_config_get();
-
-        /* Only poll when hostname is configured */
-        if (cfg->allsky_hostname[0] != '\0') {
-            allsky_client_poll(cfg->allsky_hostname, cfg->allsky_field_config, &allsky_data);
-        }
-
-        /* Sleep for the configured interval (clamped 1-300s) */
-        uint32_t interval_ms = (uint32_t)cfg->allsky_update_interval_s * 1000;
-        if (interval_ms < 1000) interval_ms = 1000;
-        ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(interval_ms));
-    }
+    poll_loop_run(&spec, NULL);
 }
 
 // =============================================================================

--- a/main/time_parse.c
+++ b/main/time_parse.c
@@ -1,0 +1,150 @@
+/*
+ * time_parse.c - Pure, host-testable date/time string parsers.
+ *
+ * No ESP-IDF dependencies, no dynamic allocation, integer arithmetic only
+ * (P4 FPU is single-precision; no doubles anywhere in this module).
+ */
+
+#include "time_parse.h"
+
+#include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * Leap-year-aware epoch conversion from a UTC struct tm. Copied verbatim
+ * from the static my_timegm() in nina_client.c (a later cleanup can dedupe;
+ * nina_client.c is owned by another change and must not be touched here).
+ */
+static time_t my_timegm(struct tm *tm) {
+    int64_t t = 0;
+    int year = tm->tm_year + 1900;
+    int mon = tm->tm_mon; // 0-11
+
+    static const int days_per_month[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+
+    for (int y = 1970; y < year; y++) {
+        t += 365 * 24 * 3600;
+        if ((y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)) {
+            t += 24 * 3600;
+        }
+    }
+
+    for (int m = 0; m < mon; m++) {
+        t += days_per_month[m] * 24 * 3600;
+        if (m == 1 && ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0))) {
+            t += 24 * 3600;
+        }
+    }
+
+    t += (tm->tm_mday - 1) * 24 * 3600;
+    t += tm->tm_hour * 3600;
+    t += tm->tm_min * 60;
+    t += tm->tm_sec;
+
+    return (time_t)t;
+}
+
+// Returns 0-11 for a 3-letter English month abbreviation, -1 otherwise.
+static int month_from_abbrev(const char *p) {
+    static const char *const names[12] = {
+        "jan", "feb", "mar", "apr", "may", "jun",
+        "jul", "aug", "sep", "oct", "nov", "dec"
+    };
+    char m[4];
+    for (int i = 0; i < 3; i++) {
+        if (!isalpha((unsigned char)p[i])) return -1;
+        m[i] = (char)tolower((unsigned char)p[i]);
+    }
+    m[3] = '\0';
+    for (int i = 0; i < 12; i++) {
+        if (strcmp(m, names[i]) == 0) return i;
+    }
+    return -1;
+}
+
+// Parses exactly min_digits..max_digits decimal digits; advances *p.
+// Returns the value, or -1 on failure.
+static int parse_uint_field(const char **p, int min_digits, int max_digits) {
+    int val = 0;
+    int n = 0;
+    while (n < max_digits && isdigit((unsigned char)(*p)[0])) {
+        val = val * 10 + ((*p)[0] - '0');
+        (*p)++;
+        n++;
+    }
+    if (n < min_digits) return -1;
+    return val;
+}
+
+static const char *skip_spaces(const char *p) {
+    while (*p == ' ') p++;
+    return p;
+}
+
+time_t time_parse_rfc1123(const char *s) {
+    if (!s || !*s) return 0;
+
+    const char *p = skip_spaces(s);
+
+    // Optional day-of-week prefix: letters followed by a comma. Skipped,
+    // not validated (some servers send abbreviated or full day names).
+    const char *q = p;
+    while (isalpha((unsigned char)*q)) q++;
+    if (*q == ',') {
+        // Only treat the leading letters as a weekday if a comma follows;
+        // otherwise they would be the month of a malformed string (reject
+        // below via the day-of-month digit check).
+        p = skip_spaces(q + 1);
+    }
+
+    int day = parse_uint_field(&p, 1, 2);
+    if (day < 1 || day > 31 || *p != ' ') return 0;
+    p = skip_spaces(p);
+
+    int mon = month_from_abbrev(p);
+    if (mon < 0) return 0;
+    p += 3;
+    if (*p != ' ') return 0;
+    p = skip_spaces(p);
+
+    int year = parse_uint_field(&p, 4, 4);
+    if (year < 1970 || *p != ' ') return 0;
+    p = skip_spaces(p);
+
+    int hour = parse_uint_field(&p, 2, 2);
+    if (hour < 0 || hour > 23 || *p != ':') return 0;
+    p++;
+    int min = parse_uint_field(&p, 2, 2);
+    if (min < 0 || min > 59 || *p != ':') return 0;
+    p++;
+    int sec = parse_uint_field(&p, 2, 2);
+    if (sec < 0 || sec > 60) return 0; // 60 tolerated for leap seconds
+
+    // Optional timezone suffix: "GMT" or "UTC" (or nothing). Anything else
+    // trailing (besides whitespace) is rejected as garbage.
+    p = skip_spaces(p);
+    if (*p != '\0') {
+        if ((strncmp(p, "GMT", 3) != 0 && strncmp(p, "UTC", 3) != 0)) return 0;
+        p = skip_spaces(p + 3);
+        if (*p != '\0') return 0;
+    }
+
+    // Reject impossible day-of-month combinations (e.g. 31 Feb).
+    static const int month_len[12] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    int max_day = month_len[mon];
+    if (mon == 1 && ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0))) {
+        max_day = 29;
+    }
+    if (day > max_day) return 0;
+
+    struct tm tm;
+    memset(&tm, 0, sizeof(tm));
+    tm.tm_year = year - 1900;
+    tm.tm_mon = mon;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = min;
+    tm.tm_sec = sec;
+    return my_timegm(&tm);
+}

--- a/main/time_parse.h
+++ b/main/time_parse.h
@@ -1,0 +1,34 @@
+/*
+ * time_parse.h - Pure, host-testable date/time string parsers.
+ *
+ * No ESP-IDF dependencies; standard C only so the module can be compiled
+ * unmodified into the host test suite (test/host).
+ */
+
+#ifndef TIME_PARSE_H
+#define TIME_PARSE_H
+
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Parse an RFC-1123 HTTP Date header ("Mon, 06 Jul 2026 19:06:19 GMT")
+ * to a Unix epoch timestamp (UTC).
+ *
+ * - The day-of-week prefix, if present, is skipped without validation.
+ * - Month is a 3-letter English abbreviation (case-insensitive).
+ * - A trailing "GMT" or "UTC" suffix is tolerated but not required.
+ * - Single-digit days ("Mon, 6 Jul 2026 ...") are accepted.
+ *
+ * Returns 0 on any parse failure (including NULL/empty input).
+ */
+time_t time_parse_rfc1123(const char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TIME_PARSE_H */

--- a/main/ui/graph_downsample.c
+++ b/main/ui/graph_downsample.c
@@ -1,0 +1,48 @@
+/**
+ * @file graph_downsample.c
+ * @brief Pure-math helpers for graph overlay decimation and Y-range sizing.
+ *
+ * No LVGL/ESP includes. Only math.h/stddef.h. Single-precision throughout
+ * (float/fabsf) — the P4 FPU is single-precision only.
+ */
+
+#include "graph_downsample.h"
+#include <math.h>
+
+graph_downsample_t graph_downsample_compute(int count) {
+    graph_downsample_t result;
+    result.stride = 1;
+    result.disp_count = count;
+    if (count > GRAPH_MAX_DISPLAY_POINTS) {
+        result.stride = (count + GRAPH_MAX_DISPLAY_POINTS - 1) / GRAPH_MAX_DISPLAY_POINTS;
+        result.disp_count = (count + result.stride - 1) / result.stride;
+    }
+    return result;
+}
+
+int graph_rms_y_range(const float *ra, const float *dec, int count) {
+    float max_val = 0.5f; /* minimum visible range */
+    for (int i = 0; i < count; i++) {
+        float abs_ra = fabsf(ra[i]);
+        float abs_dec = fabsf(dec[i]);
+        if (abs_ra > max_val) max_val = abs_ra;
+        if (abs_dec > max_val) max_val = abs_dec;
+    }
+    /* Add 20% headroom and round up */
+    int range = (int)(max_val * 120.0f + 50.0f); /* x100 then +headroom */
+    if (range < 100) range = 100;
+    return range;
+}
+
+int graph_hfr_y_range(const float *hfr, int count, float *out_sum) {
+    float max_val = 1.0f;
+    float sum = 0;
+    for (int i = 0; i < count; i++) {
+        if (hfr[i] > max_val) max_val = hfr[i];
+        sum += hfr[i];
+    }
+    int range = (int)(max_val * 120.0f + 0.5f); /* x100 + 20% headroom */
+    if (range < 200) range = 200;
+    if (out_sum) *out_sum = sum;
+    return range;
+}

--- a/main/ui/graph_downsample.h
+++ b/main/ui/graph_downsample.h
@@ -1,0 +1,66 @@
+#pragma once
+
+/**
+ * @file graph_downsample.h
+ * @brief Pure-math helpers for graph overlay decimation and Y-range sizing.
+ *
+ * Extracted from nina_graph_overlay.c so the stride/range arithmetic can be
+ * unit tested on the host without pulling in LVGL. No LVGL/ESP includes here;
+ * callers own everything display-related (lv_chart_* calls stay in the
+ * overlay). Behavior must stay byte-for-byte identical to the inline code it
+ * replaced.
+ */
+
+#include <stddef.h>
+
+/* Max points actually drawn on the chart. The chart is ~720px wide, so more
+ * than this yields sub-pixel polyline segments with no visible difference.
+ * Decimating the displayed set (storage stays GRAPH_MAX_POINTS) roughly halves
+ * the per-point loop and polyline segment count for the heavy locked redraw. */
+#define GRAPH_MAX_DISPLAY_POINTS 360
+
+/** Result of decimating `count` source points down to the chart's display width. */
+typedef struct {
+    int stride;      /**< Step through the source array (>= 1) */
+    int disp_count;  /**< Number of points that will actually be pushed to the chart */
+} graph_downsample_t;
+
+/**
+ * @brief Compute stride/disp_count for decimating a source series.
+ *
+ * @param count Number of valid source samples. Must be > 0 (caller handles
+ *              the count<=0 "no data" case before calling this).
+ * @return stride==1, disp_count==count when count <= GRAPH_MAX_DISPLAY_POINTS;
+ *         otherwise an integer stride sized so ceil(count/stride) points are
+ *         displayed.
+ */
+graph_downsample_t graph_downsample_compute(int count);
+
+/**
+ * @brief Compute the symmetric Y-range (x100, arcsec) for the RMS chart.
+ *
+ * Mirrors the inline RMS range loop: starts from a 0.5" minimum visible
+ * range, tracks the largest |ra|/|dec| magnitude, adds 20% headroom, and
+ * floors the result at 100 (i.e. 1.0").
+ *
+ * @param ra    RA sample array, length >= count.
+ * @param dec   DEC sample array, length >= count.
+ * @param count Number of valid samples. Must be > 0.
+ * @return Range in x100 arcsec units; chart range is [-range, range].
+ */
+int graph_rms_y_range(const float *ra, const float *dec, int count);
+
+/**
+ * @brief Compute the Y-range (x100) for the HFR chart, and the sample sum.
+ *
+ * Mirrors the inline HFR range loop: starts from a 1.0 minimum visible
+ * range, tracks the largest HFR value, adds 20% headroom, and floors the
+ * result at 200 (i.e. 2.0). Also accumulates the sum of all samples so the
+ * caller can compute the average for the summary label without a second pass.
+ *
+ * @param hfr     HFR sample array, length >= count.
+ * @param count   Number of valid samples. Must be > 0.
+ * @param out_sum Optional; if non-NULL, receives the sum of hfr[0..count-1].
+ * @return Range in x100 units; chart range is [0, range].
+ */
+int graph_hfr_y_range(const float *hfr, int count, float *out_sum);

--- a/main/ui/nina_clock.c
+++ b/main/ui/nina_clock.c
@@ -471,10 +471,11 @@ void clock_page_update(void) {
 
     /* Condition — uppercase */
     char cond_upper[sizeof(wd.condition)];
-    for (int i = 0; i < (int)sizeof(wd.condition) && wd.condition[i]; i++) {
-        cond_upper[i] = (char)toupper((unsigned char)wd.condition[i]);
-        cond_upper[i + 1] = '\0';
+    int cu_i = 0;
+    for (; cu_i < (int)sizeof(wd.condition) - 1 && wd.condition[cu_i]; cu_i++) {
+        cond_upper[cu_i] = (char)toupper((unsigned char)wd.condition[cu_i]);
     }
+    cond_upper[cu_i] = '\0';
     if (wd.condition[0] == '\0') {
         strcpy(cond_upper, "--");
     }

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -17,6 +17,7 @@
 #include "nina_allsky.h"
 #include "nina_spotify.h"
 #include "nina_clock.h"
+#include "page_registry.h"
 #include "nina_image_display.h"
 #include "moon_interaction.h"
 #include "nina_settings_tabview.h"
@@ -49,25 +50,126 @@ int  nina_available_count = 0;
 lv_obj_t *allsky_obj = NULL;
 static lv_obj_t *allsky_page_created = NULL;  /* Always holds the created page object */
 
+/* ── AllSky page registry ops (Task 4.7 wave P7b) ──
+ * get_obj reads allsky_obj (NOT allsky_page_created): allsky_obj is NULL
+ * whenever the page is disabled, so is_available=NULL (derive from
+ * get_obj()!=NULL) reproduces the enabled-AND-created guard used throughout
+ * this file without a separate availability check. The page itself is never
+ * destroyed once created (only hidden/tracked), so destroy stays NULL. */
+static lv_obj_t *allsky_ops_get_obj(void) { return allsky_obj; }
+
+static const page_ops_t s_allsky_page_ops = {
+    .create       = allsky_page_create,
+    .destroy      = NULL,
+    .get_obj      = allsky_ops_get_obj,
+    .show         = NULL,
+    .hide         = NULL,
+    .apply_theme  = allsky_page_apply_theme,
+    .is_available = NULL,
+};
+
 /* Spotify page — always at PAGE_IDX_SPOTIFY (1), excluded from indicators */
 lv_obj_t *spotify_obj = NULL;
 static lv_obj_t *spotify_page_created = NULL;  /* Always holds the created page object */
 
+/* ── Spotify page registry ops (Task 4.7 wave P7b) ──
+ * Same NULL-when-disabled pattern as AllSky above; show/hide route to the
+ * existing idle-timer lifecycle callbacks. */
+static lv_obj_t *spotify_ops_get_obj(void) { return spotify_obj; }
+
+static const page_ops_t s_spotify_page_ops = {
+    .create       = spotify_page_create,
+    .destroy      = NULL,
+    .get_obj      = spotify_ops_get_obj,
+    .show         = nina_spotify_on_show,
+    .hide         = nina_spotify_on_hide,
+    .apply_theme  = spotify_page_apply_theme,
+    .is_available = NULL,
+};
+
 /* Clock page — always at PAGE_IDX_CLOCK (2), always present */
 lv_obj_t *clock_obj = NULL;
+
+/* ── Clock page registry ops (Task 4.7 / retro 4.7, wave P7a proof) ──
+ * Thunks over the existing clock_page_* functions; get_obj reads the
+ * clock_obj global above (clock_obj lives here, not in nina_clock.c). */
+static lv_obj_t *clock_ops_get_obj(void) { return clock_obj; }
+
+static const page_ops_t s_clock_page_ops = {
+    .create       = clock_page_create,
+    .destroy      = NULL,   /* clock page is never destroyed, always present */
+    .get_obj      = clock_ops_get_obj,
+    .show         = clock_page_on_show,
+    .hide         = clock_page_on_hide,
+    .apply_theme  = clock_page_apply_theme,
+    .is_available = NULL,   /* NULL = derive from get_obj() != NULL (always available) */
+};
 
 /* Image Display page — always at PAGE_IDX_IMAGE_DISPLAY (3), excluded from indicators */
 lv_obj_t *image_display_obj = NULL;
 static lv_obj_t *image_display_page_created = NULL;
 
+/* ── Image Display page registry ops (Task 4.7 wave P7b) ──
+ * Registered under PAGE_REF_IMG_DEFAULT: the registry's generic "the Image
+ * Display page itself" id (page_idx = PAGE_IDX_IMAGE_DISPLAY, img_src = -1),
+ * distinct from the per-source ids (PAGE_REF_IMG_GOES/MOON/SOLAR/CUSTOM) that
+ * share the same page_idx. Page lifecycle (create/get_obj/apply_theme) is
+ * per-page, not per-source, so one ops registration covers all sources. */
+static lv_obj_t *image_display_ops_get_obj(void) { return image_display_obj; }
+
+static const page_ops_t s_image_display_page_ops = {
+    .create       = nina_image_display_create,
+    .destroy      = NULL,
+    .get_obj      = image_display_ops_get_obj,
+    .show         = NULL,
+    .hide         = NULL,
+    .apply_theme  = nina_image_display_apply_theme,
+    .is_available = NULL,
+};
+
 /* Summary page — at PAGE_IDX_SUMMARY (4), excluded from indicators */
 static lv_obj_t *summary_obj = NULL;
+
+/* ── Summary page registry ops (Task 4.7 wave P7b) ──
+ * Summary is always present (never disabled/NULL'd), so get_obj simply
+ * returns summary_obj and is_available derives to "always true" once created.
+ * show_page_at() has no summary-specific on-show behavior today beyond
+ * clearing the hidden flag (summary_page_update() runs from data_update_task
+ * on its own poll cadence, not on page-show), so show is left NULL. */
+static lv_obj_t *summary_ops_get_obj(void) { return summary_obj; }
+
+static const page_ops_t s_summary_page_ops = {
+    .create       = summary_page_create,
+    .destroy      = NULL,
+    .get_obj      = summary_ops_get_obj,
+    .show         = NULL,
+    .hide         = NULL,
+    .apply_theme  = summary_page_apply_theme,
+    .is_available = NULL,
+};
 
 /* Settings page — at SETTINGS_PAGE_IDX(page_count), excluded from indicators */
 static lv_obj_t *settings_obj = NULL;
 
 /* System info page — at SYSINFO_PAGE_IDX(page_count), excluded from indicators */
 static lv_obj_t *sysinfo_obj = NULL;
+
+/* ── System info page registry ops (Task 4.7 wave P7b) ──
+ * The pre-ops show_page_at() branch refreshed stats every time the page
+ * became visible (sysinfo_page_refresh()); fold that into the show thunk so
+ * ops-driven show reproduces the exact same on-show behavior. */
+static lv_obj_t *sysinfo_ops_get_obj(void) { return sysinfo_obj; }
+static void sysinfo_ops_show(void) { sysinfo_page_refresh(); }
+
+static const page_ops_t s_sysinfo_page_ops = {
+    .create       = sysinfo_page_create,
+    .destroy      = NULL,
+    .get_obj      = sysinfo_ops_get_obj,
+    .show         = sysinfo_ops_show,
+    .hide         = NULL,
+    .apply_theme  = sysinfo_page_apply_theme,
+    .is_available = NULL,
+};
 int total_page_count = 0;   /* page_count + EXTRA_PAGES (allsky + spotify + clock + summary + settings + sysinfo) */
 
 /* Private state */
@@ -164,23 +266,98 @@ static int abs_page_to_instance(int idx) {
     return inst;
 }
 
+/* Absolute page index -> registry page_ref id, or PAGE_REF_ID_MAX if the page
+ * has not (yet) opted into ops-based dispatch. Only pages registered via
+ * page_registry_set_ops() need an entry here; unmapped indices fall through
+ * to the hardcoded branches below unchanged. */
+static page_ref_t page_idx_to_ref_id(int idx) {
+    if (idx == PAGE_IDX_CLOCK) return PAGE_REF_CLOCK;
+    if (idx == PAGE_IDX_SUMMARY) return PAGE_REF_SUMMARY;
+    if (idx == PAGE_IDX_ALLSKY) return PAGE_REF_ALLSKY;
+    if (idx == PAGE_IDX_SPOTIFY) return PAGE_REF_SPOTIFY;
+    if (idx == PAGE_IDX_IMAGE_DISPLAY) return PAGE_REF_IMG_DEFAULT;
+    if (idx == SYSINFO_PAGE_IDX(page_count)) return PAGE_REF_SYSINFO;
+    return PAGE_REF_ID_MAX;
+}
+
+/* Ops-driven variants of the get_obj/hide/show dispatchers. Returns true if
+ * the page at idx has registered ops and was handled; false to fall back to
+ * the hardcoded branches. */
+static bool ops_get_obj(int idx, lv_obj_t **obj_out) {
+    page_ref_t rid = page_idx_to_ref_id(idx);
+    if (rid >= PAGE_REF_ID_MAX) return false;
+    const page_ops_t *ops = page_registry_get_ops(rid);
+    if (!ops) return false;
+    *obj_out = ops->get_obj();
+    return true;
+}
+
+static bool ops_hide(int idx) {
+    page_ref_t rid = page_idx_to_ref_id(idx);
+    if (rid >= PAGE_REF_ID_MAX) return false;
+    const page_ops_t *ops = page_registry_get_ops(rid);
+    if (!ops) return false;
+    /* Matches the pre-ops branch shape exactly: both the hide flag and the
+     * on-hide callback are gated on the object actually existing. */
+    lv_obj_t *obj = ops->get_obj();
+    if (obj) {
+        lv_obj_add_flag(obj, LV_OBJ_FLAG_HIDDEN);
+        if (ops->hide) ops->hide();
+    }
+    return true;
+}
+
+static bool ops_show(int idx) {
+    page_ref_t rid = page_idx_to_ref_id(idx);
+    if (rid >= PAGE_REF_ID_MAX) return false;
+    const page_ops_t *ops = page_registry_get_ops(rid);
+    if (!ops) return false;
+    /* Matches the pre-ops branch shape exactly: both the clear-hidden flag
+     * and the on-show callback are gated on the object actually existing. */
+    lv_obj_t *obj = ops->get_obj();
+    if (obj) {
+        lv_obj_clear_flag(obj, LV_OBJ_FLAG_HIDDEN);
+        if (ops->show) ops->show();
+    }
+    return true;
+}
+
+/* Ops-driven apply_theme dispatcher helper. Returns true (handled) if @p idx
+ * has registered ops, calling ops->apply_theme() unconditionally — the
+ * per-page apply_theme functions already NULL-guard their own module-level
+ * page pointer internally, so re-theming a currently-disabled/hidden page is
+ * a safe no-op, matching how summary/sysinfo already re-theme unconditionally
+ * today. Returns false (not handled) if @p idx has no registered ops, so the
+ * caller can fall back to its hardcoded branch. */
+static bool ops_apply_theme(int idx) {
+    page_ref_t rid = page_idx_to_ref_id(idx);
+    if (rid >= PAGE_REF_ID_MAX) return false;
+    const page_ops_t *ops = page_registry_get_ops(rid);
+    if (!ops) return false;
+    if (ops->apply_theme) ops->apply_theme();
+    return true;
+}
+
+/* True if the page at @p idx has registered ops AND is currently available
+ * (ops->is_available() if provided, else ops->get_obj() != NULL). False if
+ * @p idx has no registered ops — callers only use this for indices that are
+ * always mapped by page_idx_to_ref_id() once ported. */
+static bool page_ops_is_available(int idx) {
+    page_ref_t rid = page_idx_to_ref_id(idx);
+    if (rid >= PAGE_REF_ID_MAX) return false;
+    const page_ops_t *ops = page_registry_get_ops(rid);
+    if (!ops) return false;
+    if (ops->is_available) return ops->is_available();
+    return ops->get_obj() != NULL;
+}
+
 /* Hide the page object at the given index */
 static void hide_page_at(int idx) {
-    if (idx == PAGE_IDX_ALLSKY && allsky_obj)
-        lv_obj_add_flag(allsky_obj, LV_OBJ_FLAG_HIDDEN);
-    else if (idx == PAGE_IDX_SPOTIFY && spotify_obj) {
-        lv_obj_add_flag(spotify_obj, LV_OBJ_FLAG_HIDDEN);
-        nina_spotify_on_hide();
-    }
-    else if (idx == PAGE_IDX_CLOCK && clock_obj) {
-        lv_obj_add_flag(clock_obj, LV_OBJ_FLAG_HIDDEN);
-        clock_page_on_hide();
-    }
-    else if (idx == PAGE_IDX_IMAGE_DISPLAY && image_display_obj)
-        lv_obj_add_flag(image_display_obj, LV_OBJ_FLAG_HIDDEN);
-    else if (idx == PAGE_IDX_SUMMARY && summary_obj)
-        lv_obj_add_flag(summary_obj, LV_OBJ_FLAG_HIDDEN);
-    else if (abs_page_to_instance(idx) >= 0) {
+    /* Ported pages (AllSky, Spotify, Clock, Image Display, Summary, Sysinfo)
+     * are handled entirely by their registered ops. Only the NINA instance
+     * band and the Settings modal remain as hardcoded fallback branches. */
+    if (ops_hide(idx)) return;
+    if (abs_page_to_instance(idx) >= 0) {
         int inst = abs_page_to_instance(idx);
         if (nina_slot_available[inst] && pages[inst].page)
             lv_obj_add_flag(pages[inst].page, LV_OBJ_FLAG_HIDDEN);
@@ -190,27 +367,14 @@ static void hide_page_at(int idx) {
         settings_obj = NULL;
         /* Settings is a modal surface — unfreeze the arbiter on destroy. */
         nav_arbiter_notify_modal_close(esp_timer_get_time() / 1000);
-    } else if (idx == SYSINFO_PAGE_IDX(page_count) && sysinfo_obj)
-        lv_obj_add_flag(sysinfo_obj, LV_OBJ_FLAG_HIDDEN);
+    }
 }
 
 /* Show the page object at the given index */
 static void show_page_at(int idx) {
-    if (idx == PAGE_IDX_ALLSKY && allsky_obj)
-        lv_obj_clear_flag(allsky_obj, LV_OBJ_FLAG_HIDDEN);
-    else if (idx == PAGE_IDX_SPOTIFY && spotify_obj) {
-        lv_obj_clear_flag(spotify_obj, LV_OBJ_FLAG_HIDDEN);
-        nina_spotify_on_show();
-    }
-    else if (idx == PAGE_IDX_CLOCK && clock_obj) {
-        lv_obj_clear_flag(clock_obj, LV_OBJ_FLAG_HIDDEN);
-        clock_page_on_show();
-    }
-    else if (idx == PAGE_IDX_IMAGE_DISPLAY && image_display_obj)
-        lv_obj_clear_flag(image_display_obj, LV_OBJ_FLAG_HIDDEN);
-    else if (idx == PAGE_IDX_SUMMARY && summary_obj)
-        lv_obj_clear_flag(summary_obj, LV_OBJ_FLAG_HIDDEN);
-    else if (abs_page_to_instance(idx) >= 0) {
+    /* Ported pages route through ops (see hide_page_at note above). */
+    if (ops_show(idx)) return;
+    if (abs_page_to_instance(idx) >= 0) {
         int inst = abs_page_to_instance(idx);
         if (nina_slot_available[inst] && pages[inst].page)
             lv_obj_clear_flag(pages[inst].page, LV_OBJ_FLAG_HIDDEN);
@@ -225,24 +389,18 @@ static void show_page_at(int idx) {
         lv_obj_clear_flag(settings_obj, LV_OBJ_FLAG_HIDDEN);
         settings_tabview_refresh();
     }
-    else if (idx == SYSINFO_PAGE_IDX(page_count) && sysinfo_obj) {
-        lv_obj_clear_flag(sysinfo_obj, LV_OBJ_FLAG_HIDDEN);
-        sysinfo_page_refresh();
-    }
 }
 
 static lv_obj_t *get_page_obj(int idx) {
-    if (idx == PAGE_IDX_ALLSKY && allsky_obj) return allsky_obj;
-    if (idx == PAGE_IDX_SPOTIFY && spotify_obj) return spotify_obj;
-    if (idx == PAGE_IDX_CLOCK && clock_obj) return clock_obj;
-    if (idx == PAGE_IDX_IMAGE_DISPLAY && image_display_obj) return image_display_obj;
-    if (idx == PAGE_IDX_SUMMARY && summary_obj) return summary_obj;
+    /* Ported pages route through ops (see hide_page_at note above); the ops
+     * get_obj itself returns NULL when an optional page is disabled. */
+    lv_obj_t *ops_obj = NULL;
+    if (ops_get_obj(idx, &ops_obj)) return ops_obj;
     if (abs_page_to_instance(idx) >= 0) {
         int inst = abs_page_to_instance(idx);
         return (nina_slot_available[inst] && pages[inst].page) ? pages[inst].page : NULL;
     }
     if (idx == SETTINGS_PAGE_IDX(page_count) && settings_obj) return settings_obj;
-    if (idx == SYSINFO_PAGE_IDX(page_count) && sysinfo_obj) return sysinfo_obj;
     return NULL;
 }
 
@@ -330,13 +488,18 @@ void nina_dashboard_apply_theme(int theme_index) {
         apply_theme_to_page(&pages[i]);
     }
 
-    if (allsky_obj) allsky_page_apply_theme();
-    if (spotify_obj) spotify_page_apply_theme();
-    clock_page_apply_theme();
-    if (image_display_obj) nina_image_display_apply_theme();
-    summary_page_apply_theme();
+    /* Ported pages re-theme through registry ops. Each page's apply_theme
+     * NULL-guards its own module state internally, so re-theming a currently
+     * disabled optional page (AllSky/Spotify/Image Display) is safe — and
+     * keeps the hidden-but-created page current so a later re-enable shows
+     * the correct theme. Settings stays hand-dispatched (modal, lazy). */
+    ops_apply_theme(PAGE_IDX_ALLSKY);
+    ops_apply_theme(PAGE_IDX_SPOTIFY);
+    ops_apply_theme(PAGE_IDX_CLOCK);
+    ops_apply_theme(PAGE_IDX_IMAGE_DISPLAY);
+    ops_apply_theme(PAGE_IDX_SUMMARY);
     if (settings_obj) settings_tabview_apply_theme();
-    sysinfo_page_apply_theme();
+    ops_apply_theme(SYSINFO_PAGE_IDX(page_count));
     nina_graph_overlay_apply_theme();
     nina_info_overlay_apply_theme();
     nina_thumbnail_apply_theme();
@@ -750,6 +913,8 @@ static void create_dashboard_page(dashboard_page_t *p, lv_obj_t *parent, int pag
     p->cached_end_epoch = 0;
     p->cached_total = 0;
     p->gap_start_epoch = 0;
+    p->cached_nina_epoch = 0;
+    p->cached_nina_mono_us = 0;
 }
 
 /* Page indicator dots at the bottom */
@@ -836,9 +1001,13 @@ static void gesture_event_cb(lv_event_t *e) {
         for (int step = 1; step < total_page_count; step++) {
             int candidate = (active_page + step) % total_page_count;
             if (candidate == SETTINGS_PAGE_IDX(page_count)) continue;
-            if (candidate == PAGE_IDX_ALLSKY && allsky_obj == NULL) continue;
-            if (candidate == PAGE_IDX_SPOTIFY && spotify_obj == NULL) continue;
-            if (candidate == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) continue;
+            /* Optional pages (AllSky/Spotify/Image Display) are skipped when
+             * unavailable; availability comes from their registered ops
+             * (get_obj() == NULL while disabled). */
+            if ((candidate == PAGE_IDX_ALLSKY ||
+                 candidate == PAGE_IDX_SPOTIFY ||
+                 candidate == PAGE_IDX_IMAGE_DISPLAY) &&
+                !page_ops_is_available(candidate)) continue;
             new_page = candidate;
             break;
         }
@@ -846,9 +1015,10 @@ static void gesture_event_cb(lv_event_t *e) {
         for (int step = 1; step < total_page_count; step++) {
             int candidate = (active_page - step + total_page_count) % total_page_count;
             if (candidate == SETTINGS_PAGE_IDX(page_count)) continue;
-            if (candidate == PAGE_IDX_ALLSKY && allsky_obj == NULL) continue;
-            if (candidate == PAGE_IDX_SPOTIFY && spotify_obj == NULL) continue;
-            if (candidate == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) continue;
+            if ((candidate == PAGE_IDX_ALLSKY ||
+                 candidate == PAGE_IDX_SPOTIFY ||
+                 candidate == PAGE_IDX_IMAGE_DISPLAY) &&
+                !page_ops_is_available(candidate)) continue;
             new_page = candidate;
             break;
         }
@@ -971,29 +1141,37 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
     lv_obj_set_style_pad_all(main_cont, OUTER_PADDING, 0);
 
     /* AllSky page — PAGE_IDX_ALLSKY, always created but hidden initially.
-     * allsky_obj is set to NULL when disabled to remove from navigation. */
-    allsky_page_created = allsky_page_create(main_cont);
+     * allsky_obj is set to NULL when disabled to remove from navigation.
+     * Ops are registered BEFORE create so ops-based dispatch is live for
+     * every subsequent reference to the page (same for all pages below). */
+    page_registry_set_ops(PAGE_REF_ALLSKY, &s_allsky_page_ops);
+    allsky_page_created = s_allsky_page_ops.create(main_cont);
     lv_obj_add_flag(allsky_page_created, LV_OBJ_FLAG_HIDDEN);
     allsky_obj = app_config_get()->allsky_enabled ? allsky_page_created : NULL;
 
     /* Spotify page — PAGE_IDX_SPOTIFY, always created but hidden initially.
      * spotify_obj is set to NULL when disabled to remove from navigation. */
-    spotify_page_created = spotify_page_create(main_cont);
+    page_registry_set_ops(PAGE_REF_SPOTIFY, &s_spotify_page_ops);
+    spotify_page_created = s_spotify_page_ops.create(main_cont);
     lv_obj_add_flag(spotify_page_created, LV_OBJ_FLAG_HIDDEN);
     spotify_obj = app_config_get()->spotify_enabled ? spotify_page_created : NULL;
 
-    /* Clock page — PAGE_IDX_CLOCK, always present, hidden initially */
-    clock_obj = clock_page_create(main_cont);
+    /* Clock page — PAGE_IDX_CLOCK, always present, hidden initially. */
+    page_registry_set_ops(PAGE_REF_CLOCK, &s_clock_page_ops);
+    clock_obj = s_clock_page_ops.create(main_cont);
     lv_obj_add_flag(clock_obj, LV_OBJ_FLAG_HIDDEN);
 
     /* Image Display page — PAGE_IDX_IMAGE_DISPLAY, always created but hidden initially.
-     * image_display_obj is set to NULL when disabled to remove from navigation. */
-    image_display_page_created = nina_image_display_create(main_cont);
+     * image_display_obj is set to NULL when disabled to remove from navigation.
+     * Registered under PAGE_REF_IMG_DEFAULT (the page itself, source-agnostic). */
+    page_registry_set_ops(PAGE_REF_IMG_DEFAULT, &s_image_display_page_ops);
+    image_display_page_created = s_image_display_page_ops.create(main_cont);
     lv_obj_add_flag(image_display_page_created, LV_OBJ_FLAG_HIDDEN);
     image_display_obj = app_config_get()->image_display_enabled ? image_display_page_created : NULL;
 
     /* Summary page — PAGE_IDX_SUMMARY, visible by default */
-    summary_obj = summary_page_create(main_cont);
+    page_registry_set_ops(PAGE_REF_SUMMARY, &s_summary_page_ops);
+    summary_obj = s_summary_page_ops.create(main_cont);
 
     /* NINA instance pages — absolute index NINA_PAGE_OFFSET + i, hidden initially.
      * Slot i maps to instance i (fixed identity). Index positions are reserved,
@@ -1017,7 +1195,8 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
     settings_obj = NULL;
 
     /* System info page — always last (SYSINFO_PAGE_IDX), hidden initially */
-    sysinfo_obj = sysinfo_page_create(main_cont);
+    page_registry_set_ops(PAGE_REF_SYSINFO, &s_sysinfo_page_ops);
+    sysinfo_obj = s_sysinfo_page_ops.create(main_cont);
     lv_obj_add_flag(sysinfo_obj, LV_OBJ_FLAG_HIDDEN);
     total_page_count = page_count + EXTRA_PAGES;  /* allsky + spotify + clock + summary + NINA pages + settings + sysinfo */
 
@@ -1107,9 +1286,12 @@ void nina_dashboard_rebuild_slot(int instance) {
 
 void nina_dashboard_show_page(int page_index, int instance_count) {
     if (page_index < 0 || page_index >= total_page_count) return;
-    if (page_index == PAGE_IDX_ALLSKY && allsky_obj == NULL) return;  /* allsky disabled */
-    if (page_index == PAGE_IDX_SPOTIFY && spotify_obj == NULL) return;  /* spotify disabled */
-    if (page_index == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) return;  /* image display disabled */
+    /* Optional pages: reject navigation to a disabled page (ops availability,
+     * derived from ops get_obj() == NULL while disabled). */
+    if ((page_index == PAGE_IDX_ALLSKY ||
+         page_index == PAGE_IDX_SPOTIFY ||
+         page_index == PAGE_IDX_IMAGE_DISPLAY) &&
+        !page_ops_is_available(page_index)) return;
     if (page_index == active_page) return;
 
     hide_page_at(active_page);
@@ -1318,9 +1500,12 @@ static void slide_new_ready_cb(lv_anim_t *a)
 void nina_dashboard_show_page_animated(int page_index, int instance_count, int effect)
 {
     if (page_index < 0 || page_index >= total_page_count) return;
-    if (page_index == PAGE_IDX_ALLSKY && allsky_obj == NULL) return;  /* allsky disabled */
-    if (page_index == PAGE_IDX_SPOTIFY && spotify_obj == NULL) return;  /* spotify disabled */
-    if (page_index == PAGE_IDX_IMAGE_DISPLAY && image_display_obj == NULL) return;  /* image display disabled */
+    /* Optional pages: reject navigation to a disabled page (ops availability,
+     * same condition as nina_dashboard_show_page above). */
+    if ((page_index == PAGE_IDX_ALLSKY ||
+         page_index == PAGE_IDX_SPOTIFY ||
+         page_index == PAGE_IDX_IMAGE_DISPLAY) &&
+        !page_ops_is_available(page_index)) return;
     if (page_index == active_page) return;
 
     lv_obj_t *old_obj = get_page_obj(active_page);

--- a/main/ui/nina_dashboard_internal.h
+++ b/main/ui/nina_dashboard_internal.h
@@ -112,6 +112,12 @@ typedef struct {
     bool     cached_is_exposing;    // Last-known is_exposing state from poll data
     char     prev_filter[32];       // Track previous filter for change detection
 
+    // NINA-domain clock pair copied from nina_client_t in update_exposure_arc
+    // (caller holds the data lock), read lock-free by arc_interp_timer_cb.
+    // cached_nina_epoch == 0 -> unknown, fall back to time(NULL).
+    int64_t  cached_nina_epoch;     // NINA-PC UTC epoch at capture (HTTP Date)
+    int64_t  cached_nina_mono_us;   // esp_timer_get_time() at capture
+
     // Connection state (tracked for theme reapplication)
     bool nina_connected;
 

--- a/main/ui/nina_dashboard_update.c
+++ b/main/ui/nina_dashboard_update.c
@@ -117,8 +117,19 @@ void arc_interp_timer_cb(lv_timer_t *timer) {
      * small result to float for the P4 single-precision FPU. If NINA is
      * genuinely slower than our anchor predicted (paused / dither / meridian
      * flip extended the sub), the wall clock shows less elapsed than us — only
-     * then re-anchor backward. Never pull forward on wall drift. */
-    int64_t remaining_wall_ms = (p->cached_end_epoch - (int64_t)time(NULL)) * 1000;
+     * then re-anchor backward. Never pull forward on wall drift.
+     * "Wall" here is the NINA-PC clock domain (cached_end_epoch is a NINA
+     * timestamp): advance the cached Date-header epoch by monotonic time.
+     * This timer runs WITHOUT the data lock, so it reads the page's cached
+     * pair (copied under the lock in update_exposure_arc), never d directly. */
+    int64_t now_nina;
+    if (p->cached_nina_epoch != 0) {
+        now_nina = p->cached_nina_epoch +
+                   (esp_timer_get_time() - p->cached_nina_mono_us) / 1000000;
+    } else {
+        now_nina = (int64_t)time(NULL);
+    }
+    int64_t remaining_wall_ms = (p->cached_end_epoch - now_nina) * 1000;
     float elapsed_wall = p->cached_total - (float)remaining_wall_ms / 1000.0f;
 
     if (elapsed_wall < elapsed - 1.0f) {
@@ -222,6 +233,8 @@ static void update_disconnected_state(dashboard_page_t *p, int instance_idx, int
     p->cached_end_epoch = 0;
     p->cached_total = 0;
     p->gap_start_epoch = 0;
+    p->cached_nina_epoch = 0;
+    p->cached_nina_mono_us = 0;
     lv_arc_set_value(p->arc_exposure, 0);
     lv_obj_add_flag(p->row_filter_total, LV_OBJ_FLAG_HIDDEN);
     lv_anim_delete(p->lbl_rms_value, arcsec_anim_exec);
@@ -335,11 +348,24 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
         p->gap_start_epoch = 0;
         p->exp_anchor_us = 0;
         p->exp_anchor_elapsed = 0;
+        p->cached_nina_epoch = 0;
+        p->cached_nina_mono_us = 0;
         lv_arc_set_value(p->arc_exposure, 0);
         snprintf(p->prev_filter, sizeof(p->prev_filter), "%s", d->current_filter);
     }
 
-    time_t now = time(NULL);
+    /* NINA-domain "now" for all NINA-timestamp math (exposure_end_epoch is a
+     * NINA-PC timestamp). The caller (update_nina_dashboard_page, via
+     * data_update_task) holds the nina_client lock here, so reading d's clock
+     * pair is safe. Copy the pair into the page cache for the lock-free
+     * 200ms arc_interp_timer_cb.
+     * Concurrency: the cached pair is serialized by the LVGL display lock,
+     * not the nina_client lock — this writer runs under both locks, while
+     * arc_interp_timer_cb reads it under the LVGL lock only (esp_lvgl_port
+     * task). Keep any future readers inside the LVGL lock. */
+    int64_t now_nina = nina_client_now_epoch(d);
+    p->cached_nina_epoch = d->nina_clock_epoch;
+    p->cached_nina_mono_us = d->nina_clock_mono_us;
 
     /* Detect the IsExposing true->false edge BEFORE updating cached_is_exposing.
      * NINA flips IsExposing->false at sub end and the poll usually sees that
@@ -383,7 +409,7 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
 
         // Detect new exposure by end_epoch change, or idle->exposing with no anchor
         bool new_exposure = (d->exposure_end_epoch != p->cached_end_epoch
-                             && d->exposure_end_epoch > (int64_t)now)
+                             && d->exposure_end_epoch > now_nina)
                             || (p->exp_anchor_us == 0);
 
         /* Detect a material exposure_total change on the SAME ongoing exposure
@@ -405,7 +431,7 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
              * are (detection can land mid-sub on page switch / first connect).
              * Difference the epochs in int64 first to preserve precision, then
              * cast the small result to float for the P4 single-precision FPU. */
-            int64_t remaining_seed_ms = (d->exposure_end_epoch - (int64_t)now) * 1000;
+            int64_t remaining_seed_ms = (d->exposure_end_epoch - now_nina) * 1000;
             float seed = d->exposure_total - (float)remaining_seed_ms / 1000.0f;
             if (seed < 0.0f) seed = 0.0f;
             if (seed > d->exposure_total) seed = d->exposure_total;
@@ -431,7 +457,7 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
              * image-history length replaced by the real sequence length).
              * Re-anchor against the corrected total and smoothly animate the
              * one-time position correction instead of hard-jumping the arc. */
-            int64_t remaining_seed_ms = (d->exposure_end_epoch - (int64_t)now) * 1000;
+            int64_t remaining_seed_ms = (d->exposure_end_epoch - now_nina) * 1000;
             float seed = d->exposure_total - (float)remaining_seed_ms / 1000.0f;
             if (seed < 0.0f) seed = 0.0f;
             if (seed > d->exposure_total) seed = d->exposure_total;
@@ -495,11 +521,14 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
                              || strcmp(d->status, "NoState") == 0
                              || strcmp(d->status, "OFFLINE") == 0);
 
+            /* Gap timing is device-only elapsed time (a duration, not a
+             * NINA-timestamp comparison) — deliberately stays on time(NULL). */
+            int64_t now_wall = (int64_t)time(NULL);
             if (p->gap_start_epoch == 0) {
-                p->gap_start_epoch = (int64_t)now;
+                p->gap_start_epoch = now_wall;
             }
 
-            int64_t gap_duration = (int64_t)now - p->gap_start_epoch;
+            int64_t gap_duration = now_wall - p->gap_start_epoch;
             if (camera_idle || gap_duration > ARC_GAP_GRACE_S) {
                 // Grace period expired — transition to idle
                 p->cached_end_epoch = 0;
@@ -508,6 +537,8 @@ static void update_exposure_arc(dashboard_page_t *p, const nina_client_t *d,
                 p->exp_anchor_us = 0;
                 p->exp_anchor_elapsed = 0;
                 p->arc_completing = false;
+                p->cached_nina_epoch = 0;
+                p->cached_nina_mono_us = 0;
                 set_label_if_changed(p->lbl_exposure_total, "");
                 set_label_if_changed(p->lbl_loop_count, "");
                 set_label_if_changed(p->lbl_exposure_current, "--");

--- a/main/ui/nina_graph_overlay.c
+++ b/main/ui/nina_graph_overlay.c
@@ -11,6 +11,7 @@
 #include "nina_graph_internal.h"
 #include "nina_dashboard.h"
 #include "nina_nav_arbiter.h"
+#include "graph_downsample.h"
 #include "esp_timer.h"
 #include <stdio.h>
 #include <string.h>
@@ -31,11 +32,11 @@
 /* -- History point options ----------------------------------------------- */
 const int point_options[] = {25, 50, 100, 200, 400};
 
-/* Max points actually drawn on the chart. The chart is ~720px wide, so more
- * than this yields sub-pixel polyline segments with no visible difference.
- * Decimating the displayed set (storage stays GRAPH_MAX_POINTS) roughly halves
- * the per-point loop and polyline segment count for the heavy locked redraw. */
-#define GRAPH_MAX_DISPLAY_POINTS 360
+/* GRAPH_MAX_DISPLAY_POINTS is defined in graph_downsample.h (chart is ~720px
+ * wide, so more than this yields sub-pixel polyline segments with no visible
+ * difference; decimating the displayed set, storage stays GRAPH_MAX_POINTS,
+ * roughly halves the per-point loop and polyline segment count for the heavy
+ * locked redraw). */
 
 /* -- Y-scale options for RMS (arcseconds x 100) ------------------------- */
 const int rms_scale_values[] = {0, 100, 200, 400, 800, 1600};  /* 0 = auto */
@@ -575,12 +576,9 @@ void nina_graph_set_rms_data(const graph_rms_data_t *data) {
     /* Decimate the displayed set to the chart's pixel width. When the source
      * has more samples than the chart can resolve, subsample with an integer
      * stride so the polyline draws far fewer segments under the display lock. */
-    int disp_count = count;
-    int stride = 1;
-    if (count > GRAPH_MAX_DISPLAY_POINTS) {
-        stride = (count + GRAPH_MAX_DISPLAY_POINTS - 1) / GRAPH_MAX_DISPLAY_POINTS;
-        disp_count = (count + stride - 1) / stride;
-    }
+    graph_downsample_t ds = graph_downsample_compute(count);
+    int disp_count = ds.disp_count;
+    int stride = ds.stride;
 
     /* Configure chart */
     lv_chart_set_point_count(chart, disp_count);
@@ -595,16 +593,7 @@ void nina_graph_set_rms_data(const graph_rms_data_t *data) {
     update_series_colors();
 
     /* Find Y range (auto mode) */
-    float max_val = 0.5f;  /* minimum visible range */
-    for (int i = 0; i < count; i++) {
-        float abs_ra = fabsf(data->ra[i]);
-        float abs_dec = fabsf(data->dec[i]);
-        if (abs_ra > max_val) max_val = abs_ra;
-        if (abs_dec > max_val) max_val = abs_dec;
-    }
-    /* Add 20% headroom and round up */
-    int range = (int)(max_val * 120.0f + 50.0f);  /* x100 then +headroom */
-    if (range < 100) range = 100;
+    int range = graph_rms_y_range(data->ra, data->dec, count);
 
     /* Apply Y scale */
     int scale_val = 0;
@@ -660,12 +649,9 @@ void nina_graph_set_hfr_data(const graph_hfr_data_t *data) {
     if (count > GRAPH_MAX_POINTS) count = GRAPH_MAX_POINTS;
 
     /* Decimate the displayed set to the chart's pixel width (see RMS path). */
-    int disp_count = count;
-    int stride = 1;
-    if (count > GRAPH_MAX_DISPLAY_POINTS) {
-        stride = (count + GRAPH_MAX_DISPLAY_POINTS - 1) / GRAPH_MAX_DISPLAY_POINTS;
-        disp_count = (count + stride - 1) / stride;
-    }
+    graph_downsample_t ds = graph_downsample_compute(count);
+    int disp_count = ds.disp_count;
+    int stride = ds.stride;
 
     /* Configure chart */
     lv_chart_set_point_count(chart, disp_count);
@@ -680,14 +666,8 @@ void nina_graph_set_hfr_data(const graph_hfr_data_t *data) {
     update_series_colors();
 
     /* Find Y range (auto mode) -- HFR is always positive */
-    float max_val = 1.0f;
     float sum = 0;
-    for (int i = 0; i < count; i++) {
-        if (data->hfr[i] > max_val) max_val = data->hfr[i];
-        sum += data->hfr[i];
-    }
-    int range = (int)(max_val * 120.0f + 0.5f);  /* x100 + 20% headroom */
-    if (range < 200) range = 200;
+    int range = graph_hfr_y_range(data->hfr, count, &sum);
 
     /* Apply Y scale */
     int scale_val = 0;

--- a/main/ui/nina_summary.c
+++ b/main/ui/nina_summary.c
@@ -193,6 +193,11 @@ typedef struct {
     float   cached_total;       /* cached exposure_total (seconds) */
     int64_t cached_end_epoch;   /* cached exposure_end_epoch (Unix seconds) */
     int64_t gap_start_epoch;    /* inter-exposure gap grace start (Unix seconds) */
+    /* NINA-domain clock pair copied from nina_client_t while the data lock is
+     * held (summary update path); read lock-free by summary_bar_interp_cb.
+     * cached_nina_epoch == 0 -> unknown, fall back to time(NULL). */
+    int64_t cached_nina_epoch;   /* NINA-PC UTC epoch at capture (HTTP Date) */
+    int64_t cached_nina_mono_us; /* esp_timer_get_time() at capture */
     /* Cached style values — only call lv_obj_set_style_* when changed to avoid
      * unnecessary LVGL invalidations that trigger expensive full redraws. */
     uint32_t cached_name_color;
@@ -236,6 +241,8 @@ static void bar_reset_exposure_state(summary_card_t *sc) {
     sc->cached_total       = 0;
     sc->cached_end_epoch   = 0;
     sc->gap_start_epoch    = 0;
+    sc->cached_nina_epoch  = 0;
+    sc->cached_nina_mono_us = 0;
     set_bar_if_changed(sc->bar_progress, 0, LV_ANIM_OFF);
     set_label_if_changed(sc->lbl_pct, "");
 }
@@ -280,8 +287,19 @@ static void summary_bar_interp_cb(lv_timer_t *timer) {
 
         /* Backward-only wall correction. Difference epoch seconds in int64
          * first (they exceed float's 24-bit precision), then cast the small
-         * result to float for the P4 single-precision FPU. */
-        int64_t remaining_wall_ms = (sc->cached_end_epoch - (int64_t)time(NULL)) * 1000;
+         * result to float for the P4 single-precision FPU. "Wall" is the
+         * NINA-PC clock domain (cached_end_epoch is a NINA timestamp): advance
+         * the cached Date-header epoch by monotonic time. This timer runs
+         * WITHOUT the data lock, so it reads the card's cached pair (copied
+         * under the lock in summary_page_update), never the instance struct. */
+        int64_t now_nina;
+        if (sc->cached_nina_epoch != 0) {
+            now_nina = sc->cached_nina_epoch +
+                       (esp_timer_get_time() - sc->cached_nina_mono_us) / 1000000;
+        } else {
+            now_nina = (int64_t)time(NULL);
+        }
+        int64_t remaining_wall_ms = (sc->cached_end_epoch - now_nina) * 1000;
         float elapsed_wall = sc->cached_total - (float)remaining_wall_ms / 1000.0f;
 
         if (elapsed_wall < elapsed - 1.0f) {
@@ -789,6 +807,8 @@ void summary_page_rebuild(void) {
             cards[i].cached_total       = 0;
             cards[i].cached_end_epoch   = 0;
             cards[i].gap_start_epoch    = 0;
+            cards[i].cached_nina_epoch  = 0;
+            cards[i].cached_nina_mono_us = 0;
         }
     }
 
@@ -946,6 +966,11 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
      * from what the cards actually show. */
     int visible = 0;
     for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
+        /* cppcheck-suppress arrayIndexThenCheck
+         * nina_slot_available[i]/nina_connection_is_connected(i) are indexed
+         * within the loop's own MAX_NINA_INSTANCES bound; the `i < count`
+         * check is an independent additional condition, not an array-size
+         * guard for these accesses. */
         if (nina_slot_available[i] && i < count && nina_connection_is_connected(i)) visible++;
     }
 
@@ -981,6 +1006,9 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
          * Only available slots (nina_slot_available[i]) can ever be shown;
          * unavailable slots are always kept hidden regardless of connection. */
         for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
+            /* cppcheck-suppress arrayIndexThenCheck
+             * See rationale above: i is bounded by MAX_NINA_INSTANCES from
+             * the enclosing loop, independent of the `i < count` check. */
             if (nina_slot_available[i] && i < count && nina_connection_is_connected(i)) {
                 lv_obj_clear_flag(cards[i].card, LV_OBJ_FLAG_HIDDEN);
                 update_card_layout(&cards[i], visible);
@@ -1024,6 +1052,9 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
         /* No layout change — just ensure correct visibility.
          * Unavailable slots stay hidden regardless of connection state. */
         for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
+            /* cppcheck-suppress arrayIndexThenCheck
+             * See rationale above: i is bounded by MAX_NINA_INSTANCES from
+             * the enclosing loop, independent of the `i < count` check. */
             if (nina_slot_available[i] && i < count && nina_connection_is_connected(i)) {
                 lv_obj_clear_flag(cards[i].card, LV_OBJ_FLAG_HIDDEN);
             } else {
@@ -1125,7 +1156,18 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
          * handles seeding, re-anchoring, the finished edge, and the gap/idle
          * reset. */
         {
-            time_t now = time(NULL);
+            /* NINA-domain "now" for all NINA-timestamp math. locked[i] was
+             * checked above (trylock-and-skip), so the data lock is held for
+             * this card: reading d's clock pair is safe. Copy the pair into
+             * the card cache for the lock-free summary_bar_interp_cb.
+             * Concurrency: the cached pair is serialized by the LVGL display
+             * lock, not the nina_client lock — this writer runs under both
+             * locks, while summary_bar_interp_cb reads it under the LVGL lock
+             * only (esp_lvgl_port task). Keep any future readers inside the
+             * LVGL lock. */
+            int64_t now_nina = nina_client_now_epoch(d);
+            sc->cached_nina_epoch = d->nina_clock_epoch;
+            sc->cached_nina_mono_us = d->nina_clock_mono_us;
 
             /* Detect the is_exposing true->false edge BEFORE updating the cached
              * flag; NINA drops is_exposing at sub end and the poll usually sees
@@ -1160,7 +1202,7 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                  * anchor. Computed against the OLD cached_* values, so this must
                  * run BEFORE the cache assignments below. */
                 bool new_exposure = (d->exposure_end_epoch != sc->cached_end_epoch
-                                     && d->exposure_end_epoch > (int64_t)now)
+                                     && d->exposure_end_epoch > now_nina)
                                     || (sc->exp_anchor_us == 0);
                 bool same_exposure = (sc->exp_anchor_us != 0
                                       && d->exposure_end_epoch == sc->cached_end_epoch);
@@ -1174,7 +1216,7 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                     /* Anchor the monotonic clock; seed elapsed with a ONE-TIME
                      * wall estimate (detection can land mid-sub). Difference the
                      * epochs in int64 first, then cast to float for the P4 FPU. */
-                    int64_t remaining_seed_ms = (d->exposure_end_epoch - (int64_t)now) * 1000;
+                    int64_t remaining_seed_ms = (d->exposure_end_epoch - now_nina) * 1000;
                     float seed = d->exposure_total - (float)remaining_seed_ms / 1000.0f;
                     if (seed < 0.0f) seed = 0.0f;
                     if (seed > d->exposure_total) seed = d->exposure_total;
@@ -1196,7 +1238,7 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                      * smoothly animate the one-time correction; do NOT call
                      * bar_start_exposure_anim (it would delete this correction
                      * anim). The interp timer restarts the long anim afterward. */
-                    int64_t remaining_seed_ms = (d->exposure_end_epoch - (int64_t)now) * 1000;
+                    int64_t remaining_seed_ms = (d->exposure_end_epoch - now_nina) * 1000;
                     float seed = d->exposure_total - (float)remaining_seed_ms / 1000.0f;
                     if (seed < 0.0f) seed = 0.0f;
                     if (seed > d->exposure_total) seed = d->exposure_total;
@@ -1228,11 +1270,14 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                                      || strcmp(d->status, "NoState") == 0
                                      || strcmp(d->status, "OFFLINE") == 0);
 
+                    /* Gap timing is device-only elapsed time (a duration, not
+                     * a NINA-timestamp comparison) — stays on time(NULL). */
+                    int64_t now_wall = (int64_t)time(NULL);
                     if (sc->gap_start_epoch == 0) {
-                        sc->gap_start_epoch = (int64_t)now;
+                        sc->gap_start_epoch = now_wall;
                     }
 
-                    int64_t gap_duration = (int64_t)now - sc->gap_start_epoch;
+                    int64_t gap_duration = now_wall - sc->gap_start_epoch;
                     if (camera_idle || gap_duration > BAR_GAP_GRACE_S) {
                         /* Grace expired — transition to idle. */
                         sc->cached_end_epoch = 0;
@@ -1241,6 +1286,8 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                         sc->exp_anchor_us = 0;
                         sc->exp_anchor_elapsed = 0;
                         sc->bar_completing = false;
+                        sc->cached_nina_epoch = 0;
+                        sc->cached_nina_mono_us = 0;
                         lv_anim_delete(sc->bar_progress, bar_anim_exec);
 
                         lv_anim_t a;

--- a/main/ui/page_registry.c
+++ b/main/ui/page_registry.c
@@ -177,6 +177,28 @@ bool page_ref_resolve(page_ref_t id, int *page_idx_out, int8_t *img_src_out)
     return true;
 }
 
+/* ── Optional page lifecycle ops (Task 4.7) ──
+ * Parallel array indexed by id, separate from the frozen s_pages[] identity
+ * table above. Zero-initialized (all NULL) until a page module opts in via
+ * page_registry_set_ops(). */
+static const page_ops_t *s_ops[PAGE_REF_ID_MAX];
+
+void page_registry_set_ops(uint8_t page_id, const page_ops_t *ops)
+{
+    if (page_id >= PAGE_REF_ID_MAX) {
+        return;
+    }
+    s_ops[page_id] = ops;
+}
+
+const page_ops_t *page_registry_get_ops(uint8_t page_id)
+{
+    if (page_id >= PAGE_REF_ID_MAX) {
+        return NULL;
+    }
+    return s_ops[page_id];
+}
+
 bool page_ref_navigate(page_ref_t id)
 {
     int page_idx;

--- a/main/ui/page_registry.h
+++ b/main/ui/page_registry.h
@@ -34,6 +34,8 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#include "lvgl.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -129,6 +131,42 @@ bool page_ref_resolve(page_ref_t id, int *page_idx_out, int8_t *img_src_out);
  * Caller must NOT hold the LVGL lock; the arbiter takes it internally.
  */
 bool page_ref_navigate(page_ref_t id);
+
+/**
+ * OPTIONAL page lifecycle ops (Task 4.7 / retro 4.7, wave P7a).
+ *
+ * The identity table above (s_pages) is frozen metadata only — no function
+ * pointers. This ops table is a SEPARATE, opt-in registration: a page module
+ * may register a page_ops_t for its own id so generic dispatch code (see
+ * nina_dashboard.c: hide_page_at/show_page_at/get_page_obj/apply_theme) can
+ * drive it without a hardcoded branch. Pages that do not register ops keep
+ * flowing through the existing hardcoded branches unchanged.
+ *
+ * All ops are called with the LVGL display lock already held by the caller
+ * (dispatchers run under the same lock discipline as the branches they
+ * replace). `create` and `get_obj` are NOT optional for a registered page —
+ * dispatchers assume both are non-NULL if the ops pointer itself is non-NULL.
+ */
+typedef struct {
+    lv_obj_t *(*create)(lv_obj_t *parent);   /* build page, return root obj */
+    void (*destroy)(void);                    /* optional teardown; NULL = never destroyed */
+    lv_obj_t *(*get_obj)(void);               /* current root obj or NULL */
+    void (*show)(void);                       /* on-activate (after unhide); optional */
+    void (*hide)(void);                       /* on-deactivate (before hide); optional */
+    void (*apply_theme)(void);                /* re-theme existing widgets; optional */
+    bool (*is_available)(void);               /* optional; NULL = derive from get_obj()!=NULL */
+} page_ops_t;
+
+/**
+ * Register (or clear, with ops=NULL) the lifecycle ops for @p page_id.
+ * @p ops must have static storage duration (the registry stores the pointer,
+ * not a copy). Not thread-safe; call only from the UI/LVGL-owning task during
+ * page creation, before any dispatcher can reference the id.
+ */
+void page_registry_set_ops(uint8_t page_id, const page_ops_t *ops);
+
+/** Get the registered ops for @p page_id, or NULL if none registered. */
+const page_ops_t *page_registry_get_ops(uint8_t page_id);
 
 #ifdef __cplusplus
 }

--- a/main/weather_client.c
+++ b/main/weather_client.c
@@ -10,10 +10,10 @@
 #include "weather_client.h"
 #include "app_config.h"
 #include "tasks.h"
+#include "poll_task.h"
 
 #include "ui/nina_clock.h"
-#include "esp_http_client.h"
-#include "esp_crt_bundle.h"
+#include "http_fetch.h"
 #include "esp_log.h"
 #include "esp_timer.h"
 #include "esp_heap_caps.h"
@@ -106,92 +106,42 @@ static void str_to_upper(char *s) {
 }
 
 // =============================================================================
-// HTTP fetch helper — returns PSRAM-allocated buffer, caller must free()
+// HTTP fetch helper — returns PSRAM-allocated buffer, caller must
+// heap_caps_free()
 // =============================================================================
 
 /**
  * Perform an HTTP GET and return the response body as a null-terminated
  * PSRAM-allocated string.  Returns NULL on any error.
+ *
+ * Thin wrapper over the shared http_fetch_text() (main/http_fetch.h/.c):
+ * TLS cert-bundle validation on, redirects followed up to 3 hops, single
+ * attempt (this poller's own retry interval is the retry mechanism), same
+ * response-size cap as before. All transport/status/size error logging
+ * happens inside http_fetch_text() itself.
  */
 static char *http_get_body(const char *url) {
-    esp_http_client_config_t cfg = {
-        .url               = url,
-        .timeout_ms        = WEATHER_HTTP_TIMEOUT_MS,
-        .crt_bundle_attach = esp_crt_bundle_attach,
+    http_fetch_opts_t opts = {
+        .timeout_ms         = WEATHER_HTTP_TIMEOUT_MS,
+        .use_tls_bundle     = true,
+        .max_redirects      = 3,
+        .max_attempts       = 1,
+        .max_response_bytes = WEATHER_RESPONSE_BUF_SIZE,
     };
-    esp_http_client_handle_t client = esp_http_client_init(&cfg);
-    if (!client) {
-        ESP_LOGW(TAG, "Failed to init HTTP client");
+
+    char *body = NULL;
+    size_t len = 0;
+    if (http_fetch_text(url, &opts, &body, &len) != ESP_OK) {
         return NULL;
     }
 
-    esp_err_t err = esp_http_client_open(client, 0);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "HTTP open failed: %s", esp_err_to_name(err));
-        esp_http_client_cleanup(client);
-        return NULL;
-    }
-
-    int content_length = esp_http_client_fetch_headers(client);
-    int status = esp_http_client_get_status_code(client);
-
-    /* Follow Location redirects manually: the streaming open()/fetch_headers()
-     * path does NOT auto-follow. Cap the chain to avoid loops. */
-    int redirects = 0;
-    while ((status == 301 || status == 302 || status == 307 || status == 308) &&
-           redirects < 3) {
-        err = esp_http_client_set_redirection(client);
-        if (err != ESP_OK) {
-            ESP_LOGW(TAG, "set_redirection failed: %s", esp_err_to_name(err));
-            break;
-        }
-        esp_http_client_close(client);
-        err = esp_http_client_open(client, 0);
-        if (err != ESP_OK) {
-            ESP_LOGW(TAG, "HTTP re-open failed: %s", esp_err_to_name(err));
-            esp_http_client_cleanup(client);
-            return NULL;
-        }
-        content_length = esp_http_client_fetch_headers(client);
-        status = esp_http_client_get_status_code(client);
-        redirects++;
-    }
-
-    if (status < 200 || status >= 300) {
-        ESP_LOGW(TAG, "HTTP %d for %s", status, url);
-        esp_http_client_cleanup(client);
-        return NULL;
-    }
-
-    int buf_size = (content_length > 0 && content_length < WEATHER_RESPONSE_BUF_SIZE)
-                       ? (content_length + 1)
-                       : WEATHER_RESPONSE_BUF_SIZE;
-
-    char *buffer = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
-    if (!buffer) {
-        ESP_LOGE(TAG, "Failed to allocate %d bytes", buf_size);
-        esp_http_client_cleanup(client);
-        return NULL;
-    }
-
-    int total = 0;
-    int max_read = buf_size - 1;
-    while (total < max_read) {
-        int n = esp_http_client_read(client, buffer + total, max_read - total);
-        if (n <= 0) break;
-        total += n;
-    }
-    buffer[total] = '\0';
-
-    esp_http_client_cleanup(client);
-
-    if (total == 0) {
+    if (len == 0) {
         ESP_LOGW(TAG, "Empty response body");
-        free(buffer);
+        heap_caps_free(body);
         return NULL;
     }
 
-    return buffer;
+    return body;
 }
 
 // =============================================================================
@@ -212,7 +162,7 @@ static bool fetch_owm(const app_config_t *cfg, weather_data_t *out) {
     if (!body) return false;
 
     cJSON *json = cJSON_Parse(body);
-    free(body);
+    heap_caps_free(body);
     if (!json) {
         ESP_LOGW(TAG, "OWM current: JSON parse failed");
         return false;
@@ -280,7 +230,7 @@ static bool fetch_owm(const app_config_t *cfg, weather_data_t *out) {
     }
 
     json = cJSON_Parse(body);
-    free(body);
+    heap_caps_free(body);
     if (!json) return true;
 
     cJSON *list = cJSON_GetObjectItem(json, "list");
@@ -360,7 +310,7 @@ static bool fetch_open_meteo(const app_config_t *cfg, weather_data_t *out) {
     if (!body) return false;
 
     cJSON *json = cJSON_Parse(body);
-    free(body);
+    heap_caps_free(body);
     if (!json) {
         ESP_LOGW(TAG, "Open-Meteo: JSON parse failed");
         return false;
@@ -510,7 +460,7 @@ static bool fetch_wunderground(const app_config_t *cfg, weather_data_t *out) {
     if (!body) return false;
 
     cJSON *json = cJSON_Parse(body);
-    free(body);
+    heap_caps_free(body);
     if (!json) {
         ESP_LOGW(TAG, "WU current: JSON parse failed");
         return false;
@@ -575,7 +525,7 @@ static bool fetch_wunderground(const app_config_t *cfg, weather_data_t *out) {
     body = http_get_body(url);
     if (body) {
         json = cJSON_Parse(body);
-        free(body);
+        heap_caps_free(body);
         if (json) {
             cJSON *temps = cJSON_GetObjectItem(json, "temperature");
             if (temps && cJSON_IsArray(temps)) {
@@ -620,7 +570,7 @@ static bool fetch_wunderground(const app_config_t *cfg, weather_data_t *out) {
         body = http_get_body(url);
         if (body) {
             json = cJSON_Parse(body);
-            free(body);
+            heap_caps_free(body);
             if (json) {
                 cJSON *hourly = cJSON_GetObjectItem(json, "hourly");
                 if (hourly) {
@@ -699,76 +649,96 @@ static bool fetch_wunderground(const app_config_t *cfg, weather_data_t *out) {
 // Poll task
 // =============================================================================
 
+/* Poll interval (seconds) from the cfg snapshot taken during the most recent
+ * successful poll_once() -- stashed here so weather_interval_ms() (called by
+ * poll_loop_run right after a successful poll_once()) can clamp it without
+ * re-snapshotting the config. Only read/written from the weather poll task. */
+static uint32_t s_last_poll_interval_s;
+
+static bool weather_poll_once(void *arg) {
+    (void)arg;
+
+    app_config_t cfg_snap = app_config_get_snapshot();
+
+    /* Skip if no location configured */
+    bool has_location = (cfg_snap.weather_location_name[0] != '\0');
+    /* OWM and WU need an API key */
+    bool needs_key = (cfg_snap.weather_provider == 0 || cfg_snap.weather_provider == 2);
+    bool has_key   = (cfg_snap.weather_api_key[0] != '\0');
+
+    if (!has_location || (needs_key && !has_key)) {
+        ESP_LOGD(TAG, "Weather not configured (provider=%d), sleeping 60s",
+                 cfg_snap.weather_provider);
+        return false; /* backoff is fixed at WEATHER_RETRY_INTERVAL_S -- same as fetch failure */
+    }
+
+    /* Fetch from selected provider */
+    weather_data_t local;
+    memset(&local, 0, sizeof(local));
+    local.uv_index = -1.0f;
+
+    bool ok = false;
+    switch (cfg_snap.weather_provider) {
+        case 0:  ok = fetch_owm(&cfg_snap, &local);          break;
+        case 1:  ok = fetch_open_meteo(&cfg_snap, &local);   break;
+        case 2:  ok = fetch_wunderground(&cfg_snap, &local);  break;
+        default:
+            ESP_LOGW(TAG, "Unknown weather provider: %d", cfg_snap.weather_provider);
+            break;
+    }
+
+    if (!ok) {
+        ESP_LOGW(TAG, "Weather fetch failed, retrying in %ds", WEATHER_RETRY_INTERVAL_S);
+        return false;
+    }
+
+    local.valid = true;
+    local.last_update_ts = (int64_t)time(NULL);
+
+    if (xSemaphoreTake(s_mutex, pdMS_TO_TICKS(200)) == pdTRUE) {
+        memcpy(&s_data, &local, sizeof(weather_data_t));
+        xSemaphoreGive(s_mutex);
+    }
+    ESP_LOGI(TAG, "Weather updated: %.1f%s, %s",
+             local.temp_current,
+             (cfg_snap.weather_units == 0) ? "F" : "C",
+             local.condition);
+
+    /* Trigger immediate clock UI refresh */
+    clock_page_request_update();
+
+    s_last_poll_interval_s = cfg_snap.weather_poll_interval_s;
+    return true;
+}
+
+static uint32_t weather_interval_ms(void *arg) {
+    (void)arg;
+
+    /* Normal poll interval, clamped 15 min - 1 hour */
+    uint32_t interval_ms = s_last_poll_interval_s * 1000;
+    if (interval_ms < 900000)   interval_ms = 900000;   /* min 15 min */
+    if (interval_ms > 3600000)  interval_ms = 3600000;  /* max 1 hour */
+    return interval_ms;
+}
+
 static void weather_poll_task(void *arg) {
     (void)arg;
 
-    /* Wait for WiFi connection */
-    xEventGroupWaitBits(s_wifi_event_group, WIFI_CONNECTED_BIT,
-                        pdFALSE, pdFALSE, portMAX_DELAY);
-    ESP_LOGI(TAG, "WiFi connected, starting weather polling");
+    poll_loop_spec_t spec = {
+        .name = "weather",
+        .wifi_group = s_wifi_event_group,
+        .wifi_bits = WIFI_CONNECTED_BIT,
+        .page_active = &clock_page_active,
+        .poll_once = weather_poll_once,
+        .interval_ms = weather_interval_ms,
+        /* Both the "not configured" and "fetch failed" paths retry at a flat
+         * WEATHER_RETRY_INTERVAL_S: initial == max means poll_backoff_next()
+         * always returns WEATHER_RETRY_INTERVAL_S * 1000, never doubling. */
+        .backoff_initial_ms = WEATHER_RETRY_INTERVAL_S * 1000,
+        .backoff_max_ms = WEATHER_RETRY_INTERVAL_S * 1000,
+    };
 
-    while (1) {
-        /* Suspend during OTA updates or when Clock page is not visible */
-        while (ota_in_progress || !clock_page_active) {
-            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000));
-        }
-
-        app_config_t cfg_snap = app_config_get_snapshot();
-
-        /* Skip if no location configured */
-        bool has_location = (cfg_snap.weather_location_name[0] != '\0');
-        /* OWM and WU need an API key */
-        bool needs_key = (cfg_snap.weather_provider == 0 || cfg_snap.weather_provider == 2);
-        bool has_key   = (cfg_snap.weather_api_key[0] != '\0');
-
-        if (!has_location || (needs_key && !has_key)) {
-            ESP_LOGD(TAG, "Weather not configured (provider=%d), sleeping 60s",
-                     cfg_snap.weather_provider);
-            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(WEATHER_RETRY_INTERVAL_S * 1000));
-            continue;
-        }
-
-        /* Fetch from selected provider */
-        weather_data_t local;
-        memset(&local, 0, sizeof(local));
-        local.uv_index = -1.0f;
-
-        bool ok = false;
-        switch (cfg_snap.weather_provider) {
-            case 0:  ok = fetch_owm(&cfg_snap, &local);          break;
-            case 1:  ok = fetch_open_meteo(&cfg_snap, &local);   break;
-            case 2:  ok = fetch_wunderground(&cfg_snap, &local);  break;
-            default:
-                ESP_LOGW(TAG, "Unknown weather provider: %d", cfg_snap.weather_provider);
-                break;
-        }
-
-        if (ok) {
-            local.valid = true;
-            local.last_update_ts = (int64_t)time(NULL);
-
-            if (xSemaphoreTake(s_mutex, pdMS_TO_TICKS(200)) == pdTRUE) {
-                memcpy(&s_data, &local, sizeof(weather_data_t));
-                xSemaphoreGive(s_mutex);
-            }
-            ESP_LOGI(TAG, "Weather updated: %.1f%s, %s",
-                     local.temp_current,
-                     (cfg_snap.weather_units == 0) ? "F" : "C",
-                     local.condition);
-
-            /* Trigger immediate clock UI refresh */
-            clock_page_request_update();
-
-            /* Normal poll interval */
-            uint32_t interval_ms = (uint32_t)cfg_snap.weather_poll_interval_s * 1000;
-            if (interval_ms < 900000)   interval_ms = 900000;   /* min 15 min */
-            if (interval_ms > 3600000)  interval_ms = 3600000;  /* max 1 hour */
-            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(interval_ms));
-        } else {
-            ESP_LOGW(TAG, "Weather fetch failed, retrying in %ds", WEATHER_RETRY_INTERVAL_S);
-            ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(WEATHER_RETRY_INTERVAL_S * 1000));
-        }
-    }
+    poll_loop_run(&spec, NULL);
 }
 
 void weather_client_start(void) {

--- a/main/web_handlers_allsky.c
+++ b/main/web_handlers_allsky.c
@@ -1,5 +1,5 @@
 #include "web_server_internal.h"
-#include "esp_http_client.h"
+#include "http_fetch.h"
 #include "esp_heap_caps.h"
 #include <string.h>
 
@@ -11,6 +11,7 @@
  */
 esp_err_t allsky_config_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     app_config_t *cfg = app_config_get();
     cJSON *root = cJSON_CreateObject();
     if (root == NULL) {
@@ -45,6 +46,7 @@ esp_err_t allsky_config_get_handler(httpd_req_t *req)
  */
 esp_err_t allsky_proxy_get_handler(httpd_req_t *req)
 {
+    REQUIRE_AUTH(req);
     /* Snapshot the hostname into a local under the config mutex so the live
      * config is not read field-by-field during the (slow) outbound fetch.
      * app_config_t is ~7.6 KB — too large for the httpd stack, so snapshot into
@@ -70,71 +72,29 @@ esp_err_t allsky_proxy_get_handler(httpd_req_t *req)
     char url[192];
     snprintf(url, sizeof(url), "http://%s/all", allsky_hostname);
 
-    esp_http_client_config_t http_cfg = {
-        .url = url,
-        /* 3s outbound timeout: keep an httpd worker from blocking on a slow or
-         * unreachable AllSky host. */
+    /* One-shot fetch (conn=NULL): this runs on an httpd worker task, not a
+     * persistent poll loop, so there is no task-owned keep-alive slot to
+     * reuse here. 3s timeout keeps the httpd worker from blocking on a slow
+     * or unreachable AllSky host; cap matches the previous fixed buffer. */
+    http_fetch_opts_t opts = {
         .timeout_ms = 3000,
-        .buffer_size = 2048,
+        .max_response_bytes = ALLSKY_PROXY_BUF_SIZE,
     };
-    esp_http_client_handle_t client = esp_http_client_init(&http_cfg);
-    if (!client) {
-        httpd_resp_set_status(req, "502 Bad Gateway");
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_send(req, "{\"error\":\"Failed to create HTTP client\"}", HTTPD_RESP_USE_STRLEN);
-        return ESP_OK;
-    }
-
-    esp_err_t err = esp_http_client_open(client, 0);
+    char *body = NULL;
+    size_t body_len = 0;
+    esp_err_t err = http_fetch_text(url, &opts, &body, &body_len);
     if (err != ESP_OK) {
-        ESP_LOGW(TAG, "AllSky proxy: failed to connect to %s", url);
-        esp_http_client_cleanup(client);
+        ESP_LOGW(TAG, "AllSky proxy: fetch failed for %s (%s)", url, esp_err_to_name(err));
         httpd_resp_set_status(req, "502 Bad Gateway");
         httpd_resp_set_type(req, "application/json");
         httpd_resp_send(req, "{\"error\":\"Failed to reach AllSky API\"}", HTTPD_RESP_USE_STRLEN);
         return ESP_OK;
     }
-
-    int content_length = esp_http_client_fetch_headers(client);
-    int status = esp_http_client_get_status_code(client);
-
-    if (status != 200 || content_length <= 0) {
-        ESP_LOGW(TAG, "AllSky proxy: bad response status=%d content_length=%d", status, content_length);
-        esp_http_client_cleanup(client);
-        httpd_resp_set_status(req, "502 Bad Gateway");
-        httpd_resp_set_type(req, "application/json");
-        httpd_resp_send(req, "{\"error\":\"Failed to reach AllSky API\"}", HTTPD_RESP_USE_STRLEN);
-        return ESP_OK;
-    }
-
-    /* Cap to our buffer size */
-    if (content_length > ALLSKY_PROXY_BUF_SIZE - 1) {
-        content_length = ALLSKY_PROXY_BUF_SIZE - 1;
-    }
-
-    char *buffer = heap_caps_malloc(ALLSKY_PROXY_BUF_SIZE, MALLOC_CAP_SPIRAM);
-    if (!buffer) {
-        ESP_LOGE(TAG, "AllSky proxy: PSRAM malloc failed");
-        esp_http_client_cleanup(client);
-        httpd_resp_send_500(req);
-        return ESP_OK;
-    }
-
-    int total_read = 0;
-    while (total_read < content_length) {
-        int read_len = esp_http_client_read(client, buffer + total_read,
-                                            content_length - total_read);
-        if (read_len <= 0) break;
-        total_read += read_len;
-    }
-    buffer[total_read] = '\0';
-
-    esp_http_client_cleanup(client);
 
     /* Forward the AllSky JSON response to the browser */
     httpd_resp_set_type(req, "application/json");
-    httpd_resp_send(req, buffer, total_read);
+    httpd_resp_send(req, body, body_len);
 
-    free(buffer);
+    heap_caps_free(body);
     return ESP_OK;
 }

--- a/main/web_handlers_auth.c
+++ b/main/web_handlers_auth.c
@@ -179,7 +179,11 @@ esp_err_t login_post_handler(httpd_req_t *req)
     }
     cJSON_Delete(root);
 
-    if (diff != 0 || cfg->admin_password[0] == '\0') {
+    /* When auth is disabled every route is already open, so demanding the
+     * correct password here only breaks clients that unconditionally log in
+     * first (e.g. the OTA deploy script after a password change). Accept any
+     * password and issue a normal session. */
+    if (!auth_off && (diff != 0 || cfg->admin_password[0] == '\0')) {
         /* Failed attempt: bump counter, engage lockout at threshold. */
         auth_note_failure();
         httpd_resp_set_status(req, "401 Unauthorized");

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -11,7 +11,7 @@
 #include "ui/nina_dashboard_internal.h" /* PAGE_IDX_SUMMARY, SETTINGS_PAGE_IDX, SYSINFO_PAGE_IDX page-index macros */
 #include "ui/nina_nav_arbiter.h"        /* nav_arbiter_submit_user — live Home Page USER claim */
 #include "ui/page_registry.h"           /* page_ref_navigate, PAGE_REF_ID_MAX, PAGE_REF_SETTINGS */
-#include "ui/themes.h"                  /* themes_get_count() — theme_index clamp */
+#include "settings_table.h"             /* settings_json_serialize/parse — table-driven config JSON */
 
 extern const uint8_t config_html_start[] asm("_binary_config_ui_html_start");
 extern const uint8_t config_html_end[]   asm("_binary_config_ui_html_end");
@@ -19,6 +19,41 @@ extern const uint8_t setup_html_start[] asm("_binary_setup_ui_html_start");
 extern const uint8_t setup_html_end[]   asm("_binary_setup_ui_html_end");
 extern const uint8_t favicon_png_start[] asm("_binary_favicon_png_start");
 extern const uint8_t favicon_png_end[]   asm("_binary_favicon_png_end");
+
+/* P6b tab fragments -- see s_ui_fragments[] below for the lookup table these feed. */
+extern const uint8_t fragment_logs_html_start[] asm("_binary_fragment_logs_html_start");
+extern const uint8_t fragment_logs_html_end[]   asm("_binary_fragment_logs_html_end");
+extern const uint8_t fragment_backup_html_start[] asm("_binary_fragment_backup_html_start");
+extern const uint8_t fragment_backup_html_end[]   asm("_binary_fragment_backup_html_end");
+extern const uint8_t fragment_api_html_start[] asm("_binary_fragment_api_html_start");
+extern const uint8_t fragment_api_html_end[]   asm("_binary_fragment_api_html_end");
+
+/* P6c tab fragments. image-display's tab name has a hyphen; the embedded
+ * asset filename/symbol use an underscore (fragment_image_display.html),
+ * so the name->symbol mapping only lines up in the s_ui_fragments[] row
+ * below, not by naming convention alone. */
+extern const uint8_t fragment_allsky_html_start[] asm("_binary_fragment_allsky_html_start");
+extern const uint8_t fragment_allsky_html_end[]   asm("_binary_fragment_allsky_html_end");
+extern const uint8_t fragment_clock_html_start[] asm("_binary_fragment_clock_html_start");
+extern const uint8_t fragment_clock_html_end[]   asm("_binary_fragment_clock_html_end");
+extern const uint8_t fragment_spotify_html_start[] asm("_binary_fragment_spotify_html_start");
+extern const uint8_t fragment_spotify_html_end[]   asm("_binary_fragment_spotify_html_end");
+extern const uint8_t fragment_image_display_html_start[] asm("_binary_fragment_image_display_html_start");
+extern const uint8_t fragment_image_display_html_end[]   asm("_binary_fragment_image_display_html_end");
+
+/* P6d tab fragments -- final wave. Extracts the remaining four tabs (nodes,
+ * display, behavior, system), completing the migration: all 11 tabs now ship
+ * as lazily-fetched fragments and config_ui.html holds only the tab shell,
+ * loader machinery, and the shared JS (see config_ui.html's Tab Fragment
+ * Loader section for LAZY_TABS/loadedTabs). */
+extern const uint8_t fragment_nodes_html_start[] asm("_binary_fragment_nodes_html_start");
+extern const uint8_t fragment_nodes_html_end[]   asm("_binary_fragment_nodes_html_end");
+extern const uint8_t fragment_display_html_start[] asm("_binary_fragment_display_html_start");
+extern const uint8_t fragment_display_html_end[]   asm("_binary_fragment_display_html_end");
+extern const uint8_t fragment_behavior_html_start[] asm("_binary_fragment_behavior_html_start");
+extern const uint8_t fragment_behavior_html_end[]   asm("_binary_fragment_behavior_html_end");
+extern const uint8_t fragment_system_html_start[] asm("_binary_fragment_system_html_start");
+extern const uint8_t fragment_system_html_end[]   asm("_binary_fragment_system_html_end");
 
 // Handler for root URL
 esp_err_t root_get_handler(httpd_req_t *req)
@@ -33,6 +68,72 @@ esp_err_t root_get_handler(httpd_req_t *req)
     httpd_resp_set_type(req, "text/html");
     httpd_resp_send(req, (const char *)config_html_start,
                     config_html_end - config_html_start);
+    return ESP_OK;
+}
+
+/**
+ * @brief One row of the tab-fragment lookup table: a `tab` query value maps
+ * to an embedded HTML asset's start/end pointers (same EMBED_TXTFILES
+ * pattern as config_html_start/end above).
+ */
+typedef struct {
+    const char *name;
+    const uint8_t *start;
+    const uint8_t *end;
+} ui_fragment_entry_t;
+
+/*
+ * Fragment table for GET /ui/fragment?tab=<name> -- serves one config_ui.html
+ * tab's markup as a standalone HTML asset, fetched lazily by the browser on
+ * tab activation (see ensureTabLoaded() in config_ui.html). P6a landed only
+ * the loader machinery (table empty, every lookup 404s). P6b extracted logs,
+ * backup, and api. P6c extracted allsky, clock, spotify, and image-display.
+ * P6d (final wave) extracts the remaining four -- nodes, display, behavior,
+ * system -- so every tab now ships as its own fragment_NAME.html and none
+ * remain inline in config_ui.html. The "image-display" row is the one
+ * name/symbol mismatch: the tab name has a hyphen, but embedded-asset
+ * symbols cannot contain one, so the file is fragment_image_display.html
+ * and only this table maps the hyphenated tab name to the underscored
+ * symbol.
+ */
+static const ui_fragment_entry_t s_ui_fragments[] = {
+    { "__none__", NULL, NULL },  /* placeholder so the array type-checks; never matches a real tab name */
+    { "logs",   fragment_logs_html_start,   fragment_logs_html_end },
+    { "backup", fragment_backup_html_start, fragment_backup_html_end },
+    { "api",    fragment_api_html_start,    fragment_api_html_end },
+    { "allsky",        fragment_allsky_html_start,        fragment_allsky_html_end },
+    { "clock",         fragment_clock_html_start,         fragment_clock_html_end },
+    { "spotify",       fragment_spotify_html_start,       fragment_spotify_html_end },
+    { "image-display", fragment_image_display_html_start, fragment_image_display_html_end },
+    { "nodes",         fragment_nodes_html_start,         fragment_nodes_html_end },
+    { "display",       fragment_display_html_start,       fragment_display_html_end },
+    { "behavior",      fragment_behavior_html_start,      fragment_behavior_html_end },
+    { "system",        fragment_system_html_start,        fragment_system_html_end },
+};
+
+// Handler for GET /ui/fragment?tab=<name> -- serves one lazily-loaded config_ui.html tab fragment.
+esp_err_t ui_fragment_get_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    char qbuf[64] = {0};
+    char tab[32] = {0};
+    if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+        httpd_query_key_value(qbuf, "tab", tab, sizeof(tab));
+    }
+
+    for (size_t i = 0; i < sizeof(s_ui_fragments) / sizeof(s_ui_fragments[0]); i++) {
+        if (s_ui_fragments[i].start != NULL && strcmp(s_ui_fragments[i].name, tab) == 0) {
+            httpd_resp_set_type(req, "text/html");
+            httpd_resp_send(req, (const char *)s_ui_fragments[i].start,
+                             s_ui_fragments[i].end - s_ui_fragments[i].start);
+            return ESP_OK;
+        }
+    }
+
+    httpd_resp_set_status(req, "404 Not Found");
+    httpd_resp_set_type(req, "text/plain");
+    httpd_resp_send(req, "unknown fragment", HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 
@@ -59,12 +160,20 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
 
     cJSON_AddNumberToObject(obj, "config_version", APP_CONFIG_VERSION);
 
-    cJSON_AddStringToObject(obj, "hostname", cfg->hostname);
+    /* Every "simple" field (plain default + optional range check) is driven
+     * from the single SETTINGS_TABLE X-macro in settings_table.h/.c. This
+     * covers the large majority of scalar fields below; anything NOT covered
+     * (arrays, JSON-blob strings, secrets, cross-field page targets) keeps
+     * its hand-written call below, in original relative order. */
+    settings_json_serialize(cfg, obj);
+    /* idle_page_persistent is a SETTINGS_TABLE row (kept there only for
+     * settings_defaults_apply()/settings_clamp_apply() consistency) but is
+     * retired/unread outside app_config.c migrations; never expose it. */
+    cJSON_DeleteItemFromObject(obj, "idle_page_persistent");
+
     cJSON_AddStringToObject(obj, "url1", cfg->api_url[0]);
     cJSON_AddStringToObject(obj, "url2", cfg->api_url[1]);
     cJSON_AddStringToObject(obj, "url3", cfg->api_url[2]);
-    cJSON_AddStringToObject(obj, "ntp", cfg->ntp_server);
-    cJSON_AddStringToObject(obj, "timezone", cfg->tz_string);
     cJSON_AddStringToObject(obj, "filter_colors_1", cfg->filter_colors[0]);
     cJSON_AddStringToObject(obj, "filter_colors_2", cfg->filter_colors[1]);
     cJSON_AddStringToObject(obj, "filter_colors_3", cfg->filter_colors[2]);
@@ -74,21 +183,8 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     cJSON_AddStringToObject(obj, "hfr_thresholds_1", cfg->hfr_thresholds[0]);
     cJSON_AddStringToObject(obj, "hfr_thresholds_2", cfg->hfr_thresholds[1]);
     cJSON_AddStringToObject(obj, "hfr_thresholds_3", cfg->hfr_thresholds[2]);
-    cJSON_AddNumberToObject(obj, "theme_index", cfg->theme_index);
-    cJSON_AddNumberToObject(obj, "widget_style", cfg->widget_style);
-    cJSON_AddNumberToObject(obj, "brightness", cfg->brightness);
-    cJSON_AddNumberToObject(obj, "color_brightness", cfg->color_brightness);
-    cJSON_AddBoolToObject(obj, "mqtt_enabled", cfg->mqtt_enabled);
-    cJSON_AddStringToObject(obj, "mqtt_broker_url", cfg->mqtt_broker_url);
-    cJSON_AddNumberToObject(obj, "mqtt_port", cfg->mqtt_port);
-    cJSON_AddStringToObject(obj, "mqtt_username", cfg->mqtt_username);
     cJSON_AddStringToObject(obj, "mqtt_password", cfg->mqtt_password);
-    cJSON_AddStringToObject(obj, "mqtt_topic_prefix", cfg->mqtt_topic_prefix);
     cJSON_AddNumberToObject(obj, "active_page_override", cfg->active_page_override);
-    cJSON_AddBoolToObject(obj, "auto_rotate_enabled", cfg->auto_rotate_enabled);
-    cJSON_AddNumberToObject(obj, "auto_rotate_interval_s", cfg->auto_rotate_interval_s);
-    cJSON_AddNumberToObject(obj, "auto_rotate_effect", cfg->auto_rotate_effect);
-    cJSON_AddBoolToObject(obj, "auto_rotate_skip_disconnected", cfg->auto_rotate_skip_disconnected);
     cJSON_AddNumberToObject(obj, "auto_rotate_pages",
         (int)cfg->auto_rotate_pages | ((int)cfg->auto_rotate_pages_hi << 8));
     {
@@ -118,98 +214,23 @@ static cJSON *serialize_config_to_json(const app_config_t *cfg)
     }
     cJSON_AddNumberToObject(obj, "update_rate_s", cfg->update_rate_s);
     cJSON_AddNumberToObject(obj, "graph_update_interval_s", cfg->graph_update_interval_s);
-    cJSON_AddNumberToObject(obj, "connection_timeout_s", cfg->connection_timeout_s);
-    cJSON_AddNumberToObject(obj, "toast_duration_s", cfg->toast_duration_s);
-    cJSON_AddBoolToObject(obj, "debug_mode", cfg->debug_mode);
-    cJSON_AddBoolToObject(obj, "demo_mode", cfg->demo_mode);
     cJSON_AddBoolToObject(obj, "instance_enabled_1", cfg->instance_enabled[0]);
     cJSON_AddBoolToObject(obj, "instance_enabled_2", cfg->instance_enabled[1]);
     cJSON_AddBoolToObject(obj, "instance_enabled_3", cfg->instance_enabled[2]);
-    cJSON_AddBoolToObject(obj, "screen_sleep_enabled", cfg->screen_sleep_enabled);
-    cJSON_AddNumberToObject(obj, "screen_sleep_timeout_s", cfg->screen_sleep_timeout_s);
-    cJSON_AddBoolToObject(obj, "alert_flash_enabled", cfg->alert_flash_enabled);
-    cJSON_AddNumberToObject(obj, "idle_poll_interval_s", cfg->idle_poll_interval_s);
-    cJSON_AddBoolToObject(obj, "wifi_power_save", cfg->wifi_power_save);
-    cJSON_AddBoolToObject(obj, "deep_sleep_enabled", cfg->deep_sleep_enabled);
-    cJSON_AddNumberToObject(obj, "deep_sleep_wake_timer_s", cfg->deep_sleep_wake_timer_s);
-    cJSON_AddBoolToObject(obj, "deep_sleep_on_idle", cfg->deep_sleep_on_idle);
-    cJSON_AddBoolToObject(obj, "auto_update_check", cfg->auto_update_check);
-    cJSON_AddNumberToObject(obj, "update_channel", cfg->update_channel);
-    cJSON_AddNumberToObject(obj, "screen_rotation", cfg->screen_rotation);
-    cJSON_AddBoolToObject(obj, "allsky_enabled", cfg->allsky_enabled);
-    cJSON_AddStringToObject(obj, "allsky_hostname", cfg->allsky_hostname);
-    cJSON_AddNumberToObject(obj, "allsky_update_interval_s", cfg->allsky_update_interval_s);
-    cJSON_AddNumberToObject(obj, "allsky_dew_offset", (double)cfg->allsky_dew_offset);
     cJSON_AddStringToObject(obj, "allsky_field_config", cfg->allsky_field_config);
     cJSON_AddStringToObject(obj, "allsky_thresholds", cfg->allsky_thresholds);
-    cJSON_AddBoolToObject(obj, "spotify_enabled", cfg->spotify_enabled);
     cJSON_AddStringToObject(obj, "spotify_client_id", cfg->spotify_client_id);
-    cJSON_AddNumberToObject(obj, "spotify_poll_interval_ms", cfg->spotify_poll_interval_ms);
-    cJSON_AddBoolToObject(obj, "spotify_show_progress_bar", cfg->spotify_show_progress_bar);
-    cJSON_AddBoolToObject(obj, "spotify_minimal_mode", cfg->spotify_minimal_mode);
-    cJSON_AddBoolToObject(obj, "spotify_scroll_text", cfg->spotify_scroll_text);
-    cJSON_AddNumberToObject(obj, "spotify_overlay_timeout_s", cfg->spotify_overlay_timeout_s);
-    cJSON_AddBoolToObject(obj, "spotify_overlay_visible", cfg->spotify_overlay_visible);
-    cJSON_AddBoolToObject(obj, "image_display_enabled", cfg->image_display_enabled);
-    cJSON_AddBoolToObject(obj, "image_display_show_overlay", cfg->image_display_show_overlay);
-    cJSON_AddBoolToObject(obj, "image_display_crop", cfg->image_display_crop);
-    cJSON_AddStringToObject(obj, "goes_region", cfg->goes_region);
-    cJSON_AddNumberToObject(obj, "goes_update_interval_s", cfg->goes_update_interval_s);
-    cJSON_AddNumberToObject(obj, "image_display_source", cfg->image_display_source);
-    cJSON_AddStringToObject(obj, "custom_image_url", cfg->custom_image_url);
-    cJSON_AddNumberToObject(obj, "custom_orientation", cfg->custom_orientation);
-    cJSON_AddNumberToObject(obj, "custom_update_interval_s", cfg->custom_update_interval_s);
-    cJSON_AddNumberToObject(obj, "moon_bg_style", cfg->moon_bg_style);
-    cJSON_AddNumberToObject(obj, "moon_lat", (double)cfg->moon_lat);
-    cJSON_AddNumberToObject(obj, "moon_lon", (double)cfg->moon_lon);
-    cJSON_AddNumberToObject(obj, "solar_band", cfg->solar_band);
     cJSON_AddNumberToObject(obj, "moon_drag_light_mode", cfg->moon_drag_light_mode);
-    cJSON_AddNumberToObject(obj, "goes_vflip", cfg->goes_vflip);
-    cJSON_AddNumberToObject(obj, "goes_hflip", cfg->goes_hflip);
-    cJSON_AddNumberToObject(obj, "solar_vflip", cfg->solar_vflip);
-    cJSON_AddNumberToObject(obj, "solar_hflip", cfg->solar_hflip);
-    cJSON_AddNumberToObject(obj, "custom_vflip", cfg->custom_vflip);
-    cJSON_AddNumberToObject(obj, "custom_hflip", cfg->custom_hflip);
-    cJSON_AddNumberToObject(obj, "moon_flip_u", cfg->moon_flip_u);
-    cJSON_AddNumberToObject(obj, "moon_flip_v", cfg->moon_flip_v);
-    cJSON_AddNumberToObject(obj, "moon_roll_offset", (double)cfg->moon_roll_offset);
-    cJSON_AddNumberToObject(obj, "moon_yaw_offset", (double)cfg->moon_yaw_offset);
-    cJSON_AddNumberToObject(obj, "moon_pitch_offset", (double)cfg->moon_pitch_offset);
-    cJSON_AddNumberToObject(obj, "moon_north_up", cfg->moon_north_up);
-    cJSON_AddNumberToObject(obj, "moon_spin_mode", cfg->moon_spin_mode);
-    cJSON_AddNumberToObject(obj, "moon_spin_return_s", cfg->moon_spin_return_s);
-    cJSON_AddNumberToObject(obj, "toast_aggregation_window_s", cfg->toast_aggregation_window_s);
     cJSON_AddNumberToObject(obj, "toast_notify_mask", cfg->toast_notify_mask);
     cJSON_AddBoolToObject(obj, "toast_instance_muted_1", cfg->toast_instance_muted[0]);
     cJSON_AddBoolToObject(obj, "toast_instance_muted_2", cfg->toast_instance_muted[1]);
     cJSON_AddBoolToObject(obj, "toast_instance_muted_3", cfg->toast_instance_muted[2]);
 
-    // Weather
-    cJSON_AddNumberToObject(obj, "weather_provider", cfg->weather_provider);
-    cJSON_AddStringToObject(obj, "weather_api_key", cfg->weather_api_key);
-    cJSON_AddNumberToObject(obj, "weather_lat", (double)cfg->weather_lat);
-    cJSON_AddNumberToObject(obj, "weather_lon", (double)cfg->weather_lon);
-    cJSON_AddStringToObject(obj, "weather_location_name", cfg->weather_location_name);
-    cJSON_AddNumberToObject(obj, "weather_poll_interval_s", cfg->weather_poll_interval_s);
-    cJSON_AddNumberToObject(obj, "weather_units", cfg->weather_units);
-    cJSON_AddNumberToObject(obj, "weather_time_format", cfg->weather_time_format);
-
-    // Idle override
-    cJSON_AddBoolToObject(obj, "idle_page_override_enabled", cfg->idle_page_override_enabled);
+    // Idle override (target excluded from the table: cross-field page-registry semantics)
     cJSON_AddNumberToObject(obj, "idle_page_override_target", cfg->idle_page_override_target);
-    cJSON_AddBoolToObject(obj, "idle_indicator_enabled", cfg->idle_indicator_enabled);
-
-    // Navigation grace window (USER manual-nav hold time, seconds)
-    cJSON_AddNumberToObject(obj, "nav_grace_s", cfg->nav_grace_s);
 
     // Home Page lock (always show the Home Page regardless of connection state)
     cJSON_AddBoolToObject(obj, "home_page_lock", cfg->home_page_lock);
-
-    // Authentication
-    cJSON_AddBoolToObject(obj, "auth_enabled", cfg->auth_enabled);
-
-    // Crash log
-    cJSON_AddNumberToObject(obj, "crash_log_retention_days", cfg->crash_log_retention_days);
 
     return obj;
 }
@@ -898,26 +919,17 @@ static app_config_t *parse_config_from_json(cJSON *root)
     }
     memcpy(cfg, app_config_get(), sizeof(app_config_t));
 
-    JSON_TO_STRING(root, "hostname",       cfg->hostname);
+    /* Every "simple" field (plain default + optional range check) is driven
+     * from the single SETTINGS_TABLE X-macro in settings_table.h/.c. This
+     * covers the large majority of scalar fields below; anything NOT covered
+     * (arrays, JSON-blob strings, secrets with sentinel handling, cross-field
+     * page targets) keeps its hand-written parse below, in original relative
+     * order. */
+    settings_json_parse(root, cfg);
+
     JSON_TO_STRING(root, "url1",           cfg->api_url[0]);
     JSON_TO_STRING(root, "url2",           cfg->api_url[1]);
     JSON_TO_STRING(root, "url3",           cfg->api_url[2]);
-    JSON_TO_STRING(root, "ntp",            cfg->ntp_server);
-    JSON_TO_STRING(root, "timezone",       cfg->tz_string);
-    cJSON *ti_item = cJSON_GetObjectItem(root, "theme_index");
-    if (cJSON_IsNumber(ti_item)) {
-        int v = ti_item->valueint;
-        if (v < 0) v = 0;
-        if (v >= themes_get_count()) v = themes_get_count() - 1;
-        cfg->theme_index = v;
-    }
-    cJSON *ws_item = cJSON_GetObjectItem(root, "widget_style");
-    if (cJSON_IsNumber(ws_item)) {
-        int v = ws_item->valueint;
-        if (v < 0) v = 0;
-        if (v >= WIDGET_STYLE_COUNT) v = WIDGET_STYLE_COUNT - 1;
-        cfg->widget_style = (uint8_t)v;
-    }
     JSON_TO_STRING(root, "filter_colors_1", cfg->filter_colors[0]);
     JSON_TO_STRING(root, "filter_colors_2", cfg->filter_colors[1]);
     JSON_TO_STRING(root, "filter_colors_3", cfg->filter_colors[2]);
@@ -927,9 +939,6 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_STRING(root, "hfr_thresholds_1", cfg->hfr_thresholds[0]);
     JSON_TO_STRING(root, "hfr_thresholds_2", cfg->hfr_thresholds[1]);
     JSON_TO_STRING(root, "hfr_thresholds_3", cfg->hfr_thresholds[2]);
-    JSON_TO_BOOL  (root, "mqtt_enabled",   cfg->mqtt_enabled);
-    JSON_TO_STRING(root, "mqtt_broker_url", cfg->mqtt_broker_url);
-    JSON_TO_STRING(root, "mqtt_username",  cfg->mqtt_username);
     /* mqtt_password: skip write if value equals "********" sentinel */
     {
         cJSON *_mp = cJSON_GetObjectItem(root, "mqtt_password");
@@ -938,32 +947,6 @@ static app_config_t *parse_config_from_json(cJSON *root)
             cfg->mqtt_password[sizeof(cfg->mqtt_password) - 1] = '\0';
         }
     }
-    JSON_TO_STRING(root, "mqtt_topic_prefix", cfg->mqtt_topic_prefix);
-
-    // Clamped int fields
-    cJSON *brightness = cJSON_GetObjectItem(root, "brightness");
-    if (cJSON_IsNumber(brightness)) {
-        int val = brightness->valueint;
-        if (val < 0) val = 0;
-        if (val > 100) val = 100;
-        cfg->brightness = val;
-    }
-
-    cJSON *color_brightness = cJSON_GetObjectItem(root, "color_brightness");
-    if (cJSON_IsNumber(color_brightness)) {
-        int val = color_brightness->valueint;
-        if (val < 0) val = 0;
-        if (val > 100) val = 100;
-        cfg->color_brightness = val;
-    }
-
-    cJSON *mqtt_port = cJSON_GetObjectItem(root, "mqtt_port");
-    if (cJSON_IsNumber(mqtt_port)) {
-        cfg->mqtt_port = (uint16_t)mqtt_port->valueint;
-    }
-
-    JSON_TO_BOOL(root, "auto_rotate_enabled", cfg->auto_rotate_enabled);
-    JSON_TO_BOOL(root, "auto_rotate_skip_disconnected", cfg->auto_rotate_skip_disconnected);
 
     /* Home Page now stores a page_ref registry id (0..PAGE_REF_ID_MAX-1). The web
      * UI always sends a concrete id (never -1). Reject out-of-range ids and the
@@ -976,22 +959,6 @@ static app_config_t *parse_config_from_json(cJSON *root)
             v = 0;   /* Summary */
         }
         cfg->active_page_override = (int8_t)v;
-    }
-
-    cJSON *ari_item = cJSON_GetObjectItem(root, "auto_rotate_interval_s");
-    if (cJSON_IsNumber(ari_item)) {
-        int v = ari_item->valueint;
-        if (v < 0) v = 0;
-        if (v > 3600) v = 3600;
-        cfg->auto_rotate_interval_s = (uint16_t)v;
-    }
-
-    cJSON *are_item = cJSON_GetObjectItem(root, "auto_rotate_effect");
-    if (cJSON_IsNumber(are_item)) {
-        int v = are_item->valueint;
-        if (v < 0) v = 0;
-        if (v > 3) v = 3;
-        cfg->auto_rotate_effect = (uint8_t)v;
     }
 
     /* The slideshow list is the single ordered auto_rotate_order[] + ext list:
@@ -1051,100 +1018,13 @@ static app_config_t *parse_config_from_json(cJSON *root)
         cfg->graph_update_interval_s = (uint8_t)v;
     }
 
-    cJSON *ct_item = cJSON_GetObjectItem(root, "connection_timeout_s");
-    if (cJSON_IsNumber(ct_item)) {
-        int v = ct_item->valueint;
-        if (v < 2) v = 2;
-        if (v > 30) v = 30;
-        cfg->connection_timeout_s = (uint8_t)v;
-    }
-
-    cJSON *td_item = cJSON_GetObjectItem(root, "toast_duration_s");
-    if (cJSON_IsNumber(td_item)) {
-        int v = td_item->valueint;
-        if (v < 3) v = 3;
-        if (v > 30) v = 30;
-        cfg->toast_duration_s = (uint8_t)v;
-    }
-
-    JSON_TO_BOOL(root, "debug_mode", cfg->debug_mode);
-    JSON_TO_BOOL(root, "demo_mode", cfg->demo_mode);
     JSON_TO_BOOL(root, "instance_enabled_1", cfg->instance_enabled[0]);
     JSON_TO_BOOL(root, "instance_enabled_2", cfg->instance_enabled[1]);
     JSON_TO_BOOL(root, "instance_enabled_3", cfg->instance_enabled[2]);
 
-    JSON_TO_BOOL(root, "screen_sleep_enabled", cfg->screen_sleep_enabled);
-    JSON_TO_BOOL(root, "alert_flash_enabled", cfg->alert_flash_enabled);
-    cJSON *sst_item = cJSON_GetObjectItem(root, "screen_sleep_timeout_s");
-    if (cJSON_IsNumber(sst_item)) {
-        int v = sst_item->valueint;
-        if (v < 10) v = 10;
-        if (v > 3600) v = 3600;
-        cfg->screen_sleep_timeout_s = (uint16_t)v;
-    }
-
-    cJSON *ipi_item = cJSON_GetObjectItem(root, "idle_poll_interval_s");
-    if (cJSON_IsNumber(ipi_item)) {
-        int v = ipi_item->valueint;
-        if (v < 5) v = 5;
-        if (v > 120) v = 120;
-        cfg->idle_poll_interval_s = (uint8_t)v;
-    }
-
-    JSON_TO_BOOL(root, "wifi_power_save", cfg->wifi_power_save);
-
-    JSON_TO_BOOL(root, "deep_sleep_enabled", cfg->deep_sleep_enabled);
-    JSON_TO_BOOL(root, "deep_sleep_on_idle", cfg->deep_sleep_on_idle);
-
-    cJSON *dswt_item = cJSON_GetObjectItem(root, "deep_sleep_wake_timer_s");
-    if (cJSON_IsNumber(dswt_item)) {
-        int v = dswt_item->valueint;
-        if (v < 0) v = 0;
-        if (v > 259200) v = 259200;  // max 72 hours in seconds
-        cfg->deep_sleep_wake_timer_s = (uint32_t)v;
-    }
-
-    cJSON *auto_update = cJSON_GetObjectItem(root, "auto_update_check");
-    if (cJSON_IsBool(auto_update)) {
-        cfg->auto_update_check = cJSON_IsTrue(auto_update) ? 1 : 0;
-    }
-    cJSON *update_ch = cJSON_GetObjectItem(root, "update_channel");
-    if (cJSON_IsNumber(update_ch)) {
-        int v = update_ch->valueint;
-        if (v < 0 || v > 2) v = 0;
-        cfg->update_channel = (uint8_t)v;
-    }
-
-    cJSON *rot_item = cJSON_GetObjectItem(root, "screen_rotation");
-    if (cJSON_IsNumber(rot_item)) {
-        int v = rot_item->valueint;
-        if (v < 0) v = 0;
-        if (v > 3) v = 3;
-        cfg->screen_rotation = (uint8_t)v;
-    }
-
-    JSON_TO_BOOL  (root, "allsky_enabled",      cfg->allsky_enabled);
-    JSON_TO_STRING(root, "allsky_hostname",      cfg->allsky_hostname);
     JSON_TO_STRING(root, "allsky_field_config",  cfg->allsky_field_config);
     JSON_TO_STRING(root, "allsky_thresholds",    cfg->allsky_thresholds);
 
-    cJSON *as_interval = cJSON_GetObjectItem(root, "allsky_update_interval_s");
-    if (cJSON_IsNumber(as_interval)) {
-        int v = as_interval->valueint;
-        if (v < 1) v = 1;
-        if (v > 300) v = 300;
-        cfg->allsky_update_interval_s = (uint16_t)v;
-    }
-
-    cJSON *as_dew = cJSON_GetObjectItem(root, "allsky_dew_offset");
-    if (cJSON_IsNumber(as_dew)) {
-        float v = (float)as_dew->valuedouble;
-        if (v < -50.0f) v = -50.0f;
-        if (v > 50.0f) v = 50.0f;
-        cfg->allsky_dew_offset = v;
-    }
-
-    JSON_TO_BOOL  (root, "spotify_enabled",           cfg->spotify_enabled);
     /* spotify_client_id: skip write if value equals "********" sentinel */
     {
         cJSON *_scid = cJSON_GetObjectItem(root, "spotify_client_id");
@@ -1154,136 +1034,11 @@ static app_config_t *parse_config_from_json(cJSON *root)
         }
     }
     /* admin_password is never accepted via /api/config — use /api/admin-password. */
-    cJSON *spi_item = cJSON_GetObjectItem(root, "spotify_poll_interval_ms");
-    if (cJSON_IsNumber(spi_item)) {
-        int v = spi_item->valueint;
-        if (v < 1000) v = 1000;
-        if (v > 30000) v = 30000;
-        cfg->spotify_poll_interval_ms = (uint16_t)v;
-    }
-    JSON_TO_BOOL  (root, "spotify_show_progress_bar",  cfg->spotify_show_progress_bar);
-    JSON_TO_BOOL  (root, "spotify_minimal_mode",       cfg->spotify_minimal_mode);
-    JSON_TO_BOOL  (root, "spotify_scroll_text",        cfg->spotify_scroll_text);
-    cJSON *sot_item = cJSON_GetObjectItem(root, "spotify_overlay_timeout_s");
-    if (cJSON_IsNumber(sot_item)) {
-        int v = sot_item->valueint;
-        if (v < 0) v = 0;
-        if (v > 255) v = 255;   /* uint8_t; 0 = never hide */
-        cfg->spotify_overlay_timeout_s = (uint8_t)v;
-    }
-    JSON_TO_BOOL  (root, "spotify_overlay_visible",   cfg->spotify_overlay_visible);
 
-    JSON_TO_BOOL  (root, "image_display_enabled",       cfg->image_display_enabled);
-    JSON_TO_BOOL  (root, "image_display_show_overlay",   cfg->image_display_show_overlay);
-    JSON_TO_BOOL  (root, "image_display_crop",           cfg->image_display_crop);
-    JSON_TO_STRING(root, "goes_region",                  cfg->goes_region);
-
-    cJSON *goes_interval = cJSON_GetObjectItem(root, "goes_update_interval_s");
-    if (cJSON_IsNumber(goes_interval)) {
-        int v = goes_interval->valueint;
-        if (v < 300) v = 300;
-        if (v > 7200) v = 7200;
-        cfg->goes_update_interval_s = (uint16_t)v;
-    }
-
-    cJSON *jimgsrc = cJSON_GetObjectItem(root, "image_display_source");
-    if (cJSON_IsNumber(jimgsrc)) {
-        int v = jimgsrc->valueint;
-        cfg->image_display_source = (v >= 0 && v <= 3) ? (uint8_t)v : 0;
-    }
-
-    JSON_TO_STRING(root, "custom_image_url", cfg->custom_image_url);
-    cJSON *custom_orient = cJSON_GetObjectItem(root, "custom_orientation");
-    if (cJSON_IsNumber(custom_orient)) {
-        int v = custom_orient->valueint;
-        cfg->custom_orientation = (v >= 0 && v <= 3) ? (uint8_t)v : 0;
-    }
-    cJSON *custom_interval = cJSON_GetObjectItem(root, "custom_update_interval_s");
-    if (cJSON_IsNumber(custom_interval)) {
-        int v = custom_interval->valueint;
-        if (v < 10) v = 10;
-        if (v > 7200) v = 7200;
-        cfg->custom_update_interval_s = (uint16_t)v;
-    }
-
-    cJSON *jmoonbg = cJSON_GetObjectItem(root, "moon_bg_style");
-    if (cJSON_IsNumber(jmoonbg)) {
-        int v = jmoonbg->valueint;
-        cfg->moon_bg_style = (v >= 0 && v <= 3) ? (uint8_t)v : 0;
-    }
-
-    cJSON *jmoonlat = cJSON_GetObjectItem(root, "moon_lat");
-    if (jmoonlat && cJSON_IsNumber(jmoonlat)) cfg->moon_lat = (float)jmoonlat->valuedouble;
-    cJSON *jmoonlon = cJSON_GetObjectItem(root, "moon_lon");
-    if (jmoonlon && cJSON_IsNumber(jmoonlon)) cfg->moon_lon = (float)jmoonlon->valuedouble;
-
-    cJSON *jsolarband = cJSON_GetObjectItem(root, "solar_band");
-    if (cJSON_IsNumber(jsolarband)) {
-        int v = jsolarband->valueint;
-        cfg->solar_band = (v >= 0 && v <= 17) ? (uint8_t)v : 0;
-    }
     cJSON *jmoondrag = cJSON_GetObjectItem(root, "moon_drag_light_mode");
     if (cJSON_IsNumber(jmoondrag)) {
         int v = jmoondrag->valueint;
         cfg->moon_drag_light_mode = (v >= 0 && v <= 2) ? (uint8_t)v : 0;
-    }
-
-    cJSON *jgoesvf = cJSON_GetObjectItem(root, "goes_vflip");
-    if (jgoesvf && cJSON_IsNumber(jgoesvf)) cfg->goes_vflip = (jgoesvf->valueint != 0) ? 1 : 0;
-    cJSON *jgoeshf = cJSON_GetObjectItem(root, "goes_hflip");
-    if (jgoeshf && cJSON_IsNumber(jgoeshf)) cfg->goes_hflip = (jgoeshf->valueint != 0) ? 1 : 0;
-    cJSON *jsolarvf = cJSON_GetObjectItem(root, "solar_vflip");
-    if (jsolarvf && cJSON_IsNumber(jsolarvf)) cfg->solar_vflip = (jsolarvf->valueint != 0) ? 1 : 0;
-    cJSON *jsolarhf = cJSON_GetObjectItem(root, "solar_hflip");
-    if (jsolarhf && cJSON_IsNumber(jsolarhf)) cfg->solar_hflip = (jsolarhf->valueint != 0) ? 1 : 0;
-    cJSON *jcustomvf = cJSON_GetObjectItem(root, "custom_vflip");
-    if (jcustomvf && cJSON_IsNumber(jcustomvf)) cfg->custom_vflip = (jcustomvf->valueint != 0) ? 1 : 0;
-    cJSON *jcustomhf = cJSON_GetObjectItem(root, "custom_hflip");
-    if (jcustomhf && cJSON_IsNumber(jcustomhf)) cfg->custom_hflip = (jcustomhf->valueint != 0) ? 1 : 0;
-
-    cJSON *jflipu = cJSON_GetObjectItem(root, "moon_flip_u");
-    if (jflipu && cJSON_IsNumber(jflipu)) cfg->moon_flip_u = (jflipu->valueint != 0) ? 1 : 0;
-    cJSON *jflipv = cJSON_GetObjectItem(root, "moon_flip_v");
-    if (jflipv && cJSON_IsNumber(jflipv)) cfg->moon_flip_v = (jflipv->valueint != 0) ? 1 : 0;
-    cJSON *jroll = cJSON_GetObjectItem(root, "moon_roll_offset");
-    if (jroll && cJSON_IsNumber(jroll)) {
-        float v = (float)jroll->valuedouble;
-        if (v < -180.0f) v = -180.0f;
-        if (v > 180.0f) v = 180.0f;
-        cfg->moon_roll_offset = v;
-    }
-    cJSON *jyaw = cJSON_GetObjectItem(root, "moon_yaw_offset");
-    if (jyaw && cJSON_IsNumber(jyaw)) {
-        float v = (float)jyaw->valuedouble;
-        if (v < -180.0f) v = -180.0f;
-        if (v > 180.0f) v = 180.0f;
-        cfg->moon_yaw_offset = v;
-    }
-    cJSON *jpitch = cJSON_GetObjectItem(root, "moon_pitch_offset");
-    if (jpitch && cJSON_IsNumber(jpitch)) {
-        float v = (float)jpitch->valuedouble;
-        if (v < -90.0f) v = -90.0f;
-        if (v > 90.0f) v = 90.0f;
-        cfg->moon_pitch_offset = v;
-    }
-    cJSON *jnorthup = cJSON_GetObjectItem(root, "moon_north_up");
-    if (jnorthup && cJSON_IsNumber(jnorthup)) cfg->moon_north_up = (jnorthup->valueint != 0) ? 1 : 0;
-    cJSON *jspinmode = cJSON_GetObjectItem(root, "moon_spin_mode");
-    if (jspinmode && cJSON_IsNumber(jspinmode)) cfg->moon_spin_mode = (jspinmode->valueint != 0) ? 1 : 0;
-    cJSON *jspinret = cJSON_GetObjectItem(root, "moon_spin_return_s");
-    if (jspinret && cJSON_IsNumber(jspinret)) {
-        int v = jspinret->valueint;
-        if (v < 3) v = 3;
-        if (v > 60) v = 60;
-        cfg->moon_spin_return_s = (uint8_t)v;
-    }
-
-    cJSON *taw_item = cJSON_GetObjectItem(root, "toast_aggregation_window_s");
-    if (cJSON_IsNumber(taw_item)) {
-        int v = taw_item->valueint;
-        if (v < 0) v = 0;
-        if (v > 15) v = 15;
-        cfg->toast_aggregation_window_s = (uint8_t)v;
     }
 
     cJSON *tnm_item = cJSON_GetObjectItem(root, "toast_notify_mask");
@@ -1299,40 +1054,6 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_BOOL(root, "toast_instance_muted_2", cfg->toast_instance_muted[1]);
     JSON_TO_BOOL(root, "toast_instance_muted_3", cfg->toast_instance_muted[2]);
 
-    // Weather
-    cJSON *jwxprov = cJSON_GetObjectItem(root, "weather_provider");
-    if (cJSON_IsNumber(jwxprov)) {
-        int v = jwxprov->valueint;
-        cfg->weather_provider = (v >= 0 && v <= 2) ? (uint8_t)v : 0;
-    }
-    JSON_TO_STRING(root, "weather_api_key", cfg->weather_api_key);
-
-    cJSON *jlat = cJSON_GetObjectItem(root, "weather_lat");
-    if (jlat && cJSON_IsNumber(jlat)) cfg->weather_lat = (float)jlat->valuedouble;
-    cJSON *jlon = cJSON_GetObjectItem(root, "weather_lon");
-    if (jlon && cJSON_IsNumber(jlon)) cfg->weather_lon = (float)jlon->valuedouble;
-
-    JSON_TO_STRING(root, "weather_location_name", cfg->weather_location_name);
-
-    cJSON *wpi_item = cJSON_GetObjectItem(root, "weather_poll_interval_s");
-    if (cJSON_IsNumber(wpi_item)) {
-        int v = wpi_item->valueint;
-        if (v < 900) v = 900;
-        if (v > 3600) v = 3600;
-        cfg->weather_poll_interval_s = (uint16_t)v;
-    }
-
-    cJSON *wu_item = cJSON_GetObjectItem(root, "weather_units");
-    if (cJSON_IsNumber(wu_item)) {
-        cfg->weather_units = (wu_item->valueint != 0) ? 1 : 0;  /* 0=imperial, 1=metric */
-    }
-    cJSON *wtf_item = cJSON_GetObjectItem(root, "weather_time_format");
-    if (cJSON_IsNumber(wtf_item)) {
-        cfg->weather_time_format = (wtf_item->valueint != 0) ? 1 : 0;  /* 0=12h, 1=24h */
-    }
-
-    // Idle override
-    JSON_TO_BOOL(root, "idle_page_override_enabled", cfg->idle_page_override_enabled);
     /* idle_page_override_target now stores a page_ref registry id
      * (0..PAGE_REF_ID_MAX-1). Out-of-range falls back to 0 (Summary).
      * PAGE_REF_ID_MAX comes from ui/page_registry.h. */
@@ -1342,32 +1063,10 @@ static app_config_t *parse_config_from_json(cJSON *root)
         if (v < 0 || v >= PAGE_REF_ID_MAX) v = 0;
         cfg->idle_page_override_target = (int8_t)v;
     }
-    JSON_TO_BOOL(root, "idle_indicator_enabled", cfg->idle_indicator_enabled);
-
-    // Manual navigation grace window (seconds). Clamp 10-300.
-    cJSON *grace = cJSON_GetObjectItem(root, "nav_grace_s");
-    if (cJSON_IsNumber(grace)) {
-        int v = grace->valueint;
-        if (v < 10) v = 10;
-        if (v > 300) v = 300;
-        cfg->nav_grace_s = (uint16_t)v;
-    }
 
     // Home Page lock (always show the Home Page). app_config_save() normalizes
     // exclusivity: the lock clears auto-rotate and idle override when set.
     JSON_TO_BOOL(root, "home_page_lock", cfg->home_page_lock);
-
-    // Authentication toggle
-    JSON_TO_BOOL(root, "auth_enabled", cfg->auth_enabled);
-
-    // Crash log retention (days; 0 = never, clamp to common preset range)
-    cJSON *clr_item = cJSON_GetObjectItem(root, "crash_log_retention_days");
-    if (cJSON_IsNumber(clr_item)) {
-        int v = clr_item->valueint;
-        if (v < 0) v = 0;
-        if (v > 255) v = 255;
-        cfg->crash_log_retention_days = (uint8_t)v;
-    }
 
     return cfg;
 }

--- a/main/web_route_auth.c
+++ b/main/web_route_auth.c
@@ -1,0 +1,15 @@
+#include "web_route_auth.h"
+
+bool route_auth_allows(route_auth_class_t cls, bool setup_mode, bool authed)
+{
+    switch (cls) {
+        case ROUTE_PUBLIC:
+            return true;
+        case ROUTE_SETUP_EXEMPT:
+            return setup_mode || authed;
+        case ROUTE_AUTH_REQUIRED:
+        default:
+            /* Fail closed: any unrecognized classification requires auth. */
+            return authed;
+    }
+}

--- a/main/web_route_auth.h
+++ b/main/web_route_auth.h
@@ -1,0 +1,40 @@
+#pragma once
+
+/**
+ * @file web_route_auth.h
+ * @brief Pure decision function for the default-deny web route auth gate.
+ *
+ * No ESP-IDF includes on purpose: this header (and its .c) must be
+ * host-testable with nothing beyond stdbool/stddef. All ESP-specific
+ * plumbing (session cookie check, setup-mode check, sending the 401/302)
+ * lives in main/web_server.c, which calls route_auth_allows() with the
+ * already-resolved booleans.
+ */
+
+#include <stdbool.h>
+
+/**
+ * Auth classification for a registered route. Enum value 0 is the
+ * fail-closed default: a route_entry_t that omits .auth in an aggregate
+ * initializer gets ROUTE_AUTH_REQUIRED, not accidental public access.
+ */
+typedef enum {
+    ROUTE_AUTH_REQUIRED = 0, /* default: session or X-Auth-Password required */
+    ROUTE_PUBLIC,            /* always reachable, no auth check performed */
+    ROUTE_SETUP_EXEMPT,      /* reachable during first-run setup mode, or with a valid session */
+} route_auth_class_t;
+
+/**
+ * @brief Decide whether a request to a classified route is allowed through.
+ *
+ * Truth table:
+ *   ROUTE_PUBLIC       -> always true
+ *   ROUTE_SETUP_EXEMPT -> setup_mode || authed
+ *   ROUTE_AUTH_REQUIRED (or any unrecognized value) -> authed
+ *
+ * @param cls        route classification
+ * @param setup_mode true when the device is in first-run WiFi setup mode
+ * @param authed     true when the caller already has a valid session/header auth
+ * @return true if the request should be dispatched to its handler
+ */
+bool route_auth_allows(route_auth_class_t cls, bool setup_mode, bool authed);

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -1,9 +1,11 @@
 #include "web_server.h"
 #include "web_server_internal.h"
+#include "web_route_auth.h"
 #include <string.h>
 #include "esp_random.h"
 #include "esp_timer.h"
 #include "freertos/FreeRTOS.h"
+#include "ui/nina_setup_screen.h" /* is_setup_mode() */
 
 /* ---- Session store ---- */
 #define MAX_SESSIONS 8
@@ -232,6 +234,54 @@ bool validate_url_format(const char *url) {
             strncmp(url, "mqtts://", 8) == 0);
 }
 
+/**
+ * @brief One route table entry: the httpd_uri_t plus its auth classification.
+ *
+ * Aggregate-initializing only the first two/three fields of `uri` and
+ * omitting `.auth` entirely yields ROUTE_AUTH_REQUIRED (enum value 0) --
+ * a new route is secured by default unless explicitly marked otherwise.
+ */
+typedef struct {
+    httpd_uri_t uri;
+    route_auth_class_t auth;
+} route_entry_t;
+
+/**
+ * @brief Single registration-point auth gate. Registered as the handler for
+ * every route; the real handler is reached only after route_auth_allows()
+ * says so. req->user_ctx points at the owning route_entry_t (set at
+ * registration time below), so the classification and real handler are
+ * always looked up together -- no per-handler auth code to forget.
+ */
+static esp_err_t auth_gate_handler(httpd_req_t *req)
+{
+    const route_entry_t *entry = (const route_entry_t *)req->user_ctx;
+    bool setup_mode = is_setup_mode();
+    bool authed = false;
+
+    switch (entry->auth) {
+        case ROUTE_PUBLIC:
+            /* Never touch check_session() here: PUBLIC routes must not be
+             * able to trip the X-Auth-Password lockout counter. */
+            return entry->uri.handler(req);
+        case ROUTE_SETUP_EXEMPT:
+            if (setup_mode) {
+                return entry->uri.handler(req);
+            }
+            authed = check_session(req);
+            break;
+        case ROUTE_AUTH_REQUIRED:
+        default:
+            authed = check_session(req);
+            break;
+    }
+
+    if (!route_auth_allows(entry->auth, setup_mode, authed)) {
+        return send_auth_required(req);
+    }
+    return entry->uri.handler(req);
+}
+
 void start_web_server(void)
 {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
@@ -252,74 +302,79 @@ void start_web_server(void)
         return;
     }
 
-    static const httpd_uri_t routes[] = {
-        { "/",                     HTTP_GET,  root_get_handler, NULL },
-        { "/favicon.ico",          HTTP_GET,  favicon_get_handler, NULL },
-        { "/api/config",           HTTP_GET,  config_get_handler, NULL },
-        { "/api/config",           HTTP_POST, config_post_handler, NULL },
-        { "/api/brightness",       HTTP_POST, brightness_post_handler, NULL },
-        { "/api/color-brightness", HTTP_POST, color_brightness_post_handler, NULL },
-        { "/api/theme",            HTTP_POST, theme_post_handler, NULL },
-        { "/api/widget-style",     HTTP_POST, widget_style_post_handler, NULL },
-        { "/api/reboot",           HTTP_POST, reboot_post_handler, NULL },
-        { "/api/factory-reset",    HTTP_POST, factory_reset_post_handler, NULL },
-        { "/api/screenshot",       HTTP_GET,  screenshot_get_handler, NULL },
-        { "/api/page",             HTTP_POST, page_post_handler, NULL },
-        { "/api/screen-rotation", HTTP_POST, screen_rotation_post_handler, NULL },
-        { "/api/version",          HTTP_GET,  version_get_handler, NULL },
-        { "/api/ota",              HTTP_POST, ota_post_handler, NULL },
-        { "/api/perf",             HTTP_GET,  perf_get_handler, NULL },
-        { "/api/perf/reset",       HTTP_POST, perf_reset_post_handler, NULL },
-        { "/api/config/apply",     HTTP_POST, config_apply_handler, NULL },
-        { "/api/config/revert",    HTTP_POST, config_revert_handler, NULL },
-        { "/api/check-update",     HTTP_POST, check_update_post_handler, NULL },
-        { "/api/check-update-json", HTTP_GET, check_update_json_handler, NULL },
-        { "/api/ota-github",       HTTP_POST, ota_github_post_handler, NULL },
-        { "/api/allsky-config",    HTTP_GET,  allsky_config_get_handler, NULL },
-        { "/api/allsky-proxy",     HTTP_GET,  allsky_proxy_get_handler, NULL },
-        { "/api/spotify/config",         HTTP_GET,  spotify_config_get_handler, NULL },
-        { "/api/spotify/config",         HTTP_POST, spotify_config_post_handler, NULL },
-        { "/api/spotify/callback",       HTTP_GET,  spotify_callback_get_handler, NULL },
-        { "/api/spotify/token-exchange", HTTP_POST, spotify_token_exchange_post_handler, NULL },
-        { "/api/spotify/logout",         HTTP_POST, spotify_logout_post_handler, NULL },
-        { "/api/spotify/status",         HTTP_GET,  spotify_status_get_handler, NULL },
-        { "/api/spotify/control",        HTTP_POST, spotify_control_post_handler, NULL },
-        { "/api/image-display-config",   HTTP_GET,  image_display_config_get_handler, NULL },
-        { "/api/image-display-config",   HTTP_POST, image_display_config_post_handler, NULL },
-        { "/api/config/backup",          HTTP_GET,  backup_get_handler,   NULL },
-        { "/api/config/restore",         HTTP_POST, restore_post_handler, NULL },
-        { "/api/status",                 HTTP_GET,  status_get_handler, NULL },
-        { "/api/nina/status",            HTTP_GET,  nina_status_get_handler, NULL },
-        { "/api/crash",                  HTTP_GET,  crash_get_handler, NULL },
-        { "/api/weather",                HTTP_GET,  weather_get_handler, NULL },
-        { "/api/events",                 HTTP_GET,  events_get_handler, NULL },
-        { "/api/events/clear",           HTTP_POST, events_clear_post_handler, NULL },
-        { "/api/admin-password",         HTTP_POST, admin_password_post_handler, NULL },
-        { "/login",                      HTTP_GET,  login_page_get_handler, NULL },
-        { "/api/login",                  HTTP_POST, login_post_handler, NULL },
-        { "/api/logout",                 HTTP_POST, logout_post_handler, NULL },
-        { "/api/wifi/scan",              HTTP_GET,  wifi_scan_get_handler, NULL },
-        { "/api/wifi/setup",         HTTP_POST, wifi_setup_post_handler, NULL },
-        { "/api/wifi/status",        HTTP_GET,  wifi_status_get_handler, NULL },
-        { "/api/auth/status",        HTTP_GET,  auth_status_get_handler, NULL },
-        { "/api/logs",               HTTP_GET,  logs_get_handler, NULL },
-        { "/api/logs/clear",         HTTP_POST, logs_clear_post_handler, NULL },
-        { "/api/crashlog",           HTTP_GET,  crashlog_get_handler, NULL },
-        { "/api/crashlog/clear",     HTTP_POST, crashlog_clear_post_handler, NULL },
-        { "/api/coredump",           HTTP_GET,  coredump_get_handler,        NULL },
-        { "/api/coredump/info",      HTTP_GET,  coredump_info_get_handler,   NULL },
-        { "/api/coredump/clear",     HTTP_POST, coredump_clear_post_handler, NULL },
-        { "/api/pages",              HTTP_GET,  pages_get_handler,     NULL },
-        { "/api/navigate",           HTTP_GET,  navigate_post_handler, NULL },
-        { "/api/navigate",           HTTP_POST, navigate_post_handler, NULL },
-        { "/api/nav/pin",            HTTP_POST, nav_pin_post_handler,  NULL },
-        { "/api/control/list",       HTTP_GET,  control_list_get_handler,    NULL },
-        { "/api/control/get",        HTTP_GET,  control_get_get_handler,     NULL },
-        { "/api/control/toggle",     HTTP_POST, control_toggle_post_handler, NULL },
-        { "/api/control/cycle",      HTTP_POST, control_cycle_post_handler,  NULL },
-        { "/api/control/set",        HTTP_POST, control_set_post_handler,    NULL },
-        { "/api/control/adjust",     HTTP_POST, control_adjust_post_handler, NULL },
-        { "/api/image-display/refresh", HTTP_POST, image_display_refresh_post_handler, NULL },
+    /* Auth classification: every entry defaults to ROUTE_AUTH_REQUIRED
+     * (fail-closed) unless explicitly marked ROUTE_PUBLIC or
+     * ROUTE_SETUP_EXEMPT below. See main/web_route_auth.h for the truth
+     * table auth_gate_handler() evaluates via route_auth_allows(). */
+    static const route_entry_t routes[] = {
+        { { "/",                     HTTP_GET,  root_get_handler, NULL }, ROUTE_SETUP_EXEMPT },
+        { { "/ui/fragment",          HTTP_GET,  ui_fragment_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/favicon.ico",          HTTP_GET,  favicon_get_handler, NULL }, ROUTE_PUBLIC },
+        { { "/api/config",           HTTP_GET,  config_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/config",           HTTP_POST, config_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/brightness",       HTTP_POST, brightness_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/color-brightness", HTTP_POST, color_brightness_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/theme",            HTTP_POST, theme_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/widget-style",     HTTP_POST, widget_style_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/reboot",           HTTP_POST, reboot_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/factory-reset",    HTTP_POST, factory_reset_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/screenshot",       HTTP_GET,  screenshot_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/page",             HTTP_POST, page_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/screen-rotation", HTTP_POST, screen_rotation_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/version",          HTTP_GET,  version_get_handler, NULL }, ROUTE_PUBLIC },
+        { { "/api/ota",              HTTP_POST, ota_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/perf",             HTTP_GET,  perf_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/perf/reset",       HTTP_POST, perf_reset_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/config/apply",     HTTP_POST, config_apply_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/config/revert",    HTTP_POST, config_revert_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/check-update",     HTTP_POST, check_update_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/check-update-json", HTTP_GET, check_update_json_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/ota-github",       HTTP_POST, ota_github_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/allsky-config",    HTTP_GET,  allsky_config_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/allsky-proxy",     HTTP_GET,  allsky_proxy_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/spotify/config",         HTTP_GET,  spotify_config_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/spotify/config",         HTTP_POST, spotify_config_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/spotify/callback",       HTTP_GET,  spotify_callback_get_handler, NULL }, ROUTE_PUBLIC },
+        { { "/api/spotify/token-exchange", HTTP_POST, spotify_token_exchange_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/spotify/logout",         HTTP_POST, spotify_logout_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/spotify/status",         HTTP_GET,  spotify_status_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/spotify/control",        HTTP_POST, spotify_control_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/image-display-config",   HTTP_GET,  image_display_config_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/image-display-config",   HTTP_POST, image_display_config_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/config/backup",          HTTP_GET,  backup_get_handler,   NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/config/restore",         HTTP_POST, restore_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/status",                 HTTP_GET,  status_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/nina/status",            HTTP_GET,  nina_status_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/crash",                  HTTP_GET,  crash_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/weather",                HTTP_GET,  weather_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/events",                 HTTP_GET,  events_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/events/clear",           HTTP_POST, events_clear_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/admin-password",         HTTP_POST, admin_password_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/login",                      HTTP_GET,  login_page_get_handler, NULL }, ROUTE_PUBLIC },
+        { { "/api/login",                  HTTP_POST, login_post_handler, NULL }, ROUTE_PUBLIC },
+        { { "/api/logout",                 HTTP_POST, logout_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/wifi/scan",              HTTP_GET,  wifi_scan_get_handler, NULL }, ROUTE_SETUP_EXEMPT },
+        { { "/api/wifi/setup",         HTTP_POST, wifi_setup_post_handler, NULL }, ROUTE_SETUP_EXEMPT },
+        { { "/api/wifi/status",        HTTP_GET,  wifi_status_get_handler, NULL }, ROUTE_SETUP_EXEMPT },
+        { { "/api/auth/status",        HTTP_GET,  auth_status_get_handler, NULL }, ROUTE_PUBLIC },
+        { { "/api/logs",               HTTP_GET,  logs_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/logs/clear",         HTTP_POST, logs_clear_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/crashlog",           HTTP_GET,  crashlog_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/crashlog/clear",     HTTP_POST, crashlog_clear_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/coredump",           HTTP_GET,  coredump_get_handler,        NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/coredump/info",      HTTP_GET,  coredump_info_get_handler,   NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/coredump/clear",     HTTP_POST, coredump_clear_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/pages",              HTTP_GET,  pages_get_handler,     NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/navigate",           HTTP_GET,  navigate_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/navigate",           HTTP_POST, navigate_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/nav/pin",            HTTP_POST, nav_pin_post_handler,  NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/control/list",       HTTP_GET,  control_list_get_handler,    NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/control/get",        HTTP_GET,  control_get_get_handler,     NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/control/toggle",     HTTP_POST, control_toggle_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/control/cycle",      HTTP_POST, control_cycle_post_handler,  NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/control/set",        HTTP_POST, control_set_post_handler,    NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/control/adjust",     HTTP_POST, control_adjust_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/image-display/refresh", HTTP_POST, image_display_refresh_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
     };
 
     /* Keep config.max_uri_handlers (set to 69 above) in sync with the route
@@ -329,7 +384,10 @@ void start_web_server(void)
                    "max_uri_handlers too small for route table");
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {
-        httpd_register_uri_handler(server, &routes[i]);
+        httpd_uri_t gated = routes[i].uri;
+        gated.handler = auth_gate_handler;
+        gated.user_ctx = (void *)&routes[i];
+        httpd_register_uri_handler(server, &gated);
     }
 
     ESP_LOGI(TAG, "Web server started with %d routes",

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -80,6 +80,7 @@ void auth_note_success(void);   /* clear failure counter and any lockout */
 
 /* ---- Handler forward declarations (registered by start_web_server) ---- */
 esp_err_t root_get_handler(httpd_req_t *req);
+esp_err_t ui_fragment_get_handler(httpd_req_t *req);
 esp_err_t favicon_get_handler(httpd_req_t *req);
 esp_err_t config_get_handler(httpd_req_t *req);
 esp_err_t config_post_handler(httpd_req_t *req);

--- a/test/host/CMakeLists.txt
+++ b/test/host/CMakeLists.txt
@@ -1,0 +1,179 @@
+cmake_minimum_required(VERSION 3.16)
+project(nina_host_tests C)
+
+enable_testing()
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
+endif()
+
+# Repo root (test/host is two levels below the repo root: <root>/test/host).
+set(NINA_REPO_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+set(NINA_SHIM_DIR ${CMAKE_CURRENT_SOURCE_DIR}/shims)
+
+# ---------------------------------------------------------------------------
+# Vendored cJSON (copied verbatim from the ESP-IDF component the firmware
+# actually builds against: components/json/cJSON in esp-idf v5.5.2). Kept as
+# its own static lib so test executables link it the same way firmware does.
+# ---------------------------------------------------------------------------
+add_library(cjson STATIC vendor/cJSON/cJSON.c)
+target_include_directories(cjson PUBLIC vendor/cJSON)
+
+# ---------------------------------------------------------------------------
+# Host shims: header-only stand-ins for ESP-IDF/FreeRTOS APIs, plus a small
+# .c backing esp_timer_get_time()/shim_set_time_us(). Every host test that
+# compiles unmodified firmware sources should link this.
+# ---------------------------------------------------------------------------
+add_library(host_shims STATIC shims/shims.c)
+target_include_directories(host_shims PUBLIC ${NINA_SHIM_DIR} ${NINA_SHIM_DIR}/freertos)
+if(WIN32)
+    # QueryPerformanceCounter path in shims.c needs no extra libs beyond the
+    # default Windows import libs CMake already links.
+else()
+    target_link_libraries(host_shims PUBLIC m)
+endif()
+
+# ---------------------------------------------------------------------------
+# add_nina_host_test(<name> <sources...>)
+#
+# Declares one test executable + matching ctest entry. Shim include dir is
+# added FIRST so a shim header (e.g. shims/esp_log.h) always wins over any
+# same-named header CMake might otherwise find later on the include path.
+# Links cjson + host_shims by default; pass EXTRA args after a
+# LINK_LIBRARIES keyword to add more (e.g. a per-test mock .c file).
+# ---------------------------------------------------------------------------
+function(add_nina_host_test NAME)
+    set(multiValueArgs SOURCES LINK_LIBRARIES)
+    cmake_parse_arguments(ARG "" "" "${multiValueArgs}" ${ARGN})
+    if(NOT ARG_SOURCES)
+        set(ARG_SOURCES ${ARGN})
+    endif()
+
+    add_executable(${NAME} ${ARG_SOURCES})
+    target_include_directories(${NAME} PRIVATE
+        ${NINA_SHIM_DIR}
+        ${NINA_SHIM_DIR}/freertos
+        ${NINA_REPO_ROOT}/main
+        ${NINA_REPO_ROOT}/main/ui
+    )
+    target_link_libraries(${NAME} PRIVATE cjson host_shims ${ARG_LINK_LIBRARIES})
+    if(NOT MSVC)
+        target_link_libraries(${NAME} PRIVATE m)
+    endif()
+    target_compile_options(${NAME} PRIVATE
+        $<$<C_COMPILER_ID:GNU,Clang>:-Wall -Wextra>
+    )
+    add_test(NAME ${NAME} COMMAND ${NAME})
+endfunction()
+
+# ---------------------------------------------------------------------------
+# test_moon — wraps the existing test/moon/test_moon_compute.c against the
+# real main/moon_ephemeris.c. moon_ephemeris.c has no ESP-IDF dependency
+# (only <math.h>), so it needs none of the shims, but goes through the same
+# add_nina_host_test() helper as every other host test for consistency.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_moon
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../moon/test_moon_compute.c
+        ${NINA_REPO_ROOT}/main/moon_ephemeris.c
+)
+
+# ---------------------------------------------------------------------------
+# test_session_stats — exercises the real main/ui/nina_session_stats.c
+# (PSRAM ring buffers for RMS/HFR/temperature/star-count session analytics)
+# against the host shims. Depends only on app_config.h (MAX_NINA_INSTANCES),
+# display_defs.h, esp_log/esp_timer/esp_heap_caps/FreeRTOS shims -- all
+# already provided by host_shims, no per-test mocks needed.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_session_stats
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_session_stats.c
+        ${NINA_REPO_ROOT}/main/ui/nina_session_stats.c
+)
+
+# ---------------------------------------------------------------------------
+# test_graph_downsample — wraps test/host/test_graph_downsample.c against the
+# real main/ui/graph_downsample.c (stride/range math extracted from
+# nina_graph_overlay.c). No ESP-IDF dependency (only <math.h>).
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_graph_downsample
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_graph_downsample.c
+        ${NINA_REPO_ROOT}/main/ui/graph_downsample.c
+)
+
+# ---------------------------------------------------------------------------
+# test_nina_sequence — sequence/json tree walker (main/nina_sequence.c).
+# http_get_json() and parse_iso8601() (declared in nina_client_internal.h,
+# implemented in nina_client.c) are mocked directly inside the test file, so
+# nina_client.c itself is NOT linked in.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_nina_sequence
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_nina_sequence.c
+        ${NINA_REPO_ROOT}/main/nina_sequence.c
+)
+
+# ---------------------------------------------------------------------------
+# test_route_auth -- pure decision function for the default-deny web route
+# auth gate (main/web_route_auth.c). No ESP-IDF dependency (only stdbool.h).
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_route_auth
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_route_auth.c
+        ${NINA_REPO_ROOT}/main/web_route_auth.c
+)
+
+# ---------------------------------------------------------------------------
+# test_config_forward -- pure decision function for forward-tolerant config
+# load (main/app_config_forward.h). Header-only, no ESP-IDF dependency
+# (only stdint/stdbool/stddef).
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_config_forward
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_config_forward.c
+)
+
+# ---------------------------------------------------------------------------
+# test_http_policy -- pure decision functions for main/http_fetch.c
+# (main/http_fetch_policy.h): redirect classification, retry-loop
+# continuation, response-buffer sizing/growth. Header-only, no ESP-IDF
+# dependency.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_http_policy
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_http_policy.c
+)
+
+# ---------------------------------------------------------------------------
+# test_poll_backoff -- pure exponential-backoff step function for
+# main/poll_task.c (main/poll_backoff.h). Header-only, no ESP-IDF dependency.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_poll_backoff
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_poll_backoff.c
+)
+
+# ---------------------------------------------------------------------------
+# test_settings_table -- X-macro-driven defaults/clamp for the "simple"
+# app_config_t fields (main/settings_table.c). themes_get_count() (the one
+# runtime count_expr the table uses) is stubbed locally in the test file
+# rather than linking the real main/ui/themes.c, which pulls in LVGL.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_settings_table
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_settings_table.c
+        ${NINA_REPO_ROOT}/main/settings_table.c
+)
+
+# ---------------------------------------------------------------------------
+# test_time_parse -- RFC-1123 HTTP Date header parser (main/time_parse.c).
+# Pure standard C, no ESP-IDF dependency, no mocks needed.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_time_parse
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_time_parse.c
+        ${NINA_REPO_ROOT}/main/time_parse.c
+)

--- a/test/host/README.md
+++ b/test/host/README.md
@@ -1,0 +1,78 @@
+# Host-side unit tests
+
+Standalone CMake project for building and running unit tests against firmware
+source files on a development machine (Linux, macOS, or Windows), without the
+ESP-IDF toolchain. This is separate from `tests/`, which is a Python
+stress/soak harness that drives real devices over the network.
+
+## Layout
+
+```
+test/host/
+  CMakeLists.txt        Standalone CMake project (not part of the ESP-IDF build)
+  vendor/cJSON/          cJSON vendored from esp-idf components/json/cJSON
+  shims/                 Header/source stand-ins for ESP-IDF and FreeRTOS APIs
+  README.md              This file
+test/moon/
+  test_moon_compute.c    Existing moon-ephemeris test, wired in as test_moon
+```
+
+## Building and running
+
+```
+cmake -S test/host -B build_host
+cmake --build build_host
+ctest --test-dir build_host --output-on-failure
+```
+
+On Windows, pass a generator if CMake does not pick one up automatically
+(for example `-G "MinGW Makefiles"` if using MinGW, or omit `-G` to let
+CMake use whatever Visual Studio generator it detects).
+
+## Adding a new test
+
+Use the `add_nina_host_test()` CMake function defined in `CMakeLists.txt`:
+
+```
+add_nina_host_test(test_my_module
+    SOURCES
+        test/host/tests/test_my_module.c
+        main/my_module.c
+)
+```
+
+This links the vendored `cjson` library and the `host_shims` library, and
+registers the executable with `ctest`. Add extra sources (a firmware `.c`
+file plus any test-local mocks) as needed. Firmware files under `main/`
+compile unmodified: no `#ifdef HOST_TEST` branches are needed in firmware
+source.
+
+## Shim scope
+
+The shims under `test/host/shims/` exist only to satisfy compilation of
+firmware headers and the small set of ESP-IDF/FreeRTOS calls that firmware
+source references. They are not a functional reimplementation of ESP-IDF:
+
+- `esp_log.h`, `esp_err.h` are fully functional (log macros print to
+  stderr; error codes are plain ints).
+- `esp_timer.h` is fully functional: `esp_timer_get_time()` returns a real
+  monotonic clock reading by default, or a test-controlled fake value after
+  calling `shim_set_time_us()` (reset with `shim_reset_time()`).
+- `esp_heap_caps.h` is fully functional: `heap_caps_*` calls route straight
+  to the libc heap; capability flags (`MALLOC_CAP_SPIRAM`, etc.) are ignored.
+- `freertos/*.h` provide single-threaded stand-ins: mutex take/give always
+  succeed immediately, `vTaskDelay` is a no-op, and there is no real
+  scheduling or blocking. Do not use these shims for tests that depend on
+  actual concurrent task behavior.
+- `esp_http_client.h` provides only opaque types and function
+  declarations, no implementations. It is enough for a header like
+  `main/nina_client_internal.h` to compile, but any `.c` file that actually
+  calls `esp_http_client_*` functions will fail to link unless the test
+  supplies its own mock implementations of the functions it needs.
+- `esp_system.h`, `sdkconfig.h` are intentionally minimal placeholders;
+  extend them only as new tests require specific symbols, and prefer
+  defining `CONFIG_*` macros in the test file itself over adding them
+  globally to the shared `sdkconfig.h` shim.
+
+When a new firmware header pulls in an ESP-IDF header not yet covered here,
+add the smallest shim that satisfies the compiler and extend this list.

--- a/test/host/shims/esp_err.h
+++ b/test/host/shims/esp_err.h
@@ -1,0 +1,26 @@
+#pragma once
+/* Host shim for esp_err.h — minimal subset used by firmware sources under host tests. */
+
+typedef int esp_err_t;
+
+#define ESP_OK          0
+#define ESP_FAIL        -1
+#define ESP_ERR_NO_MEM        0x101
+#define ESP_ERR_INVALID_ARG   0x102
+#define ESP_ERR_INVALID_STATE 0x103
+#define ESP_ERR_INVALID_SIZE  0x104
+#define ESP_ERR_NOT_FOUND     0x105
+#define ESP_ERR_NOT_SUPPORTED 0x106
+#define ESP_ERR_TIMEOUT       0x107
+#define ESP_ERR_INVALID_RESPONSE 0x108
+#define ESP_ERR_INVALID_CRC   0x109
+#define ESP_ERR_INVALID_VERSION 0x10A
+#define ESP_ERR_INVALID_MAC   0x10B
+#define ESP_ERR_NOT_FINISHED  0x10C
+#define ESP_ERR_NOT_ALLOWED   0x10D
+
+static inline const char *esp_err_to_name(esp_err_t code)
+{
+    (void)code;
+    return "ESP_ERR";
+}

--- a/test/host/shims/esp_heap_caps.h
+++ b/test/host/shims/esp_heap_caps.h
@@ -1,0 +1,45 @@
+#pragma once
+/* Host shim for esp_heap_caps.h — routes all "PSRAM"/"internal" allocation
+ * requests to the regular libc heap. Capability flags are kept only so
+ * firmware source can bitwise-OR them without a compile error; they carry
+ * no allocation-placement meaning on host. */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MALLOC_CAP_SPIRAM   (1 << 0)
+#define MALLOC_CAP_INTERNAL (1 << 1)
+#define MALLOC_CAP_8BIT     (1 << 2)
+#define MALLOC_CAP_DMA      (1 << 3)
+#define MALLOC_CAP_DEFAULT  (1 << 4)
+
+static inline void *heap_caps_malloc(size_t size, uint32_t caps)
+{
+    (void)caps;
+    return malloc(size);
+}
+
+static inline void *heap_caps_calloc(size_t n, size_t size, uint32_t caps)
+{
+    (void)caps;
+    return calloc(n, size);
+}
+
+static inline void *heap_caps_realloc(void *ptr, size_t size, uint32_t caps)
+{
+    (void)caps;
+    return realloc(ptr, size);
+}
+
+static inline void heap_caps_free(void *ptr)
+{
+    free(ptr);
+}
+
+static inline size_t heap_caps_get_free_size(uint32_t caps)
+{
+    (void)caps;
+    return 0;
+}

--- a/test/host/shims/esp_http_client.h
+++ b/test/host/shims/esp_http_client.h
@@ -1,0 +1,83 @@
+#pragma once
+/* Host shim for esp_http_client.h — opaque type/declaration surface only.
+ *
+ * This is enough for firmware headers (e.g. main/nina_client_internal.h)
+ * that merely reference esp_http_client_handle_t to compile on host. It is
+ * NOT a functional implementation: none of these functions are defined, so
+ * any .c file that actually calls them will fail to link unless a test
+ * supplies its own stub/mock implementation.
+ */
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct esp_http_client *esp_http_client_handle_t;
+
+typedef enum {
+    HTTP_METHOD_GET = 0,
+    HTTP_METHOD_POST,
+    HTTP_METHOD_PUT,
+    HTTP_METHOD_DELETE,
+    HTTP_METHOD_HEAD,
+} esp_http_client_method_t;
+
+typedef enum {
+    HTTP_EVENT_ERROR = 0,
+    HTTP_EVENT_ON_CONNECTED,
+    HTTP_EVENT_HEADERS_SENT,
+    HTTP_EVENT_ON_HEADER,
+    HTTP_EVENT_ON_DATA,
+    HTTP_EVENT_ON_FINISH,
+    HTTP_EVENT_DISCONNECTED,
+    HTTP_EVENT_REDIRECT,
+} esp_http_client_event_id_t;
+
+typedef struct esp_http_client_event *esp_http_client_event_handle_t;
+
+struct esp_http_client_event {
+    esp_http_client_event_id_t event_id;
+    esp_http_client_handle_t client;
+    void *data;
+    int data_len;
+    void *user_data;
+    char *header_key;
+    char *header_value;
+};
+
+typedef esp_err_t (*http_event_handle_cb)(esp_http_client_event_handle_t evt);
+
+typedef struct {
+    const char *url;
+    const char *host;
+    int port;
+    const char *username;
+    const char *password;
+    const char *cert_pem;
+    esp_http_client_method_t method;
+    int timeout_ms;
+    bool disable_auto_redirect;
+    http_event_handle_cb event_handler;
+    void *user_data;
+    bool keep_alive_enable;
+} esp_http_client_config_t;
+
+/* Declarations only — no implementations on host. Linking a test against
+ * code that calls these requires supplying test-local stubs. */
+esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *config);
+esp_err_t esp_http_client_set_url(esp_http_client_handle_t client, const char *url);
+esp_err_t esp_http_client_set_method(esp_http_client_handle_t client, esp_http_client_method_t method);
+esp_err_t esp_http_client_set_header(esp_http_client_handle_t client, const char *key, const char *value);
+esp_err_t esp_http_client_set_timeout_ms(esp_http_client_handle_t client, int timeout_ms);
+esp_err_t esp_http_client_open(esp_http_client_handle_t client, int write_len);
+int64_t esp_http_client_fetch_headers(esp_http_client_handle_t client);
+int esp_http_client_read(esp_http_client_handle_t client, char *buffer, int len);
+int esp_http_client_read_response(esp_http_client_handle_t client, char *buffer, int len);
+int esp_http_client_get_status_code(esp_http_client_handle_t client);
+int64_t esp_http_client_get_content_length(esp_http_client_handle_t client);
+esp_err_t esp_http_client_close(esp_http_client_handle_t client);
+esp_err_t esp_http_client_cleanup(esp_http_client_handle_t client);
+esp_err_t esp_http_client_perform(esp_http_client_handle_t client);
+esp_err_t esp_http_client_set_redirection(esp_http_client_handle_t client);
+bool esp_http_client_is_chunked_response(esp_http_client_handle_t client);

--- a/test/host/shims/esp_log.h
+++ b/test/host/shims/esp_log.h
@@ -1,0 +1,34 @@
+#pragma once
+/* Host shim for esp_log.h — prints to stderr instead of the IDF log backend. */
+
+#include <stdio.h>
+
+typedef enum {
+    ESP_LOG_NONE = 0,
+    ESP_LOG_ERROR,
+    ESP_LOG_WARN,
+    ESP_LOG_INFO,
+    ESP_LOG_DEBUG,
+    ESP_LOG_VERBOSE
+} esp_log_level_t;
+
+#define ESP_LOG_LEVEL(level, tag, format, ...) \
+    fprintf(stderr, "[%d/%s] " format "\n", (int)(level), tag, ##__VA_ARGS__)
+
+#define ESP_LOGE(tag, format, ...) fprintf(stderr, "E (%s) " format "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGW(tag, format, ...) fprintf(stderr, "W (%s) " format "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGI(tag, format, ...) fprintf(stderr, "I (%s) " format "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGD(tag, format, ...) fprintf(stderr, "D (%s) " format "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGV(tag, format, ...) fprintf(stderr, "V (%s) " format "\n", tag, ##__VA_ARGS__)
+
+/* Buffer/hex dump helpers occasionally used by firmware code; no-ops on host. */
+#define ESP_LOG_BUFFER_HEX(tag, buffer, buff_len) \
+    do { (void)(tag); (void)(buffer); (void)(buff_len); } while (0)
+#define ESP_LOG_BUFFER_HEXDUMP(tag, buffer, buff_len, level) \
+    do { (void)(tag); (void)(buffer); (void)(buff_len); (void)(level); } while (0)
+
+static inline void esp_log_level_set(const char *tag, esp_log_level_t level)
+{
+    (void)tag;
+    (void)level;
+}

--- a/test/host/shims/esp_system.h
+++ b/test/host/shims/esp_system.h
@@ -1,0 +1,17 @@
+#pragma once
+/* Host shim for esp_system.h — minimal surface for firmware headers that
+ * pull it in transitively. Add functions here only as new host tests need
+ * them; keep this file small. */
+
+#include "esp_err.h"
+#include <stdint.h>
+
+static inline void esp_restart(void)
+{
+    /* No-op on host: nothing should actually reboot a unit test process. */
+}
+
+static inline uint32_t esp_random(void)
+{
+    return 0;
+}

--- a/test/host/shims/esp_timer.h
+++ b/test/host/shims/esp_timer.h
@@ -1,0 +1,24 @@
+#pragma once
+/* Host shim for esp_timer.h.
+ *
+ * esp_timer_get_time() returns microseconds since boot on real hardware.
+ * On host, it defaults to a monotonic clock, but tests can override it with
+ * shim_set_time_us() for deterministic timing-dependent test cases. Once
+ * overridden, the fake value sticks until shim_reset_time() is called.
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int64_t esp_timer_get_time(void);
+
+/* Test-only controls (declared here, implemented in shims.c). */
+void shim_set_time_us(int64_t us);
+void shim_reset_time(void); /* Return to real monotonic clock. */
+
+#ifdef __cplusplus
+}
+#endif

--- a/test/host/shims/freertos/FreeRTOS.h
+++ b/test/host/shims/freertos/FreeRTOS.h
@@ -1,0 +1,11 @@
+#pragma once
+/* Host shim for freertos/FreeRTOS.h — pulls in the portmacro shim and
+ * defines the handful of macros firmware headers reference directly. */
+
+#include "freertos/portmacro.h"
+
+#define pdMS_TO_TICKS(ms) ((TickType_t)(ms))
+
+typedef void *TaskHandle_t;
+typedef void *QueueHandle_t;
+typedef void *TimerHandle_t;

--- a/test/host/shims/freertos/portmacro.h
+++ b/test/host/shims/freertos/portmacro.h
@@ -1,0 +1,27 @@
+#pragma once
+/* Host shim for freertos/portmacro.h — single-threaded, no real locking. */
+
+#include <stdint.h>
+
+typedef long BaseType_t;
+typedef unsigned long UBaseType_t;
+typedef uint32_t TickType_t;
+
+#define pdFALSE ((BaseType_t)0)
+#define pdTRUE  ((BaseType_t)1)
+#define pdPASS  pdTRUE
+#define pdFAIL  pdFALSE
+
+#define portMAX_DELAY ((TickType_t)0xffffffffUL)
+#define portTICK_PERIOD_MS 1
+
+typedef struct {
+    int dummy;
+} portMUX_TYPE;
+
+#define portMUX_INITIALIZER_UNLOCKED { 0 }
+
+#define portENTER_CRITICAL(mux)   do { (void)(mux); } while (0)
+#define portEXIT_CRITICAL(mux)    do { (void)(mux); } while (0)
+#define taskENTER_CRITICAL(mux)   do { (void)(mux); } while (0)
+#define taskEXIT_CRITICAL(mux)    do { (void)(mux); } while (0)

--- a/test/host/shims/freertos/semphr.h
+++ b/test/host/shims/freertos/semphr.h
@@ -1,0 +1,38 @@
+#pragma once
+/* Host shim for freertos/semphr.h — no real synchronization; tests run
+ * single-threaded, so a non-NULL opaque handle plus always-succeeding
+ * take/give is sufficient. */
+
+#include "freertos/FreeRTOS.h"
+#include <stdlib.h>
+
+typedef void *SemaphoreHandle_t;
+
+static inline SemaphoreHandle_t xSemaphoreCreateMutex(void)
+{
+    /* Any non-NULL, distinct-enough pointer works as a handle on host. */
+    return malloc(1);
+}
+
+static inline SemaphoreHandle_t xSemaphoreCreateBinary(void)
+{
+    return malloc(1);
+}
+
+static inline BaseType_t xSemaphoreTake(SemaphoreHandle_t sem, TickType_t ticks)
+{
+    (void)sem;
+    (void)ticks;
+    return pdTRUE;
+}
+
+static inline BaseType_t xSemaphoreGive(SemaphoreHandle_t sem)
+{
+    (void)sem;
+    return pdTRUE;
+}
+
+static inline void vSemaphoreDelete(SemaphoreHandle_t sem)
+{
+    free(sem);
+}

--- a/test/host/shims/freertos/task.h
+++ b/test/host/shims/freertos/task.h
@@ -1,0 +1,22 @@
+#pragma once
+/* Host shim for freertos/task.h — single-threaded stand-ins. */
+
+#include "freertos/FreeRTOS.h"
+
+static inline void vTaskDelay(TickType_t ticks)
+{
+    (void)ticks;
+}
+
+static inline TaskHandle_t xTaskGetCurrentTaskHandle(void)
+{
+    /* Single "task" (the test process itself); a stable non-NULL identity
+     * is enough for code that uses it as a registry/lookup key. */
+    static int fake_task_marker;
+    return (TaskHandle_t)&fake_task_marker;
+}
+
+static inline TickType_t xTaskGetTickCount(void)
+{
+    return 0;
+}

--- a/test/host/shims/sdkconfig.h
+++ b/test/host/shims/sdkconfig.h
@@ -1,0 +1,8 @@
+#pragma once
+/* Host shim for sdkconfig.h — empty on purpose.
+ *
+ * Firmware sources that guard behavior with CONFIG_* macros will take the
+ * "not defined" branch under host tests. If a specific test needs a
+ * CONFIG_* value to be defined, add it here (or better, #define it in the
+ * test file before including the firmware header, to keep this shim
+ * generic across tests). */

--- a/test/host/shims/shims.c
+++ b/test/host/shims/shims.c
@@ -1,0 +1,52 @@
+/* Implementations backing the host shim headers. Link this into every
+ * test executable that includes firmware sources depending on esp_timer.h. */
+
+#include "esp_timer.h"
+
+#include <time.h>
+
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
+static int64_t s_fake_time_us = 0;
+static int s_fake_time_active = 0;
+
+void shim_set_time_us(int64_t us)
+{
+    s_fake_time_us = us;
+    s_fake_time_active = 1;
+}
+
+void shim_reset_time(void)
+{
+    s_fake_time_active = 0;
+    s_fake_time_us = 0;
+}
+
+static int64_t monotonic_time_us(void)
+{
+#if defined(_WIN32)
+    static LARGE_INTEGER freq;
+    static int freq_init = 0;
+    LARGE_INTEGER counter;
+    if (!freq_init) {
+        QueryPerformanceFrequency(&freq);
+        freq_init = 1;
+    }
+    QueryPerformanceCounter(&counter);
+    return (int64_t)((counter.QuadPart * 1000000LL) / freq.QuadPart);
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (int64_t)ts.tv_sec * 1000000LL + (int64_t)(ts.tv_nsec / 1000);
+#endif
+}
+
+int64_t esp_timer_get_time(void)
+{
+    if (s_fake_time_active) {
+        return s_fake_time_us;
+    }
+    return monotonic_time_us();
+}

--- a/test/host/test_config_forward.c
+++ b/test/host/test_config_forward.c
@@ -1,0 +1,59 @@
+/* Host test for main/app_config_forward.h -- pure decision function for
+ * forward-tolerant config load (config_accept_forward()). Header-only,
+ * no ESP/LVGL dependency; assert-style like test/host/test_route_auth.c.
+ *
+ * Fleet-safety-critical: a firmware downgrade must not wipe a newer config
+ * blob back to factory defaults. This truth table pins the exact accept/
+ * reject boundary described in main/app_config_forward.h.
+ */
+#include "app_config_forward.h"
+#include <stdio.h>
+
+static int fails = 0;
+
+static void check_bool(const char *label, bool got, bool expect) {
+    printf("%-70s got=%-5s expect=%-5s %s\n", label,
+           got ? "true" : "false", expect ? "true" : "false",
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+int main(void) {
+    const uint32_t FW = 49;
+    const size_t FW_SIZE = 7580; /* representative sizeof(app_config_t) */
+
+    /* -- accept: newer version, blob at least as large as firmware -------- */
+    check_bool("accept: v50, size > fw_size",
+               config_accept_forward(50, FW_SIZE + 128, FW, FW_SIZE), true);
+    check_bool("accept: v51, size much bigger",
+               config_accept_forward(51, FW_SIZE + 4096, FW, FW_SIZE), true);
+    check_bool("accept: boundary blob_size == fw_size",
+               config_accept_forward(50, FW_SIZE, FW, FW_SIZE), true);
+
+    /* -- reject: same version (handled by exact-match branch, not this) --- */
+    check_bool("reject: same version, larger size",
+               config_accept_forward(FW, FW_SIZE + 128, FW, FW_SIZE), false);
+    check_bool("reject: same version, exact size",
+               config_accept_forward(FW, FW_SIZE, FW, FW_SIZE), false);
+
+    /* -- reject: older version (handled by migration ladder, not this) ---- */
+    check_bool("reject: older version v48",
+               config_accept_forward(48, FW_SIZE + 128, FW, FW_SIZE), false);
+    check_bool("reject: v0",
+               config_accept_forward(0, FW_SIZE + 128, FW, FW_SIZE), false);
+
+    /* -- reject: legacy/garbage blob (huge first word, v0 ASCII SSID) ------ */
+    check_bool("reject: version >= 0x1000 (legacy ASCII SSID pattern)",
+               config_accept_forward(0x1000, FW_SIZE + 128, FW, FW_SIZE), false);
+    check_bool("reject: version way above ceiling (printable ASCII garbage)",
+               config_accept_forward(0x41414141u, FW_SIZE + 128, FW, FW_SIZE), false);
+
+    /* -- reject: newer version but truncated/corrupt/foreign blob --------- */
+    check_bool("reject: newer version, blob_size < fw_size",
+               config_accept_forward(50, FW_SIZE - 1, FW, FW_SIZE), false);
+    check_bool("reject: newer version, tiny blob_size",
+               config_accept_forward(50, 4, FW, FW_SIZE), false);
+
+    printf("\n%s (%d failures)\n", fails ? "TESTS FAILED" : "ALL TESTS PASSED", fails);
+    return fails ? 1 : 0;
+}

--- a/test/host/test_graph_downsample.c
+++ b/test/host/test_graph_downsample.c
@@ -1,0 +1,134 @@
+/* Host test for main/ui/graph_downsample.c — pure stride/range math extracted
+ * from nina_graph_overlay.c. No LVGL/ESP dependency; assert-style like
+ * test/moon/test_moon_compute.c. */
+#include "graph_downsample.h"
+#include <stdio.h>
+#include <math.h>
+
+static int fails = 0;
+
+static void check_int(const char *label, int got, int expect) {
+    printf("%-40s got=%d expect=%d %s\n", label, got, expect, got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+static void check_downsample(const char *label, int count, int expect_stride, int expect_disp) {
+    graph_downsample_t ds = graph_downsample_compute(count);
+    printf("%-40s count=%d stride=%d(exp %d) disp=%d(exp %d) %s\n",
+           label, count, ds.stride, expect_stride, ds.disp_count, expect_disp,
+           (ds.stride == expect_stride && ds.disp_count == expect_disp) ? "OK" : "FAIL");
+    if (ds.stride != expect_stride || ds.disp_count != expect_disp) fails++;
+}
+
+int main(void) {
+    /* -- Downsample stride/disp_count -------------------------------------- */
+
+    /* count <= GRAPH_MAX_DISPLAY_POINTS (360): no decimation. */
+    check_downsample("count=1 (min)", 1, 1, 1);
+    check_downsample("count=360 (== max display)", GRAPH_MAX_DISPLAY_POINTS, 1, GRAPH_MAX_DISPLAY_POINTS);
+
+    /* count just above the threshold: stride becomes 2, disp shrinks. */
+    check_downsample("count=361 (== max+1)", GRAPH_MAX_DISPLAY_POINTS + 1, 2, 181);
+
+    /* count=500 (GRAPH_MAX_POINTS, the real-world ceiling after the caller's
+     * own `if (count > GRAPH_MAX_POINTS) count = GRAPH_MAX_POINTS;` clamp). */
+    check_downsample("count=500 (GRAPH_MAX_POINTS)", 500, 2, 250);
+
+    /* stride rounding boundary: count=501 -> stride=ceil(501/360)=2,
+     * disp=ceil(501/2)=251. */
+    check_downsample("count=501 (stride rounding)", 501, 2, 251);
+
+    /* stride rounding boundary further out: count=720 exactly divides at
+     * stride=2 -> disp=360. count=721 pushes stride to 3. */
+    check_downsample("count=720 (exact stride=2)", 720, 2, 360);
+    check_downsample("count=721 (stride bumps to 3)", 721, 3, 241);
+
+    /* -- RMS Y range --------------------------------------------------------- */
+
+    /* All-zero samples: floor is the 0.5" minimum visible range ->
+     * range = (int)(0.5*120+50) = 110, still clamped to >=100 (no-op here). */
+    {
+        float ra[3] = {0, 0, 0};
+        float dec[3] = {0, 0, 0};
+        check_int("rms range: all-zero", graph_rms_y_range(ra, dec, 3), 110);
+    }
+
+    /* Negative values must use fabsf: -2.0 arcsec dominates.
+     * range = (int)(2.0*120+50) = 290. */
+    {
+        float ra[2] = {-2.0f, 0.1f};
+        float dec[2] = {0.0f, -0.05f};
+        check_int("rms range: negative dominates (fabsf)", graph_rms_y_range(ra, dec, 2), 290);
+    }
+
+    /* Tiny magnitude: max_val stays at the 0.5" default since the sample is
+     * smaller, so the range is the same as the all-zero case (110); the
+     * explicit range<100 clamp is never reachable given the 0.5f seed. */
+    {
+        float ra[1] = {0.01f};
+        float dec[1] = {0.01f};
+        check_int("rms range: tiny values use 0.5\" default", graph_rms_y_range(ra, dec, 1), 110);
+    }
+
+    /* Large magnitude forces a floor-exceeding range: max_val=10.0 ->
+     * range=(int)(10*120+50)=1250. */
+    {
+        float ra[1] = {10.0f};
+        float dec[1] = {-3.0f};
+        check_int("rms range: large magnitude", graph_rms_y_range(ra, dec, 1), 1250);
+    }
+
+    /* All-equal (padding) case: every sample identical, no branch taken past
+     * the first that sets max_val == that value; result must match the
+     * scalar formula exactly, not degrade due to ties. */
+    {
+        float ra[4] = {1.5f, 1.5f, 1.5f, 1.5f};
+        float dec[4] = {1.5f, 1.5f, 1.5f, 1.5f};
+        /* max_val=1.5 -> (int)(1.5*120+50) = (int)230.0 = 230 */
+        check_int("rms range: all-equal values", graph_rms_y_range(ra, dec, 4), 230);
+    }
+
+    /* -- HFR Y range ---------------------------------------------------------- */
+
+    /* All-zero HFR: floor is the 1.0 minimum visible range ->
+     * range=(int)(1.0*120+0.5)=120, clamped to >=200. */
+    {
+        float hfr[3] = {0, 0, 0};
+        float sum = -1.0f;
+        int range = graph_hfr_y_range(hfr, 3, &sum);
+        check_int("hfr range: all-zero (floors at 200)", range, 200);
+        check_int("hfr range: all-zero sum", (int)sum, 0);
+    }
+
+    /* Values above the 1.0 default push the range past the 200 floor.
+     * max_val=5.0 -> range=(int)(5*120+0.5)=600. sum=5+3+1=9. */
+    {
+        float hfr[3] = {5.0f, 3.0f, 1.0f};
+        float sum = 0;
+        int range = graph_hfr_y_range(hfr, 3, &sum);
+        check_int("hfr range: above floor", range, 600);
+        check_int("hfr range: sum", (int)sum, 9);
+    }
+
+    /* All-equal (padding) case for HFR too. max_val=2.5 ->
+     * (int)(2.5*120+0.5) = (int)300.5 = 300. sum=2.5*4=10. */
+    {
+        float hfr[4] = {2.5f, 2.5f, 2.5f, 2.5f};
+        float sum = 0;
+        int range = graph_hfr_y_range(hfr, 4, &sum);
+        check_int("hfr range: all-equal values", range, 300);
+        check_int("hfr range: all-equal sum", (int)sum, 10);
+    }
+
+    /* out_sum may be NULL (caller-optional): must not crash.
+     * max_val: 1.0 default, hfr[0]=1.0 (not >, stays default), hfr[1]=2.0
+     * (>1.0 -> max_val=2.0). range=(int)(2.0*120+0.5)=(int)240.5=240. */
+    {
+        float hfr[2] = {1.0f, 2.0f};
+        int range = graph_hfr_y_range(hfr, 2, NULL);
+        check_int("hfr range: NULL out_sum is safe", range, 240);
+    }
+
+    printf("\n%s (%d failures)\n", fails ? "TESTS FAILED" : "ALL TESTS PASSED", fails);
+    return fails ? 1 : 0;
+}

--- a/test/host/test_http_policy.c
+++ b/test/host/test_http_policy.c
@@ -1,0 +1,89 @@
+/* Host test for main/http_fetch_policy.h -- pure decision functions used by
+ * http_fetch.c (redirect classification, retry-loop continuation, response
+ * buffer sizing). No ESP-IDF dependency; assert-style like
+ * test/host/test_route_auth.c. */
+#include "http_fetch_policy.h"
+#include <stdio.h>
+
+static int fails = 0;
+
+static void check_bool(const char *label, bool got, bool expect) {
+    printf("%-60s got=%-5s expect=%-5s %s\n", label,
+           got ? "true" : "false", expect ? "true" : "false",
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+static void check_size(const char *label, size_t got, size_t expect) {
+    printf("%-60s got=%-8zu expect=%-8zu %s\n", label, got, expect,
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+int main(void) {
+    /* -- http_status_is_redirect: exact set esp_http_client can follow ----- */
+    check_bool("redirect: 301", http_status_is_redirect(301), true);
+    check_bool("redirect: 302", http_status_is_redirect(302), true);
+    check_bool("redirect: 303", http_status_is_redirect(303), true);
+    check_bool("redirect: 307", http_status_is_redirect(307), true);
+    check_bool("redirect: 308", http_status_is_redirect(308), true);
+    check_bool("redirect: 200 is not", http_status_is_redirect(200), false);
+    check_bool("redirect: 304 is not", http_status_is_redirect(304), false);
+    check_bool("redirect: 404 is not", http_status_is_redirect(404), false);
+    check_bool("redirect: 500 is not", http_status_is_redirect(500), false);
+    check_bool("redirect: -1 is not", http_status_is_redirect(-1), false);
+
+    /* -- http_should_retry: attempt is 0-indexed --------------------------- */
+    check_bool("retry: max_attempts=0 never retries",
+               http_should_retry(0, 0), false);
+    check_bool("retry: max_attempts=1, attempt=0 is last",
+               http_should_retry(0, 1), false);
+    check_bool("retry: max_attempts=3, attempt=0 has more",
+               http_should_retry(0, 3), true);
+    check_bool("retry: max_attempts=3, attempt=1 has more",
+               http_should_retry(1, 3), true);
+    check_bool("retry: max_attempts=3, attempt=2 is last",
+               http_should_retry(2, 3), false);
+    check_bool("retry: max_attempts=3, attempt=5 (past end)",
+               http_should_retry(5, 3), false);
+
+    /* -- http_buf_initial: known content-length ----------------------------- */
+    check_size("buf_initial: known length 100, cap 65536",
+               http_buf_initial(100, 65536), 101);
+    check_size("buf_initial: known length exactly fills cap-1",
+               http_buf_initial(999, 1000), 1000);
+    check_size("buf_initial: known length caps at cap (too large)",
+               http_buf_initial(70000, 65536), 65536);
+    check_size("buf_initial: known length == cap exactly",
+               http_buf_initial(65536, 65536), 65536);
+
+    /* -- http_buf_initial: unknown/chunked (<=0) ---------------------------- */
+    check_size("buf_initial: unknown length starts at 4096",
+               http_buf_initial(0, 65536), 4096);
+    check_size("buf_initial: negative length treated as unknown",
+               http_buf_initial(-1, 65536), 4096);
+    check_size("buf_initial: unknown length, cap below 4096",
+               http_buf_initial(0, 2048), 2048);
+
+    /* -- http_buf_initial: cap edge ------------------------------------------ */
+    check_size("buf_initial: cap=0 -> 0 (caller must fail)",
+               http_buf_initial(100, 0), 0);
+
+    /* -- http_buf_grow: doubling ---------------------------------------------- */
+    check_size("buf_grow: 4096 -> 8192 (cap 65536)",
+               http_buf_grow(4096, 65536), 8192);
+    check_size("buf_grow: 8192 -> 16384", http_buf_grow(8192, 65536), 16384);
+
+    /* -- http_buf_grow: saturates at cap ------------------------------------- */
+    check_size("buf_grow: 40000 -> cap 65536 (would overshoot doubling)",
+               http_buf_grow(40000, 65536), 65536);
+
+    /* -- http_buf_grow: cannot grow further ----------------------------------- */
+    check_size("buf_grow: cur == cap -> 0", http_buf_grow(65536, 65536), 0);
+    check_size("buf_grow: cur > cap -> 0", http_buf_grow(70000, 65536), 0);
+    check_size("buf_grow: cur == 0 -> 0 (nothing to grow from)",
+               http_buf_grow(0, 65536), 0);
+
+    printf("\n%s (%d failures)\n", fails ? "TESTS FAILED" : "ALL TESTS PASSED", fails);
+    return fails ? 1 : 0;
+}

--- a/test/host/test_poll_backoff.c
+++ b/test/host/test_poll_backoff.c
@@ -1,0 +1,52 @@
+/* Host test for main/poll_backoff.h -- pure exponential-backoff step
+ * function used by poll_task.c. No ESP-IDF dependency; assert-style like
+ * test/host/test_route_auth.c. */
+#include "poll_backoff.h"
+#include <stdio.h>
+
+static int fails = 0;
+
+static void check_u32(const char *label, uint32_t got, uint32_t expect) {
+    printf("%-60s got=%-10u expect=%-10u %s\n", label, got, expect,
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+int main(void) {
+    /* -- no-backoff mode: initial==0 always returns 0 ----------------------- */
+    check_u32("no-backoff: cur=0, initial=0", poll_backoff_next(0, 0, 5000), 0);
+    check_u32("no-backoff: cur=1000, initial=0", poll_backoff_next(1000, 0, 5000), 0);
+    check_u32("no-backoff: cur=0, initial=0, max=0",
+              poll_backoff_next(0, 0, 0), 0);
+
+    /* -- first failure: cur=0 starts at initial ------------------------------ */
+    check_u32("first failure: initial=500, max=5000",
+              poll_backoff_next(0, 500, 5000), 500);
+    check_u32("first failure: initial exceeds max, clamps",
+              poll_backoff_next(0, 8000, 5000), 5000);
+    check_u32("first failure: max=0 (unbounded), uses initial",
+              poll_backoff_next(0, 500, 0), 500);
+
+    /* -- doubling ------------------------------------------------------------- */
+    check_u32("double: 500 -> 1000", poll_backoff_next(500, 500, 5000), 1000);
+    check_u32("double: 1000 -> 2000", poll_backoff_next(1000, 500, 5000), 2000);
+    check_u32("double: 2000 -> 4000", poll_backoff_next(2000, 500, 5000), 4000);
+
+    /* -- cap saturation --------------------------------------------------------- */
+    check_u32("cap: 4000 -> 5000 (would overshoot to 8000)",
+              poll_backoff_next(4000, 500, 5000), 5000);
+    check_u32("cap: already at cap stays at cap",
+              poll_backoff_next(5000, 500, 5000), 5000);
+    check_u32("cap: unbounded (max=0) keeps doubling",
+              poll_backoff_next(1000000, 500, 0), 2000000);
+
+    /* -- reset semantics: caller responsibility, not this function ----------
+     * poll_task.c resets its backoff-state variable to 0 after a successful
+     * poll_once(); the very next failure then starts again at `initial`,
+     * which is exactly the cur=0 case already covered above. */
+    check_u32("reset-then-fail: behaves like first failure",
+              poll_backoff_next(0, 500, 5000), 500);
+
+    printf("\n%s (%d failures)\n", fails ? "TESTS FAILED" : "ALL TESTS PASSED", fails);
+    return fails ? 1 : 0;
+}

--- a/test/host/test_route_auth.c
+++ b/test/host/test_route_auth.c
@@ -1,0 +1,66 @@
+/* Host test for main/web_route_auth.c -- pure decision function for the
+ * default-deny web route auth gate (route_auth_allows()). No ESP/LVGL
+ * dependency; assert-style like test/host/test_graph_downsample.c.
+ *
+ * Also documents (in the block comment below) the route classification
+ * snapshot expected in main/web_server.c's routes[] table, so a reviewer
+ * changing one can be reminded to check the other. */
+#include "web_route_auth.h"
+#include <stdio.h>
+
+/*
+ * Expected allowlist snapshot (must match main/web_server.c routes[]):
+ *
+ *   ROUTE_PUBLIC (no auth check at all, ever):
+ *     /favicon.ico, /login, /api/login, /api/auth/status,
+ *     /api/version, /api/spotify/callback
+ *
+ *   ROUTE_SETUP_EXEMPT (reachable during first-run setup, else needs auth):
+ *     / (root GET), /api/wifi/scan, /api/wifi/setup, /api/wifi/status
+ *
+ *   ROUTE_AUTH_REQUIRED (default -- everything else, ~59 routes)
+ */
+
+static int fails = 0;
+
+static void check_bool(const char *label, bool got, bool expect) {
+    printf("%-55s got=%-5s expect=%-5s %s\n", label,
+           got ? "true" : "false", expect ? "true" : "false",
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+int main(void) {
+    /* -- ROUTE_PUBLIC: always true, regardless of setup_mode/authed -------- */
+    check_bool("PUBLIC, setup=false, authed=false",
+               route_auth_allows(ROUTE_PUBLIC, false, false), true);
+    check_bool("PUBLIC, setup=false, authed=true",
+               route_auth_allows(ROUTE_PUBLIC, false, true), true);
+    check_bool("PUBLIC, setup=true,  authed=false",
+               route_auth_allows(ROUTE_PUBLIC, true, false), true);
+    check_bool("PUBLIC, setup=true,  authed=true",
+               route_auth_allows(ROUTE_PUBLIC, true, true), true);
+
+    /* -- ROUTE_SETUP_EXEMPT: setup_mode || authed --------------------------- */
+    check_bool("SETUP_EXEMPT, setup=false, authed=false",
+               route_auth_allows(ROUTE_SETUP_EXEMPT, false, false), false);
+    check_bool("SETUP_EXEMPT, setup=false, authed=true",
+               route_auth_allows(ROUTE_SETUP_EXEMPT, false, true), true);
+    check_bool("SETUP_EXEMPT, setup=true,  authed=false",
+               route_auth_allows(ROUTE_SETUP_EXEMPT, true, false), true);
+    check_bool("SETUP_EXEMPT, setup=true,  authed=true",
+               route_auth_allows(ROUTE_SETUP_EXEMPT, true, true), true);
+
+    /* -- ROUTE_AUTH_REQUIRED: authed only ------------------------------------ */
+    check_bool("AUTH_REQUIRED, setup=false, authed=false",
+               route_auth_allows(ROUTE_AUTH_REQUIRED, false, false), false);
+    check_bool("AUTH_REQUIRED, setup=false, authed=true",
+               route_auth_allows(ROUTE_AUTH_REQUIRED, false, true), true);
+    check_bool("AUTH_REQUIRED, setup=true,  authed=false",
+               route_auth_allows(ROUTE_AUTH_REQUIRED, true, false), false);
+    check_bool("AUTH_REQUIRED, setup=true,  authed=true",
+               route_auth_allows(ROUTE_AUTH_REQUIRED, true, true), true);
+
+    printf("\n%s (%d failures)\n", fails ? "TESTS FAILED" : "ALL TESTS PASSED", fails);
+    return fails ? 1 : 0;
+}

--- a/test/host/test_session_stats.c
+++ b/test/host/test_session_stats.c
@@ -1,0 +1,257 @@
+/* Host test: exercises main/ui/nina_session_stats.c (PSRAM ring buffers for
+ * RMS/HFR/temperature/star-count session analytics) against the host shims.
+ * Style follows test/moon/test_moon_compute.c: main() with numbered sections,
+ * printf progress lines, and a running failure counter (no test framework). */
+#include "../../main/ui/nina_session_stats.h"
+#include "../../main/app_config.h" /* MAX_NINA_INSTANCES */
+#include "esp_timer.h"             /* shim_set_time_us / shim_reset_time */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <string.h>
+#include <float.h>
+
+static int fails = 0;
+
+#define CHECK(cond, fmt, ...) \
+    do { \
+        int _ok = (cond); \
+        printf("  %s: " fmt "\n", _ok ? "OK  " : "FAIL", ##__VA_ARGS__); \
+        if (!_ok) fails++; \
+    } while (0)
+
+int main(void)
+{
+    /* ── 1. Init / allocation sanity ─────────────────────────────────── */
+    printf("1. Init/allocation\n");
+    shim_reset_time();
+    nina_session_stats_init();
+
+    for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
+        const session_stats_t *st = nina_session_stats_get(i);
+        CHECK(st != NULL, "instance %d: get() returns non-null", i);
+        CHECK(st->points != NULL, "instance %d: PSRAM buffer allocated", i);
+        CHECK(st->count == 0, "instance %d: count==0 after init", i);
+        CHECK(st->write_index == 0, "instance %d: write_index==0 after init", i);
+        CHECK(st->capacity == SESSION_MAX_POINTS, "instance %d: capacity==%d", i, SESSION_MAX_POINTS);
+        CHECK(st->rms_min == FLT_MAX, "instance %d: rms_min primed to FLT_MAX", i);
+        CHECK(st->hfr_min == FLT_MAX, "instance %d: hfr_min primed to FLT_MAX", i);
+        CHECK(st->session_start_ms == 0, "instance %d: session_start_ms==0 (no records yet)", i);
+    }
+
+    /* Out-of-range instance indices must be handled defensively (no crash). */
+    CHECK(nina_session_stats_get(-1) == NULL, "get(-1) returns NULL");
+    CHECK(nina_session_stats_get(MAX_NINA_INSTANCES) == NULL, "get(MAX) returns NULL");
+    {
+        session_stats_t copy;
+        CHECK(nina_session_stats_get_copy(-1, &copy) == false, "get_copy(-1) returns false");
+        CHECK(nina_session_stats_get_copy(0, NULL) == false, "get_copy(0, NULL) returns false");
+    }
+
+    /* ── 2. Appending fewer than capacity preserves order + count ──────── */
+    printf("2. Sub-capacity append order\n");
+    const int inst = 0;
+    const int n_small = 10;
+    shim_set_time_us(1000 * 1000); /* t = 1000 ms */
+    for (int i = 0; i < n_small; i++) {
+        /* rms increases monotonically so we can check ordering via the ring
+         * buffer contents directly (no accessor exposes indexed reads, so we
+         * read the const pointer's ->points array, which is documented as
+         * legitimate for nina_session_stats_get() callers -- unlike get_copy,
+         * whose contract says the returned points ptr must not be dereferenced). */
+        nina_session_stats_record(inst, (float)(i + 1), (float)(i + 1) * 0.1f,
+                                   10.0f + i, 50 + i, 0.5f);
+        shim_set_time_us((1000 + (i + 1) * 500) * 1000); /* advance 500ms/sample */
+    }
+    {
+        const session_stats_t *st = nina_session_stats_get(inst);
+        CHECK(st->count == n_small, "count == %d after %d appends", n_small, n_small);
+        CHECK(st->write_index == n_small, "write_index == %d", n_small);
+        for (int i = 0; i < n_small; i++) {
+            CHECK(st->points[i].rms_total == (float)(i + 1),
+                  "point[%d].rms_total == %d (insertion order preserved)", i, i + 1);
+        }
+    }
+
+    /* ── 3. Exactly-at-capacity then one more: wraparound ───────────────── */
+    printf("3. Capacity + wraparound\n");
+    nina_session_stats_reset(inst);
+    shim_set_time_us(2000ULL * 1000);
+    for (int i = 0; i < SESSION_MAX_POINTS; i++) {
+        nina_session_stats_record(inst, (float)(i + 1), 1.0f, 10.0f, 1, 0.0f);
+        shim_set_time_us((2000ULL + (i + 1)) * 1000);
+    }
+    {
+        const session_stats_t *st = nina_session_stats_get(inst);
+        CHECK(st->count == SESSION_MAX_POINTS, "count clamps at capacity (%d) after exactly-full", SESSION_MAX_POINTS);
+        CHECK(st->write_index == 0, "write_index wraps to 0 after exactly filling capacity");
+        CHECK(st->points[0].rms_total == 1.0f, "point[0] still holds oldest sample (rms=1) before overflow");
+    }
+    /* One more record: oldest (rms==1, at slot 0) must be overwritten/dropped. */
+    nina_session_stats_record(inst, 9999.0f, 1.0f, 10.0f, 1, 0.0f);
+    {
+        const session_stats_t *st = nina_session_stats_get(inst);
+        CHECK(st->count == SESSION_MAX_POINTS,
+              "count still clamped at capacity (%d), not capacity+1", SESSION_MAX_POINTS);
+        CHECK(st->write_index == 1, "write_index advances to 1 after wraparound write");
+        CHECK(st->points[0].rms_total == 9999.0f,
+              "oldest sample (slot 0) overwritten by the wraparound write");
+        CHECK(st->points[1].rms_total == 2.0f,
+              "point[1] (originally 2nd-oldest) is now the logically-oldest surviving sample");
+    }
+
+    /* ── 4. Timestamps monotonic non-decreasing per the shim clock ──────── */
+    printf("4. Timestamp monotonicity\n");
+    nina_session_stats_reset(inst);
+    {
+        int64_t sim_ms[5] = { 5000, 5100, 5100, 5300, 6000 }; /* includes a tie */
+        for (int i = 0; i < 5; i++) {
+            shim_set_time_us(sim_ms[i] * 1000);
+            nina_session_stats_record(inst, 1.0f, 1.0f, 10.0f, 1, 0.0f);
+        }
+        const session_stats_t *st = nina_session_stats_get(inst);
+        CHECK(st->count == 5, "5 records taken for timestamp check");
+        int monotonic = 1;
+        for (int i = 0; i < 5; i++) {
+            CHECK(st->points[i].timestamp_ms == sim_ms[i],
+                  "point[%d].timestamp_ms == %lld (shim clock)", i, (long long)sim_ms[i]);
+            if (i > 0 && st->points[i].timestamp_ms < st->points[i - 1].timestamp_ms) monotonic = 0;
+        }
+        CHECK(monotonic, "timestamps are non-decreasing across the recorded run");
+        CHECK(st->session_start_ms == sim_ms[0], "session_start_ms == timestamp of first record");
+    }
+
+    /* ── 5. Aggregate (running min/max/sum -> avg) verification ─────────── */
+    printf("5. Aggregate min/max/avg\n");
+    nina_session_stats_reset(inst);
+    {
+        /* Known dataset. Include a <=0 rms/hfr value to verify the
+         * skip-zero/invalid guard in nina_session_stats_record(). */
+        float rms_vals[] = { 2.0f, 0.0f, 5.0f, 1.0f, 3.0f };   /* 0.0f must be skipped */
+        float hfr_vals[] = { -1.0f, 2.5f, 4.5f, 3.0f, 2.0f };  /* -1.0f must be skipped */
+        int nvals = 5;
+        shim_set_time_us(10000 * 1000);
+        for (int i = 0; i < nvals; i++) {
+            nina_session_stats_record(inst, rms_vals[i], hfr_vals[i], 10.0f, 1, 0.0f);
+        }
+        const session_stats_t *st = nina_session_stats_get(inst);
+
+        /* Hand-computed over the valid (>0) subset only. */
+        float rms_expect_min = 1.0f, rms_expect_max = 5.0f;
+        float rms_expect_sum = 2.0f + 5.0f + 1.0f + 3.0f; /* skip the 0.0f */
+        int   rms_expect_count = 4;
+        float hfr_expect_min = 2.0f, hfr_expect_max = 4.5f;
+        float hfr_expect_sum = 2.5f + 4.5f + 3.0f + 2.0f; /* skip the -1.0f */
+        int   hfr_expect_count = 4;
+
+        CHECK(fabsf(st->rms_min - rms_expect_min) < 1e-6f, "rms_min == %.3f", rms_expect_min);
+        CHECK(fabsf(st->rms_max - rms_expect_max) < 1e-6f, "rms_max == %.3f", rms_expect_max);
+        CHECK(st->rms_count == rms_expect_count, "rms_count == %d (zero sample excluded)", rms_expect_count);
+        CHECK(fabsf(st->rms_sum - rms_expect_sum) < 1e-4f, "rms_sum == %.3f", rms_expect_sum);
+        CHECK(fabsf((st->rms_sum / st->rms_count) - (rms_expect_sum / rms_expect_count)) < 1e-4f,
+              "rms avg == %.4f", rms_expect_sum / rms_expect_count);
+
+        CHECK(fabsf(st->hfr_min - hfr_expect_min) < 1e-6f, "hfr_min == %.3f", hfr_expect_min);
+        CHECK(fabsf(st->hfr_max - hfr_expect_max) < 1e-6f, "hfr_max == %.3f", hfr_expect_max);
+        CHECK(st->hfr_count == hfr_expect_count, "hfr_count == %d (negative sample excluded)", hfr_expect_count);
+        CHECK(fabsf(st->hfr_sum - hfr_expect_sum) < 1e-4f, "hfr_sum == %.3f", hfr_expect_sum);
+
+        /* Exposure accumulation is a separate running aggregate; sanity-check it too. */
+        nina_session_stats_add_exposure(inst, 30.0f);
+        nina_session_stats_add_exposure(inst, 45.5f);
+        st = nina_session_stats_get(inst);
+        CHECK(st->total_exposures == 2, "total_exposures == 2 after two add_exposure calls");
+        CHECK(fabsf(st->total_exposure_time_s - 75.5f) < 1e-4f, "total_exposure_time_s == 75.5");
+    }
+
+    /* ── 6. Reset returns to post-init empty state ───────────────────────── */
+    printf("6. Reset semantics\n");
+    nina_session_stats_reset(inst);
+    {
+        const session_stats_t *st = nina_session_stats_get(inst);
+        CHECK(st->count == 0, "count==0 after reset");
+        CHECK(st->write_index == 0, "write_index==0 after reset");
+        CHECK(st->capacity == SESSION_MAX_POINTS, "capacity preserved across reset (allocation kept)");
+        CHECK(st->rms_min == FLT_MAX, "rms_min re-primed to FLT_MAX after reset");
+        CHECK(st->hfr_min == FLT_MAX, "hfr_min re-primed to FLT_MAX after reset");
+        CHECK(st->rms_max == 0.0f, "rms_max cleared to 0 after reset");
+        CHECK(st->session_start_ms == 0, "session_start_ms cleared after reset");
+        CHECK(st->total_exposures == 0, "total_exposures cleared after reset");
+
+        /* Fresh append after reset behaves like a brand-new buffer. */
+        shim_set_time_us(20000 * 1000);
+        nina_session_stats_record(inst, 7.0f, 7.0f, 15.0f, 20, 1.0f);
+        st = nina_session_stats_get(inst);
+        CHECK(st->count == 1, "count==1 after first append post-reset");
+        CHECK(st->points[0].rms_total == 7.0f, "post-reset first sample lands at slot 0");
+        CHECK(st->session_start_ms == 20000, "session_start_ms re-set on first post-reset record");
+    }
+
+    /* ── 7. Double-init: reachable and must not crash / must not leak refs ── */
+    printf("7. Double-init safety\n");
+    {
+        /* nina_session_stats_init() is documented "call once at startup" but
+         * nothing prevents a caller from invoking it twice (e.g. a hypothetical
+         * re-init path); the implementation memset()s the whole array and
+         * reallocates every instance's PSRAM buffer unconditionally, which
+         * means a second init() call leaks the previous heap_caps_calloc()
+         * allocation (the old `points` pointer is discarded by memset(0)
+         * before the new heap_caps_calloc() call overwrites it).
+         * This is a plausible hardening gap (leak on repeated init), not
+         * something we fix here -- we just document current behavior.
+         * See main/ui/nina_session_stats.c:27-44 (nina_session_stats_init). */
+        nina_session_stats_init();
+        for (int i = 0; i < MAX_NINA_INSTANCES; i++) {
+            const session_stats_t *st = nina_session_stats_get(i);
+            CHECK(st->points != NULL, "instance %d: buffer non-null after 2nd init()", i);
+            CHECK(st->count == 0, "instance %d: count==0 after 2nd init() (state fully reset)", i);
+        }
+    }
+
+    /* ── 8. NaN / Inf / huge-magnitude pass-through (no guard exists) ───── */
+    printf("8. NaN/Inf passthrough (documents current behavior, no guard exists)\n");
+    {
+        const int inst2 = 1;
+        nina_session_stats_reset(inst2);
+        shim_set_time_us(30000 * 1000);
+
+        /* rms_total = NAN: the guard is `if (rms_total > 0.0f)`, and any
+         * comparison against NAN is false in IEEE-754, so NAN correctly
+         * fails to update rms_min/max/sum -- but it IS still stored verbatim
+         * in the ring buffer point itself (no clamp on the raw sample). */
+        nina_session_stats_record(inst2, NAN, INFINITY, 1e30f, 1, -INFINITY);
+        const session_stats_t *st = nina_session_stats_get(inst2);
+        CHECK(st->count == 1, "record with NAN/INFINITY still counts as one sample");
+        CHECK(isnan(st->points[0].rms_total), "raw NAN rms_total is stored verbatim (no clamp/guard)");
+        CHECK(isinf(st->points[0].hfr) && st->points[0].hfr > 0, "raw +INFINITY hfr stored verbatim");
+        CHECK(st->points[0].temperature == 1e30f, "huge-magnitude temperature stored verbatim");
+        CHECK(isinf(st->points[0].cooler_power) && st->points[0].cooler_power < 0,
+              "raw -INFINITY cooler_power stored verbatim");
+        /* Aggregate guard behavior differs between NAN and INFINITY:
+         * NAN fails `rms_total > 0.0f` (any comparison with NAN is false in
+         * IEEE-754), so the NAN rms sample is correctly excluded from
+         * rms_min/max/sum/count. But INFINITY *passes* `hfr > 0.0f` (IEEE-754:
+         * +INFINITY > 0.0f is true), so the +INFINITY hfr sample DOES enter
+         * the running aggregate: hfr_max becomes +INFINITY and hfr_sum becomes
+         * +INFINITY, silently poisoning every future average/graph-scale
+         * computation derived from hfr_max or hfr_sum for the rest of the
+         * session (until the next nina_session_stats_reset()). This looks
+         * like a real hardening gap: the guard `if (hfr > 0.0f)` only filters
+         * zero/negative values, not non-finite ones -- a `isfinite()` check
+         * would be needed to also exclude INFINITY/-INFINITY.
+         * See main/ui/nina_session_stats.c:82-88 (hfr aggregate update) and
+         * :74-80 (rms aggregate update, same pattern, same gap for +INFINITY
+         * rms samples). Documented here, not fixed. */
+        CHECK(st->rms_count == 0, "NAN rms_total does not enter the running aggregate (guard rejects NAN)");
+        CHECK(st->hfr_count == 1,
+              "+INFINITY hfr DOES enter the running aggregate (guard `> 0.0f` does not reject non-finite values)");
+        CHECK(isinf(st->hfr_max) && st->hfr_max > 0,
+              "hfr_max is poisoned to +INFINITY by the unguarded sample -- possible hardening gap");
+        CHECK(isinf(st->hfr_sum) && st->hfr_sum > 0,
+              "hfr_sum is poisoned to +INFINITY, corrupting any future average until next reset()");
+    }
+
+    printf("\n%s (%d failures)\n", fails ? "TESTS FAILED" : "ALL TESTS PASSED", fails);
+    return fails ? 1 : 0;
+}

--- a/test/host/test_settings_table.c
+++ b/test/host/test_settings_table.c
@@ -1,0 +1,384 @@
+/* Host test for main/settings_table.c (X-macro-driven defaults/clamp for the
+ * "simple" app_config_t fields). Style follows test/host/test_session_stats.c:
+ * main() with numbered sections, CHECK macro, running failure counter.
+ *
+ * themes_get_count() is the only runtime count_expr used by the table
+ * (theme_index row). It is not stubbed anywhere else in test/host, so a
+ * minimal local stub is provided here (not linking the real ui/themes.c,
+ * which pulls in LVGL).
+ */
+#include "../../main/app_config.h"
+#include "../../main/settings_table.h"
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int fails = 0;
+
+#define CHECK(cond, fmt, ...) \
+    do { \
+        int _ok = (cond); \
+        printf("  %s: " fmt "\n", _ok ? "OK  " : "FAIL", ##__VA_ARGS__); \
+        if (!_ok) fails++; \
+    } while (0)
+
+/* Minimal stand-in for main/ui/themes.c — only themes_get_count() is needed
+ * by the table (theme_index's ENUM row). Matches the real theme count
+ * (9 built-in dark themes) so the row's default/clamp bound is realistic,
+ * but the exact number is not load-bearing for this test. */
+int themes_get_count(void) { return 9; }
+
+int main(void)
+{
+    /* ── 1. settings_defaults_apply() is idempotent under settings_clamp_apply() ──
+     * A freshly-defaulted config must already be "clean": running the clamp
+     * pass over it must report no fix and must not change any migrated
+     * field. This is the core defaults/clamp consistency guarantee. */
+    printf("1. defaults -> clamp is a no-op\n");
+    {
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+
+        app_config_t before = cfg;
+        bool fixed = settings_clamp_apply(&cfg);
+
+        CHECK(fixed == false, "settings_clamp_apply() reports no fix on fresh defaults");
+        CHECK(memcmp(&before, &cfg, sizeof(cfg)) == 0,
+              "settings_clamp_apply() did not mutate a freshly-defaulted config");
+    }
+
+    /* ── 2. Per-row out-of-range behavior, generated from the X-macro ──
+     * For every INT/INT_RESET/FLT/FLT_RESET/ENUM row: push the field below
+     * min and above max, then confirm settings_clamp_apply() lands on the
+     * value the row's kind promises (nearest bound for a true clamp, `def`
+     * for a reset). BOOL/STR rows are covered by sections 1/3 instead. */
+    printf("2. per-row range enforcement\n");
+
+#define ROW_BOOL(field, json_key, def)                        /* covered by section 1 */
+#define ROW_STR(field, json_key, def)                          /* covered by section 3 */
+#define ROW_STR_RESET(field, json_key, def)                    /* covered by section 3 */
+
+/* Below-min is only meaningful/testable when min > 0: every INT/INT_RESET
+ * row's field is an unsigned integer type (uint8/16/32_t) except theme_index
+ * (handled by ROW_ENUM) — for a row with min == 0, (min - 1) would wrap
+ * around to the type's max value instead of underflowing below 0, which
+ * is not what "below-min" is supposed to exercise. Guarding on (min) > 0
+ * skips that sub-check for the (many) upper-bound-only rows, matching the
+ * fact that validate_config() never had a lower-bound check to replicate
+ * for those fields in the first place. */
+#define ROW_INT(field, json_key, def, min, max) \
+    do { \
+        app_config_t cfg; \
+        memset(&cfg, 0, sizeof(cfg)); \
+        settings_defaults_apply(&cfg); \
+        __typeof__(cfg.field) _type_max = (__typeof__(cfg.field))~(__typeof__(cfg.field))0; \
+        if ((min) > 0) { \
+            cfg.field = (__typeof__(cfg.field))((min) - 1); \
+            settings_clamp_apply(&cfg); \
+            CHECK(cfg.field == (min), "%s: below-min clamps to min (%ld)", json_key, (long)(min)); \
+        } \
+        if ((unsigned long)(max) < (unsigned long)_type_max) { \
+            cfg.field = (__typeof__(cfg.field))((max) + 1); \
+            settings_clamp_apply(&cfg); \
+            CHECK(cfg.field == (max), "%s: above-max clamps to max (%ld)", json_key, (long)(max)); \
+        } \
+    } while (0);
+
+#define ROW_INT_RESET(field, json_key, def, min, max) \
+    do { \
+        app_config_t cfg; \
+        memset(&cfg, 0, sizeof(cfg)); \
+        settings_defaults_apply(&cfg); \
+        __typeof__(cfg.field) _type_max = (__typeof__(cfg.field))~(__typeof__(cfg.field))0; \
+        if ((min) > 0) { \
+            cfg.field = (__typeof__(cfg.field))((min) - 1); \
+            settings_clamp_apply(&cfg); \
+            CHECK(cfg.field == (def), "%s: below-min resets to def (%ld)", json_key, (long)(def)); \
+        } \
+        if ((unsigned long)(max) < (unsigned long)_type_max) { \
+            cfg.field = (__typeof__(cfg.field))((max) + 1); \
+            settings_clamp_apply(&cfg); \
+            CHECK(cfg.field == (def), "%s: above-max resets to def (%ld)", json_key, (long)(def)); \
+        } \
+    } while (0);
+
+#define ROW_FLT(field, json_key, def, min, max) \
+    do { \
+        app_config_t cfg; \
+        memset(&cfg, 0, sizeof(cfg)); \
+        settings_defaults_apply(&cfg); \
+        cfg.field = (min) - 1.0f; \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field == (float)(min), "%s: below-min clamps to min (%f)", json_key, (double)(min)); \
+        cfg.field = (max) + 1.0f; \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field == (float)(max), "%s: above-max clamps to max (%f)", json_key, (double)(max)); \
+    } while (0);
+
+#define ROW_FLT_RESET(field, json_key, def, min, max) \
+    do { \
+        app_config_t cfg; \
+        memset(&cfg, 0, sizeof(cfg)); \
+        settings_defaults_apply(&cfg); \
+        cfg.field = (min) - 1.0f; \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field == (float)(def), "%s: below-min resets to def (%f)", json_key, (double)(def)); \
+        cfg.field = (max) + 1.0f; \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field == (float)(def), "%s: above-max resets to def (%f)", json_key, (double)(def)); \
+    } while (0);
+
+#define ROW_ENUM(field, json_key, def, count_expr) \
+    do { \
+        app_config_t cfg; \
+        memset(&cfg, 0, sizeof(cfg)); \
+        settings_defaults_apply(&cfg); \
+        cfg.field = (__typeof__(cfg.field))(-1); \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field == (def), "%s: negative resets to def (%ld)", json_key, (long)(def)); \
+        cfg.field = (__typeof__(cfg.field))(count_expr); \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field == (def), "%s: >= count resets to def (%ld)", json_key, (long)(def)); \
+    } while (0);
+
+    SETTINGS_TABLE(ROW_BOOL, ROW_INT, ROW_INT_RESET, ROW_FLT, ROW_FLT_RESET,
+                   ROW_ENUM, ROW_STR, ROW_STR_RESET)
+
+#undef ROW_BOOL
+#undef ROW_INT
+#undef ROW_INT_RESET
+#undef ROW_FLT
+#undef ROW_FLT_RESET
+#undef ROW_ENUM
+#undef ROW_STR
+#undef ROW_STR_RESET
+
+    /* ── 3. STR / STR_RESET rows: NUL-termination and empty-reset ── */
+    printf("3. string rows: NUL-termination + empty-reset\n");
+
+#define ROW2_BOOL(field, json_key, def)
+#define ROW2_INT(field, json_key, def, min, max)
+#define ROW2_INT_RESET(field, json_key, def, min, max)
+#define ROW2_FLT(field, json_key, def, min, max)
+#define ROW2_FLT_RESET(field, json_key, def, min, max)
+#define ROW2_ENUM(field, json_key, def, count_expr)
+
+#define ROW2_STR(field, json_key, def) \
+    do { \
+        app_config_t cfg; \
+        memset(&cfg, 0, sizeof(cfg)); \
+        settings_defaults_apply(&cfg); \
+        memset(cfg.field, 'A', sizeof(cfg.field)); /* unterminated garbage */ \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field[sizeof(cfg.field) - 1] == '\0', "%s: force-NUL-terminated", json_key); \
+    } while (0);
+
+#define ROW2_STR_RESET(field, json_key, def) \
+    do { \
+        app_config_t cfg; \
+        memset(&cfg, 0, sizeof(cfg)); \
+        settings_defaults_apply(&cfg); \
+        memset(cfg.field, 'A', sizeof(cfg.field)); /* unterminated garbage */ \
+        settings_clamp_apply(&cfg); \
+        CHECK(cfg.field[sizeof(cfg.field) - 1] == '\0', "%s: force-NUL-terminated", json_key); \
+        cfg.field[0] = '\0'; /* now empty */ \
+        settings_clamp_apply(&cfg); \
+        CHECK(strcmp(cfg.field, (def)) == 0, "%s: empty string resets to def", json_key); \
+    } while (0);
+
+    SETTINGS_TABLE(ROW2_BOOL, ROW2_INT, ROW2_INT_RESET, ROW2_FLT, ROW2_FLT_RESET,
+                   ROW2_ENUM, ROW2_STR, ROW2_STR_RESET)
+
+#undef ROW2_BOOL
+#undef ROW2_INT
+#undef ROW2_INT_RESET
+#undef ROW2_FLT
+#undef ROW2_FLT_RESET
+#undef ROW2_ENUM
+#undef ROW2_STR
+#undef ROW2_STR_RESET
+
+    /* ── 4. settings_json_serialize() + settings_json_parse() round-trip ──
+     * Perturb every row to a value that differs from its default (still
+     * in-range, so the perturbation itself would survive settings_clamp_apply
+     * unmodified), serialize that config to JSON, parse the JSON into a
+     * SEPARATE defaults-initialized config, and confirm every SETTINGS_TABLE
+     * field made it across unchanged. X-macro-generated so newly added rows
+     * are covered automatically. */
+    printf("4. serialize -> parse round-trip\n");
+    {
+        app_config_t src;
+        memset(&src, 0, sizeof(src));
+        settings_defaults_apply(&src);
+
+#define PERTURB_BOOL(field, json_key, def) src.field = !(def);
+#define PERTURB_INT(field, json_key, def, min, max) \
+        src.field = (__typeof__(src.field))(((max) != (def)) ? (max) : (min));
+#define PERTURB_INT_RESET(field, json_key, def, min, max) \
+        src.field = (__typeof__(src.field))(((max) != (def)) ? (max) : (min));
+#define PERTURB_FLT(field, json_key, def, min, max) \
+        src.field = (((max) != (def)) ? (max) : (min));
+#define PERTURB_FLT_RESET(field, json_key, def, min, max) \
+        src.field = (((max) != (def)) ? (max) : (min));
+#define PERTURB_ENUM(field, json_key, def, count_expr) \
+        src.field = (__typeof__(src.field))((count_expr) - 1);
+#define PERTURB_STR(field, json_key, def) \
+        strncpy(src.field, "roundtrip", sizeof(src.field) - 1);
+#define PERTURB_STR_RESET(field, json_key, def) \
+        strncpy(src.field, "roundtrip", sizeof(src.field) - 1);
+
+        SETTINGS_TABLE(PERTURB_BOOL, PERTURB_INT, PERTURB_INT_RESET, PERTURB_FLT, PERTURB_FLT_RESET,
+                       PERTURB_ENUM, PERTURB_STR, PERTURB_STR_RESET)
+
+#undef PERTURB_BOOL
+#undef PERTURB_INT
+#undef PERTURB_INT_RESET
+#undef PERTURB_FLT
+#undef PERTURB_FLT_RESET
+#undef PERTURB_ENUM
+#undef PERTURB_STR
+#undef PERTURB_STR_RESET
+
+        cJSON *root = cJSON_CreateObject();
+        settings_json_serialize(&src, root);
+
+        app_config_t dst;
+        memset(&dst, 0, sizeof(dst));
+        settings_defaults_apply(&dst);   /* dst starts at defaults: differs from src on every row */
+        settings_json_parse(root, &dst);
+        cJSON_Delete(root);
+
+#define COMPARE_BOOL(field, json_key, def) \
+        CHECK(dst.field == src.field, "%s: round-trips", json_key);
+#define COMPARE_INT(field, json_key, def, min, max) \
+        CHECK(dst.field == src.field, "%s: round-trips", json_key);
+#define COMPARE_INT_RESET(field, json_key, def, min, max) \
+        CHECK(dst.field == src.field, "%s: round-trips", json_key);
+#define COMPARE_FLT(field, json_key, def, min, max) \
+        CHECK(dst.field == src.field, "%s: round-trips", json_key);
+#define COMPARE_FLT_RESET(field, json_key, def, min, max) \
+        CHECK(dst.field == src.field, "%s: round-trips", json_key);
+#define COMPARE_ENUM(field, json_key, def, count_expr) \
+        CHECK(dst.field == src.field, "%s: round-trips", json_key);
+#define COMPARE_STR(field, json_key, def) \
+        CHECK(strcmp(dst.field, src.field) == 0, "%s: round-trips", json_key);
+#define COMPARE_STR_RESET(field, json_key, def) \
+        CHECK(strcmp(dst.field, src.field) == 0, "%s: round-trips", json_key);
+
+        SETTINGS_TABLE(COMPARE_BOOL, COMPARE_INT, COMPARE_INT_RESET, COMPARE_FLT, COMPARE_FLT_RESET,
+                       COMPARE_ENUM, COMPARE_STR, COMPARE_STR_RESET)
+
+#undef COMPARE_BOOL
+#undef COMPARE_INT
+#undef COMPARE_INT_RESET
+#undef COMPARE_FLT
+#undef COMPARE_FLT_RESET
+#undef COMPARE_ENUM
+#undef COMPARE_STR
+#undef COMPARE_STR_RESET
+    }
+
+    /* ── 5. settings_json_parse(): out-of-range JSON values get clamped/reset ──
+     * Spot-checks across kinds (per the task's own examples: brightness,
+     * mqtt_port), not a full X-macro sweep — a few representative rows are
+     * enough to prove settings_json_parse() actually invokes the same
+     * CLAMP_* logic as settings_clamp_apply() (already exhaustively swept
+     * in section 2 above) rather than skipping it. */
+    printf("5. settings_json_parse(): out-of-range values clamped/reset\n");
+    {
+        /* brightness: INT_RESET, def 50, range 0..100. int field (32-bit) —
+         * 9999 does not wrap on cast, so this exercises a genuine reset. */
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+        cJSON *root = cJSON_CreateObject();
+        cJSON_AddNumberToObject(root, "brightness", 9999);
+        settings_json_parse(root, &cfg);
+        CHECK(cfg.brightness == 50, "brightness: 9999 resets to def (50) via JSON parse");
+        cJSON_Delete(root);
+    }
+    {
+        /* mqtt_port: INT_RESET, def 1883, range 1..65535 (the full uint16_t
+         * domain except 0). A too-large JSON number just wraps back into
+         * range on cast to uint16_t, so use 0 -- the one value that casts
+         * to something below min(1) -- to trigger a genuine reset. */
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+        cJSON *root = cJSON_CreateObject();
+        cJSON_AddNumberToObject(root, "mqtt_port", 0);
+        settings_json_parse(root, &cfg);
+        CHECK(cfg.mqtt_port == 1883, "mqtt_port: 0 resets to def (1883) via JSON parse");
+        cJSON_Delete(root);
+    }
+    {
+        /* weather_lat: FLT (true clamp, not reset), def 0.0, range -90..90. */
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+        cJSON *root = cJSON_CreateObject();
+        cJSON_AddNumberToObject(root, "weather_lat", 200.0);
+        settings_json_parse(root, &cfg);
+        CHECK(cfg.weather_lat == 90.0f, "weather_lat: 200 clamps to max (90) via JSON parse");
+        cJSON_Delete(root);
+    }
+    {
+        /* theme_index: ENUM, def 0, count themes_get_count()=9 (stub above). */
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+        cfg.theme_index = 3;   /* pre-set to a non-default in-range value */
+        cJSON *root = cJSON_CreateObject();
+        cJSON_AddNumberToObject(root, "theme_index", 99);
+        settings_json_parse(root, &cfg);
+        CHECK(cfg.theme_index == 0, "theme_index: 99 (>= count) resets to def (0) via JSON parse");
+        cJSON_Delete(root);
+    }
+
+    /* ── 6. settings_json_parse(): missing keys leave fields untouched ── */
+    printf("6. missing keys leave fields untouched\n");
+    {
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+        cfg.brightness = 77;                 /* sentinel: not the default, still in-range */
+        strncpy(cfg.hostname, "sentinel-host", sizeof(cfg.hostname) - 1);
+        cfg.mqtt_enabled = true;             /* sentinel: not the default (false) */
+
+        cJSON *root = cJSON_CreateObject();   /* deliberately empty */
+        settings_json_parse(root, &cfg);
+        cJSON_Delete(root);
+
+        CHECK(cfg.brightness == 77, "brightness: missing key leaves field untouched");
+        CHECK(strcmp(cfg.hostname, "sentinel-host") == 0, "hostname: missing key leaves field untouched");
+        CHECK(cfg.mqtt_enabled == true, "mqtt_enabled: missing key leaves field untouched");
+    }
+
+    /* ── 7. settings_json_parse(): wrong-type JSON values are ignored ── */
+    printf("7. wrong-type values ignored (field left untouched)\n");
+    {
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+        cfg.brightness = 77;
+        strncpy(cfg.hostname, "sentinel-host", sizeof(cfg.hostname) - 1);
+        cfg.mqtt_enabled = false;   /* sentinel chosen to differ from the wrong-type value's content ("true"),
+                                     * so a bug that coerced the string instead of ignoring it would be caught */
+
+        cJSON *root = cJSON_CreateObject();
+        cJSON_AddStringToObject(root, "brightness", "not_a_number");   /* wrong type for INT_RESET */
+        cJSON_AddNumberToObject(root, "hostname", 12345);              /* wrong type for STR */
+        cJSON_AddStringToObject(root, "mqtt_enabled", "true");         /* wrong type for BOOL (string, not JSON bool) */
+        settings_json_parse(root, &cfg);
+        cJSON_Delete(root);
+
+        CHECK(cfg.brightness == 77, "brightness: wrong-type value ignored");
+        CHECK(strcmp(cfg.hostname, "sentinel-host") == 0, "hostname: wrong-type value ignored");
+        CHECK(cfg.mqtt_enabled == false, "mqtt_enabled: wrong-type value ignored");
+    }
+
+    printf("\n%s: %d failure(s)\n", fails == 0 ? "PASS" : "FAIL", fails);
+    return fails == 0 ? 0 : 1;
+}

--- a/test/host/tests/test_nina_sequence.c
+++ b/test/host/tests/test_nina_sequence.c
@@ -1,0 +1,417 @@
+/* Host test for main/nina_sequence.c — the NINA sequence/json tree walker.
+ *
+ * Exercises fetch_sequence_counts_optional() against hand-built JSON
+ * fixtures matching the LIVE ninaAPI v2 sequence/json shape (NOT the
+ * saved-sequence-file shape): target name lives on a container whose
+ * "Name" carries a "_Container" suffix that gets stripped; the active
+ * target is the RUNNING child of "Targets_Container"; exposure counts are
+ * only pulled from a descendant with Name=="Smart Exposure" AND
+ * Status=="RUNNING" (see test_take_many_exposures_not_matched below for
+ * the current-behavior gap this leaves for other step types).
+ *
+ * fetch_sequence_counts_optional() calls http_get_json() (declared in
+ * nina_client_internal.h, implemented in nina_client.c which is NOT
+ * linked here), parse_iso8601() (same header/source split), and
+ * nina_client_now_epoch() (declared in nina_client.h). All three are
+ * mocked below: http_get_json() parses whatever fixture string the test
+ * pointed s_mock_json at; parse_iso8601() is a stub returning 0 since no
+ * fixture here relies on the ExpectedDateTime fallback path;
+ * nina_client_now_epoch() mirrors the production time(NULL) fallback.
+ *
+ * Build: see test/host/CMakeLists.txt (add_nina_host_test(test_nina_sequence ...)).
+ */
+
+#include "nina_sequence.h"
+#include "nina_client_internal.h"
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+/* ---------------------------------------------------------------------
+ * Mocks — nina_sequence.c references these two externs (declared in
+ * nina_client_internal.h); real implementations live in nina_client.c,
+ * which is deliberately not linked into this test binary.
+ * --------------------------------------------------------------------- */
+static const char *s_mock_json = NULL; /* NULL => simulate HTTP/parse failure */
+
+cJSON *http_get_json(const char *url) {
+    (void)url;
+    if (!s_mock_json) {
+        return NULL;
+    }
+    return cJSON_Parse(s_mock_json); /* NULL on malformed JSON, same as prod */
+}
+
+time_t parse_iso8601(const char *str) {
+    (void)str;
+    return 0; /* not exercised by these fixtures (all use RemainingTime) */
+}
+
+/* nina_client_now_epoch() (declared in nina_client.h, implemented in
+ * nina_client.c) is referenced by the ExpectedDateTime fallback path in
+ * find_earliest_condition(). Mirror the production fallback (device wall
+ * clock); no fixture here exercises ExpectedDateTime, so the value is inert. */
+int64_t nina_client_now_epoch(const nina_client_t *client) {
+    (void)client;
+    return (int64_t)time(NULL);
+}
+
+/* ---------------------------------------------------------------------
+ * Assertion helpers (counter + PASS/FAIL prints, nonzero exit on failure —
+ * same style as test/moon/test_moon_compute.c).
+ * --------------------------------------------------------------------- */
+static int fails = 0;
+
+static void expect_str(const char *label, const char *got, const char *want) {
+    int ok = (strcmp(got, want) == 0);
+    printf("%-48s got=\"%s\" want=\"%s\" %s\n", label, got, want, ok ? "OK" : "FAIL");
+    if (!ok) fails++;
+}
+
+static void expect_int(const char *label, int got, int want) {
+    int ok = (got == want);
+    printf("%-48s got=%d want=%d %s\n", label, got, want, ok ? "OK" : "FAIL");
+    if (!ok) fails++;
+}
+
+static void expect_float(const char *label, float got, float want, float tol) {
+    int ok = fabsf(got - want) <= tol;
+    printf("%-48s got=%.2f want=%.2f %s\n", label, got, want, ok ? "OK" : "FAIL");
+    if (!ok) fails++;
+}
+
+static void reset_client(nina_client_t *c) {
+    memset(c, 0, sizeof(*c));
+}
+
+static void run_fetch(const char *json, nina_client_t *c) {
+    s_mock_json = json;
+    fetch_sequence_counts_optional("http://fake-host/v2/api/", c);
+    s_mock_json = NULL;
+}
+
+/* =======================================================================
+ * (a) Normal running Smart Exposure with iterations, plus earliest-
+ *     condition selection across two Conditions entries (also exercises
+ *     classify_condition()'s "Horizon" -> "SETS IN" branch).
+ * ======================================================================= */
+static void test_normal_running_smart_exposure(void) {
+    printf("\n-- test_normal_running_smart_exposure --\n");
+    const char *json =
+        "{"
+        "  \"Response\": ["
+        "    {"
+        "      \"Name\": \"Targets_Container\","
+        "      \"Items\": ["
+        "        {"
+        "          \"Name\": \"M31_Container\","
+        "          \"Status\": \"RUNNING\","
+        "          \"Conditions\": ["
+        "            { \"Name\": \"Time Limit Condition\", \"RemainingTime\": \"5:00:00\" },"
+        "            { \"Name\": \"Horizon Condition\", \"RemainingTime\": \"1:30:00\" }"
+        "          ],"
+        "          \"Items\": ["
+        "            {"
+        "              \"Name\": \"LRGBSHO_Container\","
+        "              \"Status\": \"RUNNING\","
+        "              \"Items\": ["
+        "                {"
+        "                  \"Name\": \"Smart Exposure\","
+        "                  \"Status\": \"RUNNING\","
+        "                  \"CompletedIterations\": 3,"
+        "                  \"Iterations\": 10,"
+        "                  \"ExposureCount\": 45,"
+        "                  \"ExposureTime\": 300"
+        "                }"
+        "              ]"
+        "            }"
+        "          ]"
+        "        }"
+        "      ]"
+        "    }"
+        "  ]"
+        "}";
+
+    nina_client_t c;
+    reset_client(&c);
+    run_fetch(json, &c);
+
+    expect_str("target_name (M31_Container stripped)", c.target_name, "M31");
+    expect_str("prev_target_container (new RUNNING claim)", c.prev_target_container, "M31");
+    expect_str("container_name (deepest RUNNING, stripped)", c.container_name, "LRGBSHO");
+    expect_str("container_step (leaf under running container)", c.container_step, "Smart Exposure");
+    expect_int("exposure_count (CompletedIterations)", c.exposure_count, 3);
+    expect_int("exposure_iterations (Iterations)", c.exposure_iterations, 10);
+    expect_int("exposure_total_count (ExposureCount)", c.exposure_total_count, 45);
+    expect_float("exposure_total (ExposureTime)", c.exposure_total, 300.0f, 0.01f);
+    expect_int("target_condition_count", c.target_condition_count, 2);
+    /* Earliest of 5:00:00 (18000s) and 1:30:00 (5400s) is 1:30:00 -> "1h 30m",
+     * and its Name ("Horizon Condition") classifies to "SETS IN". */
+    expect_str("target_time_remaining (min of two conditions)", c.target_time_remaining, "1h 30m");
+    expect_str("target_time_reason (Horizon -> SETS IN)", c.target_time_reason, "SETS IN");
+}
+
+/* =======================================================================
+ * (b) No RUNNING target anywhere — only a FINISHED target container and a
+ *     FINISHED Smart Exposure. Verifies the FINISHED fallback path fills
+ *     target_name/container_name but does NOT touch prev_target_container,
+ *     container_step, or the exposure counters (all stay at their
+ *     zero-initialized defaults since nothing is RUNNING).
+ * ======================================================================= */
+static void test_no_running_target(void) {
+    printf("\n-- test_no_running_target --\n");
+    const char *json =
+        "{"
+        "  \"Response\": ["
+        "    {"
+        "      \"Name\": \"Targets_Container\","
+        "      \"Items\": ["
+        "        {"
+        "          \"Name\": \"OldTarget_Container\","
+        "          \"Status\": \"FINISHED\","
+        "          \"Items\": ["
+        "            {"
+        "              \"Name\": \"Some_Container\","
+        "              \"Status\": \"FINISHED\","
+        "              \"Items\": ["
+        "                {"
+        "                  \"Name\": \"Smart Exposure\","
+        "                  \"Status\": \"FINISHED\","
+        "                  \"CompletedIterations\": 10,"
+        "                  \"Iterations\": 10"
+        "                }"
+        "              ]"
+        "            }"
+        "          ]"
+        "        }"
+        "      ]"
+        "    }"
+        "  ]"
+        "}";
+
+    nina_client_t c;
+    reset_client(&c);
+    run_fetch(json, &c);
+
+    /* find_active_target_container() falls back to the last FINISHED
+     * container when nothing is RUNNING; fetch_sequence_counts_optional()
+     * only takes the "authoritative new target" branch when that chosen
+     * container's own Status is RUNNING, so this goes through the
+     * "fill when empty" fallback instead. */
+    expect_str("target_name (FINISHED fallback fill)", c.target_name, "OldTarget");
+    expect_str("prev_target_container (untouched, no RUNNING claim)", c.prev_target_container, "");
+    expect_str("container_name (last FINISHED container, stripped)", c.container_name, "Some");
+    expect_str("container_step (nothing RUNNING -> empty)", c.container_step, "");
+    expect_int("exposure_count (no RUNNING Smart Exposure -> untouched)", c.exposure_count, 0);
+    expect_int("exposure_iterations (untouched)", c.exposure_iterations, 0);
+    expect_str("target_time_remaining (no live conditions -> empty)", c.target_time_remaining, "");
+    expect_int("target_condition_count (FINISHED subtree not scanned)", c.target_condition_count, 0);
+}
+
+/* =======================================================================
+ * (c) Three levels of nested RUNNING containers under the target, bottoming
+ *     out at a true leaf step (no "Items" key at all). Verifies
+ *     find_active_container_name() walks to the deepest RUNNING container
+ *     and find_running_step_name() walks to the actual leaf instruction
+ *     rather than stopping at an intermediate container.
+ * ======================================================================= */
+static void test_nested_containers_deep(void) {
+    printf("\n-- test_nested_containers_deep --\n");
+    const char *json =
+        "{"
+        "  \"Response\": ["
+        "    {"
+        "      \"Name\": \"Targets_Container\","
+        "      \"Items\": ["
+        "        {"
+        "          \"Name\": \"NGC7000_Container\","
+        "          \"Status\": \"RUNNING\","
+        "          \"Items\": ["
+        "            {"
+        "              \"Name\": \"Outer_Container\","
+        "              \"Status\": \"RUNNING\","
+        "              \"Items\": ["
+        "                {"
+        "                  \"Name\": \"Inner_Container\","
+        "                  \"Status\": \"RUNNING\","
+        "                  \"Items\": ["
+        "                    { \"Name\": \"Slew To Target\", \"Status\": \"RUNNING\" }"
+        "                  ]"
+        "                }"
+        "              ]"
+        "            }"
+        "          ]"
+        "        }"
+        "      ]"
+        "    }"
+        "  ]"
+        "}";
+
+    nina_client_t c;
+    reset_client(&c);
+    run_fetch(json, &c);
+
+    expect_str("target_name (NGC7000_Container stripped)", c.target_name, "NGC7000");
+    expect_str("container_name (deepest RUNNING container: Inner)", c.container_name, "Inner");
+    expect_str("container_step (true leaf: Slew To Target)", c.container_step, "Slew To Target");
+}
+
+/* =======================================================================
+ * (d) Malformed / truncated JSON must not crash: cJSON_Parse() fails and
+ *     returns NULL, and fetch_sequence_counts_optional() must handle that
+ *     gracefully (early return, client struct untouched). A second variant
+ *     covers structurally-valid JSON with an unexpected type for "Response".
+ * ======================================================================= */
+static void test_malformed_json_no_crash(void) {
+    printf("\n-- test_malformed_json_no_crash --\n");
+
+    /* Truncated mid-object -> cJSON_Parse returns NULL. */
+    const char *truncated =
+        "{\"Response\": [ { \"Name\": \"Targets_Container\", \"Items\": [ { \"Name\": ";
+
+    nina_client_t c;
+    reset_client(&c);
+    run_fetch(truncated, &c); /* must not crash */
+    expect_str("target_name untouched after parse failure", c.target_name, "");
+    expect_str("container_name untouched after parse failure", c.container_name, "");
+
+    /* Valid JSON, but "Response" is a number instead of an array. */
+    const char *wrong_type = "{\"Response\": 42}";
+    reset_client(&c);
+    run_fetch(wrong_type, &c); /* must not crash */
+    expect_str("target_name untouched after wrong-type Response", c.target_name, "");
+    expect_int("exposure_count untouched after wrong-type Response", c.exposure_count, 0);
+}
+
+/* =======================================================================
+ * (e) Empty / null input: http_get_json() returning NULL outright (e.g.
+ *     network failure), and structurally-valid JSON with an empty
+ *     "Response" array (no Targets_Container present at all).
+ * ======================================================================= */
+static void test_empty_null_input(void) {
+    printf("\n-- test_empty_null_input --\n");
+
+    nina_client_t c;
+    reset_client(&c);
+    run_fetch(NULL, &c); /* s_mock_json stays NULL -> http_get_json() returns NULL */
+    expect_str("target_name untouched (http_get_json NULL)", c.target_name, "");
+
+    reset_client(&c);
+    run_fetch("{\"Response\": []}", &c);
+    expect_str("target_name untouched (empty Response array)", c.target_name, "");
+    expect_str("container_name untouched (empty Response array)", c.container_name, "");
+}
+
+/* =======================================================================
+ * (f) "_Container" suffix stripping: a target Name with no suffix is kept
+ *     verbatim; a container Name carrying the suffix mid-string (not just
+ *     as a trailing token) is truncated at the FIRST match, discarding
+ *     everything after it — current documented behavior of
+ *     strstr(out, "_Container") + truncate, not a "strip trailing token"
+ *     operation.
+ * ======================================================================= */
+static void test_container_suffix_stripping(void) {
+    printf("\n-- test_container_suffix_stripping --\n");
+    const char *json =
+        "{"
+        "  \"Response\": ["
+        "    {"
+        "      \"Name\": \"Targets_Container\","
+        "      \"Items\": ["
+        "        {"
+        "          \"Name\": \"M42\","
+        "          \"Status\": \"RUNNING\","
+        "          \"Items\": ["
+        "            {"
+        "              \"Name\": \"Foo_Container_Extra\","
+        "              \"Status\": \"RUNNING\","
+        "              \"Items\": ["
+        "                { \"Name\": \"LeafStep\", \"Status\": \"RUNNING\" }"
+        "              ]"
+        "            }"
+        "          ]"
+        "        }"
+        "      ]"
+        "    }"
+        "  ]"
+        "}";
+
+    nina_client_t c;
+    reset_client(&c);
+    run_fetch(json, &c);
+
+    expect_str("target_name (no suffix present -> unchanged)", c.target_name, "M42");
+    /* "Foo_Container_Extra" truncates at the first "_Container" match,
+     * dropping "_Extra" too -- current behavior, not just suffix removal. */
+    expect_str("container_name (truncates at first _Container match)", c.container_name, "Foo");
+    expect_str("container_step (leaf, no suffix to strip)", c.container_step, "LeafStep");
+}
+
+/* =======================================================================
+ * (g) Bonus / regression guard for a known limitation (see project memory:
+ *     "NINA sequence parser Smart-Exposure-only"): find_running_smart_exposure()
+ *     matches ONLY Name=="Smart Exposure" AND Status=="RUNNING". A RUNNING
+ *     "Take Many Exposures" step (used by Darks/flats-style sequences) is
+ *     NOT matched at current HEAD, so exposure_count/iterations/etc. stay
+ *     at their prior values instead of reflecting the live step. This test
+ *     asserts CURRENT behavior; it is not a fix and should be updated
+ *     in lockstep if find_running_smart_exposure() is ever generalized.
+ * ======================================================================= */
+static void test_take_many_exposures_not_matched(void) {
+    printf("\n-- test_take_many_exposures_not_matched (documents current limitation) --\n");
+    const char *json =
+        "{"
+        "  \"Response\": ["
+        "    {"
+        "      \"Name\": \"Targets_Container\","
+        "      \"Items\": ["
+        "        {"
+        "          \"Name\": \"Target1_Container\","
+        "          \"Status\": \"RUNNING\","
+        "          \"Items\": ["
+        "            {"
+        "              \"Name\": \"Take Many Exposures\","
+        "              \"Status\": \"RUNNING\","
+        "              \"CompletedIterations\": 5,"
+        "              \"Iterations\": 20,"
+        "              \"ExposureCount\": 5,"
+        "              \"ExposureTime\": 60"
+        "            }"
+        "          ]"
+        "        }"
+        "      ]"
+        "    }"
+        "  ]"
+        "}";
+
+    nina_client_t c;
+    reset_client(&c);
+    run_fetch(json, &c);
+
+    expect_str("target_name (still resolved normally)", c.target_name, "Target1");
+    /* find_running_step_name() has no Name-filter, so the step label IS
+     * still surfaced even though the exposure counters are not. */
+    expect_str("container_step (leaf label still surfaces)", c.container_step, "Take Many Exposures");
+    /* "Take Many Exposures" isn't a container (no "Items" key), so it never
+     * satisfies find_active_container_name()'s container check either. */
+    expect_str("container_name (not itself a container -> empty)", c.container_name, "");
+    expect_int("exposure_count (NOT matched -- known limitation)", c.exposure_count, 0);
+    expect_int("exposure_iterations (NOT matched -- known limitation)", c.exposure_iterations, 0);
+    expect_int("exposure_total_count (NOT matched -- known limitation)", c.exposure_total_count, 0);
+    expect_float("exposure_total (NOT matched -- known limitation)", c.exposure_total, 0.0f, 0.01f);
+}
+
+int main(void) {
+    test_normal_running_smart_exposure();
+    test_no_running_target();
+    test_nested_containers_deep();
+    test_malformed_json_no_crash();
+    test_empty_null_input();
+    test_container_suffix_stripping();
+    test_take_many_exposures_not_matched();
+
+    printf("\n%s (%d failures)\n", fails ? "TESTS FAILED" : "ALL TESTS PASSED", fails);
+    return fails ? 1 : 0;
+}

--- a/test/host/tests/test_time_parse.c
+++ b/test/host/tests/test_time_parse.c
@@ -1,0 +1,73 @@
+/* Host test for main/time_parse.c — RFC-1123 HTTP Date header parser.
+ *
+ * time_parse.c is pure standard C (no ESP-IDF headers), so it links
+ * directly with no shims or mocks. Expected epoch values were computed
+ * independently (Unix epoch, UTC):
+ *   2026-07-06 19:06:19 UTC = 1783364779
+ *     (20640 days since 1970-01-01: 56 years * 365 + 14 leap days
+ *      + 181 days Jan..Jun 2026 + 5; * 86400 + 68779)
+ *   2020-02-29 12:00:00 UTC = 1582977600
+ *     (2020-03-01 00:00 UTC = 1583020800, minus 12 h)
+ *
+ * Build: see test/host/CMakeLists.txt (add_nina_host_test(test_time_parse ...)).
+ */
+
+#include "time_parse.h"
+
+#include <stdio.h>
+
+static int fails = 0;
+
+static void expect_time(const char *label, time_t got, long long want) {
+    int ok = ((long long)got == want);
+    printf("%-52s got=%lld want=%lld %s\n", label, (long long)got, want, ok ? "OK" : "FAIL");
+    if (!ok) fails++;
+}
+
+int main(void) {
+    // Canonical RFC-1123 form.
+    expect_time("canonical GMT",
+                time_parse_rfc1123("Mon, 06 Jul 2026 19:06:19 GMT"), 1783364779LL);
+
+    // Leap day in a leap year.
+    expect_time("leap day 2020-02-29",
+                time_parse_rfc1123("Sat, 29 Feb 2020 12:00:00 GMT"), 1582977600LL);
+
+    // "UTC" suffix tolerated.
+    expect_time("UTC suffix",
+                time_parse_rfc1123("Mon, 06 Jul 2026 19:06:19 UTC"), 1783364779LL);
+
+    // Missing timezone suffix tolerated.
+    expect_time("missing suffix",
+                time_parse_rfc1123("Mon, 06 Jul 2026 19:06:19"), 1783364779LL);
+
+    // Single-digit day.
+    expect_time("single-digit day",
+                time_parse_rfc1123("Mon, 6 Jul 2026 19:06:19 GMT"), 1783364779LL);
+
+    // No day-of-week prefix at all.
+    expect_time("no weekday prefix",
+                time_parse_rfc1123("06 Jul 2026 19:06:19 GMT"), 1783364779LL);
+
+    // Epoch reference point.
+    expect_time("epoch start",
+                time_parse_rfc1123("Thu, 01 Jan 1970 00:00:00 GMT"), 0LL);
+
+    // Failure cases -> 0.
+    expect_time("garbage string", time_parse_rfc1123("not a date"), 0LL);
+    expect_time("NULL input", time_parse_rfc1123(NULL), 0LL);
+    expect_time("empty string", time_parse_rfc1123(""), 0LL);
+    expect_time("truncated (no time)", time_parse_rfc1123("Mon, 06 Jul 2026"), 0LL);
+    expect_time("truncated (mid-time)", time_parse_rfc1123("Mon, 06 Jul 2026 19:06"), 0LL);
+    expect_time("bad month name", time_parse_rfc1123("Mon, 06 Xyz 2026 19:06:19 GMT"), 0LL);
+    expect_time("day out of range", time_parse_rfc1123("Mon, 32 Jul 2026 19:06:19 GMT"), 0LL);
+    expect_time("impossible 31 Feb", time_parse_rfc1123("Mon, 31 Feb 2026 19:06:19 GMT"), 0LL);
+    expect_time("29 Feb non-leap", time_parse_rfc1123("Mon, 29 Feb 2026 19:06:19 GMT"), 0LL);
+    expect_time("hour out of range", time_parse_rfc1123("Mon, 06 Jul 2026 24:06:19 GMT"), 0LL);
+    expect_time("pre-epoch year", time_parse_rfc1123("Wed, 06 Jul 1966 19:06:19 GMT"), 0LL);
+    expect_time("bad suffix", time_parse_rfc1123("Mon, 06 Jul 2026 19:06:19 PST"), 0LL);
+    expect_time("trailing garbage", time_parse_rfc1123("Mon, 06 Jul 2026 19:06:19 GMT junk"), 0LL);
+
+    printf("\n%s (%d failure%s)\n", fails == 0 ? "ALL PASS" : "FAILURES", fails, fails == 1 ? "" : "s");
+    return fails == 0 ? 0 : 1;
+}

--- a/test/host/vendor/cJSON/LICENSE
+++ b/test/host/vendor/cJSON/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/test/host/vendor/cJSON/cJSON.c
+++ b/test/host/vendor/cJSON/cJSON.c
@@ -1,0 +1,3191 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+/* cJSON */
+/* JSON parser in C. */
+
+/* disable warnings about old C89 functions in MSVC */
+#if !defined(_CRT_SECURE_NO_DEPRECATE) && defined(_MSC_VER)
+#define _CRT_SECURE_NO_DEPRECATE
+#endif
+
+#ifdef __GNUC__
+#pragma GCC visibility push(default)
+#endif
+#if defined(_MSC_VER)
+#pragma warning (push)
+/* disable warning about single line comments in system headers */
+#pragma warning (disable : 4001)
+#endif
+
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include <stdlib.h>
+#include <limits.h>
+#include <ctype.h>
+#include <float.h>
+
+#ifdef ENABLE_LOCALES
+#include <locale.h>
+#endif
+
+#if defined(_MSC_VER)
+#pragma warning (pop)
+#endif
+#ifdef __GNUC__
+#pragma GCC visibility pop
+#endif
+
+#include "cJSON.h"
+
+/* define our own boolean type */
+#ifdef true
+#undef true
+#endif
+#define true ((cJSON_bool)1)
+
+#ifdef false
+#undef false
+#endif
+#define false ((cJSON_bool)0)
+
+/* define isnan and isinf for ANSI C, if in C99 or above, isnan and isinf has been defined in math.h */
+#ifndef isinf
+#define isinf(d) (isnan((d - d)) && !isnan(d))
+#endif
+#ifndef isnan
+#define isnan(d) (d != d)
+#endif
+
+#ifndef NAN
+#ifdef _WIN32
+#define NAN sqrt(-1.0)
+#else
+#define NAN 0.0/0.0
+#endif
+#endif
+
+typedef struct {
+    const unsigned char *json;
+    size_t position;
+} error;
+static error global_error = { NULL, 0 };
+
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void)
+{
+    return (const char*) (global_error.json + global_error.position);
+}
+
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item)
+{
+    if (!cJSON_IsString(item))
+    {
+        return NULL;
+    }
+
+    return item->valuestring;
+}
+
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item)
+{
+    if (!cJSON_IsNumber(item))
+    {
+        return (double) NAN;
+    }
+
+    return item->valuedouble;
+}
+
+/* This is a safeguard to prevent copy-pasters from using incompatible C and header files */
+#if (CJSON_VERSION_MAJOR != 1) || (CJSON_VERSION_MINOR != 7) || (CJSON_VERSION_PATCH != 19)
+    #error cJSON.h and cJSON.c have different versions. Make sure that both have the same.
+#endif
+
+CJSON_PUBLIC(const char*) cJSON_Version(void)
+{
+    static char version[15];
+    sprintf(version, "%i.%i.%i", CJSON_VERSION_MAJOR, CJSON_VERSION_MINOR, CJSON_VERSION_PATCH);
+
+    return version;
+}
+
+/* Case insensitive string comparison, doesn't consider two NULL pointers equal though */
+static int case_insensitive_strcmp(const unsigned char *string1, const unsigned char *string2)
+{
+    if ((string1 == NULL) || (string2 == NULL))
+    {
+        return 1;
+    }
+
+    if (string1 == string2)
+    {
+        return 0;
+    }
+
+    for(; tolower(*string1) == tolower(*string2); (void)string1++, string2++)
+    {
+        if (*string1 == '\0')
+        {
+            return 0;
+        }
+    }
+
+    return tolower(*string1) - tolower(*string2);
+}
+
+typedef struct internal_hooks
+{
+    void *(CJSON_CDECL *allocate)(size_t size);
+    void (CJSON_CDECL *deallocate)(void *pointer);
+    void *(CJSON_CDECL *reallocate)(void *pointer, size_t size);
+} internal_hooks;
+
+#if defined(_MSC_VER)
+/* work around MSVC error C2322: '...' address of dllimport '...' is not static */
+static void * CJSON_CDECL internal_malloc(size_t size)
+{
+    return malloc(size);
+}
+static void CJSON_CDECL internal_free(void *pointer)
+{
+    free(pointer);
+}
+static void * CJSON_CDECL internal_realloc(void *pointer, size_t size)
+{
+    return realloc(pointer, size);
+}
+#else
+#define internal_malloc malloc
+#define internal_free free
+#define internal_realloc realloc
+#endif
+
+/* strlen of character literals resolved at compile time */
+#define static_strlen(string_literal) (sizeof(string_literal) - sizeof(""))
+
+static internal_hooks global_hooks = { internal_malloc, internal_free, internal_realloc };
+
+static unsigned char* cJSON_strdup(const unsigned char* string, const internal_hooks * const hooks)
+{
+    size_t length = 0;
+    unsigned char *copy = NULL;
+
+    if (string == NULL)
+    {
+        return NULL;
+    }
+
+    length = strlen((const char*)string) + sizeof("");
+    copy = (unsigned char*)hooks->allocate(length);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    memcpy(copy, string, length);
+
+    return copy;
+}
+
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks)
+{
+    if (hooks == NULL)
+    {
+        /* Reset hooks */
+        global_hooks.allocate = malloc;
+        global_hooks.deallocate = free;
+        global_hooks.reallocate = realloc;
+        return;
+    }
+
+    global_hooks.allocate = malloc;
+    if (hooks->malloc_fn != NULL)
+    {
+        global_hooks.allocate = hooks->malloc_fn;
+    }
+
+    global_hooks.deallocate = free;
+    if (hooks->free_fn != NULL)
+    {
+        global_hooks.deallocate = hooks->free_fn;
+    }
+
+    /* use realloc only if both free and malloc are used */
+    global_hooks.reallocate = NULL;
+    if ((global_hooks.allocate == malloc) && (global_hooks.deallocate == free))
+    {
+        global_hooks.reallocate = realloc;
+    }
+}
+
+/* Internal constructor. */
+static cJSON *cJSON_New_Item(const internal_hooks * const hooks)
+{
+    cJSON* node = (cJSON*)hooks->allocate(sizeof(cJSON));
+    if (node)
+    {
+        memset(node, '\0', sizeof(cJSON));
+    }
+
+    return node;
+}
+
+/* Delete a cJSON structure. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item)
+{
+    cJSON *next = NULL;
+    while (item != NULL)
+    {
+        next = item->next;
+        if (!(item->type & cJSON_IsReference) && (item->child != NULL))
+        {
+            cJSON_Delete(item->child);
+        }
+        if (!(item->type & cJSON_IsReference) && (item->valuestring != NULL))
+        {
+            global_hooks.deallocate(item->valuestring);
+            item->valuestring = NULL;
+        }
+        if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+        {
+            global_hooks.deallocate(item->string);
+            item->string = NULL;
+        }
+        global_hooks.deallocate(item);
+        item = next;
+    }
+}
+
+/* get the decimal point character of the current locale */
+static unsigned char get_decimal_point(void)
+{
+#ifdef ENABLE_LOCALES
+    struct lconv *lconv = localeconv();
+    return (unsigned char) lconv->decimal_point[0];
+#else
+    return '.';
+#endif
+}
+
+typedef struct
+{
+    const unsigned char *content;
+    size_t length;
+    size_t offset;
+    size_t depth; /* How deeply nested (in arrays/objects) is the input at the current offset. */
+    internal_hooks hooks;
+} parse_buffer;
+
+/* check if the given size is left to read in a given parse buffer (starting with 1) */
+#define can_read(buffer, size) ((buffer != NULL) && (((buffer)->offset + size) <= (buffer)->length))
+/* check if the buffer can be accessed at the given index (starting with 0) */
+#define can_access_at_index(buffer, index) ((buffer != NULL) && (((buffer)->offset + index) < (buffer)->length))
+#define cannot_access_at_index(buffer, index) (!can_access_at_index(buffer, index))
+/* get a pointer to the buffer at the position */
+#define buffer_at_offset(buffer) ((buffer)->content + (buffer)->offset)
+
+/* Parse the input text to generate a number, and populate the result into item. */
+static cJSON_bool parse_number(cJSON * const item, parse_buffer * const input_buffer)
+{
+    double number = 0;
+    unsigned char *after_end = NULL;
+    unsigned char *number_c_string;
+    unsigned char decimal_point = get_decimal_point();
+    size_t i = 0;
+    size_t number_string_length = 0;
+    cJSON_bool has_decimal_point = false;
+
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false;
+    }
+
+    /* copy the number into a temporary buffer and replace '.' with the decimal point
+     * of the current locale (for strtod)
+     * This also takes care of '\0' not necessarily being available for marking the end of the input */
+    for (i = 0; can_access_at_index(input_buffer, i); i++)
+    {
+        switch (buffer_at_offset(input_buffer)[i])
+        {
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+            case '+':
+            case '-':
+            case 'e':
+            case 'E':
+                number_string_length++;
+                break;
+
+            case '.':
+                number_string_length++;
+                has_decimal_point = true;
+                break;
+
+            default:
+                goto loop_end;
+        }
+    }
+loop_end:
+    /* malloc for temporary buffer, add 1 for '\0' */
+    number_c_string = (unsigned char *) input_buffer->hooks.allocate(number_string_length + 1);
+    if (number_c_string == NULL)
+    {
+        return false; /* allocation failure */
+    }
+
+    memcpy(number_c_string, buffer_at_offset(input_buffer), number_string_length);
+    number_c_string[number_string_length] = '\0';
+
+    if (has_decimal_point)
+    {
+        for (i = 0; i < number_string_length; i++)
+        {
+            if (number_c_string[i] == '.')
+            {
+                /* replace '.' with the decimal point of the current locale (for strtod) */
+                number_c_string[i] = decimal_point;
+            }
+        }
+    }
+
+    number = strtod((const char*)number_c_string, (char**)&after_end);
+    if (number_c_string == after_end)
+    {
+        /* free the temporary buffer */
+        input_buffer->hooks.deallocate(number_c_string);
+        return false; /* parse_error */
+    }
+
+    item->valuedouble = number;
+
+    /* use saturation in case of overflow */
+    if (number >= INT_MAX)
+    {
+        item->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        item->valueint = INT_MIN;
+    }
+    else
+    {
+        item->valueint = (int)number;
+    }
+
+    item->type = cJSON_Number;
+
+    input_buffer->offset += (size_t)(after_end - number_c_string);
+    /* free the temporary buffer */
+    input_buffer->hooks.deallocate(number_c_string);
+    return true;
+}
+
+/* don't ask me, but the original cJSON_SetNumberValue returns an integer or double */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number)
+{
+    if (number >= INT_MAX)
+    {
+        object->valueint = INT_MAX;
+    }
+    else if (number <= (double)INT_MIN)
+    {
+        object->valueint = INT_MIN;
+    }
+    else
+    {
+        object->valueint = (int)number;
+    }
+
+    return object->valuedouble = number;
+}
+
+/* Note: when passing a NULL valuestring, cJSON_SetValuestring treats this as an error and return NULL */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring)
+{
+    char *copy = NULL;
+    size_t v1_len;
+    size_t v2_len;
+    /* if object's type is not cJSON_String or is cJSON_IsReference, it should not set valuestring */
+    if ((object == NULL) || !(object->type & cJSON_String) || (object->type & cJSON_IsReference))
+    {
+        return NULL;
+    }
+    /* return NULL if the object is corrupted or valuestring is NULL */
+    if (object->valuestring == NULL || valuestring == NULL)
+    {
+        return NULL;
+    }
+
+    v1_len = strlen(valuestring);
+    v2_len = strlen(object->valuestring);
+
+    if (v1_len <= v2_len)
+    {
+        /* strcpy does not handle overlapping string: [X1, X2] [Y1, Y2] => X2 < Y1 or Y2 < X1 */
+        if (!( valuestring + v1_len < object->valuestring || object->valuestring + v2_len < valuestring ))
+        {
+            return NULL;
+        }
+        strcpy(object->valuestring, valuestring);
+        return object->valuestring;
+    }
+    copy = (char*) cJSON_strdup((const unsigned char*)valuestring, &global_hooks);
+    if (copy == NULL)
+    {
+        return NULL;
+    }
+    if (object->valuestring != NULL)
+    {
+        cJSON_free(object->valuestring);
+    }
+    object->valuestring = copy;
+
+    return copy;
+}
+
+typedef struct
+{
+    unsigned char *buffer;
+    size_t length;
+    size_t offset;
+    size_t depth; /* current nesting depth (for formatted printing) */
+    cJSON_bool noalloc;
+    cJSON_bool format; /* is this print a formatted print */
+    internal_hooks hooks;
+} printbuffer;
+
+/* realloc printbuffer if necessary to have at least "needed" bytes more */
+static unsigned char* ensure(printbuffer * const p, size_t needed)
+{
+    unsigned char *newbuffer = NULL;
+    size_t newsize = 0;
+
+    if ((p == NULL) || (p->buffer == NULL))
+    {
+        return NULL;
+    }
+
+    if ((p->length > 0) && (p->offset >= p->length))
+    {
+        /* make sure that offset is valid */
+        return NULL;
+    }
+
+    if (needed > INT_MAX)
+    {
+        /* sizes bigger than INT_MAX are currently not supported */
+        return NULL;
+    }
+
+    needed += p->offset + 1;
+    if (needed <= p->length)
+    {
+        return p->buffer + p->offset;
+    }
+
+    if (p->noalloc) {
+        return NULL;
+    }
+
+    /* calculate new buffer size */
+    if (needed > (INT_MAX / 2))
+    {
+        /* overflow of int, use INT_MAX if possible */
+        if (needed <= INT_MAX)
+        {
+            newsize = INT_MAX;
+        }
+        else
+        {
+            return NULL;
+        }
+    }
+    else
+    {
+        newsize = needed * 2;
+    }
+
+    if (p->hooks.reallocate != NULL)
+    {
+        /* reallocate with realloc if available */
+        newbuffer = (unsigned char*)p->hooks.reallocate(p->buffer, newsize);
+        if (newbuffer == NULL)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+    }
+    else
+    {
+        /* otherwise reallocate manually */
+        newbuffer = (unsigned char*)p->hooks.allocate(newsize);
+        if (!newbuffer)
+        {
+            p->hooks.deallocate(p->buffer);
+            p->length = 0;
+            p->buffer = NULL;
+
+            return NULL;
+        }
+
+        memcpy(newbuffer, p->buffer, p->offset + 1);
+        p->hooks.deallocate(p->buffer);
+    }
+    p->length = newsize;
+    p->buffer = newbuffer;
+
+    return newbuffer + p->offset;
+}
+
+/* calculate the new length of the string in a printbuffer and update the offset */
+static void update_offset(printbuffer * const buffer)
+{
+    const unsigned char *buffer_pointer = NULL;
+    if ((buffer == NULL) || (buffer->buffer == NULL))
+    {
+        return;
+    }
+    buffer_pointer = buffer->buffer + buffer->offset;
+
+    buffer->offset += strlen((const char*)buffer_pointer);
+}
+
+/* securely comparison of floating-point variables */
+static cJSON_bool compare_double(double a, double b)
+{
+    double maxVal = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
+    return (fabs(a - b) <= maxVal * DBL_EPSILON);
+}
+
+/* Render the number nicely from the given item into a string. */
+static cJSON_bool print_number(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    double d = item->valuedouble;
+    int length = 0;
+    size_t i = 0;
+    unsigned char number_buffer[26] = {0}; /* temporary buffer to print the number into */
+    unsigned char decimal_point = get_decimal_point();
+    double test = 0.0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* This checks for NaN and Infinity */
+    if (isnan(d) || isinf(d))
+    {
+        length = sprintf((char*)number_buffer, "null");
+    }
+    else if(d == (double)item->valueint)
+    {
+        length = sprintf((char*)number_buffer, "%d", item->valueint);
+    }
+    else
+    {
+        /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
+        length = sprintf((char*)number_buffer, "%1.15g", d);
+
+        /* Check whether the original double can be recovered */
+        if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || !compare_double((double)test, d))
+        {
+            /* If not, print with 17 decimal places of precision */
+            length = sprintf((char*)number_buffer, "%1.17g", d);
+        }
+    }
+
+    /* sprintf failed or buffer overrun occurred */
+    if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1)))
+    {
+        return false;
+    }
+
+    /* reserve appropriate space in the output */
+    output_pointer = ensure(output_buffer, (size_t)length + sizeof(""));
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    /* copy the printed number to the output and replace locale
+     * dependent decimal point with '.' */
+    for (i = 0; i < ((size_t)length); i++)
+    {
+        if (number_buffer[i] == decimal_point)
+        {
+            output_pointer[i] = '.';
+            continue;
+        }
+
+        output_pointer[i] = number_buffer[i];
+    }
+    output_pointer[i] = '\0';
+
+    output_buffer->offset += (size_t)length;
+
+    return true;
+}
+
+/* parse 4 digit hexadecimal number */
+static unsigned parse_hex4(const unsigned char * const input)
+{
+    unsigned int h = 0;
+    size_t i = 0;
+
+    for (i = 0; i < 4; i++)
+    {
+        /* parse digit */
+        if ((input[i] >= '0') && (input[i] <= '9'))
+        {
+            h += (unsigned int) input[i] - '0';
+        }
+        else if ((input[i] >= 'A') && (input[i] <= 'F'))
+        {
+            h += (unsigned int) 10 + input[i] - 'A';
+        }
+        else if ((input[i] >= 'a') && (input[i] <= 'f'))
+        {
+            h += (unsigned int) 10 + input[i] - 'a';
+        }
+        else /* invalid */
+        {
+            return 0;
+        }
+
+        if (i < 3)
+        {
+            /* shift left to make place for the next nibble */
+            h = h << 4;
+        }
+    }
+
+    return h;
+}
+
+/* converts a UTF-16 literal to UTF-8
+ * A literal can be one or two sequences of the form \uXXXX */
+static unsigned char utf16_literal_to_utf8(const unsigned char * const input_pointer, const unsigned char * const input_end, unsigned char **output_pointer)
+{
+    long unsigned int codepoint = 0;
+    unsigned int first_code = 0;
+    const unsigned char *first_sequence = input_pointer;
+    unsigned char utf8_length = 0;
+    unsigned char utf8_position = 0;
+    unsigned char sequence_length = 0;
+    unsigned char first_byte_mark = 0;
+
+    if ((input_end - first_sequence) < 6)
+    {
+        /* input ends unexpectedly */
+        goto fail;
+    }
+
+    /* get the first utf16 sequence */
+    first_code = parse_hex4(first_sequence + 2);
+
+    /* check that the code is valid */
+    if (((first_code >= 0xDC00) && (first_code <= 0xDFFF)))
+    {
+        goto fail;
+    }
+
+    /* UTF16 surrogate pair */
+    if ((first_code >= 0xD800) && (first_code <= 0xDBFF))
+    {
+        const unsigned char *second_sequence = first_sequence + 6;
+        unsigned int second_code = 0;
+        sequence_length = 12; /* \uXXXX\uXXXX */
+
+        if ((input_end - second_sequence) < 6)
+        {
+            /* input ends unexpectedly */
+            goto fail;
+        }
+
+        if ((second_sequence[0] != '\\') || (second_sequence[1] != 'u'))
+        {
+            /* missing second half of the surrogate pair */
+            goto fail;
+        }
+
+        /* get the second utf16 sequence */
+        second_code = parse_hex4(second_sequence + 2);
+        /* check that the code is valid */
+        if ((second_code < 0xDC00) || (second_code > 0xDFFF))
+        {
+            /* invalid second half of the surrogate pair */
+            goto fail;
+        }
+
+
+        /* calculate the unicode codepoint from the surrogate pair */
+        codepoint = 0x10000 + (((first_code & 0x3FF) << 10) | (second_code & 0x3FF));
+    }
+    else
+    {
+        sequence_length = 6; /* \uXXXX */
+        codepoint = first_code;
+    }
+
+    /* encode as UTF-8
+     * takes at maximum 4 bytes to encode:
+     * 11110xxx 10xxxxxx 10xxxxxx 10xxxxxx */
+    if (codepoint < 0x80)
+    {
+        /* normal ascii, encoding 0xxxxxxx */
+        utf8_length = 1;
+    }
+    else if (codepoint < 0x800)
+    {
+        /* two bytes, encoding 110xxxxx 10xxxxxx */
+        utf8_length = 2;
+        first_byte_mark = 0xC0; /* 11000000 */
+    }
+    else if (codepoint < 0x10000)
+    {
+        /* three bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 3;
+        first_byte_mark = 0xE0; /* 11100000 */
+    }
+    else if (codepoint <= 0x10FFFF)
+    {
+        /* four bytes, encoding 1110xxxx 10xxxxxx 10xxxxxx 10xxxxxx */
+        utf8_length = 4;
+        first_byte_mark = 0xF0; /* 11110000 */
+    }
+    else
+    {
+        /* invalid unicode codepoint */
+        goto fail;
+    }
+
+    /* encode as utf8 */
+    for (utf8_position = (unsigned char)(utf8_length - 1); utf8_position > 0; utf8_position--)
+    {
+        /* 10xxxxxx */
+        (*output_pointer)[utf8_position] = (unsigned char)((codepoint | 0x80) & 0xBF);
+        codepoint >>= 6;
+    }
+    /* encode first byte */
+    if (utf8_length > 1)
+    {
+        (*output_pointer)[0] = (unsigned char)((codepoint | first_byte_mark) & 0xFF);
+    }
+    else
+    {
+        (*output_pointer)[0] = (unsigned char)(codepoint & 0x7F);
+    }
+
+    *output_pointer += utf8_length;
+
+    return sequence_length;
+
+fail:
+    return 0;
+}
+
+/* Parse the input text into an unescaped cinput, and populate item. */
+static cJSON_bool parse_string(cJSON * const item, parse_buffer * const input_buffer)
+{
+    const unsigned char *input_pointer = buffer_at_offset(input_buffer) + 1;
+    const unsigned char *input_end = buffer_at_offset(input_buffer) + 1;
+    unsigned char *output_pointer = NULL;
+    unsigned char *output = NULL;
+
+    /* not a string */
+    if (buffer_at_offset(input_buffer)[0] != '\"')
+    {
+        goto fail;
+    }
+
+    {
+        /* calculate approximate size of the output (overestimate) */
+        size_t allocation_length = 0;
+        size_t skipped_bytes = 0;
+        while (((size_t)(input_end - input_buffer->content) < input_buffer->length) && (*input_end != '\"'))
+        {
+            /* is escape sequence */
+            if (input_end[0] == '\\')
+            {
+                if ((size_t)(input_end + 1 - input_buffer->content) >= input_buffer->length)
+                {
+                    /* prevent buffer overflow when last input character is a backslash */
+                    goto fail;
+                }
+                skipped_bytes++;
+                input_end++;
+            }
+            input_end++;
+        }
+        if (((size_t)(input_end - input_buffer->content) >= input_buffer->length) || (*input_end != '\"'))
+        {
+            goto fail; /* string ended unexpectedly */
+        }
+
+        /* This is at most how much we need for the output */
+        allocation_length = (size_t) (input_end - buffer_at_offset(input_buffer)) - skipped_bytes;
+        output = (unsigned char*)input_buffer->hooks.allocate(allocation_length + sizeof(""));
+        if (output == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+    }
+
+    output_pointer = output;
+    /* loop through the string literal */
+    while (input_pointer < input_end)
+    {
+        if (*input_pointer != '\\')
+        {
+            *output_pointer++ = *input_pointer++;
+        }
+        /* escape sequence */
+        else
+        {
+            unsigned char sequence_length = 2;
+            if ((input_end - input_pointer) < 1)
+            {
+                goto fail;
+            }
+
+            switch (input_pointer[1])
+            {
+                case 'b':
+                    *output_pointer++ = '\b';
+                    break;
+                case 'f':
+                    *output_pointer++ = '\f';
+                    break;
+                case 'n':
+                    *output_pointer++ = '\n';
+                    break;
+                case 'r':
+                    *output_pointer++ = '\r';
+                    break;
+                case 't':
+                    *output_pointer++ = '\t';
+                    break;
+                case '\"':
+                case '\\':
+                case '/':
+                    *output_pointer++ = input_pointer[1];
+                    break;
+
+                /* UTF-16 literal */
+                case 'u':
+                    sequence_length = utf16_literal_to_utf8(input_pointer, input_end, &output_pointer);
+                    if (sequence_length == 0)
+                    {
+                        /* failed to convert UTF16-literal to UTF-8 */
+                        goto fail;
+                    }
+                    break;
+
+                default:
+                    goto fail;
+            }
+            input_pointer += sequence_length;
+        }
+    }
+
+    /* zero terminate the output */
+    *output_pointer = '\0';
+
+    item->type = cJSON_String;
+    item->valuestring = (char*)output;
+
+    input_buffer->offset = (size_t) (input_end - input_buffer->content);
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (output != NULL)
+    {
+        input_buffer->hooks.deallocate(output);
+        output = NULL;
+    }
+
+    if (input_pointer != NULL)
+    {
+        input_buffer->offset = (size_t)(input_pointer - input_buffer->content);
+    }
+
+    return false;
+}
+
+/* Render the cstring provided to an escaped version that can be printed. */
+static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffer * const output_buffer)
+{
+    const unsigned char *input_pointer = NULL;
+    unsigned char *output = NULL;
+    unsigned char *output_pointer = NULL;
+    size_t output_length = 0;
+    /* numbers of additional characters needed for escaping */
+    size_t escape_characters = 0;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* empty string */
+    if (input == NULL)
+    {
+        output = ensure(output_buffer, sizeof("\"\""));
+        if (output == NULL)
+        {
+            return false;
+        }
+        strcpy((char*)output, "\"\"");
+
+        return true;
+    }
+
+    /* set "flag" to 1 if something needs to be escaped */
+    for (input_pointer = input; *input_pointer; input_pointer++)
+    {
+        switch (*input_pointer)
+        {
+            case '\"':
+            case '\\':
+            case '\b':
+            case '\f':
+            case '\n':
+            case '\r':
+            case '\t':
+                /* one character escape sequence */
+                escape_characters++;
+                break;
+            default:
+                if (*input_pointer < 32)
+                {
+                    /* UTF-16 escape sequence uXXXX */
+                    escape_characters += 5;
+                }
+                break;
+        }
+    }
+    output_length = (size_t)(input_pointer - input) + escape_characters;
+
+    output = ensure(output_buffer, output_length + sizeof("\"\""));
+    if (output == NULL)
+    {
+        return false;
+    }
+
+    /* no characters have to be escaped */
+    if (escape_characters == 0)
+    {
+        output[0] = '\"';
+        memcpy(output + 1, input, output_length);
+        output[output_length + 1] = '\"';
+        output[output_length + 2] = '\0';
+
+        return true;
+    }
+
+    output[0] = '\"';
+    output_pointer = output + 1;
+    /* copy the string */
+    for (input_pointer = input; *input_pointer != '\0'; (void)input_pointer++, output_pointer++)
+    {
+        if ((*input_pointer > 31) && (*input_pointer != '\"') && (*input_pointer != '\\'))
+        {
+            /* normal character, copy */
+            *output_pointer = *input_pointer;
+        }
+        else
+        {
+            /* character needs to be escaped */
+            *output_pointer++ = '\\';
+            switch (*input_pointer)
+            {
+                case '\\':
+                    *output_pointer = '\\';
+                    break;
+                case '\"':
+                    *output_pointer = '\"';
+                    break;
+                case '\b':
+                    *output_pointer = 'b';
+                    break;
+                case '\f':
+                    *output_pointer = 'f';
+                    break;
+                case '\n':
+                    *output_pointer = 'n';
+                    break;
+                case '\r':
+                    *output_pointer = 'r';
+                    break;
+                case '\t':
+                    *output_pointer = 't';
+                    break;
+                default:
+                    /* escape and print as unicode codepoint */
+                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    output_pointer += 4;
+                    break;
+            }
+        }
+    }
+    output[output_length + 1] = '\"';
+    output[output_length + 2] = '\0';
+
+    return true;
+}
+
+/* Invoke print_string_ptr (which is useful) on an item. */
+static cJSON_bool print_string(const cJSON * const item, printbuffer * const p)
+{
+    return print_string_ptr((unsigned char*)item->valuestring, p);
+}
+
+/* Predeclare these prototypes. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer);
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer);
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer);
+
+/* Utility to jump whitespace and cr/lf */
+static parse_buffer *buffer_skip_whitespace(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL))
+    {
+        return NULL;
+    }
+
+    if (cannot_access_at_index(buffer, 0))
+    {
+        return buffer;
+    }
+
+    while (can_access_at_index(buffer, 0) && (buffer_at_offset(buffer)[0] <= 32))
+    {
+       buffer->offset++;
+    }
+
+    if (buffer->offset == buffer->length)
+    {
+        buffer->offset--;
+    }
+
+    return buffer;
+}
+
+/* skip the UTF-8 BOM (byte order mark) if it is at the beginning of a buffer */
+static parse_buffer *skip_utf8_bom(parse_buffer * const buffer)
+{
+    if ((buffer == NULL) || (buffer->content == NULL) || (buffer->offset != 0))
+    {
+        return NULL;
+    }
+
+    if (can_access_at_index(buffer, 4) && (strncmp((const char*)buffer_at_offset(buffer), "\xEF\xBB\xBF", 3) == 0))
+    {
+        buffer->offset += 3;
+    }
+
+    return buffer;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    size_t buffer_length;
+
+    if (NULL == value)
+    {
+        return NULL;
+    }
+
+    /* Adding null character size due to require_null_terminated. */
+    buffer_length = strlen(value) + sizeof("");
+
+    return cJSON_ParseWithLengthOpts(value, buffer_length, return_parse_end, require_null_terminated);
+}
+
+/* Parse an object - create a new root, and populate. */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated)
+{
+    parse_buffer buffer = { 0, 0, 0, 0, { 0, 0, 0 } };
+    cJSON *item = NULL;
+
+    /* reset error position */
+    global_error.json = NULL;
+    global_error.position = 0;
+
+    if (value == NULL || 0 == buffer_length)
+    {
+        goto fail;
+    }
+
+    buffer.content = (const unsigned char*)value;
+    buffer.length = buffer_length;
+    buffer.offset = 0;
+    buffer.hooks = global_hooks;
+
+    item = cJSON_New_Item(&global_hooks);
+    if (item == NULL) /* memory fail */
+    {
+        goto fail;
+    }
+
+    if (!parse_value(item, buffer_skip_whitespace(skip_utf8_bom(&buffer))))
+    {
+        /* parse failure. ep is set. */
+        goto fail;
+    }
+
+    /* if we require null-terminated JSON without appended garbage, skip and then check for a null terminator */
+    if (require_null_terminated)
+    {
+        buffer_skip_whitespace(&buffer);
+        if ((buffer.offset >= buffer.length) || buffer_at_offset(&buffer)[0] != '\0')
+        {
+            goto fail;
+        }
+    }
+    if (return_parse_end)
+    {
+        *return_parse_end = (const char*)buffer_at_offset(&buffer);
+    }
+
+    return item;
+
+fail:
+    if (item != NULL)
+    {
+        cJSON_Delete(item);
+    }
+
+    if (value != NULL)
+    {
+        error local_error;
+        local_error.json = (const unsigned char*)value;
+        local_error.position = 0;
+
+        if (buffer.offset < buffer.length)
+        {
+            local_error.position = buffer.offset;
+        }
+        else if (buffer.length > 0)
+        {
+            local_error.position = buffer.length - 1;
+        }
+
+        if (return_parse_end != NULL)
+        {
+            *return_parse_end = (const char*)local_error.json + local_error.position;
+        }
+
+        global_error = local_error;
+    }
+
+    return NULL;
+}
+
+/* Default options for cJSON_Parse */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value)
+{
+    return cJSON_ParseWithOpts(value, 0, 0);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length)
+{
+    return cJSON_ParseWithLengthOpts(value, buffer_length, 0, 0);
+}
+
+#define cjson_min(a, b) (((a) < (b)) ? (a) : (b))
+
+static unsigned char *print(const cJSON * const item, cJSON_bool format, const internal_hooks * const hooks)
+{
+    static const size_t default_buffer_size = 256;
+    printbuffer buffer[1];
+    unsigned char *printed = NULL;
+
+    memset(buffer, 0, sizeof(buffer));
+
+    /* create buffer */
+    buffer->buffer = (unsigned char*) hooks->allocate(default_buffer_size);
+    buffer->length = default_buffer_size;
+    buffer->format = format;
+    buffer->hooks = *hooks;
+    if (buffer->buffer == NULL)
+    {
+        goto fail;
+    }
+
+    /* print the value */
+    if (!print_value(item, buffer))
+    {
+        goto fail;
+    }
+    update_offset(buffer);
+
+    /* check if reallocate is available */
+    if (hooks->reallocate != NULL)
+    {
+        printed = (unsigned char*) hooks->reallocate(buffer->buffer, buffer->offset + 1);
+        if (printed == NULL) {
+            goto fail;
+        }
+        buffer->buffer = NULL;
+    }
+    else /* otherwise copy the JSON over to a new buffer */
+    {
+        printed = (unsigned char*) hooks->allocate(buffer->offset + 1);
+        if (printed == NULL)
+        {
+            goto fail;
+        }
+        memcpy(printed, buffer->buffer, cjson_min(buffer->length, buffer->offset + 1));
+        printed[buffer->offset] = '\0'; /* just to be sure */
+
+        /* free the buffer */
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    return printed;
+
+fail:
+    if (buffer->buffer != NULL)
+    {
+        hooks->deallocate(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+
+    if (printed != NULL)
+    {
+        hooks->deallocate(printed);
+        printed = NULL;
+    }
+
+    return NULL;
+}
+
+/* Render a cJSON item/entity/structure to text. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item)
+{
+    return (char*)print(item, true, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item)
+{
+    return (char*)print(item, false, &global_hooks);
+}
+
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if (prebuffer < 0)
+    {
+        return NULL;
+    }
+
+    p.buffer = (unsigned char*)global_hooks.allocate((size_t)prebuffer);
+    if (!p.buffer)
+    {
+        return NULL;
+    }
+
+    p.length = (size_t)prebuffer;
+    p.offset = 0;
+    p.noalloc = false;
+    p.format = fmt;
+    p.hooks = global_hooks;
+
+    if (!print_value(item, &p))
+    {
+        global_hooks.deallocate(p.buffer);
+        p.buffer = NULL;
+        return NULL;
+    }
+
+    return (char*)p.buffer;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format)
+{
+    printbuffer p = { 0, 0, 0, 0, 0, 0, { 0, 0, 0 } };
+
+    if ((length < 0) || (buffer == NULL))
+    {
+        return false;
+    }
+
+    p.buffer = (unsigned char*)buffer;
+    p.length = (size_t)length;
+    p.offset = 0;
+    p.noalloc = true;
+    p.format = format;
+    p.hooks = global_hooks;
+
+    return print_value(item, &p);
+}
+
+/* Parser core - when encountering text, process appropriately. */
+static cJSON_bool parse_value(cJSON * const item, parse_buffer * const input_buffer)
+{
+    if ((input_buffer == NULL) || (input_buffer->content == NULL))
+    {
+        return false; /* no input */
+    }
+
+    /* parse the different types of values */
+    /* null */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "null", 4) == 0))
+    {
+        item->type = cJSON_NULL;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* false */
+    if (can_read(input_buffer, 5) && (strncmp((const char*)buffer_at_offset(input_buffer), "false", 5) == 0))
+    {
+        item->type = cJSON_False;
+        input_buffer->offset += 5;
+        return true;
+    }
+    /* true */
+    if (can_read(input_buffer, 4) && (strncmp((const char*)buffer_at_offset(input_buffer), "true", 4) == 0))
+    {
+        item->type = cJSON_True;
+        item->valueint = 1;
+        input_buffer->offset += 4;
+        return true;
+    }
+    /* string */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '\"'))
+    {
+        return parse_string(item, input_buffer);
+    }
+    /* number */
+    if (can_access_at_index(input_buffer, 0) && ((buffer_at_offset(input_buffer)[0] == '-') || ((buffer_at_offset(input_buffer)[0] >= '0') && (buffer_at_offset(input_buffer)[0] <= '9'))))
+    {
+        return parse_number(item, input_buffer);
+    }
+    /* array */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '['))
+    {
+        return parse_array(item, input_buffer);
+    }
+    /* object */
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '{'))
+    {
+        return parse_object(item, input_buffer);
+    }
+
+    return false;
+}
+
+/* Render a value to text. */
+static cJSON_bool print_value(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output = NULL;
+
+    if ((item == NULL) || (output_buffer == NULL))
+    {
+        return false;
+    }
+
+    switch ((item->type) & 0xFF)
+    {
+        case cJSON_NULL:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "null");
+            return true;
+
+        case cJSON_False:
+            output = ensure(output_buffer, 6);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "false");
+            return true;
+
+        case cJSON_True:
+            output = ensure(output_buffer, 5);
+            if (output == NULL)
+            {
+                return false;
+            }
+            strcpy((char*)output, "true");
+            return true;
+
+        case cJSON_Number:
+            return print_number(item, output_buffer);
+
+        case cJSON_Raw:
+        {
+            size_t raw_length = 0;
+            if (item->valuestring == NULL)
+            {
+                return false;
+            }
+
+            raw_length = strlen(item->valuestring) + sizeof("");
+            output = ensure(output_buffer, raw_length);
+            if (output == NULL)
+            {
+                return false;
+            }
+            memcpy(output, item->valuestring, raw_length);
+            return true;
+        }
+
+        case cJSON_String:
+            return print_string(item, output_buffer);
+
+        case cJSON_Array:
+            return print_array(item, output_buffer);
+
+        case cJSON_Object:
+            return print_object(item, output_buffer);
+
+        default:
+            return false;
+    }
+}
+
+/* Build an array from input text. */
+static cJSON_bool parse_array(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* head of the linked list */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (buffer_at_offset(input_buffer)[0] != '[')
+    {
+        /* not an array */
+        goto fail;
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ']'))
+    {
+        /* empty array */
+        goto success;
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        /* parse next value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || buffer_at_offset(input_buffer)[0] != ']')
+    {
+        goto fail; /* expected end of array */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Array;
+    item->child = head;
+
+    input_buffer->offset++;
+
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an array to text */
+static cJSON_bool print_array(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_element = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output array. */
+    /* opening square bracket */
+    output_pointer = ensure(output_buffer, 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer = '[';
+    output_buffer->offset++;
+    output_buffer->depth++;
+
+    while (current_element != NULL)
+    {
+        if (!print_value(current_element, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+        if (current_element->next)
+        {
+            length = (size_t) (output_buffer->format ? 2 : 1);
+            output_pointer = ensure(output_buffer, length + 1);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            *output_pointer++ = ',';
+            if(output_buffer->format)
+            {
+                *output_pointer++ = ' ';
+            }
+            *output_pointer = '\0';
+            output_buffer->offset += length;
+        }
+        current_element = current_element->next;
+    }
+
+    output_pointer = ensure(output_buffer, 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    *output_pointer++ = ']';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Build an object from the text. */
+static cJSON_bool parse_object(cJSON * const item, parse_buffer * const input_buffer)
+{
+    cJSON *head = NULL; /* linked list head */
+    cJSON *current_item = NULL;
+
+    if (input_buffer->depth >= CJSON_NESTING_LIMIT)
+    {
+        return false; /* to deeply nested */
+    }
+    input_buffer->depth++;
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '{'))
+    {
+        goto fail; /* not an object */
+    }
+
+    input_buffer->offset++;
+    buffer_skip_whitespace(input_buffer);
+    if (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == '}'))
+    {
+        goto success; /* empty object */
+    }
+
+    /* check if we skipped to the end of the buffer */
+    if (cannot_access_at_index(input_buffer, 0))
+    {
+        input_buffer->offset--;
+        goto fail;
+    }
+
+    /* step back to character in front of the first element */
+    input_buffer->offset--;
+    /* loop through the comma separated array elements */
+    do
+    {
+        /* allocate next item */
+        cJSON *new_item = cJSON_New_Item(&(input_buffer->hooks));
+        if (new_item == NULL)
+        {
+            goto fail; /* allocation failure */
+        }
+
+        /* attach next item to list */
+        if (head == NULL)
+        {
+            /* start the linked list */
+            current_item = head = new_item;
+        }
+        else
+        {
+            /* add to the end and advance */
+            current_item->next = new_item;
+            new_item->prev = current_item;
+            current_item = new_item;
+        }
+
+        if (cannot_access_at_index(input_buffer, 1))
+        {
+            goto fail; /* nothing comes after the comma */
+        }
+
+        /* parse the name of the child */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_string(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse name */
+        }
+        buffer_skip_whitespace(input_buffer);
+
+        /* swap valuestring and string, because we parsed the name */
+        current_item->string = current_item->valuestring;
+        current_item->valuestring = NULL;
+
+        if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != ':'))
+        {
+            goto fail; /* invalid object */
+        }
+
+        /* parse the value */
+        input_buffer->offset++;
+        buffer_skip_whitespace(input_buffer);
+        if (!parse_value(current_item, input_buffer))
+        {
+            goto fail; /* failed to parse value */
+        }
+        buffer_skip_whitespace(input_buffer);
+    }
+    while (can_access_at_index(input_buffer, 0) && (buffer_at_offset(input_buffer)[0] == ','));
+
+    if (cannot_access_at_index(input_buffer, 0) || (buffer_at_offset(input_buffer)[0] != '}'))
+    {
+        goto fail; /* expected end of object */
+    }
+
+success:
+    input_buffer->depth--;
+
+    if (head != NULL) {
+        head->prev = current_item;
+    }
+
+    item->type = cJSON_Object;
+    item->child = head;
+
+    input_buffer->offset++;
+    return true;
+
+fail:
+    if (head != NULL)
+    {
+        cJSON_Delete(head);
+    }
+
+    return false;
+}
+
+/* Render an object to text. */
+static cJSON_bool print_object(const cJSON * const item, printbuffer * const output_buffer)
+{
+    unsigned char *output_pointer = NULL;
+    size_t length = 0;
+    cJSON *current_item = item->child;
+
+    if (output_buffer == NULL)
+    {
+        return false;
+    }
+
+    /* Compose the output: */
+    length = (size_t) (output_buffer->format ? 2 : 1); /* fmt: {\n */
+    output_pointer = ensure(output_buffer, length + 1);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+
+    *output_pointer++ = '{';
+    output_buffer->depth++;
+    if (output_buffer->format)
+    {
+        *output_pointer++ = '\n';
+    }
+    output_buffer->offset += length;
+
+    while (current_item)
+    {
+        if (output_buffer->format)
+        {
+            size_t i;
+            output_pointer = ensure(output_buffer, output_buffer->depth);
+            if (output_pointer == NULL)
+            {
+                return false;
+            }
+            for (i = 0; i < output_buffer->depth; i++)
+            {
+                *output_pointer++ = '\t';
+            }
+            output_buffer->offset += output_buffer->depth;
+        }
+
+        /* print key */
+        if (!print_string_ptr((unsigned char*)current_item->string, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        length = (size_t) (output_buffer->format ? 2 : 1);
+        output_pointer = ensure(output_buffer, length);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        *output_pointer++ = ':';
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\t';
+        }
+        output_buffer->offset += length;
+
+        /* print value */
+        if (!print_value(current_item, output_buffer))
+        {
+            return false;
+        }
+        update_offset(output_buffer);
+
+        /* print comma if not last */
+        length = ((size_t)(output_buffer->format ? 1 : 0) + (size_t)(current_item->next ? 1 : 0));
+        output_pointer = ensure(output_buffer, length + 1);
+        if (output_pointer == NULL)
+        {
+            return false;
+        }
+        if (current_item->next)
+        {
+            *output_pointer++ = ',';
+        }
+
+        if (output_buffer->format)
+        {
+            *output_pointer++ = '\n';
+        }
+        *output_pointer = '\0';
+        output_buffer->offset += length;
+
+        current_item = current_item->next;
+    }
+
+    output_pointer = ensure(output_buffer, output_buffer->format ? (output_buffer->depth + 1) : 2);
+    if (output_pointer == NULL)
+    {
+        return false;
+    }
+    if (output_buffer->format)
+    {
+        size_t i;
+        for (i = 0; i < (output_buffer->depth - 1); i++)
+        {
+            *output_pointer++ = '\t';
+        }
+    }
+    *output_pointer++ = '}';
+    *output_pointer = '\0';
+    output_buffer->depth--;
+
+    return true;
+}
+
+/* Get Array size/item / object item. */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array)
+{
+    cJSON *child = NULL;
+    size_t size = 0;
+
+    if (array == NULL)
+    {
+        return 0;
+    }
+
+    child = array->child;
+
+    while(child != NULL)
+    {
+        size++;
+        child = child->next;
+    }
+
+    /* FIXME: Can overflow here. Cannot be fixed without breaking the API */
+
+    return (int)size;
+}
+
+static cJSON* get_array_item(const cJSON *array, size_t index)
+{
+    cJSON *current_child = NULL;
+
+    if (array == NULL)
+    {
+        return NULL;
+    }
+
+    current_child = array->child;
+    while ((current_child != NULL) && (index > 0))
+    {
+        index--;
+        current_child = current_child->next;
+    }
+
+    return current_child;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index)
+{
+    if (index < 0)
+    {
+        return NULL;
+    }
+
+    return get_array_item(array, (size_t)index);
+}
+
+static cJSON *get_object_item(const cJSON * const object, const char * const name, const cJSON_bool case_sensitive)
+{
+    cJSON *current_element = NULL;
+
+    if ((object == NULL) || (name == NULL))
+    {
+        return NULL;
+    }
+
+    current_element = object->child;
+    if (case_sensitive)
+    {
+        while ((current_element != NULL) && (current_element->string != NULL) && (strcmp(name, current_element->string) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+    else
+    {
+        while ((current_element != NULL) && (case_insensitive_strcmp((const unsigned char*)name, (const unsigned char*)(current_element->string)) != 0))
+        {
+            current_element = current_element->next;
+        }
+    }
+
+    if ((current_element == NULL) || (current_element->string == NULL)) {
+        return NULL;
+    }
+
+    return current_element;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, false);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string)
+{
+    return get_object_item(object, string, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string)
+{
+    return cJSON_GetObjectItem(object, string) ? 1 : 0;
+}
+
+/* Utility for array list handling. */
+static void suffix_object(cJSON *prev, cJSON *item)
+{
+    prev->next = item;
+    item->prev = prev;
+}
+
+/* Utility for handling references. */
+static cJSON *create_reference(const cJSON *item, const internal_hooks * const hooks)
+{
+    cJSON *reference = NULL;
+    if (item == NULL)
+    {
+        return NULL;
+    }
+
+    reference = cJSON_New_Item(hooks);
+    if (reference == NULL)
+    {
+        return NULL;
+    }
+
+    memcpy(reference, item, sizeof(cJSON));
+    reference->string = NULL;
+    reference->type |= cJSON_IsReference;
+    reference->next = reference->prev = NULL;
+    return reference;
+}
+
+static cJSON_bool add_item_to_array(cJSON *array, cJSON *item)
+{
+    cJSON *child = NULL;
+
+    if ((item == NULL) || (array == NULL) || (array == item))
+    {
+        return false;
+    }
+
+    child = array->child;
+    /*
+     * To find the last item in array quickly, we use prev in array
+     */
+    if (child == NULL)
+    {
+        /* list is empty, start new one */
+        array->child = item;
+        item->prev = item;
+        item->next = NULL;
+    }
+    else
+    {
+        /* append to the end */
+        if (child->prev)
+        {
+            suffix_object(child->prev, item);
+            array->child->prev = item;
+        }
+    }
+
+    return true;
+}
+
+/* Add item to array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item)
+{
+    return add_item_to_array(array, item);
+}
+
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic push
+#endif
+#ifdef __GNUC__
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#endif
+/* helper function to cast away const */
+static void* cast_away_const(const void* string)
+{
+    return (void*)string;
+}
+#if defined(__clang__) || (defined(__GNUC__)  && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5))))
+    #pragma GCC diagnostic pop
+#endif
+
+
+static cJSON_bool add_item_to_object(cJSON * const object, const char * const string, cJSON * const item, const internal_hooks * const hooks, const cJSON_bool constant_key)
+{
+    char *new_key = NULL;
+    int new_type = cJSON_Invalid;
+
+    if ((object == NULL) || (string == NULL) || (item == NULL) || (object == item))
+    {
+        return false;
+    }
+
+    if (constant_key)
+    {
+        new_key = (char*)cast_away_const(string);
+        new_type = item->type | cJSON_StringIsConst;
+    }
+    else
+    {
+        new_key = (char*)cJSON_strdup((const unsigned char*)string, hooks);
+        if (new_key == NULL)
+        {
+            return false;
+        }
+
+        new_type = item->type & ~cJSON_StringIsConst;
+    }
+
+    if (!(item->type & cJSON_StringIsConst) && (item->string != NULL))
+    {
+        hooks->deallocate(item->string);
+    }
+
+    item->string = new_key;
+    item->type = new_type;
+
+    return add_item_to_array(object, item);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, false);
+}
+
+/* Add an item to an object with constant string as key */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item)
+{
+    return add_item_to_object(object, string, item, &global_hooks, true);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item)
+{
+    if (array == NULL)
+    {
+        return false;
+    }
+
+    return add_item_to_array(array, create_reference(item, &global_hooks));
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item)
+{
+    if ((object == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    return add_item_to_object(object, string, create_reference(item, &global_hooks), &global_hooks, false);
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name)
+{
+    cJSON *null = cJSON_CreateNull();
+    if (add_item_to_object(object, name, null, &global_hooks, false))
+    {
+        return null;
+    }
+
+    cJSON_Delete(null);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name)
+{
+    cJSON *true_item = cJSON_CreateTrue();
+    if (add_item_to_object(object, name, true_item, &global_hooks, false))
+    {
+        return true_item;
+    }
+
+    cJSON_Delete(true_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name)
+{
+    cJSON *false_item = cJSON_CreateFalse();
+    if (add_item_to_object(object, name, false_item, &global_hooks, false))
+    {
+        return false_item;
+    }
+
+    cJSON_Delete(false_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean)
+{
+    cJSON *bool_item = cJSON_CreateBool(boolean);
+    if (add_item_to_object(object, name, bool_item, &global_hooks, false))
+    {
+        return bool_item;
+    }
+
+    cJSON_Delete(bool_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number)
+{
+    cJSON *number_item = cJSON_CreateNumber(number);
+    if (add_item_to_object(object, name, number_item, &global_hooks, false))
+    {
+        return number_item;
+    }
+
+    cJSON_Delete(number_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string)
+{
+    cJSON *string_item = cJSON_CreateString(string);
+    if (add_item_to_object(object, name, string_item, &global_hooks, false))
+    {
+        return string_item;
+    }
+
+    cJSON_Delete(string_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw)
+{
+    cJSON *raw_item = cJSON_CreateRaw(raw);
+    if (add_item_to_object(object, name, raw_item, &global_hooks, false))
+    {
+        return raw_item;
+    }
+
+    cJSON_Delete(raw_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name)
+{
+    cJSON *object_item = cJSON_CreateObject();
+    if (add_item_to_object(object, name, object_item, &global_hooks, false))
+    {
+        return object_item;
+    }
+
+    cJSON_Delete(object_item);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name)
+{
+    cJSON *array = cJSON_CreateArray();
+    if (add_item_to_object(object, name, array, &global_hooks, false))
+    {
+        return array;
+    }
+
+    cJSON_Delete(array);
+    return NULL;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item)
+{
+    if ((parent == NULL) || (item == NULL) || (item != parent->child && item->prev == NULL))
+    {
+        return NULL;
+    }
+
+    if (item != parent->child)
+    {
+        /* not the first element */
+        item->prev->next = item->next;
+    }
+    if (item->next != NULL)
+    {
+        /* not the last element */
+        item->next->prev = item->prev;
+    }
+
+    if (item == parent->child)
+    {
+        /* first element */
+        parent->child = item->next;
+    }
+    else if (item->next == NULL)
+    {
+        /* last element */
+        parent->child->prev = item->prev;
+    }
+
+    /* make sure the detached item doesn't point anywhere anymore */
+    item->prev = NULL;
+    item->next = NULL;
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which)
+{
+    if (which < 0)
+    {
+        return NULL;
+    }
+
+    return cJSON_DetachItemViaPointer(array, get_array_item(array, (size_t)which));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which)
+{
+    cJSON_Delete(cJSON_DetachItemFromArray(array, which));
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItem(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON *to_detach = cJSON_GetObjectItemCaseSensitive(object, string);
+
+    return cJSON_DetachItemViaPointer(object, to_detach);
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObject(object, string));
+}
+
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string)
+{
+    cJSON_Delete(cJSON_DetachItemFromObjectCaseSensitive(object, string));
+}
+
+/* Replace array/object items with new ones. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    cJSON *after_inserted = NULL;
+
+    if (which < 0 || newitem == NULL)
+    {
+        return false;
+    }
+
+    after_inserted = get_array_item(array, (size_t)which);
+    if (after_inserted == NULL)
+    {
+        return add_item_to_array(array, newitem);
+    }
+
+    if (after_inserted != array->child && after_inserted->prev == NULL) {
+        /* return false if after_inserted is a corrupted array item */
+        return false;
+    }
+
+    newitem->next = after_inserted;
+    newitem->prev = after_inserted->prev;
+    after_inserted->prev = newitem;
+    if (after_inserted == array->child)
+    {
+        array->child = newitem;
+    }
+    else
+    {
+        newitem->prev->next = newitem;
+    }
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement)
+{
+    if ((parent == NULL) || (parent->child == NULL) || (replacement == NULL) || (item == NULL))
+    {
+        return false;
+    }
+
+    if (replacement == item)
+    {
+        return true;
+    }
+
+    replacement->next = item->next;
+    replacement->prev = item->prev;
+
+    if (replacement->next != NULL)
+    {
+        replacement->next->prev = replacement;
+    }
+    if (parent->child == item)
+    {
+        if (parent->child->prev == parent->child)
+        {
+            replacement->prev = replacement;
+        }
+        parent->child = replacement;
+    }
+    else
+    {   /*
+         * To find the last item in array quickly, we use prev in array.
+         * We can't modify the last item's next pointer where this item was the parent's child
+         */
+        if (replacement->prev != NULL)
+        {
+            replacement->prev->next = replacement;
+        }
+        if (replacement->next == NULL)
+        {
+            parent->child->prev = replacement;
+        }
+    }
+
+    item->next = NULL;
+    item->prev = NULL;
+    cJSON_Delete(item);
+
+    return true;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem)
+{
+    if (which < 0)
+    {
+        return false;
+    }
+
+    return cJSON_ReplaceItemViaPointer(array, get_array_item(array, (size_t)which), newitem);
+}
+
+static cJSON_bool replace_item_in_object(cJSON *object, const char *string, cJSON *replacement, cJSON_bool case_sensitive)
+{
+    if ((replacement == NULL) || (string == NULL))
+    {
+        return false;
+    }
+
+    /* replace the name in the replacement */
+    if (!(replacement->type & cJSON_StringIsConst) && (replacement->string != NULL))
+    {
+        cJSON_free(replacement->string);
+    }
+    replacement->string = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+    if (replacement->string == NULL)
+    {
+        return false;
+    }
+
+    replacement->type &= ~cJSON_StringIsConst;
+
+    return cJSON_ReplaceItemViaPointer(object, get_object_item(object, string, case_sensitive), replacement);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, false);
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object, const char *string, cJSON *newitem)
+{
+    return replace_item_in_object(object, string, newitem, true);
+}
+
+/* Create basic types: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_NULL;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_True;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = boolean ? cJSON_True : cJSON_False;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Number;
+        item->valuedouble = num;
+
+        /* use saturation in case of overflow */
+        if (num >= INT_MAX)
+        {
+            item->valueint = INT_MAX;
+        }
+        else if (num <= (double)INT_MIN)
+        {
+            item->valueint = INT_MIN;
+        }
+        else
+        {
+            item->valueint = (int)num;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_String;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)string, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL)
+    {
+        item->type = cJSON_String | cJSON_IsReference;
+        item->valuestring = (char*)cast_away_const(string);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Object | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child) {
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item != NULL) {
+        item->type = cJSON_Array | cJSON_IsReference;
+        item->child = (cJSON*)cast_away_const(child);
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type = cJSON_Raw;
+        item->valuestring = (char*)cJSON_strdup((const unsigned char*)raw, &global_hooks);
+        if(!item->valuestring)
+        {
+            cJSON_Delete(item);
+            return NULL;
+        }
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if(item)
+    {
+        item->type=cJSON_Array;
+    }
+
+    return item;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void)
+{
+    cJSON *item = cJSON_New_Item(&global_hooks);
+    if (item)
+    {
+        item->type = cJSON_Object;
+    }
+
+    return item;
+}
+
+/* Create Arrays: */
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if (!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber((double)numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (numbers == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for(i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateNumber(numbers[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p, n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count)
+{
+    size_t i = 0;
+    cJSON *n = NULL;
+    cJSON *p = NULL;
+    cJSON *a = NULL;
+
+    if ((count < 0) || (strings == NULL))
+    {
+        return NULL;
+    }
+
+    a = cJSON_CreateArray();
+
+    for (i = 0; a && (i < (size_t)count); i++)
+    {
+        n = cJSON_CreateString(strings[i]);
+        if(!n)
+        {
+            cJSON_Delete(a);
+            return NULL;
+        }
+        if(!i)
+        {
+            a->child = n;
+        }
+        else
+        {
+            suffix_object(p,n);
+        }
+        p = n;
+    }
+
+    if (a && a->child) {
+        a->child->prev = n;
+    }
+
+    return a;
+}
+
+/* Duplication */
+cJSON * cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse);
+
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse)
+{
+    return cJSON_Duplicate_rec(item, 0, recurse );
+}
+
+cJSON * cJSON_Duplicate_rec(const cJSON *item, size_t depth, cJSON_bool recurse)
+{
+    cJSON *newitem = NULL;
+    cJSON *child = NULL;
+    cJSON *next = NULL;
+    cJSON *newchild = NULL;
+
+    /* Bail on bad ptr */
+    if (!item)
+    {
+        goto fail;
+    }
+    /* Create new item */
+    newitem = cJSON_New_Item(&global_hooks);
+    if (!newitem)
+    {
+        goto fail;
+    }
+    /* Copy over all vars */
+    newitem->type = item->type & (~cJSON_IsReference);
+    newitem->valueint = item->valueint;
+    newitem->valuedouble = item->valuedouble;
+    if (item->valuestring)
+    {
+        newitem->valuestring = (char*)cJSON_strdup((unsigned char*)item->valuestring, &global_hooks);
+        if (!newitem->valuestring)
+        {
+            goto fail;
+        }
+    }
+    if (item->string)
+    {
+        newitem->string = (item->type&cJSON_StringIsConst) ? item->string : (char*)cJSON_strdup((unsigned char*)item->string, &global_hooks);
+        if (!newitem->string)
+        {
+            goto fail;
+        }
+    }
+    /* If non-recursive, then we're done! */
+    if (!recurse)
+    {
+        return newitem;
+    }
+    /* Walk the ->next chain for the child. */
+    child = item->child;
+    while (child != NULL)
+    {
+        if(depth >= CJSON_CIRCULAR_LIMIT) {
+            goto fail;
+        }
+        newchild = cJSON_Duplicate_rec(child, depth + 1, true); /* Duplicate (with recurse) each item in the ->next chain */
+        if (!newchild)
+        {
+            goto fail;
+        }
+        if (next != NULL)
+        {
+            /* If newitem->child already set, then crosswire ->prev and ->next and move on */
+            next->next = newchild;
+            newchild->prev = next;
+            next = newchild;
+        }
+        else
+        {
+            /* Set newitem->child and move to it */
+            newitem->child = newchild;
+            next = newchild;
+        }
+        child = child->next;
+    }
+    if (newitem && newitem->child)
+    {
+        newitem->child->prev = newchild;
+    }
+
+    return newitem;
+
+fail:
+    if (newitem != NULL)
+    {
+        cJSON_Delete(newitem);
+    }
+
+    return NULL;
+}
+
+static void skip_oneline_comment(char **input)
+{
+    *input += static_strlen("//");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if ((*input)[0] == '\n') {
+            *input += static_strlen("\n");
+            return;
+        }
+    }
+}
+
+static void skip_multiline_comment(char **input)
+{
+    *input += static_strlen("/*");
+
+    for (; (*input)[0] != '\0'; ++(*input))
+    {
+        if (((*input)[0] == '*') && ((*input)[1] == '/'))
+        {
+            *input += static_strlen("*/");
+            return;
+        }
+    }
+}
+
+static void minify_string(char **input, char **output) {
+    (*output)[0] = (*input)[0];
+    *input += static_strlen("\"");
+    *output += static_strlen("\"");
+
+
+    for (; (*input)[0] != '\0'; (void)++(*input), ++(*output)) {
+        (*output)[0] = (*input)[0];
+
+        if ((*input)[0] == '\"') {
+            (*output)[0] = '\"';
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+            return;
+        } else if (((*input)[0] == '\\') && ((*input)[1] == '\"')) {
+            (*output)[1] = (*input)[1];
+            *input += static_strlen("\"");
+            *output += static_strlen("\"");
+        }
+    }
+}
+
+CJSON_PUBLIC(void) cJSON_Minify(char *json)
+{
+    char *into = json;
+
+    if (json == NULL)
+    {
+        return;
+    }
+
+    while (json[0] != '\0')
+    {
+        switch (json[0])
+        {
+            case ' ':
+            case '\t':
+            case '\r':
+            case '\n':
+                json++;
+                break;
+
+            case '/':
+                if (json[1] == '/')
+                {
+                    skip_oneline_comment(&json);
+                }
+                else if (json[1] == '*')
+                {
+                    skip_multiline_comment(&json);
+                } else {
+                    json++;
+                }
+                break;
+
+            case '\"':
+                minify_string(&json, (char**)&into);
+                break;
+
+            default:
+                into[0] = json[0];
+                json++;
+                into++;
+        }
+    }
+
+    /* and null-terminate. */
+    *into = '\0';
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Invalid;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_False;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xff) == cJSON_True;
+}
+
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & (cJSON_True | cJSON_False)) != 0;
+}
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_NULL;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Number;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_String;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Array;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Object;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item)
+{
+    if (item == NULL)
+    {
+        return false;
+    }
+
+    return (item->type & 0xFF) == cJSON_Raw;
+}
+
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive)
+{
+    if ((a == NULL) || (b == NULL) || ((a->type & 0xFF) != (b->type & 0xFF)))
+    {
+        return false;
+    }
+
+    /* check if type is valid */
+    switch (a->type & 0xFF)
+    {
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+        case cJSON_Number:
+        case cJSON_String:
+        case cJSON_Raw:
+        case cJSON_Array:
+        case cJSON_Object:
+            break;
+
+        default:
+            return false;
+    }
+
+    /* identical objects are equal */
+    if (a == b)
+    {
+        return true;
+    }
+
+    switch (a->type & 0xFF)
+    {
+        /* in these cases and equal type is enough */
+        case cJSON_False:
+        case cJSON_True:
+        case cJSON_NULL:
+            return true;
+
+        case cJSON_Number:
+            if (compare_double(a->valuedouble, b->valuedouble))
+            {
+                return true;
+            }
+            return false;
+
+        case cJSON_String:
+        case cJSON_Raw:
+            if ((a->valuestring == NULL) || (b->valuestring == NULL))
+            {
+                return false;
+            }
+            if (strcmp(a->valuestring, b->valuestring) == 0)
+            {
+                return true;
+            }
+
+            return false;
+
+        case cJSON_Array:
+        {
+            cJSON *a_element = a->child;
+            cJSON *b_element = b->child;
+
+            for (; (a_element != NULL) && (b_element != NULL);)
+            {
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+
+                a_element = a_element->next;
+                b_element = b_element->next;
+            }
+
+            /* one of the arrays is longer than the other */
+            if (a_element != b_element) {
+                return false;
+            }
+
+            return true;
+        }
+
+        case cJSON_Object:
+        {
+            cJSON *a_element = NULL;
+            cJSON *b_element = NULL;
+            cJSON_ArrayForEach(a_element, a)
+            {
+                /* TODO This has O(n^2) runtime, which is horrible! */
+                b_element = get_object_item(b, a_element->string, case_sensitive);
+                if (b_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(a_element, b_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            /* doing this twice, once on a and b to prevent true comparison if a subset of b
+             * TODO: Do this the proper way, this is just a fix for now */
+            cJSON_ArrayForEach(b_element, b)
+            {
+                a_element = get_object_item(a, b_element->string, case_sensitive);
+                if (a_element == NULL)
+                {
+                    return false;
+                }
+
+                if (!cJSON_Compare(b_element, a_element, case_sensitive))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        default:
+            return false;
+    }
+}
+
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size)
+{
+    return global_hooks.allocate(size);
+}
+
+CJSON_PUBLIC(void) cJSON_free(void *object)
+{
+    global_hooks.deallocate(object);
+    object = NULL;
+}

--- a/test/host/vendor/cJSON/cJSON.h
+++ b/test/host/vendor/cJSON/cJSON.h
@@ -1,0 +1,306 @@
+/*
+  Copyright (c) 2009-2017 Dave Gamble and cJSON contributors
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+*/
+
+#ifndef cJSON__h
+#define cJSON__h
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if !defined(__WINDOWS__) && (defined(WIN32) || defined(WIN64) || defined(_MSC_VER) || defined(_WIN32))
+#define __WINDOWS__
+#endif
+
+#ifdef __WINDOWS__
+
+/* When compiling for windows, we specify a specific calling convention to avoid issues where we are being called from a project with a different default calling convention.  For windows you have 3 define options:
+
+CJSON_HIDE_SYMBOLS - Define this in the case where you don't want to ever dllexport symbols
+CJSON_EXPORT_SYMBOLS - Define this on library build when you want to dllexport symbols (default)
+CJSON_IMPORT_SYMBOLS - Define this if you want to dllimport symbol
+
+For *nix builds that support visibility attribute, you can define similar behavior by
+
+setting default visibility to hidden by adding
+-fvisibility=hidden (for gcc)
+or
+-xldscope=hidden (for sun cc)
+to CFLAGS
+
+then using the CJSON_API_VISIBILITY flag to "export" the same symbols the way CJSON_EXPORT_SYMBOLS does
+
+*/
+
+#define CJSON_CDECL __cdecl
+#define CJSON_STDCALL __stdcall
+
+/* export symbols by default, this is necessary for copy pasting the C and header file */
+#if !defined(CJSON_HIDE_SYMBOLS) && !defined(CJSON_IMPORT_SYMBOLS) && !defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_EXPORT_SYMBOLS
+#endif
+
+#if defined(CJSON_HIDE_SYMBOLS)
+#define CJSON_PUBLIC(type)   type CJSON_STDCALL
+#elif defined(CJSON_EXPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllexport) type CJSON_STDCALL
+#elif defined(CJSON_IMPORT_SYMBOLS)
+#define CJSON_PUBLIC(type)   __declspec(dllimport) type CJSON_STDCALL
+#endif
+#else /* !__WINDOWS__ */
+#define CJSON_CDECL
+#define CJSON_STDCALL
+
+#if (defined(__GNUC__) || defined(__SUNPRO_CC) || defined (__SUNPRO_C)) && defined(CJSON_API_VISIBILITY)
+#define CJSON_PUBLIC(type)   __attribute__((visibility("default"))) type
+#else
+#define CJSON_PUBLIC(type) type
+#endif
+#endif
+
+/* project version */
+#define CJSON_VERSION_MAJOR 1
+#define CJSON_VERSION_MINOR 7
+#define CJSON_VERSION_PATCH 19
+
+#include <stddef.h>
+
+/* cJSON Types: */
+#define cJSON_Invalid (0)
+#define cJSON_False  (1 << 0)
+#define cJSON_True   (1 << 1)
+#define cJSON_NULL   (1 << 2)
+#define cJSON_Number (1 << 3)
+#define cJSON_String (1 << 4)
+#define cJSON_Array  (1 << 5)
+#define cJSON_Object (1 << 6)
+#define cJSON_Raw    (1 << 7) /* raw json */
+
+#define cJSON_IsReference 256
+#define cJSON_StringIsConst 512
+
+/* The cJSON structure: */
+typedef struct cJSON
+{
+    /* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
+    struct cJSON *next;
+    struct cJSON *prev;
+    /* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
+    struct cJSON *child;
+
+    /* The type of the item, as above. */
+    int type;
+
+    /* The item's string, if type==cJSON_String  and type == cJSON_Raw */
+    char *valuestring;
+    /* writing to valueint is DEPRECATED, use cJSON_SetNumberValue instead */
+    int valueint;
+    /* The item's number, if type==cJSON_Number */
+    double valuedouble;
+
+    /* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
+    char *string;
+} cJSON;
+
+typedef struct cJSON_Hooks
+{
+      /* malloc/free are CDECL on Windows regardless of the default calling convention of the compiler, so ensure the hooks allow passing those functions directly. */
+      void *(CJSON_CDECL *malloc_fn)(size_t sz);
+      void (CJSON_CDECL *free_fn)(void *ptr);
+} cJSON_Hooks;
+
+typedef int cJSON_bool;
+
+/* Limits how deeply nested arrays/objects can be before cJSON rejects to parse them.
+ * This is to prevent stack overflows. */
+#ifndef CJSON_NESTING_LIMIT
+#define CJSON_NESTING_LIMIT 1000
+#endif
+
+/* Limits the length of circular references can be before cJSON rejects to parse them.
+ * This is to prevent stack overflows. */
+#ifndef CJSON_CIRCULAR_LIMIT
+#define CJSON_CIRCULAR_LIMIT 10000
+#endif
+
+/* returns the version of cJSON as a string */
+CJSON_PUBLIC(const char*) cJSON_Version(void);
+
+/* Supply malloc, realloc and free functions to cJSON */
+CJSON_PUBLIC(void) cJSON_InitHooks(cJSON_Hooks* hooks);
+
+/* Memory Management: the caller is always responsible to free the results from all variants of cJSON_Parse (with cJSON_Delete) and cJSON_Print (with stdlib free, cJSON_Hooks.free_fn, or cJSON_free as appropriate). The exception is cJSON_PrintPreallocated, where the caller has full responsibility of the buffer. */
+/* Supply a block of JSON, and this returns a cJSON object you can interrogate. */
+CJSON_PUBLIC(cJSON *) cJSON_Parse(const char *value);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLength(const char *value, size_t buffer_length);
+/* ParseWithOpts allows you to require (and check) that the JSON is null terminated, and to retrieve the pointer to the final byte parsed. */
+/* If you supply a ptr in return_parse_end and parsing fails, then return_parse_end will contain a pointer to the error so will match cJSON_GetErrorPtr(). */
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithOpts(const char *value, const char **return_parse_end, cJSON_bool require_null_terminated);
+CJSON_PUBLIC(cJSON *) cJSON_ParseWithLengthOpts(const char *value, size_t buffer_length, const char **return_parse_end, cJSON_bool require_null_terminated);
+
+/* Render a cJSON entity to text for transfer/storage. */
+CJSON_PUBLIC(char *) cJSON_Print(const cJSON *item);
+/* Render a cJSON entity to text for transfer/storage without any formatting. */
+CJSON_PUBLIC(char *) cJSON_PrintUnformatted(const cJSON *item);
+/* Render a cJSON entity to text using a buffered strategy. prebuffer is a guess at the final size. guessing well reduces reallocation. fmt=0 gives unformatted, =1 gives formatted */
+CJSON_PUBLIC(char *) cJSON_PrintBuffered(const cJSON *item, int prebuffer, cJSON_bool fmt);
+/* Render a cJSON entity to text using a buffer already allocated in memory with given length. Returns 1 on success and 0 on failure. */
+/* NOTE: cJSON is not always 100% accurate in estimating how much memory it will use, so to be safe allocate 5 bytes more than you actually need */
+CJSON_PUBLIC(cJSON_bool) cJSON_PrintPreallocated(cJSON *item, char *buffer, const int length, const cJSON_bool format);
+/* Delete a cJSON entity and all subentities. */
+CJSON_PUBLIC(void) cJSON_Delete(cJSON *item);
+
+/* Returns the number of items in an array (or object). */
+CJSON_PUBLIC(int) cJSON_GetArraySize(const cJSON *array);
+/* Retrieve item number "index" from array "array". Returns NULL if unsuccessful. */
+CJSON_PUBLIC(cJSON *) cJSON_GetArrayItem(const cJSON *array, int index);
+/* Get item "string" from object. Case insensitive. */
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItem(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON *) cJSON_GetObjectItemCaseSensitive(const cJSON * const object, const char * const string);
+CJSON_PUBLIC(cJSON_bool) cJSON_HasObjectItem(const cJSON *object, const char *string);
+/* For analysing failed parses. This returns a pointer to the parse error. You'll probably need to look a few chars back to make sense of it. Defined when cJSON_Parse() returns 0. 0 when cJSON_Parse() succeeds. */
+CJSON_PUBLIC(const char *) cJSON_GetErrorPtr(void);
+
+/* Check item type and return its value */
+CJSON_PUBLIC(char *) cJSON_GetStringValue(const cJSON * const item);
+CJSON_PUBLIC(double) cJSON_GetNumberValue(const cJSON * const item);
+
+/* These functions check the type of an item */
+CJSON_PUBLIC(cJSON_bool) cJSON_IsInvalid(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsFalse(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsTrue(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsBool(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNull(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsNumber(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsString(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsArray(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsObject(const cJSON * const item);
+CJSON_PUBLIC(cJSON_bool) cJSON_IsRaw(const cJSON * const item);
+
+/* These calls create a cJSON item of the appropriate type. */
+CJSON_PUBLIC(cJSON *) cJSON_CreateNull(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateTrue(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFalse(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateBool(cJSON_bool boolean);
+CJSON_PUBLIC(cJSON *) cJSON_CreateNumber(double num);
+CJSON_PUBLIC(cJSON *) cJSON_CreateString(const char *string);
+/* raw json */
+CJSON_PUBLIC(cJSON *) cJSON_CreateRaw(const char *raw);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArray(void);
+CJSON_PUBLIC(cJSON *) cJSON_CreateObject(void);
+
+/* Create a string where valuestring references a string so
+ * it will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringReference(const char *string);
+/* Create an object/array that only references it's elements so
+ * they will not be freed by cJSON_Delete */
+CJSON_PUBLIC(cJSON *) cJSON_CreateObjectReference(const cJSON *child);
+CJSON_PUBLIC(cJSON *) cJSON_CreateArrayReference(const cJSON *child);
+
+/* These utilities create an Array of count items.
+ * The parameter count cannot be greater than the number of elements in the number array, otherwise array access will be out of bounds.*/
+CJSON_PUBLIC(cJSON *) cJSON_CreateIntArray(const int *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateFloatArray(const float *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateDoubleArray(const double *numbers, int count);
+CJSON_PUBLIC(cJSON *) cJSON_CreateStringArray(const char *const *strings, int count);
+
+/* Append item to the specified array/object. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObject(cJSON *object, const char *string, cJSON *item);
+/* Use this when string is definitely const (i.e. a literal, or as good as), and will definitely survive the cJSON object.
+ * WARNING: When this function was used, make sure to always check that (item->type & cJSON_StringIsConst) is zero before
+ * writing to `item->string` */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemToObjectCS(cJSON *object, const char *string, cJSON *item);
+/* Append reference to item to the specified array/object. Use this when you want to add an existing cJSON to a new cJSON, but don't want to corrupt your existing cJSON. */
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToArray(cJSON *array, cJSON *item);
+CJSON_PUBLIC(cJSON_bool) cJSON_AddItemReferenceToObject(cJSON *object, const char *string, cJSON *item);
+
+/* Remove/Detach items from Arrays/Objects. */
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemViaPointer(cJSON *parent, cJSON * const item);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromArray(cJSON *array, int which);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(cJSON *) cJSON_DetachItemFromObjectCaseSensitive(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObject(cJSON *object, const char *string);
+CJSON_PUBLIC(void) cJSON_DeleteItemFromObjectCaseSensitive(cJSON *object, const char *string);
+
+/* Update array items. */
+CJSON_PUBLIC(cJSON_bool) cJSON_InsertItemInArray(cJSON *array, int which, cJSON *newitem); /* Shifts pre-existing items to the right. */
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemViaPointer(cJSON * const parent, cJSON * const item, cJSON * replacement);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInArray(cJSON *array, int which, cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObject(cJSON *object,const char *string,cJSON *newitem);
+CJSON_PUBLIC(cJSON_bool) cJSON_ReplaceItemInObjectCaseSensitive(cJSON *object,const char *string,cJSON *newitem);
+
+/* Duplicate a cJSON item */
+CJSON_PUBLIC(cJSON *) cJSON_Duplicate(const cJSON *item, cJSON_bool recurse);
+/* Duplicate will create a new, identical cJSON item to the one you pass, in new memory that will
+ * need to be released. With recurse!=0, it will duplicate any children connected to the item.
+ * The item->next and ->prev pointers are always zero on return from Duplicate. */
+/* Recursively compare two cJSON items for equality. If either a or b is NULL or invalid, they will be considered unequal.
+ * case_sensitive determines if object keys are treated case sensitive (1) or case insensitive (0) */
+CJSON_PUBLIC(cJSON_bool) cJSON_Compare(const cJSON * const a, const cJSON * const b, const cJSON_bool case_sensitive);
+
+/* Minify a strings, remove blank characters(such as ' ', '\t', '\r', '\n') from strings.
+ * The input pointer json cannot point to a read-only address area, such as a string constant, 
+ * but should point to a readable and writable address area. */
+CJSON_PUBLIC(void) cJSON_Minify(char *json);
+
+/* Helper functions for creating and adding items to an object at the same time.
+ * They return the added item or NULL on failure. */
+CJSON_PUBLIC(cJSON*) cJSON_AddNullToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddTrueToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddFalseToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddBoolToObject(cJSON * const object, const char * const name, const cJSON_bool boolean);
+CJSON_PUBLIC(cJSON*) cJSON_AddNumberToObject(cJSON * const object, const char * const name, const double number);
+CJSON_PUBLIC(cJSON*) cJSON_AddStringToObject(cJSON * const object, const char * const name, const char * const string);
+CJSON_PUBLIC(cJSON*) cJSON_AddRawToObject(cJSON * const object, const char * const name, const char * const raw);
+CJSON_PUBLIC(cJSON*) cJSON_AddObjectToObject(cJSON * const object, const char * const name);
+CJSON_PUBLIC(cJSON*) cJSON_AddArrayToObject(cJSON * const object, const char * const name);
+
+/* When assigning an integer value, it needs to be propagated to valuedouble too. */
+#define cJSON_SetIntValue(object, number) ((object) ? (object)->valueint = (object)->valuedouble = (number) : (number))
+/* helper for the cJSON_SetNumberValue macro */
+CJSON_PUBLIC(double) cJSON_SetNumberHelper(cJSON *object, double number);
+#define cJSON_SetNumberValue(object, number) ((object != NULL) ? cJSON_SetNumberHelper(object, (double)number) : (number))
+/* Change the valuestring of a cJSON_String object, only takes effect when type of object is cJSON_String */
+CJSON_PUBLIC(char*) cJSON_SetValuestring(cJSON *object, const char *valuestring);
+
+/* If the object is not a boolean type this does nothing and returns cJSON_Invalid else it returns the new type*/
+#define cJSON_SetBoolValue(object, boolValue) ( \
+    (object != NULL && ((object)->type & (cJSON_False|cJSON_True))) ? \
+    (object)->type=((object)->type &(~(cJSON_False|cJSON_True)))|((boolValue)?cJSON_True:cJSON_False) : \
+    cJSON_Invalid\
+)
+
+/* Macro for iterating over an array or object */
+#define cJSON_ArrayForEach(element, array) for(element = (array != NULL) ? (array)->child : NULL; element != NULL; element = element->next)
+
+/* malloc/free objects using the malloc/free functions that have been set with cJSON_InitHooks */
+CJSON_PUBLIC(void *) cJSON_malloc(size_t size);
+CJSON_PUBLIC(void) cJSON_free(void *object);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
### Summary
This pull request significantly refactors the device's web interface, network communication, and configuration management. It splits the configuration UI into smaller, lazily loaded fragments, improves security with default-deny route authentication, and introduces robust network fetching and polling modules. These changes enhance performance, security, and maintainability across the system.

### Changes
*   The configuration web UI now loads faster by splitting `config_ui.html` into a main shell and 11 tab fragments that load only when activated.
*   Web routes now use a default-deny authentication wrapper, explicitly classifying all routes as public, setup-exempt, or requiring authentication for improved security.
*   A new X-macro settings table centrally defines all configuration settings, generating defaults, value clamping, and JSON handling, and enables forward-tolerant config loading.
*   A shared `http_fetch` module provides robust HTTP GET capabilities, including streaming JSON/text, retries, PSRAM buffers, and keep-alive connections.
*   Existing network clients for weather, AllSky, OTA, NINA, and Spotify now use the new `http_fetch` and `poll_task` modules, improving their reliability and resource usage.
*   A new host-side testing harness allows comprehensive unit testing of core modules on a host machine using ESP shim headers and vendored cJSON.
*   The UI architecture now uses a `page_ops_t` lifecycle table and `page_registry` for managing pages, making UI components more modular.
*   Added spacing above the "Capture Screenshot" button in the web UI for consistent visual layout.

---
<sub>Analyzed **5** commit(s) | Updated: 2026-07-07T00:37:06.549Z | Generated by GitHub Actions</sub>