### PR TITLE
feat: add C6 firmware update progress display

### DIFF
--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -429,6 +429,8 @@
 
     .tab-panel { display: none; animation: fadeIn 0.3s ease; }
     .tab-panel.active { display: block; }
+    /* Inline placeholder shown inside a panel while its fragment downloads. */
+    .tab-loading { text-align: center; padding: 56px 0; color: var(--text-muted); font-size: 0.85rem; }
     @keyframes fadeIn {
       from { opacity: 0; transform: translateY(8px); }
       to { opacity: 1; transform: translateY(0); }
@@ -1434,11 +1436,12 @@
        main/fragment_NAME.html (embedded, served by GET /ui/fragment?tab=NAME)
        and loadedTabs starts empty: every tab, including the default ('nodes',
        or whichever was restored from localStorage), is fetched lazily on
-       first activation. switchTab() already awaits ensureTabLoaded() before
-       marking a panel active (see below), so the initial switchTab() call at
-       boot -- which shows whichever tab was last active -- transparently
-       fetches that tab's fragment first; no separate boot-time special case
-       is needed for the default tab. */
+       first activation. switchTab() (see below) activates the panel
+       immediately with an inline loading placeholder, then awaits
+       ensureTabLoaded() before running the tab's populate/activation hooks,
+       so the initial switchTab() call at boot -- which shows whichever tab
+       was last active -- transparently fetches that tab's fragment first; no
+       separate boot-time special case is needed for the default tab. */
     const TAB_ORDER=['nodes','allsky','clock','spotify','image-display','display','behavior','system','logs','backup','api'];
     const LAZY_TABS=new Set(TAB_ORDER);
     const loadedTabs=new Set(TAB_ORDER.filter(n=>!LAZY_TABS.has(n)));
@@ -1465,16 +1468,44 @@
       }catch(e){
         console.error('Failed to load tab fragment: '+name,e);
       }
+      _queuedTabs.delete(name);
     }
 
     /* Await before showing/using a tab. Chains onto _fragInFlight so a rapid
        double-tap (or programmatic switchTab calls) can never issue two
        fragment fetches concurrently -- the socket budget only tolerates one
        polite serial GET at a time (see CLAUDE.md connection ceiling). */
+    /* Names already sitting in the chain (queued or in flight). Prevents a
+       click on a tab the idle prefetch just enqueued (or a rapid double-tap)
+       from chaining a duplicate fetch of the same fragment; cleared by
+       loadTabFragment() when the attempt finishes so a failed load can be
+       retried by the next click. */
+    const _queuedTabs=new Set();
     function ensureTabLoaded(name){
-      if(loadedTabs.has(name)) return _fragInFlight;
+      if(loadedTabs.has(name)||_queuedTabs.has(name)) return _fragInFlight;
+      _queuedTabs.add(name);
       _fragInFlight=_fragInFlight.then(()=>loadTabFragment(name));
       return _fragInFlight;
+    }
+
+    /* === Idle Tab Prefetch ===
+       After the boot tab has settled, trickle-fetch the remaining fragments
+       one at a time through the same ensureTabLoaded() chain (never in
+       parallel; the serialization comment above still holds). Only ever one
+       prefetch is enqueued at a time, so a user click on an unloaded tab
+       waits behind at most one in-flight fragment. Fragments only -- no API
+       data is prefetched. _prefetchIdx advances past failures so a bad
+       fragment cannot retry-loop. */
+    let _prefetchIdx=0;
+    function prefetchNextTab(){
+      while(_prefetchIdx<TAB_ORDER.length && loadedTabs.has(TAB_ORDER[_prefetchIdx])) _prefetchIdx++;
+      if(_prefetchIdx>=TAB_ORDER.length) return;
+      var name=TAB_ORDER[_prefetchIdx++];
+      ensureTabLoaded(name).then(function(){ setTimeout(prefetchNextTab,300); });
+    }
+    function startTabPrefetch(){
+      if(typeof requestIdleCallback==='function') requestIdleCallback(prefetchNextTab,{timeout:2000});
+      else setTimeout(prefetchNextTab,2000);
     }
 
     /* === Config Fetch Cache ===
@@ -1499,16 +1530,63 @@
     }
     function invalidateConfigCache(){ _cfgCache=null; }
 
-    /* === Tab Navigation === */
+    /* === Short-TTL Status/Version Memo ===
+       Mirrors _cfgCache for the two small read-only GETs that several tabs
+       share (/api/version, /api/status), so e.g. opening Logs then Backup a
+       moment apart reuses one response instead of hitting the device twice.
+       TTL is 4s -- deliberately under the 5s nav-metrics poll interval so
+       every poll tick still fetches fresh data (a TTL equal to the interval
+       would make alternate ticks hit the cache and halve the poll rate).
+       Errors are never cached; concurrent callers share one in-flight fetch. */
+    const _memoTTL=4000;
+    var _memoCache={};
+    var _memoInFlight={};
+    function fetchJsonMemo(url){
+      var hit=_memoCache[url];
+      if(hit && (Date.now()-hit.t)<_memoTTL) return Promise.resolve(hit.data);
+      if(_memoInFlight[url]) return _memoInFlight[url];
+      _memoInFlight[url]=fetch(url).then(function(r){
+        if(!r.ok) throw new Error('HTTP '+r.status);
+        return r.json();
+      }).then(function(data){
+        _memoCache[url]={t:Date.now(),data:data};
+        delete _memoInFlight[url];
+        return data;
+      }).catch(function(e){
+        delete _memoInFlight[url];
+        throw e;
+      });
+      return _memoInFlight[url];
+    }
+
+    /* === Tab Navigation ===
+       Active classes swap immediately on click so the nav never feels dead
+       while a fragment downloads (first visit used to block 200ms-1s with no
+       feedback); an unloaded panel shows an inline placeholder until its
+       fragment arrives. _currentTab tracks the most recent request: if the
+       user clicks elsewhere before a slow fragment resolves, the late
+       fragment still lands in its own (now background) panel via
+       loadTabFragment(), but the per-tab activation side effects below only
+       run for the tab that is still current. */
+    let _currentTab=null;
     async function switchTab(name){
-      await ensureTabLoaded(name);
+      _currentTab=name;
       $$('.tab-panel').forEach(p=>p.classList.remove('active'));
       $$('.tab-btn, .nav-btn').forEach(b=>b.classList.remove('active'));
       var panel=$('tab-'+name);
-      if(panel) panel.classList.add('active');
+      if(panel){
+        panel.classList.add('active');
+        /* Placeholder only when the fragment is genuinely absent; if a load
+           is already queued it will overwrite this on arrival. */
+        if(!loadedTabs.has(name)) panel.innerHTML='<div class="tab-loading">Loading…</div>';
+      }
       $$('[data-tab="'+name+'"]').forEach(b=>b.classList.add('active'));
       setAccent(name);
       try{localStorage.setItem('nina_tab',name);}catch(e){}
+      await ensureTabLoaded(name);
+      /* User moved on while this fragment loaded: skip activation hooks; the
+         current tab's own switchTab() call owns them now. */
+      if(_currentTab!==name) return;
       if(name==='logs'){
         /* Re-enter the currently selected source; refreshes it and (for device)
            resumes auto-refresh. Falls back to direct calls if not yet defined. */
@@ -2292,7 +2370,7 @@
     function populateTab_backup(data){
       if ($('backupCurrentVersion')) $('backupCurrentVersion').textContent = 'v' + (data.config_version || '?');
       if ($('backupFirmwareVersion')) {
-        fetch('/api/version').then(function(r){return r.json()}).then(function(v){
+        fetchJsonMemo('/api/version').then(function(v){
           $('backupFirmwareVersion').textContent = v.git_tag || '--';
         }).catch(function(){});
       }
@@ -2524,7 +2602,7 @@
          the user has necessarily opened System). Every write is guarded;
          populateTab_system() calls this again once the fragment is present
          so the grid still ends up populated. */
-      fetch('/api/version').then(r=>r.json()).then(data=>{
+      fetchJsonMemo('/api/version').then(data=>{
         if($('fw_version')) $('fw_version').textContent=data.version||'--';
         if($('fw_date')) $('fw_date').textContent=(data.date||'--')+' '+(data.time||'');
         if($('fw_idf')) $('fw_idf').textContent=data.idf||'--';
@@ -2822,7 +2900,7 @@
       return '<1m';
     }
     function refreshNavMetrics(){
-      fetch('/api/status').then(function(r){return r.json();}).then(function(d){
+      fetchJsonMemo('/api/status').then(function(d){
         if(!d) return;
         // Temperature (1 decimal, null -> --)
         var t=$('mTemp');
@@ -3844,9 +3922,12 @@
       return !!(p && p.classList.contains('active'));
     }
 
+    /* Bytes of log tail shown in the viewer; Download still serves the full log. */
+    var LOGS_TAIL_BYTES=32768;
+
     /* Hint text per source (no em dashes in user-facing strings). */
     var LOG_HINTS={
-      device:'Console output captured since boot (kept in memory; oldest lines drop off as new ones arrive).',
+      device:'Console output captured since boot (kept in memory; oldest lines drop off as new ones arrive). The viewer shows the most recent output; use Download for the full log.',
       crash:'Saved crash history (survives reboot). Records unexpected restarts and crashes, with details when available. Newest 20 records kept.'
     };
 
@@ -3904,7 +3985,10 @@
       if(btn) btn.disabled=true;
       /* Was the view scrolled to (near) the bottom before we replaced content? */
       var nearBottom = (view.scrollHeight - view.scrollTop - view.clientHeight) < 40;
-      fetch('/api/logs')
+      /* Viewer shows only the newest slice of the buffer; pulling the whole
+         512 KB capture every refresh starved the device's web server. The
+         Download link (see setLogSource) still fetches the full log. */
+      fetch('/api/logs?tail='+LOGS_TAIL_BYTES)
         .then(function(r){
           if(!r.ok) throw new Error('HTTP '+r.status);
           return r.text();
@@ -4410,6 +4494,10 @@
       setTimeout(function(){
         if(!window._updateChecked && typeof checkUpdateBadge==='function'){ window._updateChecked=true; checkUpdateBadge(); }
       }, 1500);
+      /* Quietly fetch the remaining tab fragments one at a time so later tab
+         clicks open instantly. Waits for browser idle time (2s fallback);
+         chains through the same one-at-a-time fragment queue as user clicks. */
+      setTimeout(startTabPrefetch, 2000);
     });
   </script>
 </body>

--- a/main/ui/nina_image_display.c
+++ b/main/ui/nina_image_display.c
@@ -40,8 +40,7 @@ static const char *TAG = "image_display";
  * LV_FONT_MONTSERRAT_* Kconfig toggles.  All overlay labels (bottom phase /
  * timestamp and the four moon-corner info labels) use overpass_27 for
  * readability at desk distance.  At this size the longest strings reach past
- * the inscribed moon disc; each label's translucent chip background keeps the
- * text legible where it overlaps the moon. */
+ * the inscribed moon disc and render directly over it (no chip background). */
 extern const lv_font_t lv_font_overpass_27;
 
 static lv_obj_t *page_container;
@@ -246,21 +245,18 @@ static void moon_drag_released_cb(lv_event_t *e)
     if (goes_task_handle) xTaskNotifyGive(goes_task_handle);
 }
 
-/* Apply the "chip" style to a label: small translucent rounded background that
- * keeps text legible when the main overlay bar is nearly transparent.
- * bg_opa=120 (~47%), corner radius=8, horizontal pad=8, vertical pad=3.
- * Non-red themes keep the historic black chip + white text exactly. Under the
- * Red Night theme (gated by theme_is_red_night) the chip background stays black
- * and the text becomes the theme's red (text_color) so the page emits only red
- * shades or black. nina_image_display_apply_theme() re-runs this on theme change. */
+/* Apply the "chip" style to a label: transparent background (no chip) with the
+ * historic padding so label geometry/stacking math is unchanged.
+ * Non-red themes use white text. Under the Red Night theme (gated by
+ * theme_is_red_night) the text becomes the theme's red (text_color) so the page
+ * emits only red shades or black. nina_image_display_apply_theme() re-runs this
+ * on theme change. */
 static void apply_chip_style(lv_obj_t *lbl)
 {
     const theme_t *th = current_theme;
     bool red = theme_is_red_night(th);
     lv_color_t txt = red ? lv_color_hex(th->text_color) : lv_color_white();
-    lv_obj_set_style_bg_color(lbl,   lv_color_black(), 0);
-    lv_obj_set_style_bg_opa(lbl,     120,              0);
-    lv_obj_set_style_radius(lbl,     8,                0);
+    lv_obj_set_style_bg_opa(lbl,     LV_OPA_TRANSP,    0);
     lv_obj_set_style_pad_left(lbl,   8,                0);
     lv_obj_set_style_pad_right(lbl,  8,                0);
     lv_obj_set_style_pad_top(lbl,    3,                0);
@@ -391,9 +387,9 @@ lv_obj_t *nina_image_display_create(lv_obj_t *parent)
     lv_obj_remove_style_all(overlay_bar);
     lv_obj_set_size(overlay_bar, SCREEN_SIZE, 68);
     lv_obj_align(overlay_bar, LV_ALIGN_BOTTOM_MID, 0, 0);
-    /* No bar background: each bottom label carries its own translucent chip
-     * (apply_chip_style), so overlay_bar is just an invisible positioning
-     * container for lbl_region / lbl_timestamp. */
+    /* No bar background: labels render text directly (apply_chip_style), so
+     * overlay_bar is just an invisible positioning container for
+     * lbl_region / lbl_timestamp. */
     lv_obj_set_style_bg_opa(overlay_bar, LV_OPA_TRANSP, 0);
     /* No edge padding — the bottom labels sit flush in the screen corners so they
      * stay clear of the inscribed moon disc. */
@@ -404,7 +400,7 @@ lv_obj_t *nina_image_display_create(lv_obj_t *parent)
     lbl_region = lv_label_create(overlay_bar);
     lv_obj_set_style_text_font(lbl_region, &lv_font_overpass_27, 0);
     lv_obj_align(lbl_region, LV_ALIGN_BOTTOM_LEFT, 0, 0);
-    apply_chip_style(lbl_region);   /* white text + translucent chip bg */
+    apply_chip_style(lbl_region);   /* white text, transparent bg */
     lv_label_set_text(lbl_region, "");
 
     lbl_timestamp = lv_label_create(overlay_bar);
@@ -426,8 +422,8 @@ lv_obj_t *nina_image_display_create(lv_obj_t *parent)
     lbl_moon_next = lv_label_create(page_container);
     lv_obj_set_style_text_font(lbl_moon_next, &lv_font_overpass_27, 0);
     apply_chip_style(lbl_moon_next);
-    /* Stack flush below lbl_moon_age. At 27px the chip is line_height(39)+pad(6) =
-     * 45px tall, so the second row sits at y = 45 (chips touch, no gap). */
+    /* Stack flush below lbl_moon_age. At 27px each label is line_height(39)+pad(6)
+     * = 45px tall, so the second row sits at y = 45 (rows touch, no gap). */
     lv_obj_align(lbl_moon_next, LV_ALIGN_TOP_LEFT, 0, 45);
     lv_label_set_text(lbl_moon_next, "");
     lv_obj_add_flag(lbl_moon_next, LV_OBJ_FLAG_HIDDEN);
@@ -1073,11 +1069,10 @@ void nina_image_display_set_overlay_visible(bool visible)
 
 void nina_image_display_apply_theme(void)
 {
-    /* Re-apply the chip style to every existing caption/corner label so a theme
+    /* Re-apply the label style to every existing caption/corner label so a theme
      * switch recolours them live. apply_chip_style() reads current_theme and,
-     * under Red Night, emits red text on a black chip; non-red themes keep the
-     * historic white-on-black look unchanged. Each label is NULL-guarded so this
-     * is safe before create() or after cleanup(). */
+     * under Red Night, emits red text; non-red themes use white text. Each label
+     * is NULL-guarded so this is safe before create() or after cleanup(). */
     if (lbl_region)    apply_chip_style(lbl_region);
     if (lbl_timestamp) apply_chip_style(lbl_timestamp);
     if (lbl_moon_age)  apply_chip_style(lbl_moon_age);

--- a/main/web_handlers_logs.c
+++ b/main/web_handlers_logs.c
@@ -4,6 +4,8 @@
  *
  * GET  /api/logs            -> streams the captured log oldest->newest as a
  *                              text/plain attachment, chunked from PSRAM.
+ *                              Optional ?tail=N serves only the last N bytes
+ *                              (clamped to 1 KB .. full buffer size).
  * POST /api/logs/clear      -> empties the capture buffer, returns {"ok":true}.
  * GET  /api/crashlog        -> streams the persistent crash-history JSONL file
  *                              (text/plain attachment; the UI also fetches it
@@ -23,16 +25,45 @@
 #include "esp_heap_caps.h"
 #include "esp_core_dump.h"
 #include "esp_partition.h"
+#include <stdlib.h>
 #include <string.h>
 
 /* PSRAM-backed chunk size for streaming the download. Keeps the send path off
  * the tight internal heap. */
 #define LOG_CHUNK_SIZE 4096
 
+/* Bounds for the optional ?tail=N byte count on GET /api/logs. */
+#define LOG_TAIL_MIN 1024
+#define LOG_TAIL_MAX LOG_CAPTURE_SIZE
+
 // Handler for downloading the captured log buffer
 esp_err_t logs_get_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
+
+    /* Optional ?tail=N: serve only the last N bytes of the captured log so
+     * the web UI's Logs tab can poll a small window instead of pulling the
+     * full 512 KB ring on every open (which starves other httpd requests).
+     * No param, a malformed value, or N >= captured size keeps the existing
+     * full-buffer behavior. */
+    size_t tail_bytes = 0;
+    char qbuf[64];
+    if (httpd_req_get_url_query_str(req, qbuf, sizeof(qbuf)) == ESP_OK) {
+        char val[16] = {0};
+        if (httpd_query_key_value(qbuf, "tail", val, sizeof(val)) == ESP_OK &&
+            val[0] != '\0') {
+            long n = strtol(val, NULL, 10);
+            if (n > 0) {
+                if (n < LOG_TAIL_MIN) {
+                    n = LOG_TAIL_MIN;
+                }
+                if (n > (long)LOG_TAIL_MAX) {
+                    n = (long)LOG_TAIL_MAX;
+                }
+                tail_bytes = (size_t)n;
+            }
+        }
+    }
 
     /* Build the download filename from the configured hostname. */
     const char *hostname = app_config_get()->hostname;
@@ -52,10 +83,30 @@ esp_err_t logs_get_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
+    /* When tailing, start the stream at (captured size - N). The size is
+     * sampled once; lines that arrive mid-download simply extend what later
+     * reads return, same as the full download. */
+    size_t offset = 0;
+    if (tail_bytes > 0) {
+        size_t total = log_capture_size();
+        if (tail_bytes < total) {
+            offset = total - tail_bytes;
+            /* Advance past the first (likely partial) line so the tail starts
+             * on a clean line boundary. Cheap single-chunk scan; if no newline
+             * is found in the first chunk, just start mid-line. */
+            size_t got = log_capture_read(offset, chunk, LOG_CHUNK_SIZE);
+            if (got > 0) {
+                const char *nl = memchr(chunk, '\n', got);
+                if (nl != NULL) {
+                    offset += (size_t)(nl - chunk) + 1;
+                }
+            }
+        }
+    }
+
     /* Stream oldest->newest. Each read locks the ring only for its own copy,
      * so logging is never blocked across the whole HTTP send. New lines that
      * arrive mid-download simply extend what later reads return. */
-    size_t offset = 0;
     for (;;) {
         size_t got = log_capture_read(offset, chunk, LOG_CHUNK_SIZE);
         if (got == 0) {


### PR DESCRIPTION
### Summary
The C6 coprocessor firmware is updated, now showing progress directly on screen during the update process. This PR also improves the responsiveness of the configuration UI, especially when switching tabs and viewing logs. A minor visual adjustment removes the translucent background from image display labels.

### Changes
*   Update C6 coprocessor firmware to a newer version.
*   Display on-screen progress during C6 coprocessor firmware updates.
*   Remove translucent background from image display overlay labels for a cleaner look.
*   Improve config UI tab switching speed by immediately swapping active state and showing a loading placeholder.
*   Prefetch remaining UI fragments serially after boot to speed up subsequent tab visits.
*   Cache `/api/version` and `/api/status` API responses for 4 seconds to reduce redundant requests.
*   Modify logs viewer to fetch a smaller tail of the log (`/api/logs?tail=32768`) by default, improving performance.
*   Add a `tail=N` parameter to `/api/logs` endpoint to allow fetching a specific number of bytes from the end of the log.

---
<sub>Analyzed **5** commit(s) | Updated: 2026-07-09T01:42:05.363Z | Generated by GitHub Actions</sub>