### PR TITLE
feat: add home status page at /

### DIFF
--- a/.github/workflows/build-snd.yml
+++ b/.github/workflows/build-snd.yml
@@ -62,6 +62,15 @@ jobs:
           fetch-depth: 0
           clean: false
 
+      # clean:false preserves untracked caches (managed_components), but git
+      # checkout does not restore a tracked file that was deleted in the
+      # persistent workspace when its index entry matches the target ref --
+      # a missing dependencies.lock then triggers a lockless dependency solve
+      # that can pull incompatible component versions. Restore all tracked
+      # files explicitly; untracked caches are untouched.
+      - name: Restore tracked files
+        run: git checkout --force HEAD -- .
+
       - name: Check for skip CI
         id: check_skip
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,15 @@ jobs:
           fetch-depth: 0
           clean: false
 
+      # clean:false preserves untracked caches (managed_components), but git
+      # checkout does not restore a tracked file that was deleted in the
+      # persistent workspace when its index entry matches the target ref --
+      # a missing dependencies.lock then triggers a lockless dependency solve
+      # that can pull incompatible component versions. Restore all tracked
+      # files explicitly; untracked caches are untouched.
+      - name: Restore tracked files
+        run: git checkout --force HEAD -- .
+
       - name: Check for skip CI
         id: check_skip
         run: |

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -54,7 +54,7 @@ dependencies:
       type: service
     version: 1.2.1
   espressif/esp_lcd_touch_gt911:
-    component_hash: 6029febef66eefd0910d527d7f30292779ccbf22a8dedd2bd69466acf0068a7b
+    component_hash: 07f678e4202d79bbad917805dcec4134ff08344177720f32ec4898267ad9e394
     dependencies:
     - name: espressif/esp_lcd_touch
       registry_url: https://components.espressif.com
@@ -66,7 +66,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 1.2.0~2
+    version: 1.2.0~3
   espressif/esp_lvgl_port:
     component_hash: fb6c1fdfe70d4ca39a035d63ca394a35f17ec84ce16ff98ecb13a54155d75da4
     dependencies:
@@ -122,19 +122,19 @@ dependencies:
       type: service
     version: 0.16.3
   espressif/wifi_remote_over_eppp:
-    component_hash: 06d8bc15348bbd21f1390daace36ed5adcf6026c93c5b69decc55fa04df2711a
+    component_hash: 1fd6968af20f0b19e421f6b519b0a8caf81d689afc3783b564c28559e45f66ef
     dependencies:
-    - name: idf
-      require: private
-      version: '>=5.3'
     - name: espressif/eppp_link
       registry_url: https://components.espressif.com
       require: private
       version: '>=0.1'
+    - name: idf
+      require: private
+      version: '>=5.3'
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 0.3.2
+    version: 0.3.3
   idf:
     source:
       type: idf
@@ -169,7 +169,7 @@ dependencies:
     - esp32p4
     version: 1.0.1
   waveshare/esp_lcd_st7703:
-    component_hash: 0ee99c4d38d5742f554fa10f0cc17a74529d623fb0ebdb0e9bfac1703f1d4442
+    component_hash: d82de85750df3c6c9bfae4c49fdf8cc443e2387cb19507081968f71c11976378
     dependencies:
     - name: espressif/cmake_utilities
       registry_url: https://components.espressif.com
@@ -183,7 +183,7 @@ dependencies:
       type: service
     targets:
     - esp32p4
-    version: 1.0.5
+    version: 2.0.0
 direct_dependencies:
 - espressif/esp_codec_dev
 - espressif/esp_hosted
@@ -195,6 +195,6 @@ direct_dependencies:
 - lvgl/lvgl
 - waveshare/esp32_p4_wifi6_touch_lcd_4b
 - waveshare/esp_lcd_st7703
-manifest_hash: 553b726d4b934eca3f1e80e40c5f9ff2caa96358302536ab0d7110079803539c
+manifest_hash: 25ddac7cd13120345c4f8a4b745711175bcedc11bea34c23e21d31d3bcbfb0ef
 target: esp32p4
 version: 2.0.0

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -17,7 +17,7 @@ idf_component_register(
          ui/nina_empty_state.c
          ${LV_DEMOS_SOURCES}
     INCLUDE_DIRS . ui ${LV_DEMO_DIR}
-    EMBED_TXTFILES config_ui.html login.html setup_ui.html fragment_logs.html fragment_backup.html fragment_api.html fragment_allsky.html fragment_json.html fragment_ha.html fragment_clock.html fragment_spotify.html fragment_image_display.html fragment_nodes.html fragment_display.html fragment_behavior.html fragment_system.html
+    EMBED_TXTFILES config_ui.html home_ui.html login.html setup_ui.html fragment_logs.html fragment_backup.html fragment_api.html fragment_allsky.html fragment_json.html fragment_ha.html fragment_clock.html fragment_spotify.html fragment_image_display.html fragment_nodes.html fragment_display.html fragment_behavior.html fragment_system.html
     EMBED_FILES favicon.png logo.jpg spotify_logo.png moon_texture.png moon_equirect.jpg)
 
 idf_component_get_property(LVGL_LIB lvgl__lvgl COMPONENT_LIB)

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -99,7 +99,10 @@ const char *app_config_get_ha_tiles(void) {
 
 /* Shared setter: validate length, update cache + NVS key under the config mutex.
  * Read is lock-free by contract; the write is serialized against app_config_save
- * (same mutex) so shared state is never torn between a save and a tiles-set. */
+ * (same mutex) so shared state is never torn between a save and a tiles-set.
+ * A NULL @p key updates the in-RAM cache ONLY (no NVS write) -- the preview path
+ * of the page-config POST handlers, mirroring app_config_apply() vs
+ * app_config_save() for the struct blob. */
 static esp_err_t tiles_set(const char *key, char **cache, const char *s) {
     if (!s) {
         s = "";
@@ -114,14 +117,17 @@ static esp_err_t tiles_set(const char *key, char **cache, const char *s) {
     }
     strlcpy(*cache, s, TILES_CACHE_BYTES);   /* clamps to 6143 + NUL, always terminated */
 
-    nvs_handle_t h;
-    esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h);
-    if (err == ESP_OK) {
-        err = nvs_set_str(h, key, *cache);
+    esp_err_t err = ESP_OK;
+    if (key != NULL) {
+        nvs_handle_t h;
+        err = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &h);
         if (err == ESP_OK) {
-            nvs_commit(h);
+            err = nvs_set_str(h, key, *cache);
+            if (err == ESP_OK) {
+                nvs_commit(h);
+            }
+            nvs_close(h);
         }
-        nvs_close(h);
     }
     xSemaphoreGive(s_config_mutex);
     return err;   /* cache updated regardless; a failed NVS write is logged by caller */
@@ -133,6 +139,14 @@ esp_err_t app_config_set_json_tiles(const char *s) {
 
 esp_err_t app_config_set_ha_tiles(const char *s) {
     return tiles_set("ha_tiles", &s_ha_tiles_cache, s);
+}
+
+esp_err_t app_config_set_json_tiles_ram(const char *s) {
+    return tiles_set(NULL, &s_json_tiles_cache, s);
+}
+
+esp_err_t app_config_set_ha_tiles_ram(const char *s) {
+    return tiles_set(NULL, &s_ha_tiles_cache, s);
 }
 
 // Default RMS thresholds: good <= 0.5", ok <= 1.0", bad > 1.0" - DIMMED for Night Vision
@@ -3603,14 +3617,28 @@ void app_config_get_snapshot_into(app_config_t *dst) {
     xSemaphoreGive(s_config_mutex);
 }
 
-void app_config_apply(const app_config_t *config) {
+/* Shared body of app_config_apply / app_config_apply_preview. @p mark_dirty
+ * false leaves s_config_dirty exactly as found -- neither set nor cleared -- so a
+ * preview never fabricates an "unsaved changes" state, and never hides a real one
+ * raised by an earlier live-apply. */
+static void apply_config_locked(const app_config_t *config, bool mark_dirty) {
     xSemaphoreTake(s_config_mutex, portMAX_DELAY);
     invalidate_json_caches();
     memcpy(&s_config, config, sizeof(app_config_t));
     s_config.config_version = APP_CONFIG_VERSION;
     validate_config(&s_config);
-    s_config_dirty = true;
+    if (mark_dirty) {
+        s_config_dirty = true;
+    }
     xSemaphoreGive(s_config_mutex);
+}
+
+void app_config_apply(const app_config_t *config) {
+    apply_config_locked(config, true);
+}
+
+void app_config_apply_preview(const app_config_t *config) {
+    apply_config_locked(config, false);
 }
 
 esp_err_t app_config_revert(void) {

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -3641,6 +3641,12 @@ void app_config_apply_preview(const app_config_t *config) {
     apply_config_locked(config, false);
 }
 
+void app_config_apply_external(const app_config_t *config) {
+    /* Same mechanism as app_config_apply_preview(); separate name only so the
+     * externally-commanded call sites do not have to claim to be "previewing". */
+    apply_config_locked(config, false);
+}
+
 esp_err_t app_config_revert(void) {
     nvs_handle_t handle;
     esp_err_t err = nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -3310,7 +3310,13 @@ app_config_t *app_config_get(void);
  * (overflows small poll/UI task stacks). Snapshot into a PSRAM heap buffer. */
 void app_config_get_snapshot_into(app_config_t *dst);
 void app_config_save(const app_config_t *config);
-void app_config_apply(const app_config_t *config);   // in-memory only, no NVS
+void app_config_apply(const app_config_t *config);   // in-memory only, no NVS; marks dirty
+/* Same as app_config_apply(), but leaves the unsaved-changes flag exactly as it
+ * found it (neither set nor cleared). For the "preview":true path of the
+ * page-config POST handlers: a preview is a live look at candidate values, not a
+ * pending edit, so it must not raise the web UI's "unsaved changes" bar -- nor
+ * clear it if a real live-apply already raised it. */
+void app_config_apply_preview(const app_config_t *config);
 esp_err_t app_config_revert(void);                    // reload NVS into memory
 bool app_config_is_dirty(void);                       // true if apply called without save
 int app_config_get_instance_count(void);
@@ -3338,6 +3344,16 @@ const char *app_config_get_json_tiles(void);
 const char *app_config_get_ha_tiles(void);
 esp_err_t   app_config_set_json_tiles(const char *s);
 esp_err_t   app_config_set_ha_tiles(const char *s);
+
+/* Preview (RAM-only) variants: identical to the setters above but SKIP the NVS
+ * write, so the live page picks up the new tiles while the saved value is left
+ * untouched. Same relationship as app_config_apply() vs app_config_save() for
+ * the struct blob. Used by the "preview":true path of POST /api/json-config and
+ * POST /api/ha-config. The change is device-wide and is NOT auto-reverted: a
+ * later non-preview POST, or a preview POST carrying the saved values, restores
+ * the cache; otherwise it reverts on the next reboot (NVS is authoritative). */
+esp_err_t   app_config_set_json_tiles_ram(const char *s);
+esp_err_t   app_config_set_ha_tiles_ram(const char *s);
 
 bool app_config_is_instance_enabled(int index);
 int app_config_get_enabled_instance_count(void);

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -3317,6 +3317,13 @@ void app_config_apply(const app_config_t *config);   // in-memory only, no NVS; 
  * pending edit, so it must not raise the web UI's "unsaved changes" bar -- nor
  * clear it if a real live-apply already raised it. */
 void app_config_apply_preview(const app_config_t *config);
+/* Same mechanism as app_config_apply_preview(), different name for a different
+ * caller: a config change COMMANDED FROM OUTSIDE (an HA automation, a macro
+ * keypad, any stateless API client) is not an unsaved web edit, so it must not
+ * raise the web UI's "unsaved changes" bar. The user never opened an editor;
+ * there is nothing for them to Save, and a bar they cannot explain is worse than
+ * no bar. Persistence semantics are identical to app_config_apply(): RAM only. */
+void app_config_apply_external(const app_config_t *config);
 esp_err_t app_config_revert(void);                    // reload NVS into memory
 bool app_config_is_dirty(void);                       // true if apply called without save
 int app_config_get_instance_count(void);

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -437,14 +437,14 @@
       -ms-overflow-style: none; scrollbar-width: none;
     }
     .bottom-nav .nav-items::-webkit-scrollbar { display: none; }
-    .bottom-nav .nav-btn {
+    .bottom-nav .nav-btn, .bottom-nav .nav-home {
       background: none; border: none; color: var(--text-hint); cursor: pointer;
       display: flex; flex-direction: column; align-items: center; gap: 3px;
       padding: 8px 12px; border-radius: 10px; font-size: 0.78rem;
       font-weight: 500; transition: all 0.25s ease; position: relative; font-family: inherit;
-      flex-shrink: 0;
+      flex-shrink: 0; text-decoration: none;
     }
-    .bottom-nav .nav-btn svg { width: 22px; height: 22px; }
+    .bottom-nav .nav-btn svg, .bottom-nav .nav-home svg { width: 22px; height: 22px; }
     .bottom-nav .nav-btn.active { color: var(--accent); }
     .bottom-nav .nav-btn.active::after {
       content: ''; position: absolute; bottom: 2px; left: 50%;
@@ -985,6 +985,10 @@
       </div>
     </div>
     <div class="nav-right">
+      <a class="github-link" href="/">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12l9-9 9 9"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/></svg>
+        Home
+      </a>
       <button class="update-pill" id="updatePill" style="display:none" title="Update available - click to install"></button>
       <a class="github-link" href="https://github.com/chvvkumar/ESP32-P4-NINA-Display" target="_blank" rel="noopener">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
@@ -996,6 +1000,10 @@
   <!-- ======== BOTTOM NAVIGATION (MOBILE) ======== -->
   <nav class="bottom-nav">
     <div class="nav-items" id="bottomTabs">
+      <a class="nav-home" href="/">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12l9-9 9 9"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/></svg>
+        Home
+      </a>
       <button class="nav-btn" data-tab="nodes">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="3" width="20" height="14" rx="2"/><path d="M8 21h8M12 17v4"/></svg>
         N.I.N.A.
@@ -1010,7 +1018,7 @@
       </button>
       <button class="nav-btn" data-tab="ha">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12l9-9 9 9"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/></svg>
-        Home
+        Home Asst
       </button>
       <button class="nav-btn" data-tab="clock">
         <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
@@ -1781,10 +1789,16 @@
     document.addEventListener('click',e=>{ if(!e.target.closest('.nav-group')) closeGroups(); });
 
     try{
+      var hashTab=location.hash.replace('#','');
       var saved=localStorage.getItem('nina_tab');
-      if(saved&&$('tab-'+saved)) switchTab(saved);
+      if(hashTab&&$('tab-'+hashTab)) switchTab(hashTab);
+      else if(saved&&$('tab-'+saved)) switchTab(saved);
       else switchTab('nodes');
     }catch(e){ switchTab('nodes'); }
+    window.addEventListener('hashchange',()=>{
+      var t=location.hash.replace('#','');
+      if(t&&$('tab-'+t)) switchTab(t);
+    });
 
     /* === Live API Controls === */
     function setTheme(v){postJson('/api/theme',{theme_index:parseInt(v)})}

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -955,6 +955,10 @@
   <nav class="top-nav">
     <div class="brand"><img class="logo" src="/favicon.ico" alt=""> <span id="brandName">NINA Display</span></div>
     <div class="nav-tabs-wrap">
+      <a class="github-link" href="/">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12l9-9 9 9"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/></svg>
+        Home
+      </a>
       <div class="nav-group" data-group="pages">
         <button class="group-btn" data-group="pages">Pages</button>
         <div class="group-menu">
@@ -985,10 +989,6 @@
       </div>
     </div>
     <div class="nav-right">
-      <a class="github-link" href="/">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12l9-9 9 9"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/></svg>
-        Home
-      </a>
       <button class="update-pill" id="updatePill" style="display:none" title="Update available - click to install"></button>
       <a class="github-link" href="https://github.com/chvvkumar/ESP32-P4-NINA-Display" target="_blank" rel="noopener">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -828,12 +828,16 @@
       border: 1px solid var(--border);
       padding: 14px 22px; border-radius: 16px; font-size: 0.85rem;
       box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5);
+      display: flex; align-items: center; gap: 10px; max-width: min(420px, calc(100vw - 48px));
       visibility: hidden; pointer-events: none;
       transform: translateX(120%); transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0.35s;
     }
     .toast.show { visibility: visible; pointer-events: auto; transform: translateX(0); transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0s; }
-    .toast.success { border-left: 3px solid #10b981; box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5), 0 0 20px rgba(16, 185, 129, 0.08); }
-    .toast.error { border-left: 3px solid #ef4444; box-shadow: 0 8px 40px rgba(0, 0, 0, 0.5), 0 0 20px rgba(239, 68, 68, 0.08); }
+    /* Severity reads from the icon only; the box itself stays plain. */
+    .toast-icon { display: inline-flex; flex-shrink: 0; color: var(--text-muted); }
+    .toast-icon svg { width: 18px; height: 18px; display: block; }
+    .toast.success .toast-icon { color: #10b981; }
+    .toast.error .toast-icon { color: #ef4444; }
 
     /* === RESPONSIVE === */
     @media (max-width: 768px) {
@@ -2824,7 +2828,7 @@
         console.error('Failed to load config',e);
         if(!window._cfgLoadToastShown){
           window._cfgLoadToastShown=true;
-          showToast('Could not load settings from device -- retrying...','error');
+          showToast('Could not load settings from device. Retrying.','error');
         }
         cfgOverlay('retry');
         setTimeout(loadConfig,3000);
@@ -2837,7 +2841,7 @@
     function configLoadedGuard(){
       if(_cfgCache && !_populateFailed) return true;
       if(_populateFailed) showToast('Some settings failed to load - refresh the page before saving','error');
-      else showToast('Settings not loaded from device yet -- still retrying, please wait','error');
+      else showToast('Settings not loaded from device yet. Still retrying, please wait.','error');
       return false;
     }
 
@@ -2917,10 +2921,19 @@
     }
 
     /* === Toast === */
+    /* Severity is carried by a small inline SVG (check / cross / dot) rather
+       than a colored edge on the box. */
+    var TOAST_ICONS={
+      success:'<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M16.7 5.3a1 1 0 010 1.4l-7.8 7.8a1 1 0 01-1.4 0L3.3 10.3a1 1 0 111.4-1.4l3.5 3.5 7.1-7.1a1 1 0 011.4 0z" clip-rule="evenodd"/></svg>',
+      error:'<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M5.3 5.3a1 1 0 011.4 0L10 8.6l3.3-3.3a1 1 0 111.4 1.4L11.4 10l3.3 3.3a1 1 0 01-1.4 1.4L10 11.4l-3.3 3.3a1 1 0 01-1.4-1.4L8.6 10 5.3 6.7a1 1 0 010-1.4z" clip-rule="evenodd"/></svg>',
+      info:'<svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M10 2.5a7.5 7.5 0 100 15 7.5 7.5 0 000-15zM9 9a1 1 0 012 0v5a1 1 0 01-2 0V9zm1-3.6a1.1 1.1 0 110 2.2 1.1 1.1 0 010-2.2z" clip-rule="evenodd"/></svg>'
+    };
     function showToast(msg,type){
       var t=$('toast');
-      t.textContent=msg;
       t.className='toast '+(type||'')+' show';
+      /* icon is trusted markup, the message never is: it is set as text */
+      t.innerHTML='<span class="toast-icon">'+(TOAST_ICONS[type]||TOAST_ICONS.info)+'</span><span class="toast-msg"></span>';
+      t.querySelector('.toast-msg').textContent=msg;
       clearTimeout(t._timer);
       t._timer=setTimeout(()=>{t.classList.remove('show');},3000);
     }
@@ -3498,8 +3511,17 @@
       },400);
     }
 
-    document.querySelector('.content').addEventListener('input',()=>{checkDirty();liveApply();});
-    document.querySelector('.content').addEventListener('change',()=>{checkDirty();liveApply();});
+    /* Some controls are action parameters, not device settings: a transfer
+       hostname, a password used once, an export toggle. They are not part of
+       getConfigData(), so touching them must neither raise the save bar nor
+       fire a live apply. Marked by a data-no-dirty container so every control
+       inside one is excluded, including any added later. */
+    function isNonSettingTarget(e){
+      var t=e && e.target;
+      return !!(t && t.closest && t.closest('[data-no-dirty]'));
+    }
+    document.querySelector('.content').addEventListener('input',(e)=>{if(isNonSettingTarget(e))return;checkDirty();liveApply();});
+    document.querySelector('.content').addEventListener('change',(e)=>{if(isNonSettingTarget(e))return;checkDirty();liveApply();});
 
     /* === Spotify Configuration === */
 
@@ -3586,7 +3608,7 @@
         var error=u.searchParams.get('error');
         if(error){showToast('Spotify login denied: '+error,'error');return;}
         var savedState=sessionStorage.getItem('spotify_auth_state');
-        if(cbState!==savedState){showToast('Auth state mismatch — please retry login','error');return;}
+        if(cbState!==savedState){showToast('Auth state mismatch. Please retry login.','error');return;}
         if(!code){showToast('No auth code found in URL','error');return;}
         var cv=sessionStorage.getItem('spotify_code_verifier');
         var ru=sessionStorage.getItem('spotify_redirect_uri');
@@ -3613,7 +3635,7 @@
         sessionStorage.removeItem('spotify_code_verifier');
         sessionStorage.removeItem('spotify_auth_state');
         sessionStorage.removeItem('spotify_redirect_uri');
-      }catch(e){showToast('Invalid URL — paste the full address bar URL','error');}
+      }catch(e){showToast('Invalid URL. Paste the full address bar URL.','error');}
     }
 
     function spotifyLogout(){

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -833,6 +833,8 @@
       transform: translateX(120%); transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0.35s;
     }
     .toast.show { visibility: visible; pointer-events: auto; transform: translateX(0); transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1), visibility 0s linear 0s; }
+    .restore-cb { width: 15px; height: 15px; margin: 0; flex-shrink: 0; cursor: pointer; accent-color: var(--accent); }
+
     /* Severity reads from the icon only; the box itself stays plain. */
     .toast-icon { display: inline-flex; flex-shrink: 0; color: var(--text-muted); }
     .toast-icon svg { width: 18px; height: 18px; display: block; }
@@ -4591,6 +4593,10 @@
     var _backupData = null;  /* holds parsed backup JSON for confirm step */
     var _restoreFromDevice = false;  /* preview source was another device, not a file */
     var _pullSensitiveRefused = false;  /* asked the source for secrets, it sent none */
+    var _restoreRows = [];        /* every selectable row in the preview */
+    var _restoreSkip = {};        /* field keys the user unchecked */
+    var _restoreCats = [];        /* {cat, rows, parentCb} for in-place updates */
+    var _restoreBlocked = false;  /* preview reported errors that block restoring */
 
     function downloadBackup() {
       var btn = $('backupDownloadBtn');
@@ -4659,7 +4665,13 @@
           return r.json();
         })
         .then(function(preview) { renderRestorePreview(preview); })
-        .catch(function(e) { showToast('Preview failed: ' + e.message, 'error'); });
+        .catch(function(e) {
+          showToast('Preview failed: ' + e.message, 'error');
+          /* Never leave an earlier preview on screen paired with this backup:
+             the panel would show A's rows and selection while _backupData held
+             B, and Restore would post B stripped by A's choices. */
+          cancelRestore();
+        });
     }
 
     /* Copy the configuration from another display on the network. The device
@@ -4733,6 +4745,9 @@
     function renderRestorePreview(p) {
       if (p.error) {
         showToast(p.error, 'error');
+        /* same reasoning as the fetch failure path: drop the stale panel and
+           its selection rather than pairing them with a new backup */
+        cancelRestore();
         return;
       }
 
@@ -4768,42 +4783,27 @@
         banner.style.color = color.text;
         banner.style.display = 'block';
         banner.innerHTML = '<div style="margin-bottom:4px"><strong>Version: v' + p.backup_version + ' &rarr; v' + p.current_version + '</strong></div>' +
-          p.warnings.map(function(w) { return '<div>' + w + '</div>'; }).join('');
+          p.warnings.map(function(w) { return '<div>' + escHtml(w) + '</div>'; }).join('');
       } else {
         banner.style.display = 'none';
       }
 
-      /* Changes diff grouped by category */
-      var changesDiv = $('restoreChanges');
-      changesDiv.innerHTML = '';
-      if (p.changes && p.total_changes > 0) {
-        var cats = Object.keys(p.changes);
-        cats.forEach(function(cat) {
-          var items = p.changes[cat];
-          if (!items || !items.length) return;
-          var section = document.createElement('div');
-          section.style.cssText = 'background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:10px;padding:14px 16px;margin-bottom:8px';
-          var header = '<div style="font-size:0.85rem;font-weight:600;color:#f4f4f5;margin-bottom:8px;cursor:pointer" onclick="this.nextElementSibling.style.display=this.nextElementSibling.style.display===\'none\'?\'block\':\'none\'">' +
-            cat + ' <span style="color:#71717a;font-weight:400">(' + items.length + ' change' + (items.length > 1 ? 's' : '') + ')</span></div>';
-          var body = '<div>';
-          items.forEach(function(ch) {
-            var row = '<div style="display:flex;justify-content:space-between;padding:4px 0;font-size:0.8rem;border-bottom:1px solid rgba(255,255,255,0.04)">' +
-              '<span style="color:#a1a1aa">' + ch.label + '</span>';
-            if (isSecretField(ch)) {
-              row += '<span style="color:var(--accent)">will be replaced (hidden)</span>';
-            } else if (isBlobChange(ch)) {
-              row += '<span style="color:var(--accent)">will be replaced</span>';
-            } else {
-              row += '<span><span style="color:#71717a;text-decoration:line-through">' + formatDiffValue(ch.from) + '</span>' +
-                ' &rarr; <span style="color:var(--accent)">' + formatDiffValue(ch.to) + '</span></span>';
-            }
-            body += row + '</div>';
+      /* Changes diff: flattened into one selectable row list, then grouped for
+         display. Every preview starts with everything selected, which is the
+         behavior this screen has always had. */
+      _restoreRows = [];
+      if (p.changes) {
+        Object.keys(p.changes).forEach(function(cat) {
+          (p.changes[cat] || []).forEach(function(ch) {
+            if (!ch || !ch.field) return;
+            _restoreRows.push({field: ch.field, label: ch.label || ch.field, category: cat, change: ch});
           });
-          body += '</div>';
-          section.innerHTML = header + body;
-          changesDiv.appendChild(section);
         });
       }
+      hiddenRestoreRows().forEach(function(r) { _restoreRows.push(r); });
+      _restoreSkip = {};
+      _restoreBlocked = !!p.restore_blocked;
+      renderRestoreChanges();
 
       /* No changes categories */
       var noChanges = $('restoreNoChanges');
@@ -4873,20 +4873,202 @@
           html += '<strong style="color:#f59e0b">Adjusted values:</strong><br>' +
             warns.map(escHtml).join('<br>');
         }
+        /* sits directly above the disabled Restore button */
+        if (p.restore_blocked) {
+          html += '<br><br>Leaving items out does not get around these problems. They have to be fixed before any of this backup can be restored.';
+        }
         valDiv.innerHTML = html;
       } else {
         valDiv.style.display = 'none';
       }
 
-      /* Update confirm button — block restore when there are hard errors */
-      var rcBtn = $('restoreConfirmBtn');
-      if (p.restore_blocked) {
-        rcBtn.disabled = true;
-        rcBtn.textContent = 'Resolve errors to restore';
-      } else {
-        rcBtn.disabled = false;
-        rcBtn.textContent = 'Restore (' + p.total_changes + ' change' + (p.total_changes !== 1 ? 's' : '') + ')';
+      /* Confirm button state is owned by updateRestoreButton (it also has to
+         follow the selection), called at the end of renderRestoreChanges. */
+      updateRestoreButton();
+    }
+
+    /* ---- selective restore ---- */
+
+    /* wifi_networks and admin_password are applied by a restore but never come
+       back as diff rows, so without these they would ride along invisibly with
+       no way to leave them out. The current values are masked or absent, so the
+       key being present in the backup is the only signal available. */
+    function hiddenRestoreRows() {
+      var b = _backupData || {};
+      var sections = [b.config, b.sensitive];
+      function present(key) {
+        return sections.some(function(s) { return s && s[key] !== undefined; });
       }
+      var out = [];
+      if (present('wifi_networks')) out.push({field: 'wifi_networks', label: 'WiFi networks', category: 'Credentials & Network', note: 'will be replaced'});
+      if (present('admin_password')) out.push({field: 'admin_password', label: 'Admin password', category: 'Credentials & Network', note: 'will be changed'});
+      return out;
+    }
+
+    function restoreSelectedCount() {
+      var n = 0;
+      _restoreRows.forEach(function(r) { if (!_restoreSkip[r.field]) n++; });
+      return n;
+    }
+
+    function updateRestoreButton() {
+      var btn = $('restoreConfirmBtn');
+      if (!btn) return;
+      if (_restoreBlocked) {
+        btn.disabled = true;
+        btn.textContent = 'Resolve errors to restore';
+        return;
+      }
+      var n = restoreSelectedCount();
+      btn.disabled = (n === 0);
+      btn.textContent = 'Restore (' + n + ' change' + (n !== 1 ? 's' : '') + ')';
+    }
+
+    function restoreValueHtml(ch) {
+      if (isSecretField(ch)) return '<span style="color:var(--accent)">will be replaced (hidden)</span>';
+      if (isBlobChange(ch)) return '<span style="color:var(--accent)">will be replaced</span>';
+      /* values come from a backup file, so they are escaped before display */
+      return '<span style="color:#71717a;text-decoration:line-through">' + escHtml(formatDiffValue(ch.from)) + '</span>' +
+             ' &rarr; <span style="color:var(--accent)">' + escHtml(formatDiffValue(ch.to)) + '</span>';
+    }
+
+    /* Selection changes update the existing nodes in place. Re-rendering the
+       list would re-expand collapsed categories and take focus off the checkbox
+       the user just clicked. */
+    function syncRestoreSelection() {
+      _restoreCats.forEach(function(c) {
+        var on = c.rows.filter(function(r) { return !_restoreSkip[r.field]; }).length;
+        c.parentCb.checked = (on > 0);
+        c.parentCb.indeterminate = (on > 0 && on < c.rows.length);
+      });
+      updateRestoreButton();
+    }
+
+    function restoreRowEl(r) {
+      var row = document.createElement('label');
+      row.style.cssText = 'display:flex;align-items:center;gap:10px;padding:4px 0;font-size:0.8rem;border-bottom:1px solid rgba(255,255,255,0.04);cursor:pointer';
+      var cb = document.createElement('input');
+      cb.type = 'checkbox'; cb.className = 'restore-cb';
+      cb.checked = !_restoreSkip[r.field];
+      r._cb = cb;
+      cb.onchange = function() {
+        if (cb.checked) delete _restoreSkip[r.field]; else _restoreSkip[r.field] = true;
+        syncRestoreSelection();
+      };
+      var name = document.createElement('span');
+      name.style.cssText = 'color:#a1a1aa;flex:1'; name.textContent = r.label;
+      var val = document.createElement('span');
+      if (r.note) { val.style.color = 'var(--accent)'; val.textContent = r.note; }
+      else { val.innerHTML = restoreValueHtml(r.change); }
+      row.appendChild(cb); row.appendChild(name); row.appendChild(val);
+      return row;
+    }
+
+    function restoreCatEl(cat, rows) {
+      var section = document.createElement('div');
+      section.style.cssText = 'background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:10px;padding:14px 16px;margin-bottom:8px';
+      var header = document.createElement('div');
+      header.style.cssText = 'display:flex;align-items:center;gap:10px;font-size:0.85rem;font-weight:600;color:#f4f4f5;margin-bottom:8px;cursor:pointer';
+      var parent = document.createElement('input');
+      parent.type = 'checkbox'; parent.className = 'restore-cb';
+      var on = rows.filter(function(r) { return !_restoreSkip[r.field]; }).length;
+      parent.checked = (on > 0);
+      parent.indeterminate = (on > 0 && on < rows.length);
+      parent.setAttribute('aria-label', 'Apply every change under ' + cat);
+      /* the header still collapses its body on click, so the checkbox has to
+         keep that click to itself */
+      parent.onclick = function(e) { e.stopPropagation(); };
+      parent.onchange = function() {
+        /* Decided from the selection as it was before the click, so a partly
+           selected category fills up rather than emptying: partial -> all,
+           all -> none, none -> all. */
+        var on = rows.filter(function(r) { return !_restoreSkip[r.field]; }).length;
+        var selectAll = (on < rows.length);
+        rows.forEach(function(r) {
+          if (selectAll) delete _restoreSkip[r.field]; else _restoreSkip[r.field] = true;
+          if (r._cb) r._cb.checked = selectAll;
+        });
+        syncRestoreSelection();
+      };
+      var name = document.createElement('span'); name.textContent = cat;
+      var count = document.createElement('span');
+      count.style.cssText = 'color:#71717a;font-weight:400';
+      count.textContent = '(' + rows.length + ' change' + (rows.length > 1 ? 's' : '') + ')';
+      header.appendChild(parent); header.appendChild(name); header.appendChild(count);
+      var body = document.createElement('div');
+      rows.forEach(function(r) { body.appendChild(restoreRowEl(r)); });
+      header.onclick = function(e) {
+        if (e.target === parent) return;
+        body.style.display = (body.style.display === 'none') ? 'block' : 'none';
+      };
+      section.appendChild(header); section.appendChild(body);
+      _restoreCats.push({cat: cat, rows: rows, parentCb: parent});
+      return section;
+    }
+
+    function setAllRestoreRows(on) {
+      _restoreSkip = {};
+      _restoreRows.forEach(function(r) {
+        if (!on) _restoreSkip[r.field] = true;
+        if (r._cb) r._cb.checked = on;
+      });
+      syncRestoreSelection();
+    }
+
+    function restoreSelectLink(text, onClick) {
+      var b = document.createElement('button');
+      b.type = 'button';
+      b.style.cssText = 'background:none;border:none;padding:0;color:var(--accent);cursor:pointer;font-size:0.78rem';
+      b.textContent = text;
+      b.onclick = onClick;
+      return b;
+    }
+
+    function renderRestoreChanges() {
+      var host = $('restoreChanges');
+      if (!host) return;
+      host.innerHTML = '';
+      _restoreCats = [];
+      if (!_restoreRows.length) { updateRestoreButton(); return; }
+
+      var bar = document.createElement('div');
+      bar.style.cssText = 'display:flex;gap:14px;align-items:center;margin-bottom:8px;font-size:0.78rem';
+      var lbl = document.createElement('span');
+      lbl.style.color = 'var(--text-hint)';
+      lbl.textContent = 'Choose what to restore:';
+      bar.appendChild(lbl);
+      bar.appendChild(restoreSelectLink('Select all', function() { setAllRestoreRows(true); }));
+      bar.appendChild(restoreSelectLink('Select none', function() { setAllRestoreRows(false); }));
+      host.appendChild(bar);
+
+      /* group by category, keeping the order the categories first appeared in */
+      var order = [], byCat = {};
+      _restoreRows.forEach(function(r) {
+        if (!byCat[r.category]) { byCat[r.category] = []; order.push(r.category); }
+        byCat[r.category].push(r);
+      });
+      order.forEach(function(cat) { host.appendChild(restoreCatEl(cat, byCat[cat])); });
+      updateRestoreButton();
+    }
+
+    /* Build the object actually sent: unchecked keys are removed, and a key the
+       device never receives is left exactly as it is. _backupData itself is not
+       touched, so the selection can be changed and restored again. */
+    var RESTORE_COMPANION_KEYS = {
+      /* the backup mirrors network 0's password here for older firmware, so
+         dropping only wifi_networks would still overwrite it */
+      wifi_networks: ['wifi_password']
+    };
+    function restorePayload() {
+      var copy = JSON.parse(JSON.stringify(_backupData));
+      Object.keys(_restoreSkip).forEach(function(field) {
+        var keys = [field].concat(RESTORE_COMPANION_KEYS[field] || []);
+        keys.forEach(function(k) {
+          if (copy.config) delete copy.config[k];
+          if (copy.sensitive) delete copy.sensitive[k];
+        });
+      });
+      return copy;
     }
 
     /* The device already summarises its large fields (the tile layouts arrive as
@@ -4927,6 +5109,10 @@
       _backupData = null;
       _restoreFromDevice = false;
       _pullSensitiveRefused = false;
+      _restoreRows = [];
+      _restoreSkip = {};
+      _restoreCats = [];
+      _restoreBlocked = false;
     }
 
     function confirmRestore() {
@@ -4935,7 +5121,7 @@
       if (btn.disabled) return;  /* blocked by validation errors */
       btn.disabled = true; btn.textContent = 'Restoring...';
 
-      postJson('/api/config/restore', {backup: _backupData, confirm: true})
+      postJson('/api/config/restore', {backup: restorePayload(), confirm: true})
         .then(function(r) {
           if (!r.ok) return r.json().then(function(e) { throw new Error(e.error || 'Restore failed'); });
           return r.json();

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -2243,9 +2243,38 @@
        fragments, but these two stay here: COLLECT_TAB_FNS is built at script
        parse time, and both are no-ops anyway. Each tab uses its own endpoint
        (/api/json-config, /api/ha-config), so the main /api/config Save never
-       carries their ~6 KB tiles blobs; each tab has its own Save button. */
+       carries their ~6 KB tiles blobs; savePageFragments() below posts them
+       separately instead. */
     function collectTab_json(data){ /* no-op by design */ }
     function collectTab_ha(data){ /* no-op by design */ }
+
+    /* Those two tabs apply their edits as an unsaved preview while you work;
+       Save is what stores them. Each fragment publishes a hook that returns a
+       promise to store its whole page config, or null when the tab was never
+       opened or nothing changed. A rejection here fails the Save so the error
+       is surfaced rather than silently dropped. */
+    function savePageFragments(){
+      var jobs=[];
+      [window.jdCollectAndSave,window.haCollectAndSave].forEach(function(hook){
+        if(typeof hook!=='function') return;
+        var p=hook();
+        if(p) jobs.push(p);
+      });
+      return Promise.all(jobs);
+    }
+
+    /* Discard counterpart: /api/config/revert restores the config blob but not
+       the JSON/HA tile caches, so a page previewing unsaved tiles would keep
+       showing them. Each fragment puts its own last-stored config back. */
+    function revertPageFragments(){
+      var jobs=[];
+      [window.jdRevertPreview,window.haRevertPreview].forEach(function(hook){
+        if(typeof hook!=='function') return;
+        var p=hook(false);
+        if(p) jobs.push(p);
+      });
+      return Promise.all(jobs);
+    }
 
     const COLLECT_TAB_FNS={
       nodes: collectTab_nodes,
@@ -2904,7 +2933,7 @@
       postJson('/api/config',getConfigData()).then(r=>{
         if(!r.ok) throw new Error('Save failed');
         return r.text();
-      }).then(()=>{
+      }).then(()=>savePageFragments()).then(()=>{
         invalidateConfigCache();
         showToast('Settings saved','success');
         loadedConfig=JSON.stringify(getConfigData());
@@ -2919,6 +2948,8 @@
     function reloadConfig(){
       fetch('/api/config/revert',{method:'POST'}).then(r=>{
         if(!r.ok) throw new Error('Revert failed');
+        return revertPageFragments();
+      }).then(()=>{
         invalidateConfigCache();
         loadConfig();
         $('saveBar').classList.remove('visible');
@@ -2930,6 +2961,8 @@
       if(!confirm('Apply changes and reboot now?')) return;
       postJson('/api/config',getConfigData()).then(r=>{
         if(!r.ok) throw new Error('Save failed');
+        return savePageFragments();
+      }).then(()=>{
         invalidateConfigCache();
         return fetch('/api/reboot',{method:'POST'});
       }).then(()=>{
@@ -4521,6 +4554,7 @@
     /* ---- Backup & Restore ---- */
 
     var _backupData = null;  /* holds parsed backup JSON for confirm step */
+    var _restoreFromDevice = false;  /* preview source was another device, not a file */
 
     function downloadBackup() {
       var btn = $('backupDownloadBtn');
@@ -4564,22 +4598,96 @@
 
       var reader = new FileReader();
       reader.onload = function(e) {
+        var obj;
         try {
-          _backupData = JSON.parse(e.target.result);
+          obj = JSON.parse(e.target.result);
         } catch (err) {
           showToast('Invalid JSON file', 'error');
           return;
         }
-        /* Send preview request */
-        postJson('/api/config/restore', {backup: _backupData, confirm: false})
-          .then(function(r) {
-            if (!r.ok) return r.json().then(function(e) { throw new Error(e.error || 'Preview failed'); });
-            return r.json();
-          })
-          .then(function(preview) { renderRestorePreview(preview); })
-          .catch(function(e) { showToast('Preview failed: ' + e.message, 'error'); });
+        startRestorePreview(obj, false);
       };
       reader.readAsText(input.files[0]);
+    }
+
+    /* Single entry point for the restore preview: a chosen file and a backup
+       pulled from another device both land here, so the preview, the notices,
+       and the Restore/Cancel buttons behave identically for both. */
+    function startRestorePreview(obj, fromDevice) {
+      _backupData = obj;
+      _restoreFromDevice = !!fromDevice;
+      return postJson('/api/config/restore', {backup: _backupData, confirm: false})
+        .then(function(r) {
+          if (!r.ok) return r.json().then(function(e) { throw new Error(e.error || 'Preview failed'); });
+          return r.json();
+        })
+        .then(function(preview) { renderRestorePreview(preview); })
+        .catch(function(e) { showToast('Preview failed: ' + e.message, 'error'); });
+    }
+
+    /* Copy the configuration from another display on the network. The device
+       proxies the request (it holds the network path and the credentials); the
+       reply is that device's backup JSON verbatim. */
+    function pullFromDevice() {
+      var btn = $('pullFetchBtn');
+      if (!btn) return;
+      var hostEl = $('pullHost');
+      var host = hostEl ? hostEl.value.trim() : '';
+      /* The device supplies the scheme itself and rejects a host carrying one,
+         a path, or credentials, so a pasted URL is reduced to the bare host
+         here rather than bounced back as an error. */
+      host = host.replace(/^[a-z]+:\/\//i, '').replace(/[/?#].*$/, '');
+      /* show the cleaned value rather than sending something the field does not
+         match; a password pasted with a trailing newline is rejected by the
+         device's header guard, so it is trimmed here too */
+      if (hostEl && hostEl.value !== host) hostEl.value = host;
+      if (!host) { showToast('Enter the address of the display to copy from', 'error'); if (hostEl) hostEl.focus(); return; }
+      var pwEl = $('pullPassword');
+      if (pwEl && pwEl.value !== pwEl.value.trim()) pwEl.value = pwEl.value.trim();
+      var body = {
+        host: host,
+        password: pwEl ? pwEl.value : '',
+        sensitive: $('pullSensitive') ? !!$('pullSensitive').checked : true
+      };
+      /* our own device failing to answer is a different problem from the other
+         device failing, so it gets its own message */
+      var PANEL = ' panel';
+      btn.disabled = true; btn.textContent = 'Fetching...';
+      postJson('/api/config/pull', body)
+        .then(function(r) {
+          return r.json().then(function(d) { return {ok: r.ok, d: d}; },
+                               function() { throw new Error(PANEL); });
+        }, function() { throw new Error(PANEL); })
+        .then(function(res) {
+          var d = res.d;
+          if (!d || typeof d !== 'object') throw new Error(PANEL);
+          if (d.error) {
+            if (d.error === 'unreachable')  throw new Error('Cannot reach that device - check the hostname');
+            if (d.error === 'auth')         throw new Error('That device rejected the password');
+            if (d.error === 'bad_response') throw new Error('That device answered but did not return a valid backup');
+            if (d.error === 'bad_host')     throw new Error('That address cannot be used - enter just the device name, like ninadash1.lan');
+            throw new Error('That device could not be copied from');
+          }
+          if (!res.ok) throw new Error('That device could not be copied from');
+          /* Keep-local rule: never carry a hostname across, or two displays end
+             up answering to the same name. meta.hostname stays, it is only the
+             "Source:" label in the preview. */
+          if (d.config)    delete d.config.hostname;
+          if (d.sensitive) delete d.sensitive.hostname;
+          delete d.hostname;
+          return startRestorePreview(d, true);
+        })
+        .catch(function(e) {
+          showToast(e.message === PANEL
+            ? 'This display did not respond - your session may have expired, sign in again'
+            : e.message, 'error');
+        })
+        .finally(function() {
+          btn.disabled = false; btn.textContent = 'Fetch from device';
+          /* held for exactly one transfer, whether it succeeded, failed, or the
+             preview it opened is never acted on */
+          if (pwEl) pwEl.value = '';
+        });
     }
 
     function renderRestorePreview(p) {
@@ -4595,6 +4703,10 @@
       $('restoreMac').textContent = p.backup_mac || '--';
       $('restoreFirmware').textContent = p.backup_firmware || '--';
       $('restoreDate').textContent = p.export_date || '--';
+
+      /* Device-pull notice */
+      var pullNotice = $('restorePullNotice');
+      if (pullNotice) pullNotice.style.display = _restoreFromDevice ? 'block' : 'none';
 
       /* Version warning banner */
       var banner = $('restoreWarningBanner');
@@ -4628,12 +4740,17 @@
             cat + ' <span style="color:#71717a;font-weight:400">(' + items.length + ' change' + (items.length > 1 ? 's' : '') + ')</span></div>';
           var body = '<div>';
           items.forEach(function(ch) {
-            var fromStr = formatDiffValue(ch.from);
-            var toStr = formatDiffValue(ch.to);
-            body += '<div style="display:flex;justify-content:space-between;padding:4px 0;font-size:0.8rem;border-bottom:1px solid rgba(255,255,255,0.04)">' +
-              '<span style="color:#a1a1aa">' + ch.label + '</span>' +
-              '<span><span style="color:#71717a;text-decoration:line-through">' + fromStr + '</span> &rarr; <span style="color:var(--accent)">' + toStr + '</span></span>' +
-              '</div>';
+            var row = '<div style="display:flex;justify-content:space-between;padding:4px 0;font-size:0.8rem;border-bottom:1px solid rgba(255,255,255,0.04)">' +
+              '<span style="color:#a1a1aa">' + ch.label + '</span>';
+            if (isSecretField(ch)) {
+              row += '<span style="color:var(--accent)">will be replaced (hidden)</span>';
+            } else if (isBlobChange(ch)) {
+              row += '<span style="color:var(--accent)">will be replaced</span>';
+            } else {
+              row += '<span><span style="color:#71717a;text-decoration:line-through">' + formatDiffValue(ch.from) + '</span>' +
+                ' &rarr; <span style="color:var(--accent)">' + formatDiffValue(ch.to) + '</span></span>';
+            }
+            body += row + '</div>';
           });
           body += '</div>';
           section.innerHTML = header + body;
@@ -4720,6 +4837,20 @@
       }
     }
 
+    /* The device already summarises its large fields (the tile layouts arrive as
+       "Current (812 chars)" -> "Modified (1043 chars)"), so this is only a
+       backstop for any value that still turns up too long to read as a diff. */
+    function isBlobChange(ch) {
+      return (typeof ch.from === 'string' && ch.from.length > 200) ||
+             (typeof ch.to === 'string' && ch.to.length > 200);
+    }
+    /* Credentials travel in a backup made with sensitive data included. Their
+       values are worth nothing to the reader and should not sit in the page for
+       a screen-share, so only the fact that they change is shown. */
+    function isSecretField(ch) {
+      return /password|token|api_key|auth_header|client_id/i.test(String(ch.field || ''));
+    }
+
     function formatDiffValue(val) {
       if (val === null || val === undefined) return '(empty)';
       if (typeof val === 'boolean') return val ? 'On' : 'Off';
@@ -4736,7 +4867,13 @@
       $('restoreFileLabel').appendChild(input);
       var rcBtn = $('restoreConfirmBtn');
       if (rcBtn) { rcBtn.disabled = false; rcBtn.textContent = 'Restore'; }
+      /* the other device's password is only ever held for one transfer */
+      var pw = $('pullPassword');
+      if (pw) pw.value = '';
+      var pullNotice = $('restorePullNotice');
+      if (pullNotice) pullNotice.style.display = 'none';
       _backupData = null;
+      _restoreFromDevice = false;
     }
 
     function confirmRestore() {

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -4171,6 +4171,19 @@
       });
     }
 
+    /* Open the card holding the restore preview and bring it into view. Uses the
+       same 'collapsed' class and persistence as a manual card click, so the card
+       stays open the way the user would expect afterwards. */
+    function revealRestoreCard(){
+      var panel = $('restorePreview');
+      var card = panel ? panel.closest('.card') : null;
+      if (card && card.classList.contains('collapsed')) {
+        card.classList.remove('collapsed');
+        saveCollapseState();
+      }
+      if (panel && panel.scrollIntoView) panel.scrollIntoView({behavior: 'smooth', block: 'start'});
+    }
+
     function saveCollapseState(){
       var state={};
       document.querySelectorAll('.card').forEach(function(card){
@@ -4555,6 +4568,7 @@
 
     var _backupData = null;  /* holds parsed backup JSON for confirm step */
     var _restoreFromDevice = false;  /* preview source was another device, not a file */
+    var _pullSensitiveRefused = false;  /* asked the source for secrets, it sent none */
 
     function downloadBackup() {
       var btn = $('backupDownloadBtn');
@@ -4616,6 +4630,7 @@
     function startRestorePreview(obj, fromDevice) {
       _backupData = obj;
       _restoreFromDevice = !!fromDevice;
+      if (!fromDevice) _pullSensitiveRefused = false;
       return postJson('/api/config/restore', {backup: _backupData, confirm: false})
         .then(function(r) {
           if (!r.ok) return r.json().then(function(e) { throw new Error(e.error || 'Preview failed'); });
@@ -4675,6 +4690,9 @@
           if (d.config)    delete d.config.hostname;
           if (d.sensitive) delete d.sensitive.hostname;
           delete d.hostname;
+          /* A source with its own password protection off strips secrets by
+             design, so a "sensitive" request can come back without them. */
+          _pullSensitiveRefused = !!body.sensitive && !d.sensitive;
           return startRestorePreview(d, true);
         })
         .catch(function(e) {
@@ -4707,6 +4725,13 @@
       /* Device-pull notice */
       var pullNotice = $('restorePullNotice');
       if (pullNotice) pullNotice.style.display = _restoreFromDevice ? 'block' : 'none';
+
+      /* The preview lives inside the Restore card, which starts collapsed. A
+         pull is triggered from a different card, so without this the preview
+         populates out of sight and the button looks dead. The file path needs
+         no equivalent: its input is inside this card, so it can only be reached
+         while the card is already open. */
+      if (_restoreFromDevice) revealRestoreCard();
 
       /* Version warning banner */
       var banner = $('restoreWarningBanner');
@@ -4791,7 +4816,12 @@
       if (!p.sensitive_included && p.sensitive_excluded && p.sensitive_excluded.length > 0) {
         sensDiv.style.display = 'block';
         sensDiv.innerHTML = '<strong>Sensitive fields not in backup:</strong> ' +
-          p.sensitive_excluded.join(', ') + '<br>These will remain unchanged.';
+          p.sensitive_excluded.join(', ') + '<br>These will remain unchanged.' +
+          /* asked for secrets but the source sent none: it refuses to share them
+             while its own password protection is off */
+          (_pullSensitiveRefused
+            ? '<br><br>The other display has password protection turned off, so it did not share its saved passwords and keys. Turn on its admin password if you want those copied too.'
+            : '');
       } else {
         sensDiv.style.display = 'none';
       }
@@ -4874,6 +4904,7 @@
       if (pullNotice) pullNotice.style.display = 'none';
       _backupData = null;
       _restoreFromDevice = false;
+      _pullSensitiveRefused = false;
     }
 
     function confirmRestore() {

--- a/main/fragment_backup.html
+++ b/main/fragment_backup.html
@@ -1,7 +1,7 @@
       <!-- Export Card -->
       <div class="card">
         <div class="card-title"><span class="card-title-label">Export Configuration <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Export configuration</div><p>Downloads the device configuration as a JSON file for backup or for cloning settings to another unit. The header shows the configuration version and running firmware version embedded in the file; the restore screen uses these to flag version mismatches.</p><p>Include sensitive data controls whether secrets are written to the file. With it off, the export omits every secret: the weather API key, MQTT username, password, and broker URL, the Spotify Client ID, the hostname, your saved WiFi passwords, and the admin password. Turn it on only for a private full backup that can restore those values.</p><p>Example: leave Include sensitive data off when sharing a configuration as a template, and turn it on only for a private full backup of one device.</p></div>
+        <div class="help-popover"><div class="help-popover-title">Export configuration</div><p>Downloads the device configuration as a JSON file for backup or for cloning settings to another unit. The header shows the configuration version and running firmware version embedded in the file; the restore screen uses these to flag version mismatches.</p><p>Include sensitive data controls whether secrets are written to the file. With it off, the export omits every secret: the weather API key, MQTT username, password, and broker URL, the Spotify Client ID, the Home Assistant token, the JSON source auth header, the hostname, your saved WiFi passwords, and the admin password. Turn it on only for a private full backup that can restore those values.</p><p>Example: leave Include sensitive data off when sharing a configuration as a template, and turn it on only for a private full backup of one device.</p></div>
         <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;font-size:0.82rem;color:#a1a1aa">
           <span>Config version: <strong style="color:#f4f4f5" id="backupCurrentVersion">--</strong></span>
           <span>&middot;</span>
@@ -10,11 +10,36 @@
         <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
           <div>
             <span class="toggle-label">Include sensitive data</span>
-            <div class="field-hint" style="margin-top:2px">Weather and MQTT credentials, Spotify Client ID, hostname, WiFi and admin passwords</div>
+            <div class="field-hint" style="margin-top:2px">Weather and MQTT credentials, Spotify Client ID, Home Assistant token, JSON auth header, hostname, WiFi and admin passwords</div>
           </div>
           <label class="toggle"><input type="checkbox" id="backupIncludeSensitive"><span class="toggle-track"></span></label>
         </div>
         <button class="btn btn-primary" id="backupDownloadBtn" onclick="downloadBackup()" style="margin-top:16px;width:100%">Download Backup</button>
+      </div>
+
+      <!-- Import From Another Device Card -->
+      <div class="card">
+        <div class="card-title"><span class="card-title-label">Import from another device <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+        <div class="help-popover"><div class="help-popover-title">Import from another device</div><p>Copies the configuration straight from another display on your network, without downloading a file first. Enter that device's address and its admin password, then choose whether to bring its secrets across.</p><p>The settings arrive as the same preview you get from a file: nothing changes until you press Restore. The other device's hostname is always left behind, so both displays keep their own name and stay reachable.</p><p>Example: set up one display the way you like it, then point a second one at it to copy the layout and thresholds in one step.</p></div>
+        <div class="field">
+          <label class="field-label" for="pullHost">Device address</label>
+          <input class="input" id="pullHost" maxlength="64" placeholder="ninadash1.lan">
+          <div class="field-hint">Hostname or IP address of the display to copy from.</div>
+        </div>
+        <div class="field">
+          <label class="field-label" for="pullPassword">Admin password of that device</label>
+          <input class="input" id="pullPassword" type="password" maxlength="32" autocomplete="new-password" placeholder="password for that display">
+          <div class="field-hint">Used once for this transfer and never stored.</div>
+        </div>
+        <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+          <div>
+            <span class="toggle-label">Include sensitive data</span>
+            <div class="field-hint" style="margin-top:2px">Weather and MQTT credentials, Spotify Client ID, Home Assistant token, JSON auth header, WiFi and admin passwords</div>
+          </div>
+          <label class="toggle"><input type="checkbox" id="pullSensitive" checked><span class="toggle-track"></span></label>
+        </div>
+        <button class="btn btn-primary" id="pullFetchBtn" onclick="pullFromDevice()" style="margin-top:16px;width:100%">Fetch from device</button>
+        <div class="field-hint" style="margin-top:8px">The settings are shown as a preview below before anything changes. This display always keeps its own hostname.</div>
       </div>
 
       <!-- Import Card -->
@@ -35,6 +60,9 @@
             <div>Source: <strong style="color:#f4f4f5" id="restoreHostname">--</strong> (<span id="restoreMac">--</span>)</div>
             <div>Firmware: <strong style="color:#f4f4f5" id="restoreFirmware">--</strong> &middot; Exported: <span id="restoreDate">--</span></div>
           </div>
+
+          <!-- Device-pull Notice (only when the source was another device) -->
+          <div id="restorePullNotice" style="display:none;background:rgba(255,255,255,0.03);border:1px solid rgba(255,255,255,0.06);border-radius:10px;padding:12px 16px;margin-bottom:12px;font-size:0.8rem;color:var(--text-hint)">Fetched from another device. Its hostname was left out, so this display keeps its own name.</div>
 
           <!-- Version Warning Banner -->
           <div id="restoreWarningBanner" style="border-radius:10px;padding:14px 16px;margin-bottom:12px;font-size:0.82rem;line-height:1.6;display:none"></div>

--- a/main/fragment_backup.html
+++ b/main/fragment_backup.html
@@ -1,5 +1,6 @@
-      <!-- Export Card -->
-      <div class="card">
+      <!-- Export Card: every control here is an action or an export option,
+           never a device setting, so it is excluded from dirty tracking. -->
+      <div class="card" data-no-dirty>
         <div class="card-title"><span class="card-title-label">Export Configuration <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
         <div class="help-popover"><div class="help-popover-title">Export configuration</div><p>Downloads the device configuration as a JSON file for backup or for cloning settings to another unit. The header shows the configuration version and running firmware version embedded in the file; the restore screen uses these to flag version mismatches.</p><p>Include sensitive data controls whether secrets are written to the file. With it off, the export omits every secret: the weather API key, MQTT username, password, and broker URL, the Spotify Client ID, the Home Assistant token, the JSON source auth header, the hostname, your saved WiFi passwords, and the admin password. Turn it on only for a private full backup that can restore those values.</p><p>Example: leave Include sensitive data off when sharing a configuration as a template, and turn it on only for a private full backup of one device.</p></div>
         <div style="display:flex;align-items:center;gap:12px;margin-bottom:16px;font-size:0.82rem;color:#a1a1aa">
@@ -17,8 +18,8 @@
         <button class="btn btn-primary" id="backupDownloadBtn" onclick="downloadBackup()" style="margin-top:16px;width:100%">Download Backup</button>
       </div>
 
-      <!-- Import From Another Device Card -->
-      <div class="card">
+      <!-- Import From Another Device Card: transfer parameters only. -->
+      <div class="card" data-no-dirty>
         <div class="card-title"><span class="card-title-label">Import from another device <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
         <div class="help-popover"><div class="help-popover-title">Import from another device</div><p>Copies the configuration straight from another display on your network, without downloading a file first. Enter that device's address and its admin password, then choose whether to bring its secrets across.</p><p>The settings arrive as the same preview you get from a file: nothing changes until you press Restore. The other device's hostname is always left behind, so both displays keep their own name and stay reachable.</p><p>Example: set up one display the way you like it, then point a second one at it to copy the layout and thresholds in one step.</p></div>
         <div class="field">
@@ -42,8 +43,8 @@
         <div class="field-hint" style="margin-top:8px">The settings are shown as a preview below before anything changes. This display always keeps its own hostname.</div>
       </div>
 
-      <!-- Import Card -->
-      <div class="card">
+      <!-- Import Card: file picker and restore actions only. -->
+      <div class="card" data-no-dirty>
         <div class="card-title"><span class="card-title-label">Restore Configuration <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
         <div class="help-popover"><div class="help-popover-title">Restore configuration</div><p>Loads a previously exported JSON file and previews the effect before applying it. The metadata header shows the source hostname and MAC, the firmware version the file came from, and the export date. A version warning appears when the backup's configuration version differs from this device.</p><p>The preview lists each setting that would change, plus notices for settings missing from the backup, settings this firmware does not recognize, sensitive values that were excluded from the file, and any validation issues. Nothing is written until you press Restore; Cancel discards the file.</p><p>Example: restoring a file exported without sensitive data leaves the current MQTT password and other secrets in place, shown as excluded in the preview.</p></div>
         <div class="field">

--- a/main/fragment_ha.html
+++ b/main/fragment_ha.html
@@ -33,10 +33,18 @@
       display:flex; align-items:center; gap:10px; margin-bottom:10px; cursor:pointer;
       border-radius:8px; padding:4px; margin:-4px -4px 6px; user-select:none;
     }
-    #ha-root .rb-row-head:hover { background:rgba(255,255,255,0.03); }
-    #ha-root .rb-row-head:focus-visible { outline:none; box-shadow:0 0 0 2px rgba(122,162,247,0.4); }
-    #ha-root .rb-row.collapsed .rb-row-head { margin-bottom:-4px; }
-    #ha-root .rb-caret { font-size:0.7rem; color:var(--text-muted,#94a3b8); width:12px; flex-shrink:0; }
+    #ha-root .rb-row-head:hover, #ha-root .rb-tile-head:hover { background:rgba(255,255,255,0.03); }
+    #ha-root .rb-row-head:focus-visible, #ha-root .rb-tile-head:focus-visible { outline:none; box-shadow:0 0 0 2px rgba(122,162,247,0.4); }
+    #ha-root .rb-row:not([open]) .rb-row-head { margin-bottom:-4px; }
+    /* collapsible sections use native details/summary; the marker is drawn by
+       ::before because a flex summary drops the built-in one */
+    #ha-root summary { cursor:pointer; list-style:none; }
+    #ha-root summary::-webkit-details-marker { display:none; }
+    #ha-root summary::before {
+      content:"\25B8"; display:inline-block; width:12px; flex-shrink:0;
+      font-size:0.7rem; color:var(--text-muted,#94a3b8);
+    }
+    #ha-root details[open] > summary::before { content:"\25BE"; }
     #ha-root .rb-name { font-size:0.72rem; font-weight:700; letter-spacing:0.06em; text-transform:uppercase; color:var(--text-muted,#94a3b8); }
     #ha-root .rb-fill { margin-left:auto; font-size:0.68rem; color:var(--text-hint,#7a8ba4); }
     #ha-root .rb-tiles { display:grid; gap:10px; }
@@ -44,7 +52,7 @@
       border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:var(--radius-sm,10px);
       background:var(--elevated,rgba(48,54,72,0.96)); padding:12px;
     }
-    #ha-root .rb-tile-head { display:flex; align-items:center; gap:8px; margin-bottom:10px; }
+    #ha-root .rb-tile-head { display:flex; align-items:center; gap:8px; margin-bottom:10px; border-radius:8px; padding:2px 4px; margin-left:-4px; margin-right:-4px; }
     #ha-root .rb-tile-head .idx {
       width:20px; height:20px; border-radius:6px; flex-shrink:0; background:rgba(122,162,247,0.16);
       color:var(--accent,#7aa2f7); font-size:0.66rem; font-weight:700; display:grid; place-items:center;
@@ -78,6 +86,27 @@
     #ha-root .swatch::-webkit-color-swatch-wrapper { padding:3px; }
     #ha-root .swatch::-webkit-color-swatch { border:none; border-radius:5px; }
     #ha-root .swatch-row .lab { font-size:0.74rem; color:var(--text-secondary,#b8c2d0); flex:1; }
+    /* compact color chips: one horizontal strip per tile, wraps when narrow */
+    #ha-root .swatch-strip { display:flex; flex-wrap:wrap; gap:8px; }
+    #ha-root .swatch-row.chip {
+      flex:1 1 150px; margin-bottom:0; gap:6px; padding:4px 7px;
+      border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:8px; background:rgba(255,255,255,0.02);
+    }
+    #ha-root .chip .swatch { width:26px; height:24px; }
+    #ha-root .chip .lab { font-size:0.68rem; }
+    #ha-root .sw-def {
+      font-size:0.58rem; letter-spacing:0.05em; text-transform:uppercase; color:var(--text-hint,#7a8ba4);
+      border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:999px; padding:1px 7px; flex-shrink:0;
+    }
+    #ha-root .sw-reset {
+      background:none; border:none; color:var(--text-hint,#7a8ba4); cursor:pointer;
+      font-size:1rem; line-height:1; padding:1px 6px; border-radius:6px; flex-shrink:0;
+    }
+    #ha-root .sw-reset:hover { color:var(--danger,#f87171); background:rgba(239,68,68,0.08); }
+    #ha-root .ha-defaults {
+      border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:var(--radius-sm,10px);
+      background:rgba(255,255,255,0.02); padding:12px; margin-bottom:12px;
+    }
     #ha-root .map-row { display:grid; grid-template-columns:1fr auto; gap:8px; margin-bottom:8px; align-items:center; }
 
     /* legend */
@@ -171,18 +200,18 @@
     <div class="subsection">
       <div class="field">
         <label class="field-label" for="ha_base">Base URL</label>
-        <input class="input mono" id="ha_base" maxlength="255" placeholder="http://homeassistant.local:8123" oninput="haOnSourceChange()">
+        <input class="input mono" id="ha_base" maxlength="255" placeholder="http://homeassistant.local:8123" oninput="haOnSourceEdit()" onchange="haOnSourceCommit()">
         <div class="field-hint">Scheme, host, and port only, no path (HTTP or HTTPS). The device appends <code>/api/states/&lt;entity_id&gt;</code> for each tile.</div>
       </div>
       <div class="field">
         <label class="field-label" for="ha_token">Long-Lived Access Token</label>
-        <input class="input mono" id="ha_token" maxlength="255" type="password" placeholder="paste token only" oninput="haOnSourceChange()">
+        <input class="input mono" id="ha_token" maxlength="255" type="password" placeholder="paste token only" oninput="haOnSourceEdit()" onchange="haOnSourceCommit()">
         <div class="field-hint">Paste the raw token from your Home Assistant profile. Do not include <code>Authorization:</code> or <code>Bearer</code>: the device wraps it for you.</div>
       </div>
       <div class="row2">
         <div class="field">
           <label class="field-label" for="ha_interval">Poll Interval</label>
-          <select class="input" id="ha_interval">
+          <select class="input" id="ha_interval" onchange="haOnSourceChange()">
             <option value="5">5 seconds</option>
             <option value="10">10 seconds</option>
             <option value="30" selected>30 seconds</option>
@@ -193,6 +222,9 @@
           <div class="field-hint">How often each entity is re-fetched (5 to 300 seconds).</div>
         </div>
       </div>
+      <button type="button" class="btn btn-outline full" id="ha_testBtn" onclick="haTestConnection()">Test Connection</button>
+      <div class="probe-status" id="ha_testStatus"></div>
+      <div class="field-hint" style="margin-top:6px">Checks the address and token above without saving them.</div>
     </div>
   </div>
 
@@ -200,14 +232,19 @@
   <div class="card nocollapse">
     <div class="card-title"><span class="card-title-label">Layout</span><span class="ha-count" id="ha_tileCount">0 / 15 tiles</span></div>
     <div class="field-hint" style="margin-bottom:14px">Build the page as rows of tiles. Each tile shows one entity attribute. Up to <strong>6 rows</strong>, <strong>4 tiles</strong> per row, <strong>15 tiles</strong> total. Use the row <strong>&#9650;/&#9660;</strong> and tile <strong>&#9664;/&#9654;</strong> buttons to reorder.</div>
+    <details class="ha-defaults" open>
+      <summary class="mini-label">Default colors</summary>
+      <div class="field-hint" style="margin:8px 0 10px">Used by every tile that has no color of its own.</div>
+      <div id="ha_defHost"></div>
+    </details>
     <div id="ha_rowsHost"></div>
     <button type="button" class="btn btn-outline full" id="ha_addRowBtn" onclick="haAddRow()" style="margin-top:4px">+ Add Row</button>
   </div>
 
-  <!-- SAVE -->
+  <!-- PREVIEW -->
   <div class="card nocollapse">
-    <div class="field-hint" style="margin-bottom:12px">Saving persists these settings to the device and applies them immediately.</div>
-    <button type="button" class="btn btn-primary full" id="ha_saveBtn" onclick="haSaveConfig()">Save Home Assistant</button>
+    <div class="field-hint" style="margin-bottom:12px">Shows this layout on the device straight away so you can check it. Nothing is stored until you press Save at the bottom of the page.</div>
+    <button type="button" class="btn btn-primary full" id="ha_previewBtn" onclick="haPreviewLayout()">Preview Layout on Device</button>
   </div>
 
   </div><!-- /.ha-col-settings -->
@@ -261,25 +298,37 @@
     const HA_C_NORMAL="#a3a3a3", HA_C_WARN="#d97706", HA_C_CRIT="#be123c", HA_C_OK="#059669";
     const HA_MAX_ROWS=6, HA_MAX_PER_ROW=4, HA_MAX_TILES=15;
     const HA_BOOLISH=new Set(["on","off","open","closed","home","not_home","true","false"]);
+    /* stock fallback per color slot, and the slot labels shown in the UI */
+    const HA_STOCK={cLow:HA_C_NORMAL,cNorm:HA_C_NORMAL,cHigh:HA_C_WARN,tColor:HA_C_OK,fColor:HA_C_CRIT};
+    const HA_DEF_KEYS=[["cLow","Below low"],["cNorm","In range"],["cHigh","Above high"],["tColor","True"],["fColor","False"]];
 
     let haRows=[];             /* [[tile,...],...] builder state */
+    let haDefaults={};         /* page-level color defaults; missing key -> HA_STOCK */
+    let haHealLegacy=false;    /* loaded config predates "defaults": strip baked colors */
     let haEntities={};         /* entity_id -> last probed {state,attributes} */
     let haUid=1;
     const haNextId=()=>haUid++;
-    /* collapse state keyed by row-array identity — survives re-renders */
+    /* collapse state keyed by row-array / tile identity — survives the rebuilds
+       the builder does on every edit, and is never saved to config */
     const haCollapsedRows=new WeakSet();
+    const haCollapsedTiles=new WeakSet();
 
     function haBaseTile(entity_id,attr,label){
       return {id:haNextId(),entity_id:entity_id,attr:attr||"state",label:label,probed:false,error:false};
     }
-    function haNumberTile(entity_id,attr,label,unit,dec,low,high,cLow,cNorm,cHigh){
+    /* Tiles carry a color key only as an override; absent means "inherit". */
+    function haNumberTile(entity_id,attr,label,unit,dec,low,high){
       return Object.assign(haBaseTile(entity_id,attr,label),
-        {type:"number",unit:unit,decimals:dec,low:low,high:high,cLow:cLow,cNorm:cNorm,cHigh:cHigh});
+        {type:"number",unit:unit,decimals:dec,low:low,high:high});
     }
     function haTextTile(entity_id,attr,label,maps){ return Object.assign(haBaseTile(entity_id,attr,label),{type:"text",maps:maps||[]}); }
-    function haBoolTile(entity_id,attr,label,tText,fText,tColor,fColor){
-      return Object.assign(haBaseTile(entity_id,attr,label),{type:"bool",tText:tText,fText:fText,tColor:tColor,fColor:fColor});
+    function haBoolTile(entity_id,attr,label,tText,fText){
+      return Object.assign(haBaseTile(entity_id,attr,label),{type:"bool",tText:tText,fText:fText});
     }
+    function haDefColor(key){ return haDefaults[key]||HA_STOCK[key]; }
+    /* effective color: tile override -> page default -> stock constant */
+    function haColorOf(t,key){ return t[key]||haDefColor(key); }
+    function haClearColors(t){ HA_DEF_KEYS.forEach(([k])=>{ delete t[k]; }); }
 
     function haTileCount(){ return haRows.reduce((n,r)=>n+r.length,0); }
     function haNum(v){ var n=parseFloat(v); return isFinite(n)?n:0; }
@@ -339,9 +388,9 @@
         const n=typeof raw==="number"?raw:parseFloat(raw);
         if(isFinite(n)){
           out.value=n.toFixed(haClampInt(t.decimals,0,4));
-          if(n<haNum(t.low)) out.color=t.cLow;
-          else if(n>haNum(t.high)) out.color=t.cHigh;
-          else out.color=t.cNorm;
+          if(n<haNum(t.low)) out.color=haColorOf(t,"cLow");
+          else if(n>haNum(t.high)) out.color=haColorOf(t,"cHigh");
+          else out.color=haColorOf(t,"cNorm");
         }
       } else if(t.type==="text"){
         out.value=String(raw);
@@ -350,7 +399,7 @@
       } else if(t.type==="bool"){
         const on=haTruthy(raw);
         out.value=on?(t.tText||"TRUE"):(t.fText||"FALSE");
-        out.color=on?t.tColor:t.fColor;
+        out.color=haColorOf(t,on?"tColor":"fColor");
       }
       return out;
     }
@@ -373,26 +422,61 @@
       });
       var empty=$('ha_devEmpty'); if(empty) empty.style.display=haTileCount()===0?"flex":"none";
     }
-    function haOnSourceChange(){ haRenderDevice(); }
+    /* Typing only repaints the local preview and drops a stale test result. The
+       device is never handed a half-typed address or token: those fields commit
+       on change (blur / Enter), the interval select stays on the debounce, and
+       the enable toggle applies at once. */
+    function haOnSourceEdit(){
+      haRenderDevice();
+      const st=$('ha_testStatus'); if(st){ st.textContent=""; st.className="probe-status"; }
+    }
+    /* A token pasted with a trailing newline is rejected by the device's header
+       guard and would only show up as an auth failure at poll time, so the
+       field is cleaned on commit: what you see is what gets sent. */
+    function haTrimField(id){ const e=$(id); if(e && e.value!==e.value.trim()) e.value=e.value.trim(); }
+    function haOnSourceCommit(){
+      haTrimField('ha_base'); haTrimField('ha_token');
+      haOnSourceEdit(); if(haLoaded) haPreviewNow(null);
+    }
+    function haOnSourceChange(){ haOnSourceEdit(); haSchedulePreview(); }
 
     /* ---- builder rendering ---- */
+    /* Page-level default colors. While dragging (oninput) only the preview is
+       redrawn so the open color picker survives; on commit (onchange) the tile
+       list is rebuilt so inheriting swatches show the new color. */
+    function haRenderDefaults(){
+      const host=$('ha_defHost'); if(!host) return;
+      host.innerHTML="";
+      const strip=document.createElement("div"); strip.className="swatch-strip";
+      HA_DEF_KEYS.forEach(([k,lbl])=>{
+        /* no DEFAULT badge here: these are the defaults */
+        const r=haSwatch(lbl,haDefColor(k),v=>{ haDefaults[k]=v; haRenderDevice(); });
+        r.className="swatch-row chip";
+        r.firstChild.onchange=()=>haRenderBuilder();
+        strip.appendChild(r);
+      });
+      host.appendChild(strip);
+      const b=document.createElement("button");
+      b.className="btn btn-outline sm"; b.style.marginTop="10px"; b.textContent="Apply defaults to all tiles";
+      b.onclick=()=>{
+        if(!confirm("Clear the individual colors on every tile so they all follow the defaults?")) return;
+        haRows.forEach(row=>row.forEach(haClearColors)); haSyncAll();
+      };
+      host.appendChild(b);
+    }
+
     function haRenderBuilder(){
       const host=$('ha_rowsHost'); if(!host) return;
       host.innerHTML="";
       const total=haTileCount();
       haRows.forEach((row,ri)=>{
-        const collapsed=haCollapsedRows.has(row);
-        const rEl=document.createElement("div"); rEl.className="rb-row"+(collapsed?" collapsed":"");
-        const head=document.createElement("div");
-        head.className="rb-row-head"; head.setAttribute("role","button"); head.setAttribute("tabindex","0");
-        head.setAttribute("aria-expanded",collapsed?"false":"true");
+        const rEl=document.createElement("details"); rEl.className="rb-row";
+        rEl.open=!haCollapsedRows.has(row);
+        rEl.ontoggle=()=>{ if(rEl.open) haCollapsedRows.delete(row); else haCollapsedRows.add(row); };
+        const head=document.createElement("summary"); head.className="rb-row-head";
         head.innerHTML=
-          '<span class="rb-caret" aria-hidden="true">'+(collapsed?"▸":"▾")+'</span>'+
           '<span class="rb-name">Row '+(ri+1)+'</span>'+
           '<span class="rb-fill">'+row.length+' / '+HA_MAX_PER_ROW+' tiles</span>';
-        const toggle=()=>{ if(collapsed) haCollapsedRows.delete(row); else haCollapsedRows.add(row); haRenderBuilder(); };
-        head.onclick=(e)=>{ if(!e.target.closest("button")) toggle(); };
-        head.onkeydown=(e)=>{ if(e.target.closest("button")) return; if(e.key==="Enter"||e.key===" "){ e.preventDefault(); toggle(); } };
         const upBtn=document.createElement("button");
         upBtn.className="rb-move"; upBtn.setAttribute("aria-label","Move row "+(ri+1)+" up");
         upBtn.innerHTML="&#9650;"; upBtn.disabled=ri===0;
@@ -407,17 +491,15 @@
         del.onclick=(e)=>{ e.stopPropagation(); haRows.splice(ri,1); haSyncAll(); };
         head.appendChild(del);
         rEl.appendChild(head);
-        if(!collapsed){
-          const tilesEl=document.createElement("div"); tilesEl.className="rb-tiles";
-          row.forEach((t,ti)=>tilesEl.appendChild(haTileEditor(t,ri,ti)));
-          rEl.appendChild(tilesEl);
-          const addTile=document.createElement("button");
-          addTile.className="btn btn-outline sm"; addTile.style.marginTop="10px"; addTile.textContent="+ Add Tile";
-          const canAdd=row.length<HA_MAX_PER_ROW && total<HA_MAX_TILES;
-          addTile.disabled=!canAdd;
-          addTile.onclick=()=>{ const t=haNumberTile("","state","New Tile","",1,0,100,HA_C_NORMAL,HA_C_NORMAL,HA_C_WARN); row.push(t); haSyncAll(); };
-          rEl.appendChild(addTile);
-        }
+        const tilesEl=document.createElement("div"); tilesEl.className="rb-tiles";
+        row.forEach((t,ti)=>tilesEl.appendChild(haTileEditor(t,ri,ti)));
+        rEl.appendChild(tilesEl);
+        const addTile=document.createElement("button");
+        addTile.className="btn btn-outline sm"; addTile.style.marginTop="10px"; addTile.textContent="+ Add Tile";
+        const canAdd=row.length<HA_MAX_PER_ROW && total<HA_MAX_TILES;
+        addTile.disabled=!canAdd;
+        addTile.onclick=()=>{ const t=haNumberTile("","state","New Tile","",1,0,100); row.push(t); haSyncAll(); };
+        rEl.appendChild(addTile);
         host.appendChild(rEl);
       });
       var addRowBtn=$('ha_addRowBtn'); if(addRowBtn) addRowBtn.disabled=haRows.length>=HA_MAX_ROWS || total>=HA_MAX_TILES;
@@ -425,36 +507,48 @@
       if(cnt){ cnt.textContent=total+' / '+HA_MAX_TILES+' tiles'; cnt.classList.toggle("full",total>=HA_MAX_TILES); }
     }
 
+    /* summary text: the label, else the source entity plus the attribute when it
+       is not the main state, so two tiles on one entity stay distinguishable; an
+       unset entity always stays visible on a collapsed fresh tile */
+    function haTileTitle(t){
+      if(!t.entity_id) return t.label?(t.label+" <no entity>"):"<no entity>";
+      if(t.label) return t.label;
+      return t.entity_id+((t.attr && t.attr!=="state")?(" - "+t.attr):"");
+    }
+
     function haTileEditor(t,ri,ti){
-      const el=document.createElement("div"); el.className="rb-tile";
-      const head=document.createElement("div"); head.className="rb-tile-head";
-      head.innerHTML='<span class="idx">'+(ti+1)+'</span><span class="path-preview">'+
-        escHtml(t.entity_id?(t.entity_id+" · "+t.attr):"<no entity>")+'</span>';
+      const el=document.createElement("details"); el.className="rb-tile";
+      el.open=!haCollapsedTiles.has(t);
+      el.ontoggle=()=>{ if(el.open) haCollapsedTiles.delete(t); else haCollapsedTiles.add(t); };
+      const head=document.createElement("summary"); head.className="rb-tile-head";
+      head.innerHTML='<span class="idx">'+(ti+1)+'</span><span class="path-preview">'+escHtml(haTileTitle(t))+'</span>';
+      const setTitle=()=>{ head.querySelector(".path-preview").textContent=haTileTitle(t); };
       const lBtn=document.createElement("button");
       lBtn.className="rb-move tile"; lBtn.setAttribute("aria-label","Move tile "+(ti+1)+" left");
       lBtn.innerHTML="&#9664;"; lBtn.disabled=ti===0;
-      lBtn.onclick=()=>haMoveTile(ri,ti,-1);
+      lBtn.onclick=(e)=>{ e.stopPropagation(); haMoveTile(ri,ti,-1); };
       const rBtn=document.createElement("button");
       rBtn.className="rb-move tile"; rBtn.setAttribute("aria-label","Move tile "+(ti+1)+" right");
       rBtn.innerHTML="&#9654;"; rBtn.disabled=ti===haRows[ri].length-1;
-      rBtn.onclick=()=>haMoveTile(ri,ti,1);
+      rBtn.onclick=(e)=>{ e.stopPropagation(); haMoveTile(ri,ti,1); };
       const x=document.createElement("button");
       x.className="x"; x.setAttribute("aria-label","Remove tile"); x.innerHTML="&times;";
-      x.onclick=()=>{ haRows[ri].splice(ti,1); haSyncAll(); };
+      x.onclick=(e)=>{ e.stopPropagation(); haRows[ri].splice(ti,1); haSyncAll(); };
       head.appendChild(lBtn); head.appendChild(rBtn); head.appendChild(x); el.appendChild(head);
 
-      /* ---- entity_id + Probe ---- */
-      const eWrap=document.createElement("div"); eWrap.style.marginBottom="8px";
-      eWrap.innerHTML='<div class="mini-label">Entity ID</div>';
+      /* ---- entity_id + Probe, sharing a row with the attribute picker ----
+         .row2 wraps to one column when the card is narrow */
+      const idRow=document.createElement("div"); idRow.className="row2";
       const pr=document.createElement("div"); pr.className="probe-row";
       const eIn=document.createElement("input");
       eIn.className="input mono sm"; eIn.value=t.entity_id||""; eIn.placeholder="sensor.outside_temp";
-      eIn.oninput=()=>{ t.entity_id=eIn.value.trim(); head.querySelector(".path-preview").textContent=t.entity_id?(t.entity_id+" · "+t.attr):"<no entity>"; };
+      eIn.oninput=()=>{ t.entity_id=eIn.value.trim(); setTitle(); };
       const probeBtn=document.createElement("button");
       probeBtn.className="btn btn-primary sm"; probeBtn.textContent="Probe";
       probeBtn.onclick=()=>haProbeTile(t,probeBtn);
       pr.appendChild(eIn); pr.appendChild(probeBtn);
-      eWrap.appendChild(pr);
+      const eF=haMiniField("Entity ID",pr); eF.style.flex="1.5 1 200px";
+      idRow.appendChild(eF);
 
       const status=document.createElement("div"); status.className="probe-status";
       const ent=haGetEntity(t.entity_id);
@@ -467,15 +561,8 @@
         status.classList.add("ok");
         status.innerHTML="&#10003; "+(fn?escHtml(fn):"(no friendly_name)")+' <span class="dom">· '+(nAttr+1)+' fields available</span>';
       }
-      eWrap.appendChild(status); el.appendChild(eWrap);
-
-      /* fresh, never-probed tile with no cached entity: stop at entity + Probe */
-      if(!t.probed && !ent) return el;
-
       /* ---- attribute dropdown (only when we have cached entity data) ---- */
       if(ent){
-        const aWrap=document.createElement("div"); aWrap.style.marginBottom="8px";
-        aWrap.innerHTML='<div class="mini-label">Show</div>';
         const aSel=document.createElement("select"); aSel.className="input sm";
         const keys=["state"].concat(ent.attributes?Object.keys(ent.attributes):[]);
         keys.forEach(k=>{
@@ -484,21 +571,23 @@
           if(t.attr===k) o.selected=true; aSel.appendChild(o);
         });
         aSel.onchange=()=>{ t.attr=aSel.value; haDeriveDefaults(t); haSyncAll(); };
-        aWrap.appendChild(aSel); el.appendChild(aWrap);
+        idRow.appendChild(haMiniField("Show",aSel));
       }
+      el.appendChild(idRow); el.appendChild(status);
 
-      /* label */
-      el.appendChild(haLabeledInput("Label","sm",t.label,haEntityLocalTitle(t.entity_id)||"Label",v=>{ t.label=v; haRenderDevice(); }));
+      /* fresh, never-probed tile with no cached entity: stop at entity + Probe */
+      if(!t.probed && !ent) return el;
 
-      /* type */
-      const typeWrap=document.createElement("div");
-      typeWrap.innerHTML='<div class="mini-label">Type</div>';
+      /* ---- label + type share one row ---- */
+      const metaRow=document.createElement("div"); metaRow.className="row2"; metaRow.style.marginTop="8px";
+      metaRow.appendChild(haMiniField("Label",haInp(t.label,haEntityLocalTitle(t.entity_id)||"Label",v=>{ t.label=v; setTitle(); haRenderDevice(); },"sm")));
       const sel=document.createElement("select"); sel.className="input sm";
       [["number","Number"],["text","Text"],["bool","Boolean"]].forEach(([v,lbl])=>{
         const o=document.createElement("option"); o.value=v; o.textContent=lbl; if(t.type===v) o.selected=true; sel.appendChild(o);
       });
       sel.onchange=()=>{ haConvertType(t,sel.value); haSyncAll(); };
-      typeWrap.appendChild(sel); el.appendChild(typeWrap);
+      metaRow.appendChild(haMiniField("Type",sel));
+      el.appendChild(metaRow);
 
       const tf=document.createElement("div"); tf.className="type-fields";
       if(t.type==="number") tf.appendChild(haNumberFields(t));
@@ -514,18 +603,10 @@
       if(type==="number"){
         t.unit=t.unit||""; t.decimals=(t.decimals!=null)?t.decimals:1;
         t.low=(t.low!=null)?t.low:0; t.high=(t.high!=null)?t.high:100;
-        t.cLow=t.cLow||HA_C_NORMAL; t.cNorm=t.cNorm||HA_C_NORMAL; t.cHigh=t.cHigh||HA_C_WARN;
       } else if(type==="text"){ t.maps=t.maps||[]; }
-      else { t.tText=t.tText||"ON"; t.fText=t.fText||"OFF"; t.tColor=t.tColor||HA_C_OK; t.fColor=t.fColor||HA_C_CRIT; }
+      else { t.tText=t.tText||"ON"; t.fText=t.fText||"OFF"; }
     }
 
-    function haLabeledInput(label,cls,value,ph,onInput){
-      const w=document.createElement("div"); w.style.marginBottom="8px";
-      const l=document.createElement("div"); l.className="mini-label"; l.textContent=label;
-      const i=document.createElement("input"); i.className="input "+cls; i.value=value||""; i.placeholder=ph||"";
-      i.oninput=()=>onInput(i.value);
-      w.appendChild(l); w.appendChild(i); return w;
-    }
     function haMiniField(label,inputEl){
       const w=document.createElement("div"); w.style.flex="1 1 100px";
       const l=document.createElement("div"); l.className="mini-label"; l.textContent=label;
@@ -543,9 +624,28 @@
     function haSwatch(label,color,onInput){
       const r=document.createElement("div"); r.className="swatch-row";
       const c=document.createElement("input"); c.type="color"; c.className="swatch"; c.value=color||HA_C_NORMAL;
-      c.setAttribute("aria-label",label); c.oninput=()=>onInput(c.value);
+      c.setAttribute("aria-label",label); if(onInput) c.oninput=()=>onInput(c.value);
       const l=document.createElement("span"); l.className="lab"; l.textContent=label;
       r.appendChild(c); r.appendChild(l); return r;
+    }
+    /* Tile swatch: shows the effective color, badged "default" while the tile
+       inherits. Picking a color sets the override, the x clears it back to
+       inherit -- both update in place so the color picker stays open. */
+    function haTileSwatch(label,t,key){
+      const r=haSwatch(label,haColorOf(t,key),null);
+      r.className="swatch-row chip";
+      const c=r.firstChild;
+      const badge=document.createElement("span"); badge.className="sw-def"; badge.textContent="default";
+      const x=document.createElement("button"); x.className="sw-reset";
+      x.setAttribute("aria-label","Use the default "+label+" color"); x.innerHTML="&times;";
+      function sync(){
+        c.value=haColorOf(t,key);
+        badge.style.display=t[key]?"none":"";
+        x.style.display=t[key]?"":"none";
+      }
+      c.oninput=()=>{ t[key]=c.value; sync(); haRenderDevice(); };
+      x.onclick=()=>{ delete t[key]; sync(); haRenderDevice(); };
+      r.appendChild(badge); r.appendChild(x); sync(); return r;
     }
 
     function haNumberFields(t){
@@ -560,9 +660,11 @@
       w.appendChild(row2);
       const sw=document.createElement("div"); sw.style.marginTop="10px";
       sw.innerHTML='<div class="mini-label">Colors by threshold</div>';
-      sw.appendChild(haSwatch("Below low",t.cLow,v=>{ t.cLow=v; haRenderDevice(); }));
-      sw.appendChild(haSwatch("In range",t.cNorm,v=>{ t.cNorm=v; haRenderDevice(); }));
-      sw.appendChild(haSwatch("Above high",t.cHigh,v=>{ t.cHigh=v; haRenderDevice(); }));
+      const strip=document.createElement("div"); strip.className="swatch-strip";
+      strip.appendChild(haTileSwatch("Below low",t,"cLow"));
+      strip.appendChild(haTileSwatch("In range",t,"cNorm"));
+      strip.appendChild(haTileSwatch("Above high",t,"cHigh"));
+      sw.appendChild(strip);
       w.appendChild(sw); return w;
     }
     function haTextFields(t){
@@ -597,9 +699,9 @@
       row.appendChild(haMiniField("True text",haInp(t.tText,"ON",v=>{ t.tText=v; haRenderDevice(); },"sm")));
       row.appendChild(haMiniField("False text",haInp(t.fText,"OFF",v=>{ t.fText=v; haRenderDevice(); },"sm")));
       w.appendChild(row);
-      const sw=document.createElement("div"); sw.style.marginTop="10px";
-      sw.appendChild(haSwatch("True color",t.tColor,v=>{ t.tColor=v; haRenderDevice(); }));
-      sw.appendChild(haSwatch("False color",t.fColor,v=>{ t.fColor=v; haRenderDevice(); }));
+      const sw=document.createElement("div"); sw.className="swatch-strip"; sw.style.marginTop="10px";
+      sw.appendChild(haTileSwatch("True color",t,"tColor"));
+      sw.appendChild(haTileSwatch("False color",t,"fColor"));
       w.appendChild(sw);
       const note=document.createElement("div"); note.className="field-hint"; note.style.marginTop="8px";
       note.textContent="on / off, open / closed, home / not_home, and true / false all map to True / False. An unavailable state renders as --.";
@@ -630,7 +732,7 @@
 
     function haAddRow(){
       if(haRows.length>=HA_MAX_ROWS || haTileCount()>=HA_MAX_TILES) return;
-      haRows.push([ haNumberTile("","state","New Tile","",1,0,100,HA_C_NORMAL,HA_C_NORMAL,HA_C_WARN) ]);
+      haRows.push([ haNumberTile("","state","New Tile","",1,0,100) ]);
       haSyncAll();
     }
     /* reorder a whole row up (-1) / down (+1); collapse state travels with the
@@ -649,29 +751,50 @@
       const tmp=row[ti]; row[ti]=row[ni]; row[ni]=tmp;
       haSyncAll();
     }
-    function haSyncAll(){ haRenderBuilder(); haRenderDevice(); }
+    function haSyncAll(){ haRenderDefaults(); haRenderBuilder(); haRenderDevice(); }
 
     /* ---- serialize / parse ha_tiles_config ---- */
+    /* only real overrides are written; an absent key means "inherit" */
+    function haPutColors(o,t,keys){ keys.forEach(k=>{ if(t[k]) o[k]=t[k]; }); return o; }
+    /* Adopt saved per-tile colors as overrides. In a legacy config (no top-level
+       "defaults") a value that merely repeats the stock constant was baked in by
+       an older build, never chosen, so it is dropped back to inherit. Once the
+       config carries "defaults" every stored color is a deliberate override and
+       is kept verbatim -- including one set back to a stock color on purpose. */
+    function haAdoptColors(t,src,keys){
+      keys.forEach(k=>{
+        const v=src[k];
+        if(typeof v!=="string" || !v) return;
+        if(haHealLegacy && v.toLowerCase()===HA_STOCK[k].toLowerCase()) return;
+        t[k]=v;
+      });
+      return t;
+    }
     function haSerializeTiles(){
+      const defaults={};
+      HA_DEF_KEYS.forEach(([k])=>{ defaults[k]=haDefColor(k); });
       const rows=haRows.map(row=>row.map(t=>{
         const base={entity_id:t.entity_id||"",attr:t.attr||"state",label:t.label||""};
         if(t.type==="number"){
-          return Object.assign(base,{type:"number",unit:t.unit||"",
-            decimals:haClampInt(t.decimals,0,4),low:haNum(t.low),high:haNum(t.high),
-            cLow:t.cLow||HA_C_NORMAL,cNorm:t.cNorm||HA_C_NORMAL,cHigh:t.cHigh||HA_C_WARN});
+          return haPutColors(Object.assign(base,{type:"number",unit:t.unit||"",
+            decimals:haClampInt(t.decimals,0,4),low:haNum(t.low),high:haNum(t.high)}),t,["cLow","cNorm","cHigh"]);
         } else if(t.type==="text"){
           return Object.assign(base,{type:"text",
             maps:(t.maps||[]).slice(0,4).map(m=>({val:m.val||"",color:m.color||HA_C_NORMAL}))});
         }
-        return Object.assign(base,{type:"bool",
-          tText:t.tText||"ON",fText:t.fText||"OFF",tColor:t.tColor||HA_C_OK,fColor:t.fColor||HA_C_CRIT});
+        return haPutColors(Object.assign(base,{type:"bool",
+          tText:t.tText||"ON",fText:t.fText||"OFF"}),t,["tColor","fColor"]);
       }));
-      return JSON.stringify({rows:rows});
+      return JSON.stringify({defaults:defaults,rows:rows});
     }
     function haParseTiles(str){
-      haRows=[];
+      haRows=[]; haDefaults={};
       let cfg=null;
       try{ cfg=JSON.parse(str||"{}"); }catch(e){ cfg=null; }
+      const hasDefs=!!(cfg && cfg.defaults && typeof cfg.defaults==="object");
+      haHealLegacy=!hasDefs;
+      const defs=hasDefs?cfg.defaults:{};
+      HA_DEF_KEYS.forEach(([k])=>{ if(typeof defs[k]==="string" && defs[k]) haDefaults[k]=defs[k]; });
       const rows=(cfg && Array.isArray(cfg.rows))?cfg.rows:[];
       rows.slice(0,HA_MAX_ROWS).forEach(row=>{
         if(!Array.isArray(row)) return;
@@ -680,8 +803,8 @@
           if(!t||typeof t!=="object") return;
           let tile;
           if(t.type==="text") tile=haTextTile(t.entity_id||"",t.attr||"state",t.label||"",(t.maps||[]).slice(0,4).map(m=>({val:m.val||"",color:m.color||HA_C_NORMAL})));
-          else if(t.type==="bool") tile=haBoolTile(t.entity_id||"",t.attr||"state",t.label||"",t.tText||"ON",t.fText||"OFF",t.tColor||HA_C_OK,t.fColor||HA_C_CRIT);
-          else tile=haNumberTile(t.entity_id||"",t.attr||"state",t.label||"",t.unit||"",haClampInt(t.decimals,0,4),haNum(t.low),haNum(t.high),t.cLow||HA_C_NORMAL,t.cNorm||HA_C_NORMAL,t.cHigh||HA_C_WARN);
+          else if(t.type==="bool") tile=haAdoptColors(haBoolTile(t.entity_id||"",t.attr||"state",t.label||"",t.tText||"ON",t.fText||"OFF"),t,["tColor","fColor"]);
+          else tile=haAdoptColors(haNumberTile(t.entity_id||"",t.attr||"state",t.label||"",t.unit||"",haClampInt(t.decimals,0,4),haNum(t.low),haNum(t.high)),t,["cLow","cNorm","cHigh"]);
           /* a saved tile is treated as probed so its full editor shows; the
              attribute dropdown reappears only after a fresh Probe. */
           tile.probed=true;
@@ -691,7 +814,18 @@
       });
     }
 
-    /* ---- tab populate / save ---- */
+    /* ---- tab populate / preview / save ----
+       Two ways this page reaches the device:
+         preview:true  -> apply now, store nothing (this tab's own button, the
+                          enable toggle, and the debounced connection-field apply)
+         no flag       -> apply and store (the page-wide Save, through the
+                          window.haCollectAndSave hook below)
+       Dirtiness is derived by comparing the current payload against the one
+       last loaded or stored, so no edit path has to remember to flag it. */
+    let haLoaded=false;     /* populate has run at least once */
+    let haStored="";        /* pristine payload: as last loaded / stored */
+    let haPreviewSent=false;/* device is showing something that is not stored */
+    let haPrevTimer=null;
 
     function populateTab_ha(data){
       /* Ignore the main-config blob; load Home Assistant from its own endpoint. */
@@ -705,49 +839,145 @@
           if($('ha_interval')) $('ha_interval').value=String(d.ha_update_interval_s||30);
           haParseTiles(d.ha_tiles_config||"");
           haSyncAll();
+          haLoaded=true; haStored=JSON.stringify(haPayload(false));
         })
         .catch(e=>{ console.error('Load Home Assistant config failed',e); haParseTiles(""); haSyncAll(); });
     }
 
-    /* Build the /api/ha-config payload from the current form + builder state.
-       Includes ha_enabled so both explicit Save and the live enable-toggle
-       persist the page on/off state to NVS. */
-    function haBuildConfigBody(){
-      return {
+    /* Build the /api/ha-config payload from the current form + builder state. */
+    function haPayload(preview){
+      const body={
         ha_enabled: $('ha_enabled')?!!$('ha_enabled').checked:false,
         ha_base_url: $('ha_base')?$('ha_base').value.trim():"",
         ha_token: $('ha_token')?$('ha_token').value.trim():"",
         ha_update_interval_s: $('ha_interval')?parseInt($('ha_interval').value,10)||30:30,
         ha_tiles_config: haSerializeTiles()
       };
+      if(preview) body.preview=true;
+      return body;
+    }
+    /* An immediate preview supersedes any pending debounced one. previewSent is
+       only set once the device has actually accepted the preview, so a failed
+       POST does not arm the unload restore. */
+    function haPreviewNow(okMsg){
+      clearTimeout(haPrevTimer); haPrevTimer=null;
+      return postJson('/api/ha-config',haPayload(true))
+        .then(r=>{ if(!r.ok) throw new Error('HTTP '+r.status); return r.text(); })
+        .then(()=>{ haPreviewSent=true; if(okMsg) showToast(okMsg,'success'); })
+        .catch(e=>{ showToast('Preview failed: '+e.message,'error'); });
+    }
+    /* A preview lives in the device's RAM until something replaces it: there is
+       no timeout, and the main Discard does not restore tiles. So if the user
+       walks away from unsaved previews, push the pristine config back as one
+       more preview. On unload that has to be sendBeacon (a normal fetch is
+       killed with the page); the Blob type keeps the JSON content-type. */
+    function haRevertPreview(unloading){
+      /* kill a pending debounce first: a timer armed by the keystroke that has
+         not fired yet would otherwise outlive the discard */
+      clearTimeout(haPrevTimer); haPrevTimer=null;
+      if(!haPreviewSent || !haStored) return null;
+      haPreviewSent=false;
+      const body=JSON.parse(haStored); body.preview=true;
+      const json=JSON.stringify(body);
+      if(unloading){
+        if(navigator.sendBeacon) navigator.sendBeacon('/api/ha-config',new Blob([json],{type:'application/json'}));
+        return null;
+      }
+      return postJson('/api/ha-config',body).catch(()=>{});
+    }
+    window.addEventListener('beforeunload',()=>{ haRevertPreview(true); });
+    function haSchedulePreview(){
+      if(!haLoaded) return;
+      clearTimeout(haPrevTimer);
+      haPrevTimer=setTimeout(()=>{ haPreviewNow(null); },600);
+    }
+    function haPreviewLayout(){
+      const btn=$('ha_previewBtn'); if(!btn) return;
+      btn.disabled=true; btn.textContent="Sending...";
+      haPreviewNow('Preview sent to the device - not saved yet')
+        .finally(()=>{ btn.disabled=false; btn.textContent="Preview Layout on Device"; });
+    }
+    /* Page-wide Save hook: a promise that stores this page's whole config
+       (connection fields + tiles + default colors), or null when the tab was
+       never opened or nothing changed since it was loaded. */
+    function haCollectAndSave(){
+      /* drop any pending debounced preview: firing it after this save would
+         re-apply unsaved values and race the page-wide config POST */
+      clearTimeout(haPrevTimer); haPrevTimer=null;
+      if(!haLoaded || !$('ha_rowsHost')) return null;
+      const body=haPayload(false);
+      const json=JSON.stringify(body);
+      if(json===haStored) return null;
+      return postJson('/api/ha-config',body).then(r=>{
+        if(!r.ok) throw new Error('Home Assistant: HTTP '+r.status);
+        haStored=json; haPreviewSent=false;
+      });
     }
 
-    function haSaveConfig(){
-      const btn=$('ha_saveBtn'); if(!btn) return;
-      btn.disabled=true; btn.textContent="Saving...";
-      postJson('/api/ha-config',haBuildConfigBody()).then(r=>{ if(!r.ok) throw new Error('HTTP '+r.status); return r.text(); })
-        .then(()=>{ showToast('Home Assistant saved','success'); })
-        .catch(e=>{ showToast('Save failed: '+e.message,'error'); })
-        .finally(()=>{ btn.disabled=false; btn.textContent="Save Home Assistant"; });
-    }
-
-    /* Enable-toggle live-apply: the POST handler applies ha_enabled immediately
-       (shows/hides the page, starts/stops polling) and persists to NVS, so the
-       toggle takes effect without waiting for an explicit Save. */
+    /* Enable-toggle: shows or hides the page on the device right away as a
+       preview; the page-wide Save is what stores it. */
     function haOnEnabledToggle(){
-      haRenderDevice();
       const on=$('ha_enabled')?!!$('ha_enabled').checked:false;
-      postJson('/api/ha-config',haBuildConfigBody()).then(r=>{ if(!r.ok) throw new Error('HTTP '+r.status); return r.text(); })
-        .then(()=>{ showToast(on?'Home Assistant page enabled':'Home Assistant page disabled','success'); })
-        .catch(e=>{ showToast('Apply failed: '+e.message,'error'); });
+      haRenderDevice();
+      haPreviewNow(on?'Home Assistant page shown - not saved yet':'Home Assistant page hidden - not saved yet');
+    }
+
+    /* ---- test the connection without saving it (GET /api/ha-test) ---- */
+    function haTestConnection(){
+      const btn=$('ha_testBtn'), out=$('ha_testStatus');
+      if(!btn||!out) return;
+      /* Send the live (possibly unsaved) base URL + token as headers, same as
+       * Probe, so the token never lands in a request-URI log. */
+      var haHdrs={};
+      var baseEl=$('ha_base'); if(baseEl && baseEl.value.trim()) haHdrs['X-HA-BASE']=baseEl.value.trim();
+      var tokEl=$('ha_token'); if(tokEl && tokEl.value.trim()) haHdrs['X-HA-TOKEN']=tokEl.value.trim();
+      btn.disabled=true; btn.textContent="Testing...";
+      out.className="probe-status"; out.textContent="Testing...";
+      /* The verdict rides in the body, so the body is read whatever the HTTP
+         status is: an "error" key means the request could not even be made
+         (no address configured), not a verdict about the server. */
+      /* A missing verdict body means this display did not answer (or answered
+         with the login page) -- that says nothing about the Home Assistant
+         address, so it gets its own message. */
+      const panelFailed=()=>{
+        out.className="probe-status err";
+        out.textContent="Could not run the test - this display did not answer. Sign in again, then retry.";
+      };
+      fetch('/api/ha-test',{headers:haHdrs})
+        .then(r=>r.json().catch(()=>null))
+        .then(d=>{
+          if(!d || (!d.stage && !d.error)){ panelFailed(); return; }
+          out.classList.add(d.ok?"ok":"err");
+          if(d.error){
+            out.textContent="Enter the Home Assistant address above first";
+          } else if(d.stage==="ok"){
+            out.textContent="Connected - "+(d.location_name||"Home Assistant")+" (HA "+(d.version||"?")+")";
+          } else if(d.stage==="auth"){
+            out.textContent="Auth rejected - check the token";
+          } else if(d.stage==="not_ha"){
+            /* status 200 = reachable but the wrong kind of server; any other
+               status = reachable but nothing useful at that address */
+            out.textContent="Server responded but does not look like Home Assistant"+
+              ((d.status && d.status!==200)?(" (responded with "+d.status+")"):"");
+          } else {
+            out.textContent="Cannot reach server - check the URL";
+          }
+        })
+        .catch(e=>{ panelFailed(); })
+        .finally(()=>{ btn.disabled=false; btn.textContent="Test Connection"; });
     }
 
   /* Published for the shell (POPULATE_TAB_FNS looks populateTab_ha up on
      window at call time) and for the inline handlers in the markup above. */
   window.populateTab_ha=populateTab_ha;
   window.haOnSourceChange=haOnSourceChange;
+  window.haOnSourceEdit=haOnSourceEdit;
+  window.haOnSourceCommit=haOnSourceCommit;
   window.haOnEnabledToggle=haOnEnabledToggle;
   window.haAddRow=haAddRow;
-  window.haSaveConfig=haSaveConfig;
+  window.haPreviewLayout=haPreviewLayout;
+  window.haTestConnection=haTestConnection;
+  window.haCollectAndSave=haCollectAndSave;
+  window.haRevertPreview=haRevertPreview;
 })();
 </script>

--- a/main/fragment_json.html
+++ b/main/fragment_json.html
@@ -54,10 +54,18 @@
       display:flex; align-items:center; gap:10px; margin-bottom:10px; cursor:pointer;
       border-radius:8px; padding:4px; margin:-4px -4px 6px; user-select:none;
     }
-    #jd-root .rb-row-head:hover { background:rgba(255,255,255,0.03); }
-    #jd-root .rb-row-head:focus-visible { outline:none; box-shadow:0 0 0 2px rgba(122,162,247,0.4); }
-    #jd-root .rb-row.collapsed .rb-row-head { margin-bottom:-4px; }
-    #jd-root .rb-caret { font-size:0.7rem; color:var(--text-muted,#94a3b8); width:12px; flex-shrink:0; }
+    #jd-root .rb-row-head:hover, #jd-root .rb-tile-head:hover { background:rgba(255,255,255,0.03); }
+    #jd-root .rb-row-head:focus-visible, #jd-root .rb-tile-head:focus-visible { outline:none; box-shadow:0 0 0 2px rgba(122,162,247,0.4); }
+    #jd-root .rb-row:not([open]) .rb-row-head { margin-bottom:-4px; }
+    /* collapsible sections use native details/summary; the marker is drawn by
+       ::before because a flex summary drops the built-in one */
+    #jd-root summary { cursor:pointer; list-style:none; }
+    #jd-root summary::-webkit-details-marker { display:none; }
+    #jd-root summary::before {
+      content:"\25B8"; display:inline-block; width:12px; flex-shrink:0;
+      font-size:0.7rem; color:var(--text-muted,#94a3b8);
+    }
+    #jd-root details[open] > summary::before { content:"\25BE"; }
     #jd-root .rb-name { font-size:0.72rem; font-weight:700; letter-spacing:0.06em; text-transform:uppercase; color:var(--text-muted,#94a3b8); }
     #jd-root .rb-fill { margin-left:auto; font-size:0.68rem; color:var(--text-hint,#7a8ba4); }
     #jd-root .rb-tiles { display:grid; gap:10px; }
@@ -65,7 +73,7 @@
       border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:var(--radius-sm,10px);
       background:var(--elevated,rgba(48,54,72,0.96)); padding:12px;
     }
-    #jd-root .rb-tile-head { display:flex; align-items:center; gap:8px; margin-bottom:10px; }
+    #jd-root .rb-tile-head { display:flex; align-items:center; gap:8px; margin-bottom:10px; border-radius:8px; padding:2px 4px; margin-left:-4px; margin-right:-4px; }
     #jd-root .rb-tile-head .idx {
       width:20px; height:20px; border-radius:6px; flex-shrink:0; background:rgba(122,162,247,0.16);
       color:var(--accent,#7aa2f7); font-size:0.66rem; font-weight:700; display:grid; place-items:center;
@@ -90,6 +98,27 @@
     #jd-root .swatch::-webkit-color-swatch-wrapper { padding:3px; }
     #jd-root .swatch::-webkit-color-swatch { border:none; border-radius:5px; }
     #jd-root .swatch-row .lab { font-size:0.74rem; color:var(--text-secondary,#b8c2d0); flex:1; }
+    /* compact color chips: one horizontal strip per tile, wraps when narrow */
+    #jd-root .swatch-strip { display:flex; flex-wrap:wrap; gap:8px; }
+    #jd-root .swatch-row.chip {
+      flex:1 1 150px; margin-bottom:0; gap:6px; padding:4px 7px;
+      border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:8px; background:rgba(255,255,255,0.02);
+    }
+    #jd-root .chip .swatch { width:26px; height:24px; }
+    #jd-root .chip .lab { font-size:0.68rem; }
+    #jd-root .sw-def {
+      font-size:0.58rem; letter-spacing:0.05em; text-transform:uppercase; color:var(--text-hint,#7a8ba4);
+      border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:999px; padding:1px 7px; flex-shrink:0;
+    }
+    #jd-root .sw-reset {
+      background:none; border:none; color:var(--text-hint,#7a8ba4); cursor:pointer;
+      font-size:1rem; line-height:1; padding:1px 6px; border-radius:6px; flex-shrink:0;
+    }
+    #jd-root .sw-reset:hover { color:var(--danger,#f87171); background:rgba(239,68,68,0.08); }
+    #jd-root .jd-defaults {
+      border:1px solid var(--border,rgba(255,255,255,0.12)); border-radius:var(--radius-sm,10px);
+      background:rgba(255,255,255,0.02); padding:12px; margin-bottom:12px;
+    }
     #jd-root .map-row { display:grid; grid-template-columns:1fr auto; gap:8px; margin-bottom:8px; align-items:center; }
 
     /* legend */
@@ -159,25 +188,25 @@
     <div class="card-title"><span class="card-title-label">Source</span></div>
     <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
       <span class="toggle-label">Enable JSON Display</span>
-      <label class="toggle"><input type="checkbox" id="jd_enabled" onchange="jdOnSourceChange()"><span class="toggle-track"></span></label>
+      <label class="toggle"><input type="checkbox" id="jd_enabled" onchange="jdOnEnabledToggle()"><span class="toggle-track"></span></label>
     </div>
     <div class="field-hint">Turns on the page and starts reading the source. Off hides the page and stops requests.</div>
 
     <div class="subsection">
       <div class="field">
         <label class="field-label" for="jd_url">JSON URL</label>
-        <input class="input mono" id="jd_url" maxlength="255" placeholder="http://192.168.1.50:8080/api/status" oninput="jdOnSourceChange()">
+        <input class="input mono" id="jd_url" maxlength="255" placeholder="http://192.168.1.50:8080/api/status" oninput="jdOnSourceEdit()" onchange="jdOnSourceCommit()">
         <div class="field-hint">Full address of a JSON endpoint (HTTP or HTTPS, up to 255 characters). Point at a <strong>single, curated endpoint</strong> that returns just the values you need, not a large collection. A response with thousands of items (over 1&nbsp;MB) is too large to poll on the device.</div>
       </div>
       <div class="field">
         <label class="field-label" for="jd_auth">Auth Header <span style="color:var(--text-hint);font-weight:400">(optional)</span></label>
-        <input class="input mono" id="jd_auth" maxlength="255" placeholder="X-API-Key: &lt;key&gt;">
+        <input class="input mono" id="jd_auth" maxlength="255" placeholder="X-API-Key: &lt;key&gt;" oninput="jdOnSourceEdit()" onchange="jdOnSourceCommit()">
         <div class="field-hint">One header sent with each request, written as <code>Name: value</code> (for example <code>Authorization: Bearer &lt;token&gt;</code> or <code>X-API-Key: &lt;key&gt;</code>). Tile key paths read nested values with dot and <code>[index]</code> notation; a <code>[field=value]</code> selector matches an array element by one of its fields. Leave blank for none.</div>
       </div>
       <div class="row2">
         <div class="field">
           <label class="field-label" for="jd_interval">Poll Interval</label>
-          <select class="input" id="jd_interval">
+          <select class="input" id="jd_interval" onchange="jdOnSourceChange()">
             <option value="5">5 seconds</option>
             <option value="10">10 seconds</option>
             <option value="30" selected>30 seconds</option>
@@ -202,14 +231,19 @@
   <div class="card nocollapse">
     <div class="card-title"><span class="card-title-label">Layout</span><span class="jd-count" id="jd_tileCount">0 / 15 tiles</span></div>
     <div class="field-hint" style="margin-bottom:14px">Build the page as rows of tiles. Up to <strong>6 rows</strong>, <strong>4 tiles</strong> per row, <strong>15 tiles</strong> total.</div>
+    <details class="jd-defaults" open>
+      <summary class="mini-label">Default colors</summary>
+      <div class="field-hint" style="margin:8px 0 10px">Used by every tile that has no color of its own.</div>
+      <div id="jd_defHost"></div>
+    </details>
     <div id="jd_rowsHost"></div>
     <button type="button" class="btn btn-outline full" id="jd_addRowBtn" onclick="jdAddRow()" style="margin-top:4px">+ Add Row</button>
   </div>
 
-  <!-- SAVE -->
+  <!-- PREVIEW -->
   <div class="card nocollapse">
-    <div class="field-hint" style="margin-bottom:12px">Saving persists these settings to the device and applies them immediately.</div>
-    <button type="button" class="btn btn-primary full" id="jd_saveBtn" onclick="jdSaveConfig()">Save JSON Display</button>
+    <div class="field-hint" style="margin-bottom:12px">Shows this layout on the device straight away so you can check it. Nothing is stored until you press Save at the bottom of the page.</div>
+    <button type="button" class="btn btn-primary full" id="jd_previewBtn" onclick="jdPreviewLayout()">Preview Layout on Device</button>
   </div>
 
   </div><!-- /.jd-col-settings -->
@@ -259,21 +293,33 @@
     /* threshold color defaults taken from the on-device Default theme */
     const JD_C_NORMAL="#a3a3a3", JD_C_WARN="#d97706", JD_C_CRIT="#be123c", JD_C_OK="#059669";
     const JD_MAX_ROWS=6, JD_MAX_PER_ROW=4, JD_MAX_TILES=15;
+    /* stock fallback per color slot, and the slot labels shown in the UI */
+    const JD_STOCK={cLow:JD_C_NORMAL,cNorm:JD_C_NORMAL,cHigh:JD_C_WARN,tColor:JD_C_OK,fColor:JD_C_CRIT};
+    const JD_DEF_KEYS=[["cLow","Below low"],["cNorm","In range"],["cHigh","Above high"],["tColor","True"],["fColor","False"]];
 
     let jdRows=[];          /* [[tile,...],...] builder state */
+    let jdDefaults={};      /* page-level color defaults; missing key -> JD_STOCK */
+    let jdHealLegacy=false; /* loaded config predates "defaults": strip baked colors */
     let jdSample=null;      /* last fetched JSON response (for live preview) */
     let jdUid=1;
     const jdNextId=()=>jdUid++;
-    /* collapse state keyed by row-array identity — survives re-renders */
+    /* collapse state keyed by row-array / tile identity — survives the rebuilds
+       the builder does on every edit, and is never saved to config */
     const jdCollapsedRows=new WeakSet();
+    const jdCollapsedTiles=new WeakSet();
 
-    function jdNumberTile(path,label,unit,dec,low,high,cLow,cNorm,cHigh){
-      return {id:jdNextId(),path:path,label:label,type:"number",unit:unit,decimals:dec,low:low,high:high,cLow:cLow,cNorm:cNorm,cHigh:cHigh};
+    /* Tiles carry a color key only as an override; absent means "inherit". */
+    function jdNumberTile(path,label,unit,dec,low,high){
+      return {id:jdNextId(),path:path,label:label,type:"number",unit:unit,decimals:dec,low:low,high:high};
     }
     function jdTextTile(path,label,maps){ return {id:jdNextId(),path:path,label:label,type:"text",maps:maps||[]}; }
-    function jdBoolTile(path,label,tText,fText,tColor,fColor){
-      return {id:jdNextId(),path:path,label:label,type:"bool",tText:tText,fText:fText,tColor:tColor,fColor:fColor};
+    function jdBoolTile(path,label,tText,fText){
+      return {id:jdNextId(),path:path,label:label,type:"bool",tText:tText,fText:fText};
     }
+    function jdDefColor(key){ return jdDefaults[key]||JD_STOCK[key]; }
+    /* effective color: tile override -> page default -> stock constant */
+    function jdColorOf(t,key){ return t[key]||jdDefColor(key); }
+    function jdClearColors(t){ JD_DEF_KEYS.forEach(([k])=>{ delete t[k]; }); }
 
     function jdTileCount(){ return jdRows.reduce((n,r)=>n+r.length,0); }
     function jdNum(v){ var n=parseFloat(v); return isFinite(n)?n:0; }
@@ -347,9 +393,9 @@
         const n=typeof raw==="number"?raw:parseFloat(raw);
         if(isFinite(n)){
           out.value=n.toFixed(jdClampInt(t.decimals,0,4));
-          if(n<jdNum(t.low)) out.color=t.cLow;
-          else if(n>jdNum(t.high)) out.color=t.cHigh;
-          else out.color=t.cNorm;
+          if(n<jdNum(t.low)) out.color=jdColorOf(t,"cLow");
+          else if(n>jdNum(t.high)) out.color=jdColorOf(t,"cHigh");
+          else out.color=jdColorOf(t,"cNorm");
         }
       } else if(t.type==="text"){
         if(raw!=null){
@@ -362,7 +408,7 @@
         if(raw!==undefined){
           const on=jdTruthy(raw);
           out.value=on?(t.tText||"TRUE"):(t.fText||"FALSE");
-          out.color=on?t.tColor:t.fColor;
+          out.color=jdColorOf(t,on?"tColor":"fColor");
         }
       }
       return out;
@@ -386,42 +432,79 @@
       });
       var empty=$('jd_devEmpty'); if(empty) empty.style.display=jdTileCount()===0?"flex":"none";
     }
-    function jdOnSourceChange(){ jdRenderDevice(); }
+    /* Typing only repaints the local preview. The device is not told about a
+       half-typed URL or key: text fields commit on change (blur / Enter), the
+       interval select stays on the debounce, and the enable toggle applies at
+       once. */
+    function jdOnSourceEdit(){ jdRenderDevice(); }
+    /* A key pasted with a trailing newline is rejected by the device's header
+       guard and would only show up as a failed fetch later, so the field is
+       cleaned on commit: what you see is what gets sent. */
+    function jdTrimField(id){ const e=$(id); if(e && e.value!==e.value.trim()) e.value=e.value.trim(); }
+    function jdOnSourceCommit(){
+      jdTrimField('jd_url'); jdTrimField('jd_auth');
+      jdRenderDevice(); if(jdLoaded) jdPreviewNow(null);
+    }
+    function jdOnSourceChange(){ jdRenderDevice(); jdSchedulePreview(); }
+    /* Enable toggle: show or hide the page on the device right away as a
+       preview; the page-wide Save is what stores it. */
+    function jdOnEnabledToggle(){
+      const on=$('jd_enabled')?!!$('jd_enabled').checked:false;
+      jdRenderDevice();
+      jdPreviewNow(on?'JSON Display page shown - not saved yet':'JSON Display page hidden - not saved yet');
+    }
 
     /* ---- builder rendering ---- */
+    /* Page-level default colors. While dragging (oninput) only the preview is
+       redrawn so the open color picker survives; on commit (onchange) the tile
+       list is rebuilt so inheriting swatches show the new color. */
+    function jdRenderDefaults(){
+      const host=$('jd_defHost'); if(!host) return;
+      host.innerHTML="";
+      const strip=document.createElement("div"); strip.className="swatch-strip";
+      JD_DEF_KEYS.forEach(([k,lbl])=>{
+        /* no DEFAULT badge here: these are the defaults */
+        const r=jdSwatch(lbl,jdDefColor(k),v=>{ jdDefaults[k]=v; jdRenderDevice(); });
+        r.className="swatch-row chip";
+        r.firstChild.onchange=()=>jdRenderBuilder();
+        strip.appendChild(r);
+      });
+      host.appendChild(strip);
+      const b=document.createElement("button");
+      b.className="btn btn-outline sm"; b.style.marginTop="10px"; b.textContent="Apply defaults to all tiles";
+      b.onclick=()=>{
+        if(!confirm("Clear the individual colors on every tile so they all follow the defaults?")) return;
+        jdRows.forEach(row=>row.forEach(jdClearColors)); jdSyncAll();
+      };
+      host.appendChild(b);
+    }
+
     function jdRenderBuilder(){
       const host=$('jd_rowsHost'); if(!host) return;
       host.innerHTML="";
       const total=jdTileCount();
       jdRows.forEach((row,ri)=>{
-        const collapsed=jdCollapsedRows.has(row);
-        const rEl=document.createElement("div"); rEl.className="rb-row"+(collapsed?" collapsed":"");
-        const head=document.createElement("div");
-        head.className="rb-row-head"; head.setAttribute("role","button"); head.setAttribute("tabindex","0");
-        head.setAttribute("aria-expanded",collapsed?"false":"true");
+        const rEl=document.createElement("details"); rEl.className="rb-row";
+        rEl.open=!jdCollapsedRows.has(row);
+        rEl.ontoggle=()=>{ if(rEl.open) jdCollapsedRows.delete(row); else jdCollapsedRows.add(row); };
+        const head=document.createElement("summary"); head.className="rb-row-head";
         head.innerHTML=
-          '<span class="rb-caret" aria-hidden="true">'+(collapsed?"▸":"▾")+'</span>'+
           '<span class="rb-name">Row '+(ri+1)+'</span>'+
           '<span class="rb-fill">'+row.length+' / '+JD_MAX_PER_ROW+' tiles</span>';
-        const toggle=()=>{ if(collapsed) jdCollapsedRows.delete(row); else jdCollapsedRows.add(row); jdRenderBuilder(); };
-        head.onclick=(e)=>{ if(!e.target.closest("button")) toggle(); };
-        head.onkeydown=(e)=>{ if(e.key==="Enter"||e.key===" "){ e.preventDefault(); toggle(); } };
         const del=document.createElement("button");
         del.className="btn btn-danger sm"; del.textContent="Remove Row";
         del.onclick=(e)=>{ e.stopPropagation(); jdRows.splice(ri,1); jdSyncAll(); };
         head.appendChild(del);
         rEl.appendChild(head);
-        if(!collapsed){
-          const tilesEl=document.createElement("div"); tilesEl.className="rb-tiles";
-          row.forEach((t,ti)=>tilesEl.appendChild(jdTileEditor(t,ri,ti)));
-          rEl.appendChild(tilesEl);
-          const addTile=document.createElement("button");
-          addTile.className="btn btn-outline sm"; addTile.style.marginTop="10px"; addTile.textContent="+ Add Tile";
-          const canAdd=row.length<JD_MAX_PER_ROW && total<JD_MAX_TILES;
-          addTile.disabled=!canAdd;
-          addTile.onclick=()=>{ row.push(jdNumberTile("","New Tile","",1,0,100,JD_C_NORMAL,JD_C_NORMAL,JD_C_WARN)); jdSyncAll(); };
-          rEl.appendChild(addTile);
-        }
+        const tilesEl=document.createElement("div"); tilesEl.className="rb-tiles";
+        row.forEach((t,ti)=>tilesEl.appendChild(jdTileEditor(t,ri,ti)));
+        rEl.appendChild(tilesEl);
+        const addTile=document.createElement("button");
+        addTile.className="btn btn-outline sm"; addTile.style.marginTop="10px"; addTile.textContent="+ Add Tile";
+        const canAdd=row.length<JD_MAX_PER_ROW && total<JD_MAX_TILES;
+        addTile.disabled=!canAdd;
+        addTile.onclick=()=>{ row.push(jdNumberTile("","New Tile","",1,0,100)); jdSyncAll(); };
+        rEl.appendChild(addTile);
         host.appendChild(rEl);
       });
       var addRowBtn=$('jd_addRowBtn'); if(addRowBtn) addRowBtn.disabled=jdRows.length>=JD_MAX_ROWS || total>=JD_MAX_TILES;
@@ -429,28 +512,38 @@
       if(cnt){ cnt.textContent=total+' / '+JD_MAX_TILES+' tiles'; cnt.classList.toggle("full",total>=JD_MAX_TILES); }
     }
 
+    /* summary text: the label, but an unset key path always stays visible so a
+       collapsed fresh tile still shows it has no source */
+    function jdTileTitle(t){
+      if(t.path) return t.label||t.path;
+      return t.label?(t.label+" <no key path>"):"<no key path>";
+    }
+
     function jdTileEditor(t,ri,ti){
-      const el=document.createElement("div"); el.className="rb-tile";
-      const head=document.createElement("div"); head.className="rb-tile-head";
-      head.innerHTML='<span class="idx">'+(ti+1)+'</span><span class="path-preview">'+escHtml(t.path||"<no key>")+'</span>';
+      const el=document.createElement("details"); el.className="rb-tile";
+      el.open=!jdCollapsedTiles.has(t);
+      el.ontoggle=()=>{ if(el.open) jdCollapsedTiles.delete(t); else jdCollapsedTiles.add(t); };
+      const head=document.createElement("summary"); head.className="rb-tile-head";
+      head.innerHTML='<span class="idx">'+(ti+1)+'</span><span class="path-preview">'+escHtml(jdTileTitle(t))+'</span>';
+      const setTitle=()=>{ head.querySelector(".path-preview").textContent=jdTileTitle(t); };
       const x=document.createElement("button");
       x.className="x"; x.setAttribute("aria-label","Remove tile"); x.innerHTML="&times;";
-      x.onclick=()=>{ jdRows[ri].splice(ti,1); jdSyncAll(); };
+      x.onclick=(e)=>{ e.stopPropagation(); jdRows[ri].splice(ti,1); jdSyncAll(); };
       head.appendChild(x); el.appendChild(head);
 
-      el.appendChild(jdLabeledInput("Key path","mono sm",t.path,"items[0].value",v=>{
-        t.path=v; head.querySelector(".path-preview").textContent=v||"<no key>"; jdRenderDevice();
-      }));
-      el.appendChild(jdLabeledInput("Label","sm",t.label,jdLastSeg(t.path)||"Label",v=>{ t.label=v; jdRenderDevice(); }));
-
-      const typeWrap=document.createElement("div");
-      typeWrap.innerHTML='<div class="mini-label">Type</div>';
+      /* identity fields sit above the dashed rule; .row2 wraps when narrow */
+      const idRow=document.createElement("div"); idRow.className="row2";
+      const pathF=jdMiniField("Key path",jdInp(t.path,"items[0].value",v=>{ t.path=v; setTitle(); jdRenderDevice(); },"mono sm"));
+      pathF.style.flex="1.5 1 180px";
+      idRow.appendChild(pathF);
+      idRow.appendChild(jdMiniField("Label",jdInp(t.label,jdLastSeg(t.path)||"Label",v=>{ t.label=v; setTitle(); jdRenderDevice(); },"sm")));
       const sel=document.createElement("select"); sel.className="input sm";
       [["number","Number"],["text","Text"],["bool","Boolean"]].forEach(([v,lbl])=>{
         const o=document.createElement("option"); o.value=v; o.textContent=lbl; if(t.type===v) o.selected=true; sel.appendChild(o);
       });
       sel.onchange=()=>{ jdConvertType(t,sel.value); jdSyncAll(); };
-      typeWrap.appendChild(sel); el.appendChild(typeWrap);
+      idRow.appendChild(jdMiniField("Type",sel));
+      el.appendChild(idRow);
 
       const tf=document.createElement("div"); tf.className="type-fields";
       if(t.type==="number") tf.appendChild(jdNumberFields(t));
@@ -466,18 +559,10 @@
       if(type==="number"){
         t.unit=t.unit||""; t.decimals=(t.decimals!=null)?t.decimals:1;
         t.low=(t.low!=null)?t.low:0; t.high=(t.high!=null)?t.high:100;
-        t.cLow=t.cLow||JD_C_NORMAL; t.cNorm=t.cNorm||JD_C_NORMAL; t.cHigh=t.cHigh||JD_C_WARN;
       } else if(type==="text"){ t.maps=t.maps||[]; }
-      else { t.tText=t.tText||"TRUE"; t.fText=t.fText||"FALSE"; t.tColor=t.tColor||JD_C_OK; t.fColor=t.fColor||JD_C_CRIT; }
+      else { t.tText=t.tText||"TRUE"; t.fText=t.fText||"FALSE"; }
     }
 
-    function jdLabeledInput(label,cls,value,ph,onInput){
-      const w=document.createElement("div"); w.style.marginBottom="8px";
-      const l=document.createElement("div"); l.className="mini-label"; l.textContent=label;
-      const i=document.createElement("input"); i.className="input "+cls; i.value=value||""; i.placeholder=ph||"";
-      i.oninput=()=>onInput(i.value);
-      w.appendChild(l); w.appendChild(i); return w;
-    }
     function jdMiniField(label,inputEl){
       const w=document.createElement("div"); w.style.flex="1 1 100px";
       const l=document.createElement("div"); l.className="mini-label"; l.textContent=label;
@@ -495,9 +580,28 @@
     function jdSwatch(label,color,onInput){
       const r=document.createElement("div"); r.className="swatch-row";
       const c=document.createElement("input"); c.type="color"; c.className="swatch"; c.value=color||JD_C_NORMAL;
-      c.setAttribute("aria-label",label); c.oninput=()=>onInput(c.value);
+      c.setAttribute("aria-label",label); if(onInput) c.oninput=()=>onInput(c.value);
       const l=document.createElement("span"); l.className="lab"; l.textContent=label;
       r.appendChild(c); r.appendChild(l); return r;
+    }
+    /* Tile swatch: shows the effective color, badged "default" while the tile
+       inherits. Picking a color sets the override, the x clears it back to
+       inherit -- both update in place so the color picker stays open. */
+    function jdTileSwatch(label,t,key){
+      const r=jdSwatch(label,jdColorOf(t,key),null);
+      r.className="swatch-row chip";
+      const c=r.firstChild;
+      const badge=document.createElement("span"); badge.className="sw-def"; badge.textContent="default";
+      const x=document.createElement("button"); x.className="sw-reset";
+      x.setAttribute("aria-label","Use the default "+label+" color"); x.innerHTML="&times;";
+      function sync(){
+        c.value=jdColorOf(t,key);
+        badge.style.display=t[key]?"none":"";
+        x.style.display=t[key]?"":"none";
+      }
+      c.oninput=()=>{ t[key]=c.value; sync(); jdRenderDevice(); };
+      x.onclick=()=>{ delete t[key]; sync(); jdRenderDevice(); };
+      r.appendChild(badge); r.appendChild(x); sync(); return r;
     }
 
     function jdNumberFields(t){
@@ -512,14 +616,16 @@
       w.appendChild(row2);
       const sw=document.createElement("div"); sw.style.marginTop="10px";
       sw.innerHTML='<div class="mini-label">Colors by threshold</div>';
-      sw.appendChild(jdSwatch("Below low",t.cLow,v=>{ t.cLow=v; jdRenderDevice(); }));
-      sw.appendChild(jdSwatch("In range",t.cNorm,v=>{ t.cNorm=v; jdRenderDevice(); }));
-      sw.appendChild(jdSwatch("Above high",t.cHigh,v=>{ t.cHigh=v; jdRenderDevice(); }));
+      const strip=document.createElement("div"); strip.className="swatch-strip";
+      strip.appendChild(jdTileSwatch("Below low",t,"cLow"));
+      strip.appendChild(jdTileSwatch("In range",t,"cNorm"));
+      strip.appendChild(jdTileSwatch("Above high",t,"cHigh"));
+      sw.appendChild(strip);
       w.appendChild(sw); return w;
     }
     function jdTextFields(t){
       const w=document.createElement("div");
-      w.innerHTML='<div class="mini-label">Value → color (up to 4)</div>';
+      w.insertAdjacentHTML("beforeend",'<div class="mini-label">Value &rarr; color (up to 4)</div>');
       const listHost=document.createElement("div"); w.appendChild(listHost);
       function drawMaps(){
         listHost.innerHTML="";
@@ -549,9 +655,9 @@
       row.appendChild(jdMiniField("True text",jdInp(t.tText,"ON",v=>{ t.tText=v; jdRenderDevice(); },"sm")));
       row.appendChild(jdMiniField("False text",jdInp(t.fText,"OFF",v=>{ t.fText=v; jdRenderDevice(); },"sm")));
       w.appendChild(row);
-      const sw=document.createElement("div"); sw.style.marginTop="10px";
-      sw.appendChild(jdSwatch("True color",t.tColor,v=>{ t.tColor=v; jdRenderDevice(); }));
-      sw.appendChild(jdSwatch("False color",t.fColor,v=>{ t.fColor=v; jdRenderDevice(); }));
+      const sw=document.createElement("div"); sw.className="swatch-strip"; sw.style.marginTop="10px";
+      sw.appendChild(jdTileSwatch("True color",t,"tColor"));
+      sw.appendChild(jdTileSwatch("False color",t,"fColor"));
       w.appendChild(sw); return w;
     }
 
@@ -618,8 +724,8 @@
       const isBinary=entTok && String(entTok.value).startsWith("binary_sensor.");
       const numericStr=typeof rawVal==="string" && isFinite(parseFloat(rawVal)) && rawVal.trim()!=="";
       let tile;
-      if(typeof rawVal==="boolean" || (isBinary && isStateLeaf)) tile=jdBoolTile(path,label,"YES","NO",JD_C_OK,JD_C_CRIT);
-      else if(typeof rawVal==="number" || numericStr) tile=jdNumberTile(path,label,"",1,0,100,JD_C_NORMAL,JD_C_NORMAL,JD_C_WARN);
+      if(typeof rawVal==="boolean" || (isBinary && isStateLeaf)) tile=jdBoolTile(path,label,"YES","NO");
+      else if(typeof rawVal==="number" || numericStr) tile=jdNumberTile(path,label,"",1,0,100);
       else tile=jdTextTile(path,label,[]);
       target.push(tile); jdSyncAll();
     }
@@ -631,31 +737,52 @@
 
     function jdAddRow(){
       if(jdRows.length>=JD_MAX_ROWS || jdTileCount()>=JD_MAX_TILES) return;
-      jdRows.push([ jdNumberTile("","New Tile","",1,0,100,JD_C_NORMAL,JD_C_NORMAL,JD_C_WARN) ]);
+      jdRows.push([ jdNumberTile("","New Tile","",1,0,100) ]);
       jdSyncAll();
     }
-    function jdSyncAll(){ jdRenderBuilder(); jdRenderDevice(); }
+    function jdSyncAll(){ jdRenderDefaults(); jdRenderBuilder(); jdRenderDevice(); }
 
     /* ---- serialize / parse tiles_config ---- */
+    /* only real overrides are written; an absent key means "inherit" */
+    function jdPutColors(o,t,keys){ keys.forEach(k=>{ if(t[k]) o[k]=t[k]; }); return o; }
+    /* Adopt saved per-tile colors as overrides. In a legacy config (no top-level
+       "defaults") a value that merely repeats the stock constant was baked in by
+       an older build, never chosen, so it is dropped back to inherit. Once the
+       config carries "defaults" every stored color is a deliberate override and
+       is kept verbatim -- including one set back to a stock color on purpose. */
+    function jdAdoptColors(t,src,keys){
+      keys.forEach(k=>{
+        const v=src[k];
+        if(typeof v!=="string" || !v) return;
+        if(jdHealLegacy && v.toLowerCase()===JD_STOCK[k].toLowerCase()) return;
+        t[k]=v;
+      });
+      return t;
+    }
     function jdSerializeTiles(){
+      const defaults={};
+      JD_DEF_KEYS.forEach(([k])=>{ defaults[k]=jdDefColor(k); });
       const rows=jdRows.map(row=>row.map(t=>{
         if(t.type==="number"){
-          return {path:t.path||"",label:t.label||"",type:"number",unit:t.unit||"",
-            decimals:jdClampInt(t.decimals,0,4),low:jdNum(t.low),high:jdNum(t.high),
-            cLow:t.cLow||JD_C_NORMAL,cNorm:t.cNorm||JD_C_NORMAL,cHigh:t.cHigh||JD_C_WARN};
+          return jdPutColors({path:t.path||"",label:t.label||"",type:"number",unit:t.unit||"",
+            decimals:jdClampInt(t.decimals,0,4),low:jdNum(t.low),high:jdNum(t.high)},t,["cLow","cNorm","cHigh"]);
         } else if(t.type==="text"){
           return {path:t.path||"",label:t.label||"",type:"text",
             maps:(t.maps||[]).slice(0,4).map(m=>({val:m.val||"",color:m.color||JD_C_NORMAL}))};
         }
-        return {path:t.path||"",label:t.label||"",type:"bool",
-          tText:t.tText||"TRUE",fText:t.fText||"FALSE",tColor:t.tColor||JD_C_OK,fColor:t.fColor||JD_C_CRIT};
+        return jdPutColors({path:t.path||"",label:t.label||"",type:"bool",
+          tText:t.tText||"TRUE",fText:t.fText||"FALSE"},t,["tColor","fColor"]);
       }));
-      return JSON.stringify({rows:rows});
+      return JSON.stringify({defaults:defaults,rows:rows});
     }
     function jdParseTiles(str){
-      jdRows=[];
+      jdRows=[]; jdDefaults={};
       let cfg=null;
       try{ cfg=JSON.parse(str||"{}"); }catch(e){ cfg=null; }
+      const hasDefs=!!(cfg && cfg.defaults && typeof cfg.defaults==="object");
+      jdHealLegacy=!hasDefs;
+      const defs=hasDefs?cfg.defaults:{};
+      JD_DEF_KEYS.forEach(([k])=>{ if(typeof defs[k]==="string" && defs[k]) jdDefaults[k]=defs[k]; });
       const rows=(cfg && Array.isArray(cfg.rows))?cfg.rows:[];
       rows.slice(0,JD_MAX_ROWS).forEach(row=>{
         if(!Array.isArray(row)) return;
@@ -663,14 +790,94 @@
         row.slice(0,JD_MAX_PER_ROW).forEach(t=>{
           if(!t||typeof t!=="object") return;
           if(t.type==="text") outRow.push(jdTextTile(t.path||"",t.label||"",(t.maps||[]).slice(0,4).map(m=>({val:m.val||"",color:m.color||JD_C_NORMAL}))));
-          else if(t.type==="bool") outRow.push(jdBoolTile(t.path||"",t.label||"",t.tText||"TRUE",t.fText||"FALSE",t.tColor||JD_C_OK,t.fColor||JD_C_CRIT));
-          else outRow.push(jdNumberTile(t.path||"",t.label||"",t.unit||"",jdClampInt(t.decimals,0,4),jdNum(t.low),jdNum(t.high),t.cLow||JD_C_NORMAL,t.cNorm||JD_C_NORMAL,t.cHigh||JD_C_WARN));
+          else if(t.type==="bool") outRow.push(jdAdoptColors(jdBoolTile(t.path||"",t.label||"",t.tText||"TRUE",t.fText||"FALSE"),t,["tColor","fColor"]));
+          else outRow.push(jdAdoptColors(jdNumberTile(t.path||"",t.label||"",t.unit||"",jdClampInt(t.decimals,0,4),jdNum(t.low),jdNum(t.high)),t,["cLow","cNorm","cHigh"]));
         });
         jdRows.push(outRow);
       });
     }
 
-    /* ---- tab populate / save ---- */
+    /* ---- tab populate / preview / save ----
+       Two ways this page reaches the device:
+         preview:true  -> apply now, store nothing (this tab's own button, the
+                          enable toggle, and the debounced source-field apply)
+         no flag       -> apply and store (the page-wide Save, through the
+                          window.jdCollectAndSave hook below)
+       Dirtiness is derived by comparing the current payload against the one
+       last loaded or stored, so no edit path has to remember to flag it. */
+    let jdLoaded=false;     /* populate has run at least once */
+    let jdStored="";        /* pristine payload: as last loaded / stored */
+    let jdPreviewSent=false;/* device is showing something that is not stored */
+    let jdPrevTimer=null;
+
+    function jdPayload(preview){
+      const body={
+        json_enabled: $('jd_enabled')?!!$('jd_enabled').checked:false,
+        json_url: $('jd_url')?$('jd_url').value.trim():"",
+        json_auth_header: $('jd_auth')?$('jd_auth').value.trim():"",
+        json_update_interval_s: $('jd_interval')?parseInt($('jd_interval').value,10)||30:30,
+        json_tiles_config: jdSerializeTiles()
+      };
+      if(preview) body.preview=true;
+      return body;
+    }
+    /* An immediate preview supersedes any pending debounced one. previewSent is
+       only set once the device has actually accepted the preview, so a failed
+       POST does not arm the unload restore. */
+    function jdPreviewNow(okMsg){
+      clearTimeout(jdPrevTimer); jdPrevTimer=null;
+      return postJson('/api/json-config',jdPayload(true))
+        .then(r=>{ if(!r.ok) throw new Error('HTTP '+r.status); return r.text(); })
+        .then(()=>{ jdPreviewSent=true; if(okMsg) showToast(okMsg,'success'); })
+        .catch(e=>{ showToast('Preview failed: '+e.message,'error'); });
+    }
+    /* A preview lives in the device's RAM until something replaces it: there is
+       no timeout, and the main Discard does not restore tiles. So if the user
+       walks away from unsaved previews, push the pristine config back as one
+       more preview. On unload that has to be sendBeacon (a normal fetch is
+       killed with the page); the Blob type keeps the JSON content-type. */
+    function jdRevertPreview(unloading){
+      /* kill a pending debounce first: a timer armed by the keystroke that has
+         not fired yet would otherwise outlive the discard */
+      clearTimeout(jdPrevTimer); jdPrevTimer=null;
+      if(!jdPreviewSent || !jdStored) return null;
+      jdPreviewSent=false;
+      const body=JSON.parse(jdStored); body.preview=true;
+      const json=JSON.stringify(body);
+      if(unloading){
+        if(navigator.sendBeacon) navigator.sendBeacon('/api/json-config',new Blob([json],{type:'application/json'}));
+        return null;
+      }
+      return postJson('/api/json-config',body).catch(()=>{});
+    }
+    window.addEventListener('beforeunload',()=>{ jdRevertPreview(true); });
+    function jdSchedulePreview(){
+      if(!jdLoaded) return;
+      clearTimeout(jdPrevTimer);
+      jdPrevTimer=setTimeout(()=>{ jdPreviewNow(null); },600);
+    }
+    function jdPreviewLayout(){
+      const btn=$('jd_previewBtn'); if(!btn) return;
+      btn.disabled=true; btn.textContent="Sending...";
+      jdPreviewNow('Preview sent to the device - not saved yet')
+        .finally(()=>{ btn.disabled=false; btn.textContent="Preview Layout on Device"; });
+    }
+    /* Page-wide Save hook: a promise that stores this page's whole config
+       (source fields + tiles + default colors), or null when the tab was never
+       opened or nothing changed since it was loaded. */
+    function jdCollectAndSave(){
+      /* drop any pending debounced preview: firing it after this save would
+         re-apply unsaved values and race the page-wide config POST */
+      clearTimeout(jdPrevTimer); jdPrevTimer=null;
+      if(!jdLoaded || !$('jd_rowsHost')) return null;
+      const body=jdPayload(false);
+      const json=JSON.stringify(body);
+      if(json===jdStored) return null;
+      return postJson('/api/json-config',body).then(r=>{
+        if(!r.ok) throw new Error('JSON Display: HTTP '+r.status);
+        jdStored=json; jdPreviewSent=false;
+      });
+    }
 
     function populateTab_json(data){
       /* Ignore the main-config blob; load JSON Display from its own endpoint. */
@@ -683,32 +890,22 @@
           if($('jd_interval')) $('jd_interval').value=String(d.json_update_interval_s||30);
           jdParseTiles(d.json_tiles_config||"");
           jdSyncAll();
+          jdLoaded=true; jdStored=JSON.stringify(jdPayload(false));
         })
         .catch(e=>{ console.error('Load JSON Display config failed',e); jdParseTiles(""); jdSyncAll(); });
-    }
-
-    function jdSaveConfig(){
-      const btn=$('jd_saveBtn'); if(!btn) return;
-      const body={
-        json_enabled: $('jd_enabled')?!!$('jd_enabled').checked:false,
-        json_url: $('jd_url')?$('jd_url').value.trim():"",
-        json_auth_header: $('jd_auth')?$('jd_auth').value.trim():"",
-        json_update_interval_s: $('jd_interval')?parseInt($('jd_interval').value,10)||30:30,
-        json_tiles_config: jdSerializeTiles()
-      };
-      btn.disabled=true; btn.textContent="Saving...";
-      postJson('/api/json-config',body).then(r=>{ if(!r.ok) throw new Error('HTTP '+r.status); return r.text(); })
-        .then(()=>{ showToast('JSON Display saved','success'); })
-        .catch(e=>{ showToast('Save failed: '+e.message,'error'); })
-        .finally(()=>{ btn.disabled=false; btn.textContent="Save JSON Display"; });
     }
 
   /* Published for the shell (POPULATE_TAB_FNS looks populateTab_json up on
      window at call time) and for the inline handlers in the markup above. */
   window.populateTab_json=populateTab_json;
   window.jdOnSourceChange=jdOnSourceChange;
+  window.jdOnSourceEdit=jdOnSourceEdit;
+  window.jdOnSourceCommit=jdOnSourceCommit;
+  window.jdOnEnabledToggle=jdOnEnabledToggle;
   window.jdFetchJson=jdFetchJson;
   window.jdAddRow=jdAddRow;
-  window.jdSaveConfig=jdSaveConfig;
+  window.jdPreviewLayout=jdPreviewLayout;
+  window.jdCollectAndSave=jdCollectAndSave;
+  window.jdRevertPreview=jdRevertPreview;
 })();
 </script>

--- a/main/ha_client.c
+++ b/main/ha_client.c
@@ -61,6 +61,9 @@ static http_fetch_conn_t *s_conn = NULL;
 static bool   cjson_scalar_str(const cJSON *node, char *buf, size_t len);
 static void   invalidate_tiles_config(void);
 static int    get_tiles_config(const char *tiles_config_json);
+static cJSON *fetch_path_core(const char *base_url, const char *token,
+                              const char *path, http_fetch_conn_t *conn,
+                              int *status_out);
 static cJSON *fetch_entity_core(const char *base_url, const char *token,
                                 const char *entity_id, http_fetch_conn_t *conn);
 static bool   resolve_tile_value(cJSON *entity, const char *attr,
@@ -277,18 +280,28 @@ static bool resolve_tile_value(cJSON *entity, const char *attr,
 // =============================================================================
 
 /**
- * Fetch GET {base_url}/api/states/{entity_id} with Bearer auth. @p conn may be a
- * keep-alive slot (poll task) or NULL for a one-shot client (probe handler).
- * Returns the parsed entity JSON (caller cJSON_Delete) or NULL on failure.
+ * Fetch GET {base_url}/{path} with Bearer auth. @p path is a root-relative path
+ * WITHOUT a leading slash ("api/states/<id>", "api/config"). @p conn may be a
+ * keep-alive slot (poll task) or NULL for a one-shot client (httpd handlers).
+ * Returns the parsed JSON (caller cJSON_Delete) or NULL on failure.
+ *
+ * @p status_out (optional) is pre-set to 0 and receives the upstream HTTP status
+ * whenever headers were reached, so a caller can tell a transport failure (0)
+ * from an auth rejection (401/403) from a 200 whose body would not parse. NULL
+ * disables status reporting.
  */
-static cJSON *fetch_entity_core(const char *base_url, const char *token,
-                                const char *entity_id, http_fetch_conn_t *conn) {
-    if (!base_url || base_url[0] == '\0' || !entity_id || entity_id[0] == '\0') {
+static cJSON *fetch_path_core(const char *base_url, const char *token,
+                              const char *path, http_fetch_conn_t *conn,
+                              int *status_out) {
+    if (status_out) {
+        *status_out = 0;
+    }
+    if (!base_url || base_url[0] == '\0' || !path || path[0] == '\0') {
         return NULL;
     }
 
-    /* Strip any trailing slash(es) from base so "{base}/api/states/{id}" never
-     * produces a double slash. base_url is <=255 chars. */
+    /* Strip any trailing slash(es) from base so "{base}/{path}" never produces a
+     * double slash. base_url is <=255 chars. */
     char base[256];
     size_t blen = strlen(base_url);
     if (blen >= sizeof(base)) {
@@ -300,11 +313,11 @@ static cJSON *fetch_entity_core(const char *base_url, const char *token,
         base[--blen] = '\0';
     }
 
-    /* url[512] covers base[256] + "/api/states/" + entity_id (<=127). */
+    /* url[512] covers base[<=255] + '/' + path[<=191]. */
     char url[512];
-    int un = snprintf(url, sizeof(url), "%s/api/states/%s", base, entity_id);
+    int un = snprintf(url, sizeof(url), "%s/%s", base, path);
     if (un <= 0 || un >= (int)sizeof(url)) {
-        ESP_LOGW(TAG, "HA URL truncated for entity %s", entity_id);
+        ESP_LOGW(TAG, "HA URL truncated for path %s", path);
         return NULL;
     }
 
@@ -329,17 +342,18 @@ static cJSON *fetch_entity_core(const char *base_url, const char *token,
         .max_response_bytes = HA_RESPONSE_BUF_SIZE,
         .extra_header = (auth[0] != '\0') ? auth : NULL,
         .conn = conn,
+        .status_out = status_out,
     };
 
     char *buffer = NULL;
     size_t total_read = 0;
     esp_err_t err = http_fetch_text(url, &opts, &buffer, &total_read);
     if (err != ESP_OK) {
-        ESP_LOGW(TAG, "HA fetch failed for %s: %s", entity_id, esp_err_to_name(err));
+        ESP_LOGW(TAG, "HA fetch failed for %s: %s", path, esp_err_to_name(err));
         return NULL;
     }
     if (total_read == 0) {
-        ESP_LOGW(TAG, "HA: empty response for %s", entity_id);
+        ESP_LOGW(TAG, "HA: empty response for %s", path);
         heap_caps_free(buffer);
         return NULL;
     }
@@ -347,16 +361,52 @@ static cJSON *fetch_entity_core(const char *base_url, const char *token,
     cJSON *json = cJSON_Parse(buffer);
     heap_caps_free(buffer);
     if (!json) {
-        ESP_LOGW(TAG, "HA: failed to parse response for %s", entity_id);
+        ESP_LOGW(TAG, "HA: failed to parse response for %s", path);
         return NULL;
     }
     return json;
+}
+
+/** Build "api/states/<entity_id>" and fetch it. Status is not reported. */
+static cJSON *fetch_entity_core(const char *base_url, const char *token,
+                                const char *entity_id, http_fetch_conn_t *conn) {
+    if (!entity_id || entity_id[0] == '\0') {
+        return NULL;
+    }
+    /* path[192] covers "api/states/" (11) + the longest entity id the probe
+     * handler accepts (159) + NUL. */
+    char path[192];
+    int pn = snprintf(path, sizeof(path), "api/states/%s", entity_id);
+    if (pn <= 0 || pn >= (int)sizeof(path)) {
+        ESP_LOGW(TAG, "HA entity path truncated: %s", entity_id);
+        return NULL;
+    }
+    return fetch_path_core(base_url, token, path, conn, NULL);
 }
 
 cJSON *ha_client_fetch_entity(const char *base_url, const char *token,
                               const char *entity_id) {
     /* One-shot (conn=NULL): safe to call from the httpd worker task. */
     return fetch_entity_core(base_url, token, entity_id, NULL);
+}
+
+int ha_client_fetch_config(const char *base_url, const char *token,
+                           cJSON **out_json) {
+    if (out_json) {
+        *out_json = NULL;
+    }
+    /* One-shot (conn=NULL): safe from the httpd worker task, and never disturbs
+     * the poll task's keep-alive slot. */
+    int status = 0;
+    cJSON *json = fetch_path_core(base_url, token, "api/config", NULL, &status);
+    if (json) {
+        if (out_json) {
+            *out_json = json;
+        } else {
+            cJSON_Delete(json);
+        }
+    }
+    return status;
 }
 
 // =============================================================================

--- a/main/ha_client.h
+++ b/main/ha_client.h
@@ -65,3 +65,16 @@ void ha_client_invalidate_config_cache(void);
  */
 cJSON *ha_client_fetch_entity(const char *base_url, const char *token,
                               const char *entity_id);
+
+/**
+ * Credentials check -- used by the /api/ha-test handler (one-shot, safe from the
+ * httpd worker task). Fetches GET {base_url}/api/config with Bearer auth.
+ *
+ * Returns the upstream HTTP status code, or 0 when no response ever arrived
+ * (DNS/connect/timeout) -- ha_client_fetch_entity collapses all of those into
+ * NULL, which is why this variant exists. On HTTP 200 with a parseable body,
+ * *out_json receives the parsed JSON (caller must cJSON_Delete); in every other
+ * case *out_json is set to NULL. @p out_json may be NULL (body discarded).
+ */
+int ha_client_fetch_config(const char *base_url, const char *token,
+                           cJSON **out_json);

--- a/main/home_ui.html
+++ b/main/home_ui.html
@@ -59,31 +59,47 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
 .main-grid>.card,.side-col>.card{margin-bottom:0}
 .side-col{display:flex;flex-direction:column;gap:20px}
 .side-col>.card:last-child{flex:1}
-/* ladder hero */
+/* decision-flow hero */
 .hero-card{padding:24px 28px 28px;display:flex;flex-direction:column}
 .mode-chip{font-size:.7rem;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-2);background:rgba(255,255,255,.05);border:1px solid var(--border);border-radius:8px;padding:3px 10px;white-space:nowrap;min-width:118px;text-align:center}
 .hero-body{flex:1;position:relative;display:grid;grid-template-columns:minmax(0,1fr) 190px;gap:44px}
-.ladder{display:flex;flex-direction:column;justify-content:space-between;position:relative}
-.ladder::before{content:'';position:absolute;left:17px;top:20px;bottom:20px;width:2px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.1) 50%,rgba(255,255,255,.04));border-radius:1px}
-.rung{position:relative;display:flex;align-items:flex-start;gap:14px;padding:12px 14px 12px 0;border-radius:12px;border:1px solid transparent}
-.rung+.rung{margin-top:4px}
-.rung-num{width:36px;height:36px;border-radius:50%;flex-shrink:0;align-self:center;display:flex;align-items:center;justify-content:center;line-height:1;padding:0;font-size:.75rem;font-weight:700;font-variant-numeric:tabular-nums;background:var(--input-bg);border:1px solid var(--border);color:var(--hint);position:relative;z-index:1}
-.rung-main{min-width:0;flex:1;padding-top:2px}
-.rung-name{font-size:.88rem;font-weight:600;color:var(--text-2)}
-.rung-desc{font-size:.75rem;color:var(--hint);line-height:1.45;margin-top:2px}
-.rung-state{flex-shrink:0;align-self:center;font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 9px;border-radius:8px;white-space:nowrap;min-width:84px;text-align:center;color:var(--hint);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.07)}
-.rung.inactive .rung-name{color:var(--muted)}
-.rung.dimmed{opacity:.6}
-.rung.active{background:rgba(var(--a),.09);border-color:rgba(var(--a),.4)}
-.rung.active .rung-num{background:var(--accent);color:#0a0a0b;border-color:var(--accent)}
-.rung.active .rung-name{color:#f4f4f5}
-.rung.active .rung-desc{color:var(--text-2)}
-.rung.active .rung-state{color:#0a0a0b;background:var(--accent);border-color:var(--accent)}
-.rung.active::after{content:'';position:absolute;right:-9px;top:50%;transform:translateY(-50%);width:0;height:0;border-top:7px solid transparent;border-bottom:7px solid transparent;border-left:9px solid rgba(var(--a),.9)}
-/* override countdown row: height always reserved so rungs below never shift */
-.rung-extra{margin-top:8px}
+/* flow grid: col 1 = questions, col 2 = yes connector, col 3 = yes outcomes.
+   Each step emits a question row, then a NO-connector row; auto-placement keeps them paired. */
+.flow{position:relative;display:grid;grid-template-columns:minmax(0,1.12fr) 44px minmax(0,1fr);align-content:start}
+.fstep{display:contents}
+.fq{grid-column:1;align-self:center;background:var(--input-bg);border:1px solid var(--border);border-radius:12px;padding:11px 14px;font-size:.8rem;font-weight:600;line-height:1.35;color:var(--muted);transition:border-color .3s,background-color .3s,color .3s,opacity .3s}
+.fyes{grid-column:2;align-self:center;position:relative;height:2px;background:rgba(255,255,255,.1);transition:background-color .3s,opacity .3s}
+.fyes::before{content:'yes';position:absolute;top:-15px;left:50%;transform:translateX(-50%);font-size:.56rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--hint)}
+.fyes::after{content:'';position:absolute;right:-1px;top:50%;transform:translateY(-50%);width:0;height:0;border-top:4px solid transparent;border-bottom:4px solid transparent;border-left:6px solid rgba(255,255,255,.18)}
+.fout{grid-column:3;align-self:center;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.08);border-radius:12px;padding:10px 12px;font-size:.74rem;font-weight:600;line-height:1.35;color:var(--muted);transition:border-color .3s,background-color .3s,color .3s,opacity .3s,box-shadow .3s}
+.fno{grid-column:1;justify-self:center;position:relative;width:2px;height:36px;background:rgba(255,255,255,.1);transition:opacity .3s}
+.fno::before{content:'no';position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);font-size:.56rem;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--hint);background:var(--glass-bg);padding:1px 6px;border-radius:6px}
+.fno::after{content:'';position:absolute;bottom:-1px;left:50%;transform:translateX(-50%);width:0;height:0;border-left:4px solid transparent;border-right:4px solid transparent;border-top:6px solid rgba(255,255,255,.18)}
+.fterm{grid-column:1;display:flex;align-items:center;gap:10px;background:rgba(255,255,255,.02);border:1px dashed rgba(255,255,255,.16);border-radius:12px;padding:11px 14px;font-size:.78rem;font-weight:600;color:var(--muted);transition:border-color .3s,background-color .3s,color .3s,opacity .3s,box-shadow .3s}
+.fterm .ic{opacity:.7}
+/* answered steps above the winner: lit question, lit NO path, dim yes branch */
+.fstep.past .fq{color:#f4f4f5;border-color:rgba(var(--a),.3);background:rgba(var(--a),.05)}
+.fstep.past .fno{background:linear-gradient(180deg,rgba(var(--a),.8),rgba(var(--a),.45))}
+.fstep.past .fno::before{color:var(--accent)}
+.fstep.past .fno::after{border-top-color:rgba(var(--a),.7)}
+.fstep.past .fyes,.fstep.past .fout{opacity:.42}
+/* the winning step: question answered yes, outcome takes the screen */
+.fstep.active .fq{color:#f4f4f5;border-color:rgba(var(--a),.5);background:rgba(var(--a),.09)}
+.fstep.active .fyes{background:rgba(var(--a),.85)}
+.fstep.active .fyes::before{color:var(--accent)}
+.fstep.active .fyes::after{border-left-color:rgba(var(--a),.9)}
+.fstep.active .fout{color:#f4f4f5;border-color:rgba(var(--a),.55);background:rgba(var(--a),.13);box-shadow:0 0 20px rgba(var(--a),.22)}
+.fstep.active .fno{opacity:.35}
+.fstep.active .fterm{border-style:solid;border-color:rgba(var(--a),.55);background:rgba(var(--a),.12);color:#f4f4f5;box-shadow:0 0 20px rgba(var(--a),.22)}
+.fstep.active .fterm .ic{opacity:1;color:var(--accent)}
+/* steps the decision never reached */
+.fstep.future .fq,.fstep.future .fyes,.fstep.future .fout,.fstep.future .fno,.fstep.future .fterm{opacity:.38}
+/* step whose feature is turned off in Settings: dimmed like future, never lit as "answered no" */
+.fstep.off .fq,.fstep.off .fyes,.fstep.off .fout,.fstep.off .fno{opacity:.38}
+/* extras inside outcome nodes: countdown space is always reserved (no layout shift) */
+.fextra{margin-top:8px}
 #overrideExtra{visibility:hidden}
-.rung.active #overrideExtra.has-content{visibility:visible}
+#overrideExtra.has-content{visibility:visible}
 #slideshowExtra{display:none}
 #slideshowExtra.has-content{display:block}
 .countdown-wrap{display:flex;align-items:center;gap:10px}
@@ -95,8 +111,9 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
 .rot-arrow{width:10px;height:10px;color:var(--hint)}
 .rot-step{font-size:.7rem;font-weight:600;color:var(--muted);padding:3px 10px;border-radius:8px;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.08)}
 .rot-step.now{color:var(--accent);background:rgba(var(--a),.13);border-color:rgba(var(--a),.45)}
-/* connector from active row to panel preview */
+/* connector from winning node to panel preview, with arrowhead */
 .connector{position:absolute;top:0;left:0;height:2px;background:linear-gradient(90deg,rgba(var(--a),.9),rgba(var(--a),.35));border-radius:1px;z-index:0;transition:transform .3s;pointer-events:none}
+.connector::after{content:'';position:absolute;right:0;top:50%;transform:translateY(-50%);width:0;height:0;border-top:5px solid transparent;border-bottom:5px solid transparent;border-left:8px solid rgba(var(--a),.8)}
 /* panel preview */
 .panel-col{display:flex;flex-direction:column;align-items:center;gap:12px;align-self:start;position:relative;z-index:1;transition:transform .3s}
 .panel-label{font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--hint)}
@@ -166,7 +183,7 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
 .deck-hint{font-size:.75rem;color:var(--hint);margin-top:12px;line-height:1.5}
 /* responsive */
 @media (max-width:900px){.main-grid{grid-template-columns:1fr}.content{padding:16px 16px 48px}.card{padding:20px}}
-@media (max-width:640px){.hero-body{grid-template-columns:1fr;gap:20px}.connector{display:none}.rung.active::after{display:none}.panel-col{align-self:stretch}.rung-desc{font-size:.7rem}.brand-meta{display:none}}
+@media (max-width:640px){.hero-body{grid-template-columns:1fr;gap:20px}.connector{display:none}.panel-col{align-self:stretch}.flow{grid-template-columns:minmax(0,1fr) 36px minmax(0,1fr)}.fq{font-size:.74rem;padding:10px 12px}.fout{font-size:.68rem;padding:9px 10px}.fterm{font-size:.72rem}.brand-meta{display:none}}
 @media (prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
 </style>
 </head>
@@ -257,63 +274,58 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
    <div class="hero-body" id="heroBody">
     <div class="connector" id="connector"></div>
 
-    <div class="ladder" id="ladder">
-     <div class="rung inactive" data-level="menu">
-      <div class="rung-num">1</div>
-      <div class="rung-main">
-       <div class="rung-name">Menu open</div>
-       <div class="rung-desc">A settings or detail screen is open on the panel. The page holds until it closes.</div>
-      </div>
-      <span class="rung-state" id="menuState">Waiting</span>
+    <div class="flow" id="flow">
+     <div class="fstep future" data-level="menu">
+      <div class="fq">Is a menu open on the panel?</div>
+      <div class="fyes"></div>
+      <div class="fout" id="outMenu">The screen stays where it is</div>
+      <div class="fno"></div>
      </div>
-     <div class="rung inactive" data-level="override">
-      <div class="rung-num">2</div>
-      <div class="rung-main">
-       <div class="rung-name">Manual override</div>
-       <div class="rung-desc" id="overrideDesc">After you swipe, tap, or pick a page here, it stays on screen for 10 seconds.</div>
-       <div class="rung-extra" id="overrideExtra">
+     <div class="fstep future" data-level="override">
+      <div class="fq">Did you just pick a page?</div>
+      <div class="fyes"></div>
+      <div class="fout" id="outOverride">
+       <div>Your page shows for a while</div>
+       <div class="fextra" id="overrideExtra">
         <div class="countdown-wrap">
          <div class="countdown-bar"><div class="countdown-fill" id="countdownFill"></div></div>
          <span class="countdown-num" id="countdownNum">10s</span>
         </div>
        </div>
       </div>
-      <span class="rung-state" id="overrideState">Waiting</span>
+      <div class="fno"></div>
      </div>
-     <div class="rung inactive" data-level="slideshow">
-      <div class="rung-num">3</div>
-      <div class="rung-main">
-       <div class="rung-name">Slideshow</div>
-       <div class="rung-desc" id="slideshowDesc">Auto-rotate is off. Turn it on below to cycle through selected pages.</div>
-       <div class="rung-extra" id="slideshowExtra">
+     <div class="fstep future" data-level="lock">
+      <div class="fq">Is 'Always show the Home Page' on?</div>
+      <div class="fyes"></div>
+      <div class="fout" id="outLock">Show your home page</div>
+      <div class="fno"></div>
+     </div>
+     <div class="fstep future" data-level="slideshow">
+      <div class="fq">Is the slideshow on?</div>
+      <div class="fyes"></div>
+      <div class="fout" id="outSlideshow">
+       <div>Pages take turns</div>
+       <div class="fextra" id="slideshowExtra">
         <div class="rotation-order" id="rotationOrder"></div>
        </div>
       </div>
-      <span class="rung-state" id="slideshowState">Off</span>
+      <div class="fno"></div>
      </div>
-     <div class="rung inactive" data-level="session">
-      <div class="rung-num">4</div>
-      <div class="rung-main">
-       <div class="rung-name">Session</div>
-       <div class="rung-desc" id="sessionDesc">When a NINA computer is connected, the panel follows its page.</div>
-      </div>
-      <span class="rung-state" id="sessionState">Waiting</span>
+     <div class="fstep future" data-level="session">
+      <div class="fq">Is a telescope busy imaging?</div>
+      <div class="fyes"></div>
+      <div class="fout" id="outSession">Show that telescope's page</div>
+      <div class="fno"></div>
      </div>
-     <div class="rung inactive" data-level="idle">
-      <div class="rung-num">5</div>
-      <div class="rung-main">
-       <div class="rung-name">Idle page</div>
-       <div class="rung-desc" id="idleDesc">When every NINA computer is offline, show your chosen idle page instead.</div>
-      </div>
-      <span class="rung-state" id="idleState">Waiting</span>
+     <div class="fstep future" data-level="idle">
+      <div class="fq">Are all your telescope computers offline?</div>
+      <div class="fyes"></div>
+      <div class="fout" id="outIdle">Show your idle page</div>
+      <div class="fno"></div>
      </div>
-     <div class="rung inactive" data-level="home">
-      <div class="rung-num">6</div>
-      <div class="rung-main">
-       <div class="rung-name" id="homeRungName">Home page: Summary</div>
-       <div class="rung-desc">If nothing above applies, the panel falls back to your home page.</div>
-      </div>
-      <span class="rung-state" id="homeState">Fallback</span>
+     <div class="fstep future" data-level="home">
+      <div class="fterm" id="outHome"><svg class="ic"><use href="#i-grid"/></svg><span id="homeTermText">Show your home page (Summary)</span></div>
      </div>
     </div>
 
@@ -360,7 +372,7 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
    <div class="card">
     <div class="card-title"><span>Panel Pages</span></div>
     <div class="deck" id="deck"></div>
-    <div class="deck-hint" id="deckHint">Tap a page to send the panel there. It holds for 10 seconds, then normal rules take over again.</div>
+    <div class="deck-hint" id="deckHint">Tap a page to send the panel there. It holds for a short while, then normal rules take over again.</div>
    </div>
   </div>
  </div>
@@ -398,19 +410,23 @@ var state = {
 var pagesBySlug = {};
 
 /* ---- DOM refs ---- */
-var rungs = {};
-document.querySelectorAll('.rung').forEach(function (el) { rungs[el.dataset.level] = el; });
-var heroBody = $('heroBody'), ladderEl = $('ladder'), connector = $('connector');
+/* flow steps: top-down question order; the resolved level wins its row */
+var ORDER = ['menu', 'override', 'lock', 'slideshow', 'session', 'idle', 'home'];
+var steps = {};
+document.querySelectorAll('.fstep').forEach(function (el) { steps[el.dataset.level] = el; });
+var outcomes = {
+ menu: $('outMenu'), override: $('outOverride'), lock: $('outLock'), slideshow: $('outSlideshow'),
+ session: $('outSession'), idle: $('outIdle'), home: $('outHome')
+};
+var activeTarget = null;
+var heroBody = $('heroBody'), flowEl = $('flow'), connector = $('connector');
 var panelCol = $('panelCol'), panelFrame = $('panelFrame'), panelUse = $('panelUse');
 var panelPageName = $('panelPageName'), panelPageSub = $('panelPageSub'), panelDots = $('panelDots');
 var whyLevel = $('whyLevel'), whyRest = $('whyRest');
 var deck = $('deck'), modeChip = $('modeChip'), toggleHint = $('toggleHint');
 var rotationOrder = $('rotationOrder'), countdownFill = $('countdownFill'), countdownNum = $('countdownNum');
-var overrideState = $('overrideState'), overrideExtra = $('overrideExtra'), overrideDesc = $('overrideDesc');
-var slideshowState = $('slideshowState'), slideshowDesc = $('slideshowDesc'), slideshowExtra = $('slideshowExtra');
-var sessionState = $('sessionState'), sessionDesc = $('sessionDesc');
-var menuState = $('menuState'), idleState = $('idleState'), idleDesc = $('idleDesc');
-var homeRungName = $('homeRungName'), homeState = $('homeState');
+var overrideExtra = $('overrideExtra'), slideshowExtra = $('slideshowExtra');
+var outIdle = outcomes.idle, outLock = outcomes.lock, homeTermText = $('homeTermText');
 var autoRotateToggle = $('autoRotateToggle'), connPill = $('connPill'), deckHint = $('deckHint');
 var rigList = $('rigList'), rigEmpty = $('rigEmpty');
 var metricUptime = $('metricUptime'), metricTemp = $('metricTemp'), tempSub = $('tempSub');
@@ -611,18 +627,24 @@ function renderRigs(instances, uptimeMs) {
 }
 
 /* ---- panel-why copy per level (end-user language) ---- */
-var WHY_LABEL = { menu: 'Menu open', override: 'Manual override', slideshow: 'Slideshow',
-                  session: 'Session', idle: 'Idle page', home: 'Home page' };
+var WHY_LABEL = {
+ menu: 'A menu is open', override: 'You chose this page',
+ lock: "'Always show the Home Page' is on", slideshow: 'The slideshow is on',
+ session: 'A telescope is imaging', idle: 'All your telescope computers are offline', home: 'Nothing else applies'
+};
 var WHY = {
- menu:      function ()  { return ' decides: a menu is open on the panel.'; },
- override:  function (n) { return ' decides: you picked ' + n + '. Normal rules resume shortly.'; },
- slideshow: function (n) { return ' decides: auto-rotate is showing ' + n + '.'; },
+ menu:      function ()  { return ', so the screen stays where it is.'; },
+ override:  function (n) { return ': ' + n + ' shows for a short while, then normal rules take over.'; },
+ lock:      function ()  { return ', so the panel stays on ' + pageLabel(state.homeSlug) + '.'; },
+ slideshow: function (n) { return ': ' + n + ' is taking its turn.'; },
  session:   function ()  {
-  if (state.sessionCount > 1) return ' decides: several computers are connected.';
-  return ' decides: ' + (state.sessionRig || 'a NINA computer') + ' is connected.';
+  if (state.sessionCount > 1) return ', so the panel shows the summary of every computer.';
+  return ': ' + (state.sessionRig || 'a NINA computer') + ' is connected, so the panel follows it.';
  },
- idle:      function ()  { return ' decides: every NINA computer is offline.'; },
- home:      function ()  { return ' decides: nothing else applies, so the panel shows your home page.'; }
+ idle:      function ()  {
+  return ', so the panel shows ' + pageLabel(state.idleSlug || state.currentSlug) + '.';
+ },
+ home:      function ()  { return ', so the panel shows your home page, ' + pageLabel(state.homeSlug) + '.'; }
 };
 
 /* ---- per-tick countdown: two targeted writes, no layout reads ---- */
@@ -634,57 +656,41 @@ function tickCountdown() {
 /* ---- full render: idempotent, textContent/class writes only ---- */
 var lastLevel = '';
 function render() {
- var lvl = rungs[state.level] ? state.level : 'home';
+ var lvl = steps[state.level] ? state.level : 'home';
  var slug = state.currentSlug;
 
- Object.keys(rungs).forEach(function (l) {
-  var el = rungs[l];
-  el.classList.remove('active', 'inactive', 'dimmed');
-  el.classList.add(l === lvl ? 'active' : 'inactive');
+ /* light the taken path: questions above the winner answered "no",
+    the winner answered "yes", everything below unreached */
+ var ai = ORDER.indexOf(lvl);
+ ORDER.forEach(function (l, i) {
+  var el = steps[l];
+  el.classList.remove('past', 'active', 'future', 'off');
+  /* idle step turned off in Settings: dim it instead of "answered no" */
+  if (l === 'idle' && !state.idleEnabled && i !== ai) el.classList.add('off');
+  else el.classList.add(i < ai ? 'past' : i === ai ? 'active' : 'future');
  });
- if (state.autoRotate) {
-  rungs.session.classList.add('dimmed');
-  rungs.idle.classList.add('dimmed');
-  rungs.home.classList.add('dimmed');
- } else {
-  rungs.slideshow.classList.add('dimmed');
- }
- rungs[lvl].classList.remove('dimmed');
+ activeTarget = outcomes[lvl];
 
- menuState.textContent = lvl === 'menu' ? 'Active' : 'Waiting';
-
- /* fixed-width state labels: the countdown number never rides in the pill */
- overrideState.textContent = lvl === 'override' ? 'Active' : 'Waiting';
+ /* countdown row: space is always reserved inside the outcome node (no layout shift) */
  overrideExtra.classList.toggle('has-content', lvl === 'override');
- overrideDesc.textContent = 'After you swipe, tap, or pick a page here, it stays on screen for ' +
-  state.graceS + ' seconds.';
  if (lvl === 'override') tickCountdown();
 
- slideshowState.textContent = state.autoRotate ? (lvl === 'slideshow' ? 'Active' : 'Paused') : 'Off';
- slideshowDesc.textContent = state.autoRotate
-  ? 'Auto-rotate cycles through your selected pages.'
-  : 'Auto-rotate is off. Turn it on below to cycle through selected pages.';
  slideshowExtra.classList.toggle('has-content', state.autoRotate && state.rotation.length > 0);
  renderRotation();
 
- sessionState.textContent = lvl === 'session' ? 'Active' : (state.autoRotate ? 'Bypassed' : 'Waiting');
- if (state.sessionCount > 1) {
-  sessionDesc.textContent = 'Several computers are connected, so the panel shows the summary.';
- } else if (state.sessionRig) {
-  sessionDesc.textContent = state.sessionRig + ' is connected, so the panel follows its page.';
- } else {
-  sessionDesc.textContent = 'When a NINA computer is connected, the panel follows its page.';
- }
+ outIdle.textContent = !state.idleEnabled
+  ? "Off. Turn on 'Switch page when no connections' in Settings to use this."
+  : state.idleSlug
+   ? 'Show your idle page (' + pageLabel(state.idleSlug) + ')'
+   : 'Show your idle page';
 
- idleState.textContent = !state.idleEnabled ? 'Off' : (lvl === 'idle' ? 'Active' : 'Waiting');
- idleDesc.textContent = state.idleEnabled && state.idleSlug
-  ? 'When every NINA computer is offline, show ' + pageLabel(state.idleSlug) + ' instead.'
-  : 'When every NINA computer is offline, show your chosen idle page instead.';
-
- homeRungName.textContent = 'Home page: ' + pageLabel(state.homeSlug);
- homeState.textContent = lvl === 'home' ? 'Active' : 'Fallback';
+ outLock.textContent = 'Show your home page (' + pageLabel(state.homeSlug) + ')';
+ homeTermText.textContent = 'Show your home page (' + pageLabel(state.homeSlug) + ')';
 
  modeChip.textContent = state.mode === 'slideshow' ? 'Slideshow mode' : 'Pinned mode';
+ modeChip.title = state.mode === 'slideshow'
+  ? 'Auto-rotate is on. The panel takes turns showing your selected pages. Turn it off below to pin the panel to one page.'
+  : 'Auto-rotate is off. The panel stays on the page chosen by the rules below, such as following an imaging telescope. Turn on Auto-rotate below to cycle pages instead.';
  toggleHint.textContent = state.autoRotate
   ? 'On. The panel cycles through the slideshow pages.'
   : 'Off. The panel stays pinned to the active session.';
@@ -713,33 +719,34 @@ function render() {
  * Runs only on level change, resize, breakpoint change, or font load; never per tick. */
 var mq640 = window.matchMedia('(max-width: 640px)');
 function layout() {
- var active = ladderEl.querySelector('.rung.active');
+ var active = activeTarget;
  if (!active || mq640.matches) {
   connector.style.display = 'none';
   panelCol.style.transform = '';
   return;
  }
- var rungCenter = ladderEl.offsetTop + active.offsetTop + active.offsetHeight / 2;
- var rungRight = ladderEl.offsetLeft + active.offsetLeft + active.offsetWidth;
+ var nodeCenter = flowEl.offsetTop + active.offsetTop + active.offsetHeight / 2;
+ var nodeRight = flowEl.offsetLeft + active.offsetLeft + active.offsetWidth;
+ /* slide the preview column so the frame centers on the winning node (clamped inside the hero) */
  var frameCenter = panelCol.offsetTop + panelFrame.offsetTop + panelFrame.offsetHeight / 2;
- var delta = rungCenter - frameCenter;
+ var delta = nodeCenter - frameCenter;
  var maxDown = heroBody.clientHeight - (panelCol.offsetTop + panelCol.offsetHeight);
  var maxUp = -panelCol.offsetTop;
  if (delta > maxDown) delta = maxDown;
  if (delta < maxUp) delta = maxUp;
  panelCol.style.transform = 'translateY(' + delta + 'px)';
- var width = panelCol.offsetLeft + panelFrame.offsetLeft - rungRight;
+ var width = panelCol.offsetLeft + panelFrame.offsetLeft - nodeRight;
  if (width < 8) { connector.style.display = 'none'; return; }
  connector.style.display = 'block';
- connector.style.left = rungRight + 'px';
+ connector.style.left = nodeRight + 'px';
  connector.style.width = width + 'px';
- connector.style.transform = 'translateY(' + (rungCenter - 1) + 'px)';
+ connector.style.transform = 'translateY(' + (nodeCenter - 1) + 'px)';
 }
 mq640.addEventListener('change', layout);
 if (window.ResizeObserver) {
  var ro = new ResizeObserver(layout);
  ro.observe(heroBody);
- ro.observe(ladderEl);
+ ro.observe(flowEl);
 } else {
  var rafPending = false;
  window.addEventListener('resize', function () {
@@ -817,7 +824,7 @@ function applyStatus(st, ns) {
   intChips[k].classList.toggle('off', !ints[k]);
  });
 
- /* NINA instances: session rung copy, tile subtitles, connection rows */
+ /* NINA instances: session why-line copy, tile subtitles, connection rows */
  var instances = (ns && ns.instances) || [];
  var connected = [];
  instances.forEach(function (inst) {
@@ -903,6 +910,7 @@ setInterval(function () {
 
 /* ---- init: sequential loads to be kind to the single-worker httpd ---- */
 $('brandName').textContent = location.hostname || 'NINA Display';
+if (location.hostname) document.title = location.hostname.split('.')[0];
 getJSON('/api/version').then(function (v) {
  $('fwVer').textContent = v.git_tag || v.version || '--';
 }).catch(function () {}).then(function () {

--- a/main/home_ui.html
+++ b/main/home_ui.html
@@ -13,23 +13,24 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
 .ic{fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;width:16px;height:16px;flex-shrink:0}
 .ic3{stroke-width:3}
 /* top nav */
-.top-nav{position:sticky;top:0;z-index:100;background:rgba(10,10,11,.97);border-bottom:1px solid rgba(255,255,255,.06);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px 16px;padding:10px 24px;min-height:60px}
-.brand{display:flex;align-items:center;gap:12px;min-width:0}
-.brand-logo{width:36px;height:36px;border-radius:10px;flex-shrink:0;background:linear-gradient(135deg,rgba(var(--a),.28),rgba(var(--a),.08));border:1px solid rgba(var(--a),.35);display:flex;align-items:center;justify-content:center;color:var(--accent)}
-.brand-logo .ic{width:20px;height:20px}
+.top-nav{position:sticky;top:0;z-index:100;background:rgba(10,10,11,.7);backdrop-filter:blur(20px);-webkit-backdrop-filter:blur(20px);border-bottom:1px solid rgba(255,255,255,.06);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px 16px;padding:8px 24px;min-height:60px}
+.brand{display:flex;align-items:center;gap:10px;min-width:0}
+.brand .logo{width:36px;height:36px;flex-shrink:0}
 .brand-name{font-size:.95rem;font-weight:700;letter-spacing:-.02em;color:#f4f4f5}
 .brand-meta{font-size:.7rem;color:var(--hint);font-variant-numeric:tabular-nums;white-space:nowrap;min-height:1em}
 .nav-right{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
 .nav-group{display:inline-flex;align-items:center;gap:10px;font-size:.75rem;color:var(--muted);padding:6px 12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;background:rgba(255,255,255,.02);white-space:nowrap;font-variant-numeric:tabular-nums}
 .nav-group .fw-ver{color:#f4f4f5;font-weight:600;min-width:5ch;text-align:center}
-.update-badge{color:var(--accent);font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:2px 8px;border:1px solid rgba(var(--a),.4);border-radius:8px;background:rgba(var(--a),.1);text-decoration:none;transition:border-color .2s}
+.update-badge{color:var(--accent);font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:2px 8px;border:1px solid rgba(var(--a),.4);border-radius:10px;background:rgba(var(--a),.1);text-decoration:none;transition:border-color .2s}
 .update-badge:hover{border-color:rgba(var(--a),.7)}
 .update-badge.hide{display:none}
+.github-link{color:var(--hint);text-decoration:none;font-size:.75rem;display:flex;align-items:center;gap:6px;padding:7px 12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;transition:all .2s ease;background:rgba(255,255,255,.02);white-space:nowrap}
+.github-link:hover{color:#f4f4f5;border-color:rgba(var(--a),.3);background:rgba(255,255,255,.04)}
 .btn{border:none;border-radius:10px;padding:9px 18px;font-weight:600;cursor:pointer;font-size:.82rem;transition:transform .2s;display:inline-flex;align-items:center;justify-content:center;gap:8px;font-family:inherit;text-decoration:none}
 .btn-primary{background:linear-gradient(135deg,var(--accent),rgba(var(--a),.8));color:#0a0a0b;box-shadow:0 4px 16px rgba(var(--a),.2)}
 .btn-primary:hover{transform:translateY(-1px)}
 .btn .ic{width:15px;height:15px}
-.btn:focus-visible,.deck-chip:focus-visible,.rig-row:focus-visible,.int-chip:focus-visible,.update-badge:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.btn:focus-visible,.deck-chip:focus-visible,.rig-row:focus-visible,.int-chip:focus-visible,.update-badge:focus-visible,.github-link:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
 .content{max-width:1180px;margin:0 auto;padding:24px 24px 60px}
 .card{background:var(--glass-bg);border:1px solid var(--glass-border);border-radius:var(--radius);padding:24px 28px;margin-bottom:20px;box-shadow:0 8px 24px rgba(0,0,0,.5)}
 .card-title{font-size:.7rem;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:.08em;margin-bottom:18px;opacity:.9;display:flex;align-items:center;justify-content:space-between;gap:12px}
@@ -215,7 +216,7 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
 
 <nav class="top-nav">
  <div class="brand">
-  <div class="brand-logo"><svg class="ic"><use href="#i-star"/></svg></div>
+  <img class="logo" src="/favicon.ico" alt="">
   <div>
    <div class="brand-name" id="brandName">NINA Display</div>
    <div class="brand-meta" id="brandIp"></div>
@@ -226,6 +227,10 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
    <span class="fw-ver" id="fwVer">--</span>
    <a class="update-badge hide" id="updateBadge" href="/config#system">Update available</a>
   </span>
+  <a class="github-link" href="https://github.com/chvvkumar/ESP32-P4-NINA-Display" target="_blank" rel="noopener">
+   <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+   GitHub
+  </a>
   <a class="btn btn-primary" href="/config"><svg class="ic"><use href="#i-gear"/></svg>Settings</a>
  </div>
 </nav>

--- a/main/home_ui.html
+++ b/main/home_ui.html
@@ -1,0 +1,920 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>NinaDash Home</title>
+<link rel="icon" type="image/png" href="/favicon.ico">
+<style>
+:root{--bg:#080a10;--border:rgba(255,255,255,.12);--accent:#7aa2f7;--a:122,162,247;--text:#e2e8f0;--text-2:#b8c2d0;--muted:#94a3b8;--hint:#7a8ba4;--danger:#f87171;--warning:#fbbf24;--success:#4ade80;--radius:16px;--radius-sm:10px;--glass-bg:#1e2330;--glass-border:rgba(255,255,255,.14);--elevated:rgba(48,54,72,.96);--input-bg:rgba(12,14,20,.92)}
+*{box-sizing:border-box;margin:0;padding:0;-webkit-tap-highlight-color:transparent}
+body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;background:var(--bg);background-image:radial-gradient(ellipse at 20% 0%,rgba(122,162,247,.05) 0%,transparent 50%),radial-gradient(ellipse at 80% 100%,rgba(124,141,240,.04) 0%,transparent 50%),linear-gradient(135deg,#0a0c14 0%,#0f1320 100%);color:var(--text);line-height:1.5;overflow-x:hidden;min-height:100dvh}
+/* shared icon rules: one place for stroke attrs (SVG sprite) */
+.ic{fill:none;stroke:currentColor;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;width:16px;height:16px;flex-shrink:0}
+.ic3{stroke-width:3}
+/* top nav */
+.top-nav{position:sticky;top:0;z-index:100;background:rgba(10,10,11,.97);border-bottom:1px solid rgba(255,255,255,.06);display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:8px 16px;padding:10px 24px;min-height:60px}
+.brand{display:flex;align-items:center;gap:12px;min-width:0}
+.brand-logo{width:36px;height:36px;border-radius:10px;flex-shrink:0;background:linear-gradient(135deg,rgba(var(--a),.28),rgba(var(--a),.08));border:1px solid rgba(var(--a),.35);display:flex;align-items:center;justify-content:center;color:var(--accent)}
+.brand-logo .ic{width:20px;height:20px}
+.brand-name{font-size:.95rem;font-weight:700;letter-spacing:-.02em;color:#f4f4f5}
+.brand-meta{font-size:.7rem;color:var(--hint);font-variant-numeric:tabular-nums;white-space:nowrap;min-height:1em}
+.nav-right{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.nav-group{display:inline-flex;align-items:center;gap:10px;font-size:.75rem;color:var(--muted);padding:6px 12px;border:1px solid rgba(255,255,255,.06);border-radius:10px;background:rgba(255,255,255,.02);white-space:nowrap;font-variant-numeric:tabular-nums}
+.nav-group .fw-ver{color:#f4f4f5;font-weight:600;min-width:5ch;text-align:center}
+.update-badge{color:var(--accent);font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:2px 8px;border:1px solid rgba(var(--a),.4);border-radius:8px;background:rgba(var(--a),.1);text-decoration:none;transition:border-color .2s}
+.update-badge:hover{border-color:rgba(var(--a),.7)}
+.update-badge.hide{display:none}
+.btn{border:none;border-radius:10px;padding:9px 18px;font-weight:600;cursor:pointer;font-size:.82rem;transition:transform .2s;display:inline-flex;align-items:center;justify-content:center;gap:8px;font-family:inherit;text-decoration:none}
+.btn-primary{background:linear-gradient(135deg,var(--accent),rgba(var(--a),.8));color:#0a0a0b;box-shadow:0 4px 16px rgba(var(--a),.2)}
+.btn-primary:hover{transform:translateY(-1px)}
+.btn .ic{width:15px;height:15px}
+.btn:focus-visible,.deck-chip:focus-visible,.rig-row:focus-visible,.int-chip:focus-visible,.update-badge:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
+.content{max-width:1180px;margin:0 auto;padding:24px 24px 60px}
+.card{background:var(--glass-bg);border:1px solid var(--glass-border);border-radius:var(--radius);padding:24px 28px;margin-bottom:20px;box-shadow:0 8px 24px rgba(0,0,0,.5)}
+.card-title{font-size:.7rem;font-weight:700;color:var(--accent);text-transform:uppercase;letter-spacing:.08em;margin-bottom:18px;opacity:.9;display:flex;align-items:center;justify-content:space-between;gap:12px}
+/* connection-lost pill: position fixed, so showing it never shifts layout */
+.conn-pill{position:fixed;bottom:16px;left:50%;transform:translateX(-50%);z-index:200;font-size:.75rem;font-weight:600;color:var(--warning);background:rgba(20,22,30,.96);border:1px solid rgba(251,191,36,.35);border-radius:10px;padding:7px 14px;opacity:0;pointer-events:none;transition:opacity .3s;white-space:nowrap}
+.conn-pill.show{opacity:1}
+/* metrics row */
+.sys-metrics{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:14px;margin-bottom:20px}
+.sys-metric{background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.06);border-radius:14px;padding:16px 18px;display:flex;flex-direction:column;gap:10px}
+.sm-label{display:flex;align-items:center;gap:8px;color:var(--hint);font-size:.7rem;font-weight:600;text-transform:uppercase;letter-spacing:.06em}
+.sm-label .ic{width:15px;height:15px;opacity:.7}
+.sm-value{color:#f4f4f5;font-size:1.35rem;font-weight:700;line-height:1;font-variant-numeric:tabular-nums;display:flex;align-items:baseline;gap:8px;flex-wrap:wrap}
+.sm-sub{font-size:.7rem;color:var(--hint);font-weight:500;min-height:1em}
+.sm-bar{background:rgba(255,255,255,.06);border-radius:4px;height:6px;overflow:hidden}
+.sm-bar-fill{height:100%;border-radius:4px;background:linear-gradient(90deg,var(--accent),rgba(var(--a),.7));transition:width .5s}
+.sm-bar-fill.warn{background:linear-gradient(90deg,var(--warning),rgba(251,191,36,.7))}
+.bars{display:inline-flex;align-items:flex-end;gap:3px;height:22px}
+.bars span{width:5px;border-radius:1px;background:rgba(255,255,255,.12)}
+.bars span.on{background:var(--success)}
+/* reserved widths so live values never shift layout */
+#metricUptime{min-width:14ch}
+#metricTemp{min-width:6ch}
+#metricRssi{min-width:3ch;text-align:right}
+#memFree,#psFree{min-width:4ch;text-align:right}
+/* main grid: side column stretches so both columns bottom-align */
+.main-grid{display:grid;grid-template-columns:minmax(0,1.7fr) minmax(0,1fr);gap:20px}
+.main-grid>.card,.side-col>.card{margin-bottom:0}
+.side-col{display:flex;flex-direction:column;gap:20px}
+.side-col>.card:last-child{flex:1}
+/* ladder hero */
+.hero-card{padding:24px 28px 28px;display:flex;flex-direction:column}
+.mode-chip{font-size:.7rem;font-weight:600;letter-spacing:.06em;text-transform:uppercase;color:var(--text-2);background:rgba(255,255,255,.05);border:1px solid var(--border);border-radius:8px;padding:3px 10px;white-space:nowrap;min-width:118px;text-align:center}
+.hero-body{flex:1;position:relative;display:grid;grid-template-columns:minmax(0,1fr) 190px;gap:44px}
+.ladder{display:flex;flex-direction:column;justify-content:space-between;position:relative}
+.ladder::before{content:'';position:absolute;left:17px;top:20px;bottom:20px;width:2px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.1) 50%,rgba(255,255,255,.04));border-radius:1px}
+.rung{position:relative;display:flex;align-items:flex-start;gap:14px;padding:12px 14px 12px 0;border-radius:12px;border:1px solid transparent}
+.rung+.rung{margin-top:4px}
+.rung-num{width:36px;height:36px;border-radius:50%;flex-shrink:0;align-self:center;display:flex;align-items:center;justify-content:center;line-height:1;padding:0;font-size:.75rem;font-weight:700;font-variant-numeric:tabular-nums;background:var(--input-bg);border:1px solid var(--border);color:var(--hint);position:relative;z-index:1}
+.rung-main{min-width:0;flex:1;padding-top:2px}
+.rung-name{font-size:.88rem;font-weight:600;color:var(--text-2)}
+.rung-desc{font-size:.75rem;color:var(--hint);line-height:1.45;margin-top:2px}
+.rung-state{flex-shrink:0;align-self:center;font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 9px;border-radius:8px;white-space:nowrap;min-width:84px;text-align:center;color:var(--hint);background:rgba(255,255,255,.04);border:1px solid rgba(255,255,255,.07)}
+.rung.inactive .rung-name{color:var(--muted)}
+.rung.dimmed{opacity:.6}
+.rung.active{background:rgba(var(--a),.09);border-color:rgba(var(--a),.4)}
+.rung.active .rung-num{background:var(--accent);color:#0a0a0b;border-color:var(--accent)}
+.rung.active .rung-name{color:#f4f4f5}
+.rung.active .rung-desc{color:var(--text-2)}
+.rung.active .rung-state{color:#0a0a0b;background:var(--accent);border-color:var(--accent)}
+.rung.active::after{content:'';position:absolute;right:-9px;top:50%;transform:translateY(-50%);width:0;height:0;border-top:7px solid transparent;border-bottom:7px solid transparent;border-left:9px solid rgba(var(--a),.9)}
+/* override countdown row: height always reserved so rungs below never shift */
+.rung-extra{margin-top:8px}
+#overrideExtra{visibility:hidden}
+.rung.active #overrideExtra.has-content{visibility:visible}
+#slideshowExtra{display:none}
+#slideshowExtra.has-content{display:block}
+.countdown-wrap{display:flex;align-items:center;gap:10px}
+.countdown-bar{flex:1;height:5px;background:rgba(255,255,255,.08);border-radius:3px;overflow:hidden}
+.countdown-fill{height:100%;width:100%;background:var(--accent);border-radius:3px;transform-origin:left;transition:transform 1s linear}
+.countdown-num{font-size:.75rem;font-weight:700;color:var(--accent);font-variant-numeric:tabular-nums;min-width:4ch;text-align:right}
+.rotation-order{display:flex;flex-wrap:wrap;gap:6px 8px;align-items:center}
+.rot-pair{display:inline-flex;align-items:center;gap:6px;white-space:nowrap}
+.rot-arrow{width:10px;height:10px;color:var(--hint)}
+.rot-step{font-size:.7rem;font-weight:600;color:var(--muted);padding:3px 10px;border-radius:8px;background:rgba(0,0,0,.3);border:1px solid rgba(255,255,255,.08)}
+.rot-step.now{color:var(--accent);background:rgba(var(--a),.13);border-color:rgba(var(--a),.45)}
+/* connector from active row to panel preview */
+.connector{position:absolute;top:0;left:0;height:2px;background:linear-gradient(90deg,rgba(var(--a),.9),rgba(var(--a),.35));border-radius:1px;z-index:0;transition:transform .3s;pointer-events:none}
+/* panel preview */
+.panel-col{display:flex;flex-direction:column;align-items:center;gap:12px;align-self:start;position:relative;z-index:1;transition:transform .3s}
+.panel-label{font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--hint)}
+.panel-frame{width:172px;height:172px;border-radius:26px;background:#05070c;border:3px solid rgba(255,255,255,.14);box-shadow:0 8px 30px rgba(0,0,0,.7);display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;padding:16px;text-align:center;position:relative;overflow:hidden}
+.panel-frame::before{content:'';position:absolute;inset:0;background:radial-gradient(ellipse at 30% 20%,rgba(var(--a),.12),transparent 60%)}
+.panel-icon{color:var(--accent);position:relative}
+.panel-icon .ic{width:34px;height:34px}
+.panel-page-name,.panel-page-sub{position:relative;max-width:100%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.panel-page-name{font-size:.82rem;font-weight:700;color:#f4f4f5;line-height:1.3}
+.panel-page-sub{font-size:.7rem;color:var(--hint);min-height:1em}
+.panel-dots{display:flex;gap:5px;position:relative;margin-top:4px;min-height:5px}
+.panel-dots span{width:5px;height:5px;border-radius:50%;background:rgba(255,255,255,.18)}
+.panel-dots span.on{background:var(--accent)}
+.panel-why{font-size:.7rem;color:var(--muted);text-align:center;line-height:1.45;max-width:190px;min-height:3em}
+.panel-why strong{color:var(--accent);font-weight:600}
+/* auto-rotate toggle row (whole row is the label = big hit area) */
+.toggle-row{display:flex;align-items:center;justify-content:space-between;gap:14px;margin-top:18px;padding:12px 14px;cursor:pointer;background:var(--elevated);border:1px solid var(--border);border-radius:var(--radius-sm)}
+.toggle-label{display:block;font-size:.82rem;color:var(--text-2)}
+.toggle-hint{display:block;font-size:.7rem;color:var(--hint);margin-top:1px}
+.toggle{position:relative;display:inline-block;width:48px;height:26px;flex-shrink:0}
+.toggle input{opacity:0;width:0;height:0;position:absolute}
+.toggle-track{position:absolute;inset:0;background:rgba(255,255,255,.08);border:1px solid rgba(255,255,255,.06);border-radius:26px;transition:background-color .3s,border-color .3s}
+.toggle-track::before{content:'';position:absolute;height:20px;width:20px;left:3px;bottom:2px;background:#71717a;border-radius:50%;transition:transform .3s cubic-bezier(.4,0,.2,1),background-color .3s}
+.toggle input:checked+.toggle-track{background:rgba(var(--a),.3);border-color:rgba(var(--a),.4)}
+.toggle input:checked+.toggle-track::before{transform:translateX(20px);background:var(--accent)}
+.toggle input:focus-visible+.toggle-track{outline:2px solid var(--accent);outline-offset:2px}
+/* rig rows */
+.rig-row{display:flex;align-items:center;gap:12px;padding:12px 14px;border-radius:var(--radius-sm);background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.06);text-decoration:none;color:inherit;transition:border-color .2s}
+.rig-row:hover{border-color:rgba(255,255,255,.18)}
+.rig-row+.rig-row{margin-top:10px}
+.rig-dot{width:9px;height:9px;border-radius:50%;flex-shrink:0;background:rgba(255,255,255,.18)}
+.rig-dot.ok{background:var(--success)}
+.rig-dot.bad{background:var(--danger)}
+.rig-dot.mid{background:var(--warning);animation:pulse 1.2s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.35}}
+.rig-main{min-width:0;flex:1}
+.rig-name{font-size:.82rem;font-weight:600;color:#f4f4f5;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.rig-sub{font-size:.7rem;color:var(--hint);display:flex;align-items:center;gap:6px;min-height:1.1em}
+.rig-sub .ic{width:11px;height:11px;color:var(--success)}
+.status-pill{flex-shrink:0;font-size:.64rem;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 9px;border-radius:8px;white-space:nowrap;min-width:104px;text-align:center}
+.status-pill.ok{background:rgba(74,222,128,.12);color:var(--success);border:1px solid rgba(74,222,128,.28)}
+.status-pill.bad{background:rgba(248,113,113,.1);color:var(--danger);border:1px solid rgba(248,113,113,.26)}
+.status-pill.mid{background:rgba(251,191,36,.12);color:var(--warning);border:1px solid rgba(251,191,36,.28)}
+/* reserved 3ch keeps the pill width constant across all ellipsis frames */
+.status-pill .ell{display:inline-block;width:3ch;text-align:left}
+.status-pill.mid .ell::after{content:'';animation:ell 1.5s steps(4) infinite}
+@keyframes ell{0%{content:''}25%{content:'.'}50%{content:'..'}75%{content:'...'}}
+.rig-empty{font-size:.75rem;color:var(--hint)}
+/* integrations */
+.integrations{display:flex;flex-wrap:wrap;gap:8px}
+.int-chip{display:inline-flex;align-items:center;gap:8px;font-size:.75rem;font-weight:600;color:var(--text-2);padding:7px 13px;border-radius:10px;background:rgba(255,255,255,.02);border:1px solid rgba(255,255,255,.07);text-decoration:none;transition:border-color .2s}
+.int-chip:hover{border-color:rgba(255,255,255,.18)}
+.int-chip .ic{width:14px;height:14px;opacity:.75}
+.int-chip .int-dot{width:7px;height:7px;border-radius:50%;background:rgba(255,255,255,.18)}
+.int-chip.on .int-dot{background:var(--success)}
+.int-chip.off{color:var(--muted)}
+/* page deck: uniform tile grid */
+.deck{display:grid;grid-template-columns:repeat(auto-fill,minmax(110px,1fr));gap:8px;min-height:76px}
+.deck-chip{display:flex;flex-direction:column;align-items:center;justify-content:flex-start;gap:4px;min-height:76px;padding:10px 8px;border-radius:var(--radius-sm);text-align:center;border:1px solid rgba(255,255,255,.08);background:rgba(0,0,0,.3);color:var(--muted);cursor:pointer;user-select:none;font-family:inherit;transition:border-color .2s,color .2s}
+.deck-chip .ic{width:18px;height:18px}
+.deck-chip .pt-name{font-size:.76rem;font-weight:600;line-height:1.2}
+.deck-chip .pt-sub{font-size:.62rem;color:var(--hint);min-height:1em}
+.deck-chip:hover:not(.disabled){border-color:rgba(255,255,255,.18);color:var(--text-2)}
+.deck-chip.current{background:rgba(var(--a),.13);border-color:rgba(var(--a),.45)}
+.deck-chip.current .pt-name{color:var(--accent)}
+.deck-chip.disabled{opacity:.35;cursor:default}
+.deck-hint{font-size:.75rem;color:var(--hint);margin-top:12px;line-height:1.5}
+/* responsive */
+@media (max-width:900px){.main-grid{grid-template-columns:1fr}.content{padding:16px 16px 48px}.card{padding:20px}}
+@media (max-width:640px){.hero-body{grid-template-columns:1fr;gap:20px}.connector{display:none}.rung.active::after{display:none}.panel-col{align-self:stretch}.rung-desc{font-size:.7rem}.brand-meta{display:none}}
+@media (prefers-reduced-motion:reduce){*,*::before,*::after{animation:none!important;transition:none!important}}
+</style>
+</head>
+<body>
+
+<!-- SVG sprite: single copy of every icon path -->
+<svg aria-hidden="true" style="position:absolute;width:0;height:0;overflow:hidden">
+<defs>
+<symbol id="i-star" viewBox="0 0 24 24"><circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M4.9 4.9l2.1 2.1M17 17l2.1 2.1M4.9 19.1L7 17M17 7l2.1-2.1"/></symbol>
+<symbol id="i-gear" viewBox="0 0 24 24"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></symbol>
+<symbol id="i-clock" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></symbol>
+<symbol id="i-chip" viewBox="0 0 24 24"><rect x="4" y="4" width="16" height="16" rx="2"/><path d="M9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2"/></symbol>
+<symbol id="i-bars" viewBox="0 0 24 24"><path d="M6 19v-3M10 19v-6M14 19v-9M18 19V5"/></symbol>
+<symbol id="i-therm" viewBox="0 0 24 24"><path d="M14 14.76V3.5a2.5 2.5 0 0 0-5 0v11.26a4.5 4.5 0 1 0 5 0z"/></symbol>
+<symbol id="i-wifi" viewBox="0 0 24 24"><path d="M5 12.55a11 11 0 0 1 14.08 0M1.42 9a16 16 0 0 1 21.16 0M8.53 16.11a6 6 0 0 1 6.95 0M12 20h.01"/></symbol>
+<symbol id="i-check" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></symbol>
+<symbol id="i-signal" viewBox="0 0 24 24"><path d="M4 11a9 9 0 0 1 9 9M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></symbol>
+<symbol id="i-sun" viewBox="0 0 24 24"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></symbol>
+<symbol id="i-cloud" viewBox="0 0 24 24"><path d="M17.5 19H9a7 7 0 1 1 6.71-9h1.79a4.5 4.5 0 1 1 0 9z"/></symbol>
+<symbol id="i-spotify" viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M8 14.5c2.5-1 5.5-1 8 .5M7.5 11c3-1.2 6.5-1.2 9.5.5M7 7.8c3.5-1.4 7.5-1.4 11 .5"/></symbol>
+<symbol id="i-grid" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></symbol>
+<symbol id="i-image" viewBox="0 0 24 24"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><path d="M21 15l-5-5L5 21"/></symbol>
+<symbol id="i-code" viewBox="0 0 24 24"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></symbol>
+<symbol id="i-home" viewBox="0 0 24 24"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></symbol>
+<symbol id="i-music" viewBox="0 0 24 24"><path d="M9 18V5l12-2v13"/><circle cx="6" cy="18" r="3"/><circle cx="18" cy="16" r="3"/></symbol>
+<symbol id="i-chev" viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></symbol>
+</defs>
+</svg>
+
+<nav class="top-nav">
+ <div class="brand">
+  <div class="brand-logo"><svg class="ic"><use href="#i-star"/></svg></div>
+  <div>
+   <div class="brand-name" id="brandName">NINA Display</div>
+   <div class="brand-meta" id="brandIp"></div>
+  </div>
+ </div>
+ <div class="nav-right">
+  <span class="nav-group">
+   <span class="fw-ver" id="fwVer">--</span>
+   <a class="update-badge hide" id="updateBadge" href="/config#system">Update available</a>
+  </span>
+  <a class="btn btn-primary" href="/config"><svg class="ic"><use href="#i-gear"/></svg>Settings</a>
+ </div>
+</nav>
+
+<div class="content">
+ <div class="sys-metrics">
+  <div class="sys-metric">
+   <div class="sm-label"><svg class="ic"><use href="#i-clock"/></svg>Uptime</div>
+   <div class="sm-value" id="metricUptime">--</div>
+   <div class="sm-sub">Since last restart</div>
+  </div>
+  <div class="sys-metric">
+   <div class="sm-label"><svg class="ic"><use href="#i-chip"/></svg>Memory</div>
+   <div class="sm-value"><span id="memFree">--</span><span class="sm-sub">free of <span id="memTotal">--</span></span></div>
+   <div class="sm-bar"><div class="sm-bar-fill" id="memBar" style="width:0%"></div></div>
+   <div class="sm-sub" id="memPct"></div>
+  </div>
+  <div class="sys-metric">
+   <div class="sm-label"><svg class="ic"><use href="#i-bars"/></svg>PSRAM</div>
+   <div class="sm-value"><span id="psFree">--</span><span class="sm-sub">free of <span id="psTotal">--</span></span></div>
+   <div class="sm-bar"><div class="sm-bar-fill" id="psBar" style="width:0%"></div></div>
+   <div class="sm-sub" id="psPct"></div>
+  </div>
+  <div class="sys-metric">
+   <div class="sm-label"><svg class="ic"><use href="#i-therm"/></svg>SoC Temp</div>
+   <div class="sm-value" id="metricTemp">--</div>
+   <div class="sm-sub" id="tempSub"></div>
+  </div>
+  <div class="sys-metric">
+   <div class="sm-label"><svg class="ic"><use href="#i-wifi"/></svg>WiFi</div>
+   <div class="sm-value">
+    <span id="metricRssi">--</span><span class="sm-sub">dBm</span>
+    <span class="bars" id="rssiBars"><span style="height:8px"></span><span style="height:13px"></span><span style="height:18px"></span><span style="height:22px"></span></span>
+   </div>
+   <div class="sm-sub" id="wifiSsid"></div>
+  </div>
+ </div>
+
+ <div class="main-grid">
+  <div class="card hero-card">
+   <div class="card-title">
+    <span>Why the panel shows this page</span>
+    <span class="mode-chip" id="modeChip">Pinned mode</span>
+   </div>
+
+   <div class="hero-body" id="heroBody">
+    <div class="connector" id="connector"></div>
+
+    <div class="ladder" id="ladder">
+     <div class="rung inactive" data-level="menu">
+      <div class="rung-num">1</div>
+      <div class="rung-main">
+       <div class="rung-name">Menu open</div>
+       <div class="rung-desc">A settings or detail screen is open on the panel. The page holds until it closes.</div>
+      </div>
+      <span class="rung-state" id="menuState">Waiting</span>
+     </div>
+     <div class="rung inactive" data-level="override">
+      <div class="rung-num">2</div>
+      <div class="rung-main">
+       <div class="rung-name">Manual override</div>
+       <div class="rung-desc" id="overrideDesc">After you swipe, tap, or pick a page here, it stays on screen for 10 seconds.</div>
+       <div class="rung-extra" id="overrideExtra">
+        <div class="countdown-wrap">
+         <div class="countdown-bar"><div class="countdown-fill" id="countdownFill"></div></div>
+         <span class="countdown-num" id="countdownNum">10s</span>
+        </div>
+       </div>
+      </div>
+      <span class="rung-state" id="overrideState">Waiting</span>
+     </div>
+     <div class="rung inactive" data-level="slideshow">
+      <div class="rung-num">3</div>
+      <div class="rung-main">
+       <div class="rung-name">Slideshow</div>
+       <div class="rung-desc" id="slideshowDesc">Auto-rotate is off. Turn it on below to cycle through selected pages.</div>
+       <div class="rung-extra" id="slideshowExtra">
+        <div class="rotation-order" id="rotationOrder"></div>
+       </div>
+      </div>
+      <span class="rung-state" id="slideshowState">Off</span>
+     </div>
+     <div class="rung inactive" data-level="session">
+      <div class="rung-num">4</div>
+      <div class="rung-main">
+       <div class="rung-name">Session</div>
+       <div class="rung-desc" id="sessionDesc">When a NINA computer is connected, the panel follows its page.</div>
+      </div>
+      <span class="rung-state" id="sessionState">Waiting</span>
+     </div>
+     <div class="rung inactive" data-level="idle">
+      <div class="rung-num">5</div>
+      <div class="rung-main">
+       <div class="rung-name">Idle page</div>
+       <div class="rung-desc" id="idleDesc">When every NINA computer is offline, show your chosen idle page instead.</div>
+      </div>
+      <span class="rung-state" id="idleState">Waiting</span>
+     </div>
+     <div class="rung inactive" data-level="home">
+      <div class="rung-num">6</div>
+      <div class="rung-main">
+       <div class="rung-name" id="homeRungName">Home page: Summary</div>
+       <div class="rung-desc">If nothing above applies, the panel falls back to your home page.</div>
+      </div>
+      <span class="rung-state" id="homeState">Fallback</span>
+     </div>
+    </div>
+
+    <div class="panel-col" id="panelCol">
+     <div class="panel-label">Panel is showing</div>
+     <div class="panel-frame" id="panelFrame">
+      <div class="panel-icon"><svg class="ic"><use id="panelUse" href="#i-grid"/></svg></div>
+      <div class="panel-page-name" id="panelPageName">Summary</div>
+      <div class="panel-page-sub" id="panelPageSub"></div>
+      <div class="panel-dots" id="panelDots"></div>
+     </div>
+     <div class="panel-why"><strong id="whyLevel">Home page</strong><span id="whyRest"> decides what the panel shows.</span></div>
+    </div>
+   </div>
+
+   <label class="toggle-row">
+    <span>
+     <span class="toggle-label">Auto-rotate</span>
+     <span class="toggle-hint" id="toggleHint">Off. The panel stays pinned to the active session.</span>
+    </span>
+    <span class="toggle">
+     <input type="checkbox" id="autoRotateToggle" aria-label="Auto-rotate">
+     <span class="toggle-track"></span>
+    </span>
+   </label>
+  </div>
+
+  <div class="side-col">
+   <div class="card">
+    <div class="card-title"><span>NINA Connections</span></div>
+    <div id="rigList"><div class="rig-empty" id="rigEmpty">Waiting for device data.</div></div>
+   </div>
+
+   <div class="card">
+    <div class="card-title"><span>Integrations</span></div>
+    <div class="integrations">
+     <a class="int-chip off" id="intMqtt" href="/config#system"><svg class="ic"><use href="#i-signal"/></svg>MQTT <span class="int-dot"></span></a>
+     <a class="int-chip off" id="intAllsky" href="/config#allsky"><svg class="ic"><use href="#i-sun"/></svg>AllSky <span class="int-dot"></span></a>
+     <a class="int-chip off" id="intWeather" href="/config#clock"><svg class="ic"><use href="#i-cloud"/></svg>Weather <span class="int-dot"></span></a>
+     <a class="int-chip off" id="intSpotify" href="/config#spotify"><svg class="ic"><use href="#i-spotify"/></svg>Spotify <span class="int-dot"></span></a>
+    </div>
+   </div>
+
+   <div class="card">
+    <div class="card-title"><span>Panel Pages</span></div>
+    <div class="deck" id="deck"></div>
+    <div class="deck-hint" id="deckHint">Tap a page to send the panel there. It holds for 10 seconds, then normal rules take over again.</div>
+   </div>
+  </div>
+ </div>
+</div>
+
+<div class="conn-pill" id="connPill">Device unreachable, retrying</div>
+
+<script>
+'use strict';
+
+var $ = function (id) { return document.getElementById(id); };
+
+/* ---- slug -> icon / subtitle mapping (presentation only; data comes from the API) ---- */
+var ICONS = { summary: 'i-grid', sysinfo: 'i-chip', allsky: 'i-sun', spotify: 'i-music',
+              clock: 'i-clock', json: 'i-code', ha: 'i-home' };
+var SUBS  = { summary: 'All computers', sysinfo: 'Device status', allsky: 'Sky conditions',
+              spotify: 'Music player', clock: 'Time and weather', json: 'Custom tiles',
+              ha: 'Entity tiles', 'image.goes': 'Satellite view', 'image.moon': 'Moon phase',
+              'image.solar': 'Solar view', 'image.custom': 'Your image' };
+function iconFor(slug) {
+ if (slug.indexOf('nina.') === 0) return 'i-star';
+ if (slug.indexOf('image') === 0) return 'i-image';
+ return ICONS[slug] || 'i-grid';
+}
+
+/* ---- state (filled from the device APIs) ---- */
+var state = {
+ level: 'home', mode: 'pinned', autoRotate: false,
+ currentSlug: 'summary', homeSlug: 'summary',
+ idleEnabled: false, idleSlug: '',
+ graceS: 10, rotation: [], overrideRemaining: 0,
+ sessionRig: '', sessionCount: 0,
+ ninaSubs: {}
+};
+var pagesBySlug = {};
+
+/* ---- DOM refs ---- */
+var rungs = {};
+document.querySelectorAll('.rung').forEach(function (el) { rungs[el.dataset.level] = el; });
+var heroBody = $('heroBody'), ladderEl = $('ladder'), connector = $('connector');
+var panelCol = $('panelCol'), panelFrame = $('panelFrame'), panelUse = $('panelUse');
+var panelPageName = $('panelPageName'), panelPageSub = $('panelPageSub'), panelDots = $('panelDots');
+var whyLevel = $('whyLevel'), whyRest = $('whyRest');
+var deck = $('deck'), modeChip = $('modeChip'), toggleHint = $('toggleHint');
+var rotationOrder = $('rotationOrder'), countdownFill = $('countdownFill'), countdownNum = $('countdownNum');
+var overrideState = $('overrideState'), overrideExtra = $('overrideExtra'), overrideDesc = $('overrideDesc');
+var slideshowState = $('slideshowState'), slideshowDesc = $('slideshowDesc'), slideshowExtra = $('slideshowExtra');
+var sessionState = $('sessionState'), sessionDesc = $('sessionDesc');
+var menuState = $('menuState'), idleState = $('idleState'), idleDesc = $('idleDesc');
+var homeRungName = $('homeRungName'), homeState = $('homeState');
+var autoRotateToggle = $('autoRotateToggle'), connPill = $('connPill'), deckHint = $('deckHint');
+var rigList = $('rigList'), rigEmpty = $('rigEmpty');
+var metricUptime = $('metricUptime'), metricTemp = $('metricTemp'), tempSub = $('tempSub');
+var metricRssi = $('metricRssi'), wifiSsid = $('wifiSsid');
+var rssiBars = Array.prototype.slice.call($('rssiBars').children);
+var memFree = $('memFree'), memTotal = $('memTotal'), memBar = $('memBar'), memPct = $('memPct');
+var psFree = $('psFree'), psTotal = $('psTotal'), psBar = $('psBar'), psPct = $('psPct');
+var intChips = { mqtt: $('intMqtt'), allsky: $('intAllsky'), weather: $('intWeather'), spotify: $('intSpotify') };
+
+var SVG_NS = 'http://www.w3.org/2000/svg';
+function makeIcon(symbolId, cls) {
+ var svg = document.createElementNS(SVG_NS, 'svg');
+ svg.setAttribute('class', cls || 'ic');
+ var use = document.createElementNS(SVG_NS, 'use');
+ use.setAttribute('href', '#' + symbolId);
+ svg.appendChild(use);
+ return svg;
+}
+
+function getJSON(url, opts) {
+ return fetch(url, opts).then(function (r) {
+  if (!r.ok) throw new Error('HTTP ' + r.status);
+  return r.json();
+ });
+}
+
+function hostOf(url) {
+ if (!url) return '';
+ return url.replace(/^https?:\/\//, '').split(/[:/]/)[0];
+}
+
+function pageLabel(slug) {
+ var p = pagesBySlug[slug];
+ return p ? p.label : (slug || 'page');
+}
+function pageSub(slug) {
+ if (state.ninaSubs[slug]) return state.ninaSubs[slug];
+ return SUBS[slug] || '';
+}
+
+function p2(n) { return (n < 10 ? '0' : '') + n; }
+/* zero-padded h/m/s: string length is constant, so tabular digits never shift layout */
+function fmtUptime(t) {
+ return Math.floor(t / 86400) + 'd ' + p2(Math.floor(t % 86400 / 3600)) + 'h ' +
+  p2(Math.floor(t % 3600 / 60)) + 'm ' + p2(t % 60) + 's';
+}
+function fmtK(b) { return Math.round(b / 1024) + 'K'; }
+function fmtM(b) { return (b / 1048576).toFixed(1) + 'M'; }
+function fmtAgo(ms) {
+ var m = Math.floor(ms / 60000);
+ if (m < 1) return 'moments ago';
+ var h = Math.floor(m / 60), d = Math.floor(h / 24);
+ if (d > 0) return d + 'd ' + (h % 24) + 'h ago';
+ if (h > 0) return h + 'h ' + (m % 60) + 'm ago';
+ return m + 'm ago';
+}
+
+/* ---- page deck: built once from /api/pages ---- */
+var deckChips = {};
+function buildDeck(pages) {
+ pages.forEach(function (p) { pagesBySlug[p.slug] = p; });
+ pages.filter(function (p) {
+  return p.targetable && (p.kind === 'page' || p.kind === 'image_source');
+ }).forEach(function (p) {
+  var b = document.createElement('button');
+  b.type = 'button';
+  b.className = 'deck-chip' + (p.available ? '' : ' disabled');
+  b.dataset.page = p.slug;
+  b.appendChild(makeIcon(iconFor(p.slug), 'ic'));
+  var nm = document.createElement('span');
+  nm.className = 'pt-name';
+  nm.textContent = p.label;
+  b.appendChild(nm);
+  var sub = document.createElement('span');
+  sub.className = 'pt-sub';
+  sub.textContent = pageSub(p.slug);
+  b.appendChild(sub);
+  if (p.available) {
+   b.addEventListener('click', function () { gotoPage(p.slug); });
+  } else {
+   b.disabled = true;
+   b.title = 'Enable in Settings';
+  }
+  deck.appendChild(b);
+  deckChips[p.slug] = { btn: b, sub: sub };
+ });
+ /* panel dots: one per available NINA page */
+ pages.filter(function (p) { return p.slug.indexOf('nina.') === 0 && p.available; })
+  .forEach(function (p) {
+   var s = document.createElement('span');
+   s.dataset.p = p.slug;
+   panelDots.appendChild(s);
+  });
+}
+
+/* ---- rotation order list: rebuilt only when the slug list changes ---- */
+var lastRot = null, rotSteps = [];
+function renderRotation() {
+ var key = state.rotation.join(',');
+ if (key !== lastRot) {
+  lastRot = key;
+  rotationOrder.textContent = '';
+  rotSteps = [];
+  state.rotation.forEach(function (slug, i) {
+   var pair = document.createElement('span');
+   pair.className = 'rot-pair';
+   if (i > 0) pair.appendChild(makeIcon('i-chev', 'ic rot-arrow'));
+   var s = document.createElement('span');
+   s.className = 'rot-step';
+   s.dataset.rot = slug;
+   s.textContent = pageLabel(slug);
+   pair.appendChild(s);
+   rotationOrder.appendChild(pair);
+   rotSteps.push(s);
+  });
+ }
+ rotSteps.forEach(function (s) {
+  s.classList.toggle('now', state.autoRotate && s.dataset.rot === state.currentSlug);
+ });
+}
+
+/* ---- NINA connection rows: rebuilt only on topology change ---- */
+var rigRefs = [], lastRigSig = null;
+function renderRigs(instances, uptimeMs) {
+ var list = instances.filter(function (i) { return i.enabled; });
+ rigEmpty.style.display = list.length ? 'none' : '';
+ if (!list.length) { rigEmpty.textContent = 'No NINA computers enabled.'; }
+ var sig = list.map(function (i) { return i.index + ':' + hostOf(i.url); }).join('|');
+ if (sig !== lastRigSig) {
+  lastRigSig = sig;
+  rigRefs.forEach(function (r) { r.row.remove(); });
+  rigRefs = [];
+  list.forEach(function (inst) {
+   var row = document.createElement('a');
+   row.className = 'rig-row';
+   row.href = '/config#nodes';
+   var dot = document.createElement('span');
+   dot.className = 'rig-dot';
+   row.appendChild(dot);
+   var main = document.createElement('div');
+   main.className = 'rig-main';
+   var name = document.createElement('div');
+   name.className = 'rig-name';
+   name.textContent = hostOf(inst.url) || ('NINA ' + (inst.index + 1));
+   main.appendChild(name);
+   var sub = document.createElement('div');
+   sub.className = 'rig-sub';
+   var subIcon = makeIcon('i-check', 'ic ic3');
+   subIcon.style.display = 'none';
+   sub.appendChild(subIcon);
+   var subText = document.createElement('span');
+   sub.appendChild(subText);
+   main.appendChild(sub);
+   row.appendChild(main);
+   var pill = document.createElement('span');
+   pill.className = 'status-pill';
+   row.appendChild(pill);
+   rigList.appendChild(row);
+   rigRefs.push({ row: row, dot: dot, subIcon: subIcon, subText: subText, pill: pill, lastState: '' });
+  });
+ }
+ list.forEach(function (inst, n) {
+  var r = rigRefs[n];
+  if (!r) return;
+  var st = inst.connection_state;
+  if (st === 'unknown') st = 'connecting';
+  if (st !== r.lastState) {
+   r.lastState = st;
+   if (st === 'connected') {
+    r.dot.className = 'rig-dot ok';
+    r.pill.className = 'status-pill ok';
+    r.pill.textContent = 'Connected';
+   } else if (st === 'connecting') {
+    r.dot.className = 'rig-dot mid';
+    r.pill.className = 'status-pill mid';
+    r.pill.textContent = 'Connecting';
+    var ell = document.createElement('span');
+    ell.className = 'ell';
+    r.pill.appendChild(ell);
+   } else {
+    r.dot.className = 'rig-dot bad';
+    r.pill.className = 'status-pill bad';
+    r.pill.textContent = 'Disconnected';
+   }
+  }
+  var subMsg = '', showIcon = false;
+  if (st === 'connected') {
+   if (inst.websocket_connected) { subMsg = 'Live updates active'; showIcon = true; }
+   else subMsg = 'Polling for updates';
+  } else if (st === 'connecting') {
+   subMsg = 'Checking now';
+  } else if (inst.last_successful_poll_ms > 0 && uptimeMs > inst.last_successful_poll_ms) {
+   subMsg = 'Last seen ' + fmtAgo(uptimeMs - inst.last_successful_poll_ms);
+  }
+  r.subIcon.style.display = showIcon ? '' : 'none';
+  r.subText.textContent = subMsg;
+ });
+}
+
+/* ---- panel-why copy per level (end-user language) ---- */
+var WHY_LABEL = { menu: 'Menu open', override: 'Manual override', slideshow: 'Slideshow',
+                  session: 'Session', idle: 'Idle page', home: 'Home page' };
+var WHY = {
+ menu:      function ()  { return ' decides: a menu is open on the panel.'; },
+ override:  function (n) { return ' decides: you picked ' + n + '. Normal rules resume shortly.'; },
+ slideshow: function (n) { return ' decides: auto-rotate is showing ' + n + '.'; },
+ session:   function ()  {
+  if (state.sessionCount > 1) return ' decides: several computers are connected.';
+  return ' decides: ' + (state.sessionRig || 'a NINA computer') + ' is connected.';
+ },
+ idle:      function ()  { return ' decides: every NINA computer is offline.'; },
+ home:      function ()  { return ' decides: nothing else applies, so the panel shows your home page.'; }
+};
+
+/* ---- per-tick countdown: two targeted writes, no layout reads ---- */
+function tickCountdown() {
+ countdownNum.textContent = state.overrideRemaining + 's';
+ countdownFill.style.transform = 'scaleX(' + (state.graceS ? state.overrideRemaining / state.graceS : 0) + ')';
+}
+
+/* ---- full render: idempotent, textContent/class writes only ---- */
+var lastLevel = '';
+function render() {
+ var lvl = rungs[state.level] ? state.level : 'home';
+ var slug = state.currentSlug;
+
+ Object.keys(rungs).forEach(function (l) {
+  var el = rungs[l];
+  el.classList.remove('active', 'inactive', 'dimmed');
+  el.classList.add(l === lvl ? 'active' : 'inactive');
+ });
+ if (state.autoRotate) {
+  rungs.session.classList.add('dimmed');
+  rungs.idle.classList.add('dimmed');
+  rungs.home.classList.add('dimmed');
+ } else {
+  rungs.slideshow.classList.add('dimmed');
+ }
+ rungs[lvl].classList.remove('dimmed');
+
+ menuState.textContent = lvl === 'menu' ? 'Active' : 'Waiting';
+
+ /* fixed-width state labels: the countdown number never rides in the pill */
+ overrideState.textContent = lvl === 'override' ? 'Active' : 'Waiting';
+ overrideExtra.classList.toggle('has-content', lvl === 'override');
+ overrideDesc.textContent = 'After you swipe, tap, or pick a page here, it stays on screen for ' +
+  state.graceS + ' seconds.';
+ if (lvl === 'override') tickCountdown();
+
+ slideshowState.textContent = state.autoRotate ? (lvl === 'slideshow' ? 'Active' : 'Paused') : 'Off';
+ slideshowDesc.textContent = state.autoRotate
+  ? 'Auto-rotate cycles through your selected pages.'
+  : 'Auto-rotate is off. Turn it on below to cycle through selected pages.';
+ slideshowExtra.classList.toggle('has-content', state.autoRotate && state.rotation.length > 0);
+ renderRotation();
+
+ sessionState.textContent = lvl === 'session' ? 'Active' : (state.autoRotate ? 'Bypassed' : 'Waiting');
+ if (state.sessionCount > 1) {
+  sessionDesc.textContent = 'Several computers are connected, so the panel shows the summary.';
+ } else if (state.sessionRig) {
+  sessionDesc.textContent = state.sessionRig + ' is connected, so the panel follows its page.';
+ } else {
+  sessionDesc.textContent = 'When a NINA computer is connected, the panel follows its page.';
+ }
+
+ idleState.textContent = !state.idleEnabled ? 'Off' : (lvl === 'idle' ? 'Active' : 'Waiting');
+ idleDesc.textContent = state.idleEnabled && state.idleSlug
+  ? 'When every NINA computer is offline, show ' + pageLabel(state.idleSlug) + ' instead.'
+  : 'When every NINA computer is offline, show your chosen idle page instead.';
+
+ homeRungName.textContent = 'Home page: ' + pageLabel(state.homeSlug);
+ homeState.textContent = lvl === 'home' ? 'Active' : 'Fallback';
+
+ modeChip.textContent = state.mode === 'slideshow' ? 'Slideshow mode' : 'Pinned mode';
+ toggleHint.textContent = state.autoRotate
+  ? 'On. The panel cycles through the slideshow pages.'
+  : 'Off. The panel stays pinned to the active session.';
+ if (autoRotateToggle.checked !== state.autoRotate) autoRotateToggle.checked = state.autoRotate;
+
+ deckHint.textContent = 'Tap a page to send the panel there. It holds for ' + state.graceS +
+  ' seconds, then normal rules take over again.';
+
+ /* panel preview: swap sprite reference + text on stable nodes (no innerHTML) */
+ panelUse.setAttribute('href', '#' + iconFor(slug));
+ panelPageName.textContent = pageLabel(slug);
+ panelPageSub.textContent = pageSub(slug);
+ whyLevel.textContent = WHY_LABEL[lvl];
+ whyRest.textContent = WHY[lvl](pageLabel(slug));
+ Array.prototype.forEach.call(panelDots.children, function (s) {
+  s.classList.toggle('on', s.dataset.p === slug);
+ });
+ Object.keys(deckChips).forEach(function (k) {
+  deckChips[k].btn.classList.toggle('current', k === slug);
+ });
+
+ if (lvl !== lastLevel) { lastLevel = lvl; layout(); }
+}
+
+/* ---- connector + preview alignment ----
+ * Runs only on level change, resize, breakpoint change, or font load; never per tick. */
+var mq640 = window.matchMedia('(max-width: 640px)');
+function layout() {
+ var active = ladderEl.querySelector('.rung.active');
+ if (!active || mq640.matches) {
+  connector.style.display = 'none';
+  panelCol.style.transform = '';
+  return;
+ }
+ var rungCenter = ladderEl.offsetTop + active.offsetTop + active.offsetHeight / 2;
+ var rungRight = ladderEl.offsetLeft + active.offsetLeft + active.offsetWidth;
+ var frameCenter = panelCol.offsetTop + panelFrame.offsetTop + panelFrame.offsetHeight / 2;
+ var delta = rungCenter - frameCenter;
+ var maxDown = heroBody.clientHeight - (panelCol.offsetTop + panelCol.offsetHeight);
+ var maxUp = -panelCol.offsetTop;
+ if (delta > maxDown) delta = maxDown;
+ if (delta < maxUp) delta = maxUp;
+ panelCol.style.transform = 'translateY(' + delta + 'px)';
+ var width = panelCol.offsetLeft + panelFrame.offsetLeft - rungRight;
+ if (width < 8) { connector.style.display = 'none'; return; }
+ connector.style.display = 'block';
+ connector.style.left = rungRight + 'px';
+ connector.style.width = width + 'px';
+ connector.style.transform = 'translateY(' + (rungCenter - 1) + 'px)';
+}
+mq640.addEventListener('change', layout);
+if (window.ResizeObserver) {
+ var ro = new ResizeObserver(layout);
+ ro.observe(heroBody);
+ ro.observe(ladderEl);
+} else {
+ var rafPending = false;
+ window.addEventListener('resize', function () {
+  if (rafPending) return;
+  rafPending = true;
+  requestAnimationFrame(function () { rafPending = false; layout(); });
+ });
+}
+if (document.fonts && document.fonts.ready) document.fonts.ready.then(layout);
+
+/* ---- metrics ---- */
+var uptimeBase = null, uptimeT0 = 0;
+function updUptime() {
+ if (uptimeBase === null) return;
+ metricUptime.textContent = fmtUptime(Math.floor((uptimeBase + (Date.now() - uptimeT0)) / 1000));
+}
+
+function applyStatus(st, ns) {
+ var nav = st.nav || {};
+ state.autoRotate = !!nav.auto_rotate;
+ state.mode = nav.mode || (state.autoRotate ? 'slideshow' : 'pinned');
+ state.level = nav.level || 'home';
+ state.currentSlug = nav.current_page_slug || state.currentSlug;
+ state.homeSlug = nav.home_page_slug || 'summary';
+ state.idleEnabled = !!nav.idle_enabled;
+ state.idleSlug = nav.idle_page_slug || '';
+ state.graceS = nav.grace_s > 0 ? nav.grace_s : 10;
+ state.rotation = nav.rotation || [];
+ state.overrideRemaining = state.level === 'override'
+  ? (nav.override_remaining_s != null ? nav.override_remaining_s : state.graceS) : 0;
+
+ uptimeBase = st.uptime_ms || 0;
+ uptimeT0 = Date.now();
+ updUptime();
+
+ if (st.heap_total > 0) {
+  memFree.textContent = fmtK(st.heap_internal_free);
+  memTotal.textContent = fmtK(st.heap_total);
+  var mu = Math.round((1 - st.heap_internal_free / st.heap_total) * 100);
+  memBar.style.width = mu + '%';
+  memBar.classList.toggle('warn', mu > 80);
+  memPct.textContent = mu + '% used';
+ }
+ if (st.psram_total > 0) {
+  psFree.textContent = fmtM(st.psram_free);
+  psTotal.textContent = fmtM(st.psram_total);
+  var pu = Math.round((1 - st.psram_free / st.psram_total) * 100);
+  psBar.style.width = pu + '%';
+  psBar.classList.toggle('warn', pu > 80);
+  psPct.textContent = pu + '% used';
+ }
+ if (st.temperature_c != null) {
+  metricTemp.textContent = st.temperature_c.toFixed(1) + '°C';
+  tempSub.textContent = st.temperature_c > 75 ? 'Running hot' : 'Normal range';
+ } else {
+  metricTemp.textContent = '--';
+  tempSub.textContent = 'Not available';
+ }
+ if (st.wifi_rssi != null) {
+  metricRssi.textContent = st.wifi_rssi;
+  var lit = st.wifi_rssi >= -55 ? 4 : st.wifi_rssi >= -65 ? 3 : st.wifi_rssi >= -75 ? 2 : st.wifi_rssi >= -85 ? 1 : 0;
+  rssiBars.forEach(function (b, i) { b.classList.toggle('on', i < lit); });
+  wifiSsid.textContent = st.wifi_ssid || '';
+ } else {
+  metricRssi.textContent = '--';
+  rssiBars.forEach(function (b) { b.classList.remove('on'); });
+  wifiSsid.textContent = 'Offline';
+ }
+
+ $('updateBadge').classList.toggle('hide', !st.update_available);
+
+ var ints = st.integrations || {};
+ Object.keys(intChips).forEach(function (k) {
+  intChips[k].classList.toggle('on', !!ints[k]);
+  intChips[k].classList.toggle('off', !ints[k]);
+ });
+
+ /* NINA instances: session rung copy, tile subtitles, connection rows */
+ var instances = (ns && ns.instances) || [];
+ var connected = [];
+ instances.forEach(function (inst) {
+  if (!inst.enabled) return;
+  var slug = 'nina.' + (inst.index + 1);
+  var host = hostOf(inst.url);
+  state.ninaSubs[slug] = host;
+  if (deckChips[slug]) deckChips[slug].sub.textContent = host;
+  if (inst.connection_state === 'connected') connected.push(host);
+ });
+ state.sessionRig = connected[0] || '';
+ state.sessionCount = connected.length;
+ renderRigs(instances, st.uptime_ms || 0);
+
+ render();
+}
+
+/* ---- poll loop: sequential fetches, 5s cadence, 15s backoff after 3 failures ---- */
+var pollTimer = null, failCount = 0;
+function schedule() {
+ pollTimer = setTimeout(poll, failCount >= 3 ? 15000 : 5000);
+}
+function poll() {
+ pollTimer = null;
+ if (document.hidden) return; /* visibilitychange resumes */
+ getJSON('/api/status').then(function (st) {
+  return getJSON('/api/nina/status').then(function (ns) {
+   applyStatus(st, ns);
+   failCount = 0;
+  });
+ }).catch(function () {
+  failCount++;
+ }).then(function () {
+  connPill.classList.toggle('show', failCount > 0);
+  schedule();
+ });
+}
+document.addEventListener('visibilitychange', function () {
+ if (document.hidden) {
+  if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+ } else if (!pollTimer) {
+  poll();
+ }
+});
+
+/* ---- interactions ---- */
+function gotoPage(slug) {
+ /* optimistic local override; the next poll resyncs with the device */
+ state.level = 'override';
+ state.currentSlug = slug;
+ state.overrideRemaining = state.graceS;
+ render();
+ fetch('/api/navigate?ref=' + encodeURIComponent(slug), { method: 'POST' }).catch(function () {});
+}
+
+autoRotateToggle.addEventListener('change', function (e) {
+ var want = e.target.checked;
+ state.autoRotate = want;
+ state.mode = want ? 'slideshow' : 'pinned';
+ render();
+ fetch('/api/control/toggle?name=auto_rotate_enabled', { method: 'POST' })
+  .then(function (r) {
+   if (!r.ok) throw new Error('HTTP ' + r.status);
+   if (pollTimer) { clearTimeout(pollTimer); pollTimer = null; }
+   poll();
+  })
+  .catch(function () {
+   state.autoRotate = !want;
+   state.mode = state.autoRotate ? 'slideshow' : 'pinned';
+   render();
+  });
+});
+
+/* ---- 1s ticker: uptime + local override countdown only ---- */
+setInterval(function () {
+ if (document.hidden) return;
+ updUptime();
+ if (state.level === 'override' && state.overrideRemaining > 0) {
+  state.overrideRemaining--;
+  tickCountdown();
+ }
+}, 1000);
+
+/* ---- init: sequential loads to be kind to the single-worker httpd ---- */
+$('brandName').textContent = location.hostname || 'NINA Display';
+getJSON('/api/version').then(function (v) {
+ $('fwVer').textContent = v.git_tag || v.version || '--';
+}).catch(function () {}).then(function () {
+ return getJSON('/api/wifi/status').then(function (w) {
+  $('brandIp').textContent = w.ip || '';
+ }).catch(function () {});
+}).then(function () {
+ return getJSON('/api/pages').then(buildDeck).catch(function () {});
+}).then(function () {
+ render();
+ poll();
+});
+</script>
+</body>
+</html>

--- a/main/http_fetch.c
+++ b/main/http_fetch.c
@@ -88,13 +88,52 @@ static esp_http_client_handle_t make_client(const char *url,
     return esp_http_client_init(&cfg);
 }
 
+/** True if @p s contains no CR or LF. NUL cannot appear inside a C string, so
+ * CR/LF are the only characters that can terminate a header line early. */
+static bool header_token_is_clean(const char *s) {
+    for (const char *p = s; *p; p++) {
+        if (*p == '\r' || *p == '\n') return false;
+    }
+    return true;
+}
+
+/**
+ * Set one request header, refusing anything that could inject additional
+ * headers or split the request.
+ *
+ * Every header this module emits routes through here, which matters because the
+ * values are caller-supplied secrets that ultimately come from a user-editable
+ * field: the /api/config/pull password, ha_token, json_auth_header, a Spotify
+ * bearer. A CR or LF inside any of them would end the header line early and let
+ * the remainder be read as further headers (or as a body). Reject the whole
+ * header rather than strip the offending bytes -- a credential containing a
+ * newline is malformed input, not something to silently repair, and stripping
+ * would send a subtly wrong secret instead of failing visibly.
+ *
+ * The value is NEVER logged; it is the secret. The name is logged only once it
+ * is known clean, so a crafted name cannot forge log lines either.
+ */
+static void set_header_checked(esp_http_client_handle_t client,
+                               const char *name, const char *value) {
+    if (!name || !value) return;
+    if (!header_token_is_clean(name)) {
+        ESP_LOGW(TAG, "Dropping request header: name contains CR/LF");
+        return;
+    }
+    if (!header_token_is_clean(value)) {
+        ESP_LOGW(TAG, "Dropping request header '%s': value contains CR/LF", name);
+        return;
+    }
+    esp_http_client_set_header(client, name, value);
+}
+
 /** Apply the optional headers from @p opts to @p client. */
 static void apply_headers(esp_http_client_handle_t client, const http_fetch_opts_t *opts) {
     if (opts->host_header) {
         /* Re-assert on every call: a reused keep-alive handle may have served
          * a different Host on a prior request, and esp_http_client_set_url()
          * does not update an already-set Host header. */
-        esp_http_client_set_header(client, "Host", opts->host_header);
+        set_header_checked(client, "Host", opts->host_header);
     }
     if (opts->bearer_token) {
         /* 1200 bytes: real-world bearer tokens (e.g. Spotify OAuth access
@@ -103,7 +142,7 @@ static void apply_headers(esp_http_client_handle_t client, const http_fetch_opts
         char hdr[1200];
         int n = snprintf(hdr, sizeof(hdr), "Bearer %s", opts->bearer_token);
         if (n > 0 && n < (int)sizeof(hdr)) {
-            esp_http_client_set_header(client, "Authorization", hdr);
+            set_header_checked(client, "Authorization", hdr);
         }
     }
     if (opts->extra_header && opts->extra_header[0] != '\0') {
@@ -123,15 +162,15 @@ static void apply_headers(esp_http_client_handle_t client, const http_fetch_opts
                 while (*value == ' ') {
                     value++;
                 }
-                esp_http_client_set_header(client, name, value);
+                set_header_checked(client, name, value);
             }
         }
     }
     if (opts->user_agent) {
-        esp_http_client_set_header(client, "User-Agent", opts->user_agent);
+        set_header_checked(client, "User-Agent", opts->user_agent);
     }
     if (opts->accept) {
-        esp_http_client_set_header(client, "Accept", opts->accept);
+        set_header_checked(client, "Accept", opts->accept);
     }
 }
 

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -3,6 +3,10 @@ dependencies:
   espressif/esp_hosted: ">=2.12.3,<2.12.4"
   espressif/esp_wifi_remote: "~0.16.3"
   espressif/esp_websocket_client: "~1.6.1"
+  # Explicit pin: 2.9.0 uses on_frame_buf_complete (IDF 6.x API) and breaks
+  # IDF 5.5.2 builds. Guards against a lockless solve picking it via the
+  # BSP's transitive ^2 requirement.
+  espressif/esp_lvgl_port: "~2.8.0"
   lvgl/lvgl:
     version: "~9.5.0"
     public: true

--- a/main/mqtt_ha.c
+++ b/main/mqtt_ha.c
@@ -7,6 +7,7 @@
 #include "esp_netif.h"
 #include "esp_system.h"
 #include "esp_app_desc.h"
+#include "esp_heap_caps.h"   /* PSRAM snapshot for the config apply below */
 #include "esp_timer.h"
 #include "cJSON.h"
 #include "bsp/esp-bsp.h"
@@ -28,8 +29,10 @@ static const char *TAG = "mqtt_ha";
  * mutate live config, or write NVS (all of which can block and stall the MQTT
  * keepalive). The callback only PARSES a command and enqueues the requested
  * change here. mqtt_ha_process_pending(), called from the UI-context
- * data_update_task each cycle, applies the change under the display lock and
- * persists config via the snapshot+save pattern. */
+ * data_update_task each cycle, applies the change under the display lock.
+ * Both brightness commands are deliberately LIVE-ONLY: they go through a PSRAM
+ * config snapshot + app_config_apply_external() (RAM, no NVS, no unsaved-changes
+ * flag), never app_config_save() and never a field-write on the live s_config. */
 typedef enum {
     MQTT_CMD_SCREEN_BRIGHTNESS,  /* value = 0..100 backlight brightness */
     MQTT_CMD_TEXT_BRIGHTNESS,    /* value = 0..100 color (text) brightness */
@@ -386,26 +389,44 @@ void mqtt_ha_process_pending(void)
             break;
         }
         case MQTT_CMD_TEXT_BRIGHTNESS: {
-            /* LIVE-ONLY: never persist. The rendered theme reads color_brightness
-             * from the live app_config (apply_theme_to_page() in nina_dashboard.c),
-             * so the live effect requires the in-memory value to be visible to the
-             * theme code. Replicate the web UI live-preview (color_brightness_post_handler
-             * in web_handlers_display.c): write the single scalar field on the live
-             * config, then re-apply the theme — but skip app_config_save(). A single
-             * aligned int store is the same mechanism the UI uses; no torn-write race. */
-            app_config_t *cfg = app_config_get();
+            /* LIVE-ONLY: never persist. NVS writes run with the CPU cache
+             * disabled, which can starve the esp-hosted SDIO transport, and an HA
+             * automation can publish these very frequently.
+             *
+             * The rendered theme reads color_brightness from the LIVE app_config
+             * (apply_theme_to_page() in nina_dashboard.c), so the in-memory value
+             * must be updated for the change to show. Snapshot + apply, never a
+             * field-write on the live s_config: app_config_apply_external() is
+             * exactly this case -- RAM-only like app_config_apply(), but it leaves
+             * the "unsaved changes" flag alone, because a change commanded over
+             * MQTT is not a pending web edit the user could Save.
+             *
+             * We run on data_update_task (see mqtt_ha.h), not the MQTT event task,
+             * so blocking is fine -- but app_config_t is several KB, so the copy
+             * goes in PSRAM and never on the task stack (same reasoning as
+             * app_config_sync_filters()). */
             int newv = cmd.value;
-            if (newv < 0) {  /* "ON" with no value */
-                newv = (cfg->color_brightness == 0) ? 100 : cfg->color_brightness;
+            app_config_t *snap = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+            if (!snap) {
+                ESP_LOGE(TAG, "Text brightness: config snapshot alloc failed");
+                break;   /* nothing applied; leave state untouched */
             }
-            cfg->color_brightness = newv;  /* live scalar write, NOT saved */
+            app_config_get_snapshot_into(snap);
+            if (newv < 0) {  /* "ON" with no value */
+                newv = (snap->color_brightness == 0) ? 100 : snap->color_brightness;
+            }
+            snap->color_brightness = newv;
+            app_config_apply_external(snap);   /* live only: no NVS, no dirty flag */
+
             /* Re-apply theme so the new color brightness takes effect live. */
             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                nina_dashboard_apply_theme(cfg->theme_index);
+                nina_dashboard_apply_theme(snap->theme_index);
                 bsp_display_unlock();
             } else {
                 ESP_LOGW(TAG, "Display lock timeout (MQTT theme apply)");
             }
+            heap_caps_free(snap);
+
             ESP_LOGI(TAG, "Text brightness set to %d%% via MQTT (live, not saved)", newv);
             brightness_applied = true;
             break;

--- a/main/mqtt_ha.h
+++ b/main/mqtt_ha.h
@@ -34,8 +34,9 @@ bool mqtt_ha_is_connected(void);
  *
  * Must be called from a UI-context task that may take the display lock
  * (e.g. data_update_task). The MQTT event callback only parses and enqueues;
- * the actual apply and config persist happen here so the esp-mqtt event loop
- * is never blocked. Safe to call when MQTT is disabled (no-op).
+ * the actual apply happens here so the esp-mqtt event loop is never blocked.
+ * Brightness commands apply live only -- nothing is written to NVS. Safe to
+ * call when MQTT is disabled (no-op).
  */
 void mqtt_ha_process_pending(void);
 

--- a/main/ui/nina_nav_arbiter.c
+++ b/main/ui/nina_nav_arbiter.c
@@ -431,7 +431,7 @@ void nav_arbiter_resolve(int64_t now_ms) {
         int8_t hs = -1;
         desired = home_page_with_src(&hs);
         s_arb.pending_img_source = hs;
-        src = NAV_SRC_DEFAULT;
+        src = NAV_SRC_HOME_LOCK;
     } else if (auto_rotate) {
         if (s_arb.slideshow_advance) {
             s_arb.slideshow_advance = false;

--- a/main/ui/nina_nav_arbiter.c
+++ b/main/ui/nina_nav_arbiter.c
@@ -17,6 +17,7 @@
 #include "goes_client.h"               /* goes_region_name, solar_band_label */
 #include "bsp/esp-bsp.h"
 #include "esp_log.h"
+#include "esp_timer.h"   /* nav_arbiter_get_web_status: grace-remaining clock */
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "tasks.h"   /* image_source_* override API + goes_task_handle */
@@ -49,6 +50,10 @@ static struct {
                                     * Atomic: written by the web/LVGL task
                                     * (set_pin), read by the data task (resolve),
                                     * mirroring user_stamp_ms's cross-core guard. */
+    _Atomic uint8_t last_level;    /* nav_source_t rung that won the last resolve
+                                    * (NAV_SRC_HOLD while modal-frozen). Written
+                                    * by resolve() (data task), read by
+                                    * nav_arbiter_get_web_status() (httpd task). */
 } s_arb;
 
 /* Pack/unpack the USER claim (page index + image source) into one 32-bit word.
@@ -73,6 +78,7 @@ void nav_arbiter_init(void) {
     s_arb.pending_img_source = -1;
     s_arb.current_committed_img_source = -1;
     s_arb.pinned = false;
+    s_arb.last_level = (uint8_t)NAV_SRC_DEFAULT;
     s_arb.current_committed = nina_dashboard_get_active_page();
     ESP_LOGI(TAG, "nav arbiter init (committed page=%d)", s_arb.current_committed);
 }
@@ -141,6 +147,27 @@ void nav_arbiter_set_pin(bool on, int abs_page, int8_t img_src, int64_t now_ms) 
 }
 
 bool nav_arbiter_is_pinned(void) { return s_arb.pinned; }
+
+void nav_arbiter_get_web_status(nav_arbiter_web_status_t *out)
+{
+    if (!out) return;
+    out->level = (nav_source_t)s_arb.last_level;
+    out->grace_remaining_s = 0;
+    /* Grace remaining: recomputed here from the atomic claim fields rather than
+     * stored at resolve time, so pollers see it count down between resolves.
+     * The pin holds without expiry, so it reports 0. */
+    int user_page;
+    int8_t user_src;
+    unpack_claim(s_arb.user_claim, &user_page, &user_src);
+    if (user_page >= 0 && !s_arb.pinned) {
+        int64_t now_ms = esp_timer_get_time() / 1000;
+        int64_t left_ms = (int64_t)app_config_get()->nav_grace_s * 1000
+                        - (now_ms - s_arb.user_stamp_ms);
+        if (left_ms > 0) {
+            out->grace_remaining_s = (int)((left_ms + 999) / 1000);
+        }
+    }
+}
 
 /* ── Ladder helpers (Task 3.2) ──
  *
@@ -345,7 +372,10 @@ void nav_arbiter_resolve(int64_t now_ms) {
 
     /* Rung 0: modal freeze. Closing a modal restamps grace in
      * nav_arbiter_notify_modal_close, so the next resolve holds the page. */
-    if (s_arb.modal_depth > 0) return;
+    if (s_arb.modal_depth > 0) {
+        s_arb.last_level = (uint8_t)NAV_SRC_HOLD;
+        return;
+    }
 
     /* Topology rebuild consumed before resolution. */
     if (s_arb.topology_dirty) {
@@ -438,6 +468,10 @@ void nav_arbiter_resolve(int64_t now_ms) {
         desired = home_page_with_src(&hs);
         s_arb.pending_img_source = hs;
     }
+
+    /* Publish the winning rung for the web API (level state, read atomically
+     * by nav_arbiter_get_web_status from the httpd task). */
+    s_arb.last_level = (uint8_t)src;
 
     /* Idle indicator coupling. */
     bool now_idle = (src == NAV_SRC_IDLE);

--- a/main/ui/nina_nav_arbiter.h
+++ b/main/ui/nina_nav_arbiter.h
@@ -78,6 +78,19 @@ void nav_arbiter_set_pin(bool on, int abs_page, int8_t img_src, int64_t now_ms);
 /** True if the navigation pin is currently engaged. */
 bool nav_arbiter_is_pinned(void);
 
+/** Snapshot of the arbiter's last resolve outcome, for the web API. */
+typedef struct {
+    nav_source_t level;             /* winning rung at the last resolve
+                                     * (NAV_SRC_HOLD while a modal is open) */
+    int          grace_remaining_s; /* seconds left in the USER grace window,
+                                     * 0 when no grace claim is active (the
+                                     * runtime pin has no expiry and reports 0) */
+} nav_arbiter_web_status_t;
+
+/** Fill @p out with the last resolve outcome. Safe to call from any task
+ *  (httpd included): reads only the arbiter's atomic fields. */
+void nav_arbiter_get_web_status(nav_arbiter_web_status_t *out);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/ui/nina_nav_arbiter.h
+++ b/main/ui/nina_nav_arbiter.h
@@ -29,6 +29,7 @@ typedef enum {
     NAV_SRC_IDLE,       /* idle-override active, all rigs confirmed down */
     NAV_SRC_DEFAULT,    /* Home Page fallback */
     NAV_SRC_HOLD,       /* modal open: no change */
+    NAV_SRC_HOME_LOCK,  /* home_page_lock rung won (appended v49+; keep last) */
 } nav_source_t;
 
 /** One-time init. Call from app_main after the dashboard is created. */

--- a/main/ui/nina_tile_grid.c
+++ b/main/ui/nina_tile_grid.c
@@ -63,7 +63,7 @@ typedef struct {
     tile_grid_type_t type;
     char     label[32];
     /* number */
-    char     unit[12];
+    char     unit[16];   /* UTF-8; fits "mag/arcsec²" (13 B incl NUL) */
     int      decimals;
     float    low;
     float    high;
@@ -79,6 +79,17 @@ typedef struct {
     uint32_t t_color;
     uint32_t f_color;
 } tile_grid_tile_cfg_t;
+
+/* Page-level color defaults (optional top-level "defaults" object). Each member
+ * is already resolved against its stock constant, so a tile whose own key is
+ * absent falls back here and a page without "defaults" falls back to stock. */
+typedef struct {
+    uint32_t c_low;
+    uint32_t c_norm;
+    uint32_t c_high;
+    uint32_t t_color;
+    uint32_t f_color;
+} tile_grid_defaults_t;
 
 /* ── Per-tile widget storage ──────────────────────────────────────────── */
 
@@ -133,7 +144,8 @@ static inline void set_font_if_changed(lv_obj_t *obj, const lv_font_t **cached,
 static const lv_font_t *unit_font_for_value_size(int value_size);
 static void fit_tile_fonts(tile_grid_w_t *tw, const tile_grid_tile_cfg_t *tc,
                            const char *value_str, const char *unit_str);
-static void parse_one_tile(const cJSON *t, tile_grid_tile_cfg_t *tc);
+static void parse_one_tile(const cJSON *t, const tile_grid_defaults_t *d,
+                           tile_grid_tile_cfg_t *tc);
 static void parse_tiles_config(nina_tile_grid_t *g, const char *tiles_config_json);
 static void build_tile(tile_grid_w_t *tw, lv_obj_t *parent,
                        const tile_grid_tile_cfg_t *tc, int rows, int gb);
@@ -275,15 +287,39 @@ static inline void set_font_if_changed(lv_obj_t *obj, const lv_font_t **cached,
     }
 }
 
-/* Scale the unit proportionally to the chosen value font (simple switch). */
+/* ── Superscript font fallback (same pattern as nina_allsky.c) ─────────── */
+
+extern const lv_font_t lv_font_superscript_24;
+
+/* Mutable copies of the built-in montserrat unit fonts with the superscript
+ * font attached as fallback, so units like "mag/arcsec²" render instead of
+ * tofu. The built-ins live in const flash (DROM) on ESP32-P4 so their fallback
+ * pointer cannot be patched in-place. */
+static lv_font_t unit_font_16_super;
+static lv_font_t unit_font_22_super;
+static lv_font_t unit_font_28_super;
+static bool      unit_fonts_super_init = false;
+
+/* Scale the unit proportionally to the chosen value font (simple switch).
+ * Lazily builds the fallback copies on first use; every caller runs under the
+ * display lock held by this module's caller, so a plain flag is sufficient. */
 static const lv_font_t *unit_font_for_value_size(int value_size) {
+    if (!unit_fonts_super_init) {
+        memcpy(&unit_font_16_super, &lv_font_montserrat_16, sizeof(lv_font_t));
+        memcpy(&unit_font_22_super, &lv_font_montserrat_22, sizeof(lv_font_t));
+        memcpy(&unit_font_28_super, &lv_font_montserrat_28, sizeof(lv_font_t));
+        unit_font_16_super.fallback = &lv_font_superscript_24;
+        unit_font_22_super.fallback = &lv_font_superscript_24;
+        unit_font_28_super.fallback = &lv_font_superscript_24;
+        unit_fonts_super_init = true;
+    }
     if (value_size >= 64) {
-        return &lv_font_montserrat_28;
+        return &unit_font_28_super;
     }
     if (value_size >= 48) {
-        return &lv_font_montserrat_22;
+        return &unit_font_22_super;
     }
-    return &lv_font_montserrat_16;
+    return &unit_font_16_super;
 }
 
 /* Measure width of a string in a given font (letter_space matches the label
@@ -314,7 +350,7 @@ static void fit_tile_fonts(tile_grid_w_t *tw, const tile_grid_tile_cfg_t *tc,
         set_font_if_changed(tw->lbl_label, &tw->cached_label_font,
                             label_font_for_rows(tw->rows));
         set_font_if_changed(tw->lbl_unit, &tw->cached_unit_font,
-                            &lv_font_montserrat_16);
+                            unit_font_for_value_size(0));
         tw->cached_fit_str[0] = '\0';
         return;
     }
@@ -384,19 +420,21 @@ static void fit_tile_fonts(tile_grid_w_t *tw, const tile_grid_tile_cfg_t *tc,
 
 /* ── Config parsing (tiles_config → tile_cfg[] + row structure) ────────── */
 
-static void parse_one_tile(const cJSON *t, tile_grid_tile_cfg_t *tc) {
+static void parse_one_tile(const cJSON *t, const tile_grid_defaults_t *d,
+                           tile_grid_tile_cfg_t *tc) {
     memset(tc, 0, sizeof(*tc));
 
-    /* Defaults (mockup convertType). */
+    /* Defaults (mockup convertType); colors come from the page defaults, which
+     * already collapse to the stock constants when the page declares none. */
     tc->type     = TG_NUMBER;
     tc->decimals = 1;
     tc->low      = 0.0f;
     tc->high     = 100.0f;
-    tc->c_low    = C_NORMAL;
-    tc->c_norm   = C_NORMAL;
-    tc->c_high   = C_WARN;
-    tc->t_color  = C_OK;
-    tc->f_color  = C_CRIT;
+    tc->c_low    = d->c_low;
+    tc->c_norm   = d->c_norm;
+    tc->c_high   = d->c_high;
+    tc->t_color  = d->t_color;
+    tc->f_color  = d->f_color;
 
     const char *label = obj_str(t, "label");
     if (label) {
@@ -440,9 +478,9 @@ static void parse_one_tile(const cJSON *t, tile_grid_tile_cfg_t *tc) {
         if (cJSON_IsNumber(j_high)) {
             tc->high = (float)j_high->valuedouble;
         }
-        tc->c_low  = parse_hex_color(obj_str(t, "cLow"),  C_NORMAL);
-        tc->c_norm = parse_hex_color(obj_str(t, "cNorm"), C_NORMAL);
-        tc->c_high = parse_hex_color(obj_str(t, "cHigh"), C_WARN);
+        tc->c_low  = parse_hex_color(obj_str(t, "cLow"),  d->c_low);
+        tc->c_norm = parse_hex_color(obj_str(t, "cNorm"), d->c_norm);
+        tc->c_high = parse_hex_color(obj_str(t, "cHigh"), d->c_high);
     } else if (tc->type == TG_TEXT) {
         cJSON *maps = cJSON_GetObjectItem(t, "maps");
         int mc = 0;
@@ -467,8 +505,8 @@ static void parse_one_tile(const cJSON *t, tile_grid_tile_cfg_t *tc) {
         const char *ft = obj_str(t, "fText");
         snprintf(tc->t_text, sizeof(tc->t_text), "%s", tt ? tt : "TRUE");
         snprintf(tc->f_text, sizeof(tc->f_text), "%s", ft ? ft : "FALSE");
-        tc->t_color = parse_hex_color(obj_str(t, "tColor"), C_OK);
-        tc->f_color = parse_hex_color(obj_str(t, "fColor"), C_CRIT);
+        tc->t_color = parse_hex_color(obj_str(t, "tColor"), d->t_color);
+        tc->f_color = parse_hex_color(obj_str(t, "fColor"), d->f_color);
     }
 }
 
@@ -494,6 +532,22 @@ static void parse_tiles_config(nina_tile_grid_t *g, const char *tiles_config_jso
         return;
     }
 
+    /* Optional top-level "defaults": page-level fallbacks for the threshold and
+     * boolean colors. Missing object or missing key collapses to the stock
+     * constant, so every tile still resolves the same way as before. Text-tile
+     * "maps" colors are deliberately not covered. */
+    cJSON *defs = cJSON_GetObjectItem(root, "defaults");
+    if (!cJSON_IsObject(defs)) {
+        defs = NULL;
+    }
+    tile_grid_defaults_t d = {
+        .c_low   = parse_hex_color(defs ? obj_str(defs, "cLow")   : NULL, C_NORMAL),
+        .c_norm  = parse_hex_color(defs ? obj_str(defs, "cNorm")  : NULL, C_NORMAL),
+        .c_high  = parse_hex_color(defs ? obj_str(defs, "cHigh")  : NULL, C_WARN),
+        .t_color = parse_hex_color(defs ? obj_str(defs, "tColor") : NULL, C_OK),
+        .f_color = parse_hex_color(defs ? obj_str(defs, "fColor") : NULL, C_CRIT),
+    };
+
     int ri = 0;
     cJSON *row;
     cJSON_ArrayForEach(row, rows) {
@@ -512,7 +566,7 @@ static void parse_tiles_config(nina_tile_grid_t *g, const char *tiles_config_jso
             if (!cJSON_IsObject(tile)) {
                 continue;
             }
-            parse_one_tile(tile, &g->tile_cfg[g->tile_count]);
+            parse_one_tile(tile, &d, &g->tile_cfg[g->tile_count]);
             g->tile_count++;
             in_row++;
         }
@@ -571,8 +625,8 @@ static void build_tile(tile_grid_w_t *tw, lv_obj_t *parent,
 
     /* Unit (empty for text/bool tiles). */
     tw->lbl_unit = lv_label_create(tw->tile);
-    lv_obj_set_style_text_font(tw->lbl_unit, &lv_font_montserrat_16, 0);
-    tw->cached_unit_font = &lv_font_montserrat_16;
+    lv_obj_set_style_text_font(tw->lbl_unit, unit_font_for_value_size(0), 0);
+    tw->cached_unit_font = unit_font_for_value_size(0);
     lv_obj_set_style_text_align(tw->lbl_unit, LV_TEXT_ALIGN_CENTER, 0);
     lv_obj_set_width(tw->lbl_unit, LV_PCT(100));
     lv_label_set_long_mode(tw->lbl_unit, LV_LABEL_LONG_DOT);

--- a/main/ui/nina_tile_grid.h
+++ b/main/ui/nina_tile_grid.h
@@ -17,12 +17,16 @@
  * / ha_client) fills a values[]/resolved[] array in ROW-MAJOR flatten order that
  * matches the SAME tiles-config; this module renders it.
  *
- * Tiles-config JSON schema (shared): { "rows": [ [ tile, ... ], ... ] } where
- * each tile carries the DISPLAY keys this module reads:
+ * Tiles-config JSON schema (shared): { "defaults": {...}, "rows": [ [ tile, ...
+ * ], ... ] } where each tile carries the DISPLAY keys this module reads:
  *   label, type ("number"|"text"|"bool"),
  *   number: unit, decimals(0-4), low, high, cLow, cNorm, cHigh
  *   text:   maps: [ {val,color}, ... ]  (<=4)
  *   bool:   tText, fText, tColor, fColor
+ * The optional top-level "defaults" object { cLow, cNorm, cHigh, tColor, fColor
+ * } (all "#RRGGBB", all optional) supplies page-level fallbacks: a tile's own
+ * key wins, then the page default, then the stock constant. Text-tile "maps"
+ * colors are not covered by defaults.
  * Any source field ("path" for JSON, "entity_id"/"attr" for HA) is IGNORED here
  * and parsed only by the page's client.
  *

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -1,6 +1,8 @@
 #include "web_server_internal.h"
 #include "mqtt_ha.h"
+#include "http_fetch.h"                 /* http_fetch_text — /api/config/pull proxy */
 #include <string.h>
+#include <strings.h>                    /* strncasecmp */
 #include <time.h>
 #include "esp_heap_caps.h"
 #include "build_version.h"
@@ -425,12 +427,24 @@ esp_err_t config_get_handler(httpd_req_t *req)
 
 /* ---- Backup/Restore Field Registry ---- */
 
+/* is_sensitive and mask_preview are related but NOT the same question:
+ *   is_sensitive  -- "may this leave the device in a redacted export?"
+ *                    Drives the config/sensitive split and the "********"
+ *                    leave-alone sentinel on the write path.
+ *   mask_preview  -- "is the value itself a credential?" Drives whether a
+ *                    restore-preview diff row shows the value or a placeholder.
+ * hostname is the case that separates them: sensitive enough to withhold from a
+ * redacted export, but its real from/to must be visible in the preview -- it is
+ * the one change that renames the device mid-session, and masking it would hide
+ * exactly the diff a user needs to see. mask_preview implies is_sensitive; the
+ * reverse does not hold. */
 typedef struct {
     const char *json_key;      /* JSON key as used in GET /api/config */
     const char *label;         /* Human-readable label for diff display */
     const char *category;      /* Tab/group name for diff grouping */
     bool        is_sensitive;  /* true = only exported in "sensitive" section */
     bool        is_large;      /* true = truncate value in diff display */
+    bool        mask_preview;  /* true = never put the value in a preview diff */
 } backup_field_t;
 
 static const backup_field_t s_backup_fields[] = {
@@ -478,6 +492,28 @@ static const backup_field_t s_backup_fields[] = {
     {"hfr_thresholds_1",   "HFR Thresholds 1",    "Nodes & Data", false, true},
     {"hfr_thresholds_2",   "HFR Thresholds 2",    "Nodes & Data", false, true},
     {"hfr_thresholds_3",   "HFR Thresholds 3",    "Nodes & Data", false, true},
+    /* JSON Display + Home Assistant pages. None of these reach the backup by
+     * default: the tile layouts live in dedicated NVS keys (v52 moved them out
+     * of app_config_t to keep ~6 KB each off the main /api/config payload), and
+     * the eight scalars are not SETTINGS_TABLE rows, so serialize_config_to_json()
+     * emits none of them. backup_get_handler and the restore preview inject all
+     * ten into their local JSON explicitly; the confirm path applies the scalars
+     * onto new_cfg and the layouts through app_config_set_*_tiles(). Registered
+     * here so the diff, category grouping, is_large truncation, sensitive split,
+     * and unknown-field detection treat them like any other field.
+     *
+     * Sensitivity: the two credential-bearing headers are sensitive; a tile
+     * layout, a URL, an interval, and an enable flag are not. */
+    {"json_enabled",           "JSON Display Page",        "Nodes & Data", false, false},
+    {"json_url",               "JSON Source URL",          "Nodes & Data", false, false},
+    {"json_auth_header",       "JSON Auth Header",         "Nodes & Data", true,  false, true},
+    {"json_update_interval_s", "JSON Poll Interval",       "Nodes & Data", false, false},
+    {"json_tiles_config",      "JSON Display Tiles",       "Nodes & Data", false, true},
+    {"ha_enabled",             "Home Assistant Page",      "Nodes & Data", false, false},
+    {"ha_base_url",            "Home Assistant URL",       "Nodes & Data", false, false},
+    {"ha_token",               "Home Assistant Token",     "Nodes & Data", true,  false, true},
+    {"ha_update_interval_s",   "Home Assistant Interval",  "Nodes & Data", false, false},
+    {"ha_tiles_config",        "Home Assistant Tiles",     "Nodes & Data", false, true},
 
     /* System */
     {"ntp",                  "NTP Server",          "System", false, false},
@@ -561,15 +597,20 @@ static const backup_field_t s_backup_fields[] = {
     {"home_page_lock",           "Always show Home Page",  "Behavior", false, false},
     {"auth_enabled",             "Authentication Enabled", "System",   false, false},
 
-    /* Sensitive */
-    {"weather_api_key",    "Weather API Key",    "Weather", true, false},
-    {"mqtt_username",      "MQTT Username",      "MQTT",    true, false},
-    {"mqtt_password",      "MQTT Password",      "MQTT",    true, false},
-    {"mqtt_broker_url",    "MQTT Broker URL",    "MQTT",    true, false},
-    {"spotify_client_id",  "Spotify Client ID",  "Spotify", true, false},
-    {"hostname",           "Hostname",           "System",  true, false},
+    /* Sensitive. mask_preview (6th column) is set on everything whose VALUE is a
+     * credential -- including mqtt_broker_url, which may embed user:pass@host.
+     * hostname is deliberately left unmasked: still withheld from a redacted
+     * export, but its real from/to shows in the preview, because a hostname
+     * change renames the device mid-session and is the diff a user most needs
+     * to see. */
+    {"weather_api_key",    "Weather API Key",    "Weather", true, false, true},
+    {"mqtt_username",      "MQTT Username",      "MQTT",    true, false, true},
+    {"mqtt_password",      "MQTT Password",      "MQTT",    true, false, true},
+    {"mqtt_broker_url",    "MQTT Broker URL",    "MQTT",    true, false, true},
+    {"spotify_client_id",  "Spotify Client ID",  "Spotify", true, false, true},
+    {"hostname",           "Hostname",           "System",  true, false, false},
 
-    {NULL, NULL, NULL, false, false}  /* sentinel */
+    {NULL, NULL, NULL, false, false, false}  /* sentinel */
 };
 
 /* Returns true if two cJSON values are equal */
@@ -615,9 +656,31 @@ static const restore_strmax_t s_restore_strmax[] = {
     {"allsky_field_config", 1536},
     {"allsky_thresholds",   1024},
     {"custom_image_url",    256},
+    {"json_tiles_config",   JSON_TILES_CONFIG_MAX},
+    {"ha_tiles_config",     HA_TILES_CONFIG_MAX},
+    {"json_url",            256},
+    {"json_auth_header",    256},
+    {"ha_base_url",         256},
+    {"ha_token",            256},
     /* goes_region max sourced from the struct field size at runtime below */
     {NULL, 0}
 };
+
+/* Fields whose value must satisfy validate_url_format() (empty allowed = "not
+ * configured"). ONE list drives both the restore-preview check
+ * (check_restore_field step 4) and the write-path check (validate_config_fields),
+ * so a field can never preview clean and then 400 on confirm. Adding a URL field
+ * means adding one row here, not editing two strcmp chains. */
+static const char *const s_url_fields[] = {
+    "url1", "url2", "url3", "mqtt_broker_url", "json_url", "ha_base_url", NULL
+};
+
+static bool is_url_field(const char *json_key) {
+    for (const char *const *k = s_url_fields; *k; k++) {
+        if (strcmp(*k, json_key) == 0) return true;
+    }
+    return false;
+}
 
 /* Numeric fields with a confirmable [min,max] clamp. Ranges sourced directly
  * from app_config.c validate_config() (line refs in comments). is_float marks
@@ -637,6 +700,8 @@ static const restore_numrange_t s_restore_numrange[] = {
     {"idle_poll_interval_s",    5,    120,   false},  /* app_config.c:2536 */
     {"screen_rotation",         0,    3,     false},  /* app_config.c:2544 */
     {"allsky_update_interval_s",1,    300,   false},  /* app_config.c:2548 */
+    {"json_update_interval_s",  5,    300,   false},  /* app_config.c validate_config (out of range -> 30) */
+    {"ha_update_interval_s",    5,    300,   false},  /* app_config.c validate_config (out of range -> 30) */
     {"allsky_dew_offset",       -50,  50,    true},   /* app_config.c:2552 */
     {"goes_update_interval_s",  300,  7200,  false},  /* app_config.c:2556 */
     {"image_display_source",    0,    3,     false},  /* app_config.c:2598 (0=GOES,1=Moon,2=Solar,3=Custom URL) */
@@ -727,12 +792,10 @@ static void check_restore_field(const backup_field_t *f,
         }
     }
 
-    /* 4. Invalid URL -> ERROR */
+    /* 4. Invalid URL -> ERROR. Same s_url_fields list validate_config_fields
+     *    enforces on confirm, so preview and confirm cannot disagree. */
     if (cJSON_IsString(backup_value) && backup_value->valuestring[0] != '\0') {
-        if ((strcmp(f->json_key, "url1") == 0 ||
-             strcmp(f->json_key, "url2") == 0 ||
-             strcmp(f->json_key, "url3") == 0 ||
-             strcmp(f->json_key, "mqtt_broker_url") == 0) &&
+        if (is_url_field(f->json_key) &&
             !validate_url_format(backup_value->valuestring)) {
             snprintf(msg, sizeof(msg), "%s: is not a valid URL.", f->label);
             add_validation_note(notes, blocked, "error", msg);
@@ -781,6 +844,17 @@ static void check_restore_field(const backup_field_t *f,
                 "use only letters, numbers, and hyphens.");
         }
     }
+}
+
+/* Display stand-in for a secret in a preview diff row. Reveals only whether a
+ * value is present, never the value itself. "********" is the same sentinel the
+ * restore confirm path already treats as "leave the live credential alone", so
+ * a preview row that is echoed back verbatim is inert. */
+static const char *sensitive_placeholder(const cJSON *v)
+{
+    if (v == NULL || cJSON_IsNull(v)) return "(not set)";
+    if (cJSON_IsString(v) && v->valuestring[0] == '\0') return "(not set)";
+    return "********";
 }
 
 /*
@@ -927,8 +1001,23 @@ static cJSON *build_restore_preview(const cJSON *backup_root, const cJSON *curre
         cJSON_AddStringToObject(change, "field", f->json_key);
         cJSON_AddStringToObject(change, "label", f->label);
 
-        /* Add from/to values — truncate large strings */
-        if (f->is_large && cJSON_IsString(backup_value)) {
+        /* Add from/to values.
+         *
+         * A credential never goes on the wire, not even in a preview the browser
+         * only renders masked: the row's existence already says "this changes",
+         * and the placeholders say whether a value is being set or cleared. This
+         * is the single choke point every diff row passes through, so a secret
+         * added later is protected by setting mask_preview in the registry -- not
+         * by remembering to mask at a call site. The other preview arrays carry key
+         * names only (missing_fields, unknown_fields, sensitive_excluded) and the
+         * validation notes are built from f->label, so this is the only path that
+         * ever had a value to leak.
+         *
+         * Large JSON-blob fields are summarized by length rather than inlined. */
+        if (f->mask_preview) {
+            cJSON_AddStringToObject(change, "from", sensitive_placeholder(current_value));
+            cJSON_AddStringToObject(change, "to",   sensitive_placeholder(backup_value));
+        } else if (f->is_large && cJSON_IsString(backup_value)) {
             char trunc[80];
             snprintf(trunc, sizeof(trunc), "Modified (%d chars)", (int)strlen(backup_value->valuestring));
             cJSON_AddStringToObject(change, "to", trunc);
@@ -1017,29 +1106,66 @@ static bool validate_config_fields(cJSON *root, httpd_req_t *req)
         !validate_string_len(root, "allsky_field_config", 1536) ||
         !validate_string_len(root, "allsky_thresholds", 1024) ||
         !validate_string_len(root, "goes_region", sizeof(((app_config_t *)0)->goes_region)) ||
-        !validate_string_len(root, "custom_image_url", sizeof(((app_config_t *)0)->custom_image_url))) {
+        !validate_string_len(root, "custom_image_url", sizeof(((app_config_t *)0)->custom_image_url)) ||
+        /* JSON Display / Home Assistant page fields (restore path only; absent
+         * from the config POST body, which routes them through their own
+         * endpoints). Bounds mirror json_config_post_handler /
+         * ha_config_post_handler exactly. */
+        !validate_string_len(root, "json_url", sizeof(((app_config_t *)0)->json_url)) ||
+        !validate_string_len(root, "json_auth_header", sizeof(((app_config_t *)0)->json_auth_header)) ||
+        !validate_string_len(root, "json_tiles_config", JSON_TILES_CONFIG_MAX) ||
+        !validate_string_len(root, "ha_base_url", sizeof(((app_config_t *)0)->ha_base_url)) ||
+        !validate_string_len(root, "ha_token", sizeof(((app_config_t *)0)->ha_token)) ||
+        !validate_string_len(root, "ha_tiles_config", HA_TILES_CONFIG_MAX)) {
         send_400(req, "String field exceeds maximum length");
         return false;
     }
 
-    cJSON *url_items[] = {
-        cJSON_GetObjectItem(root, "url1"),
-        cJSON_GetObjectItem(root, "url2"),
-        cJSON_GetObjectItem(root, "url3"),
-        cJSON_GetObjectItem(root, "mqtt_broker_url"),
-    };
-    for (int i = 0; i < 4; i++) {
-        if (cJSON_IsString(url_items[i]) && !validate_url_format(url_items[i]->valuestring)) {
-            send_400(req, "Invalid URL format");
+    /* Driven by s_url_fields, the same list check_restore_field step 4 uses for
+     * the preview, so a malformed URL is reported at preview time instead of
+     * surfacing here as a field-less 400 on confirm. validate_url_format() lets
+     * an empty string through, so clearing any of these still works. */
+    for (const char *const *k = s_url_fields; *k; k++) {
+        cJSON *u = cJSON_GetObjectItem(root, *k);
+        if (cJSON_IsString(u) && !validate_url_format(u->valuestring)) {
+            char msg[80];
+            snprintf(msg, sizeof(msg), "Invalid URL format in '%s'", *k);
+            send_400(req, msg);
             return false;
         }
     }
     return true;
 }
 
+/* Delete every sensitive key whose incoming value is the redaction sentinel.
+ *
+ * GET /api/config and the restore preview both hand out "********" in place of a
+ * real secret, so a round-tripped payload carries the sentinel rather than the
+ * value. Because parse_config_from_json() starts from a copy of the live config
+ * and every field parse is key-present-gated, deleting the key IS "preserve the
+ * existing value" -- one registry-driven pass replaces a per-secret `if (strcmp
+ * != "********")` arm, and covers a hand-edited backup with literal asterisks in
+ * a field nobody remembered to guard.
+ *
+ * Driven by is_sensitive (all 8), not mask_preview (7): hostname shows its real
+ * value in a preview but must still honour the sentinel on the write path. */
+static void strip_masked_secrets(cJSON *root)
+{
+    for (const backup_field_t *f = s_backup_fields; f->json_key; f++) {
+        if (!f->is_sensitive) continue;
+        cJSON *v = cJSON_GetObjectItem(root, f->json_key);
+        if (cJSON_IsString(v) && strcmp(v->valuestring, "********") == 0) {
+            cJSON_DeleteItemFromObject(root, f->json_key);
+        }
+    }
+}
+
 // Parse JSON into a new app_config_t (heap-allocated).
 // Starts from a copy of the current config so missing fields are preserved.
 // Returns NULL on allocation failure.
+// NOTE: mutates `root` -- strip_masked_secrets() removes redacted secrets so
+// they cannot be written. Callers delete `root` shortly after, and the restore
+// path relies on the same removal.
 static app_config_t *parse_config_from_json(cJSON *root)
 {
     app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
@@ -1048,6 +1174,8 @@ static app_config_t *parse_config_from_json(cJSON *root)
         return NULL;
     }
     memcpy(cfg, app_config_get(), sizeof(app_config_t));
+
+    strip_masked_secrets(root);
 
     /* Every "simple" field (plain default + optional range check) is driven
      * from the single SETTINGS_TABLE X-macro in settings_table.h/.c. This
@@ -1069,14 +1197,9 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_STRING(root, "hfr_thresholds_1", cfg->hfr_thresholds[0]);
     JSON_TO_STRING(root, "hfr_thresholds_2", cfg->hfr_thresholds[1]);
     JSON_TO_STRING(root, "hfr_thresholds_3", cfg->hfr_thresholds[2]);
-    /* mqtt_password: skip write if value equals "********" sentinel */
-    {
-        cJSON *_mp = cJSON_GetObjectItem(root, "mqtt_password");
-        if (cJSON_IsString(_mp) && strcmp(_mp->valuestring, "********") != 0) {
-            strncpy(cfg->mqtt_password, _mp->valuestring, sizeof(cfg->mqtt_password) - 1);
-            cfg->mqtt_password[sizeof(cfg->mqtt_password) - 1] = '\0';
-        }
-    }
+    /* mqtt_password: a sentinel value was already removed by
+     * strip_masked_secrets(), so key-present means "a real new value". */
+    JSON_TO_STRING(root, "mqtt_password", cfg->mqtt_password);
 
     /* Home Page now stores a page_ref registry id (0..PAGE_REF_ID_MAX-1). The web
      * UI always sends a concrete id (never -1). Reject out-of-range ids and the
@@ -1155,14 +1278,8 @@ static app_config_t *parse_config_from_json(cJSON *root)
     JSON_TO_STRING(root, "allsky_field_config",  cfg->allsky_field_config);
     JSON_TO_STRING(root, "allsky_thresholds",    cfg->allsky_thresholds);
 
-    /* spotify_client_id: skip write if value equals "********" sentinel */
-    {
-        cJSON *_scid = cJSON_GetObjectItem(root, "spotify_client_id");
-        if (cJSON_IsString(_scid) && strcmp(_scid->valuestring, "********") != 0) {
-            strncpy(cfg->spotify_client_id, _scid->valuestring, sizeof(cfg->spotify_client_id) - 1);
-            cfg->spotify_client_id[sizeof(cfg->spotify_client_id) - 1] = '\0';
-        }
-    }
+    /* spotify_client_id: sentinel already removed by strip_masked_secrets(). */
+    JSON_TO_STRING(root, "spotify_client_id", cfg->spotify_client_id);
     /* admin_password is never accepted via /api/config — use /api/admin-password. */
 
     cJSON *jmoondrag = cJSON_GetObjectItem(root, "moon_drag_light_mode");
@@ -1223,6 +1340,7 @@ cJSON *receive_json_body(httpd_req_t *req, int max_size)
     while (received < remaining) {
         int ret = httpd_req_recv(req, buf + received, remaining - received);
         if (ret <= 0) {
+            memset(buf, 0, (size_t)received);   /* see scrub note below */
             free(buf);
             if (ret == HTTPD_SOCK_ERR_TIMEOUT) {
                 ESP_LOGW(TAG, "Config handler: recv timeout (got %d/%d bytes)", received, remaining);
@@ -1237,6 +1355,12 @@ cJSON *receive_json_body(httpd_req_t *req, int max_size)
     buf[received] = '\0';
 
     cJSON *root = cJSON_Parse(buf);
+    /* Scrub before releasing: config POST bodies routinely carry the admin
+     * password, WiFi passphrases, an HA token, or a source device's password
+     * (/api/config/pull). free() does not clear, and this PSRAM block is handed
+     * straight to the next allocation, so a later handler could read a stale
+     * secret out of its own fresh buffer. One memset here covers every caller. */
+    memset(buf, 0, (size_t)received);
     free(buf);
     if (!root) {
         send_400(req, "Invalid JSON");
@@ -1527,6 +1651,25 @@ esp_err_t backup_get_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
+    /* The JSON Display / Home Assistant page config never reaches this object on
+     * its own: the tile layouts live in their own NVS keys (and must stay off
+     * this payload -- it also backs GET /api/config, deliberately slimmed by
+     * moving those ~6 KB blobs out), and the eight scalars are not SETTINGS_TABLE
+     * rows. Inject all ten here so the s_backup_fields split below routes them
+     * for us -- json_auth_header and ha_token into sensitive_section, the rest
+     * into config_section. Everything except those two carries no credential, so
+     * it is exported regardless of include_sensitive. */
+    cJSON_AddBoolToObject(full_config,   "json_enabled",           cfg->json_enabled);
+    cJSON_AddStringToObject(full_config, "json_url",               cfg->json_url);
+    cJSON_AddStringToObject(full_config, "json_auth_header",       cfg->json_auth_header);
+    cJSON_AddNumberToObject(full_config, "json_update_interval_s", cfg->json_update_interval_s);
+    cJSON_AddStringToObject(full_config, "json_tiles_config",      app_config_get_json_tiles());
+    cJSON_AddBoolToObject(full_config,   "ha_enabled",             cfg->ha_enabled);
+    cJSON_AddStringToObject(full_config, "ha_base_url",            cfg->ha_base_url);
+    cJSON_AddStringToObject(full_config, "ha_token",               cfg->ha_token);
+    cJSON_AddNumberToObject(full_config, "ha_update_interval_s",   cfg->ha_update_interval_s);
+    cJSON_AddStringToObject(full_config, "ha_tiles_config",        app_config_get_ha_tiles());
+
     /* Split into config and sensitive sections */
     cJSON *config_section = cJSON_CreateObject();
     cJSON *sensitive_section = include_sensitive ? cJSON_CreateObject() : NULL;
@@ -1651,6 +1794,22 @@ esp_err_t restore_post_handler(httpd_req_t *req)
             cJSON_Delete(root);
             httpd_resp_send_500(req);
             return ESP_OK;
+        }
+        /* Mirror the injection in backup_get_handler so the JSON Display / HA
+         * fields have a current value to diff against; without it every restore
+         * would report all ten as changing from (empty). */
+        {
+            const app_config_t *live = app_config_get();
+            cJSON_AddBoolToObject(current_json,   "json_enabled",           live->json_enabled);
+            cJSON_AddStringToObject(current_json, "json_url",               live->json_url);
+            cJSON_AddStringToObject(current_json, "json_auth_header",       live->json_auth_header);
+            cJSON_AddNumberToObject(current_json, "json_update_interval_s", live->json_update_interval_s);
+            cJSON_AddStringToObject(current_json, "json_tiles_config",      app_config_get_json_tiles());
+            cJSON_AddBoolToObject(current_json,   "ha_enabled",             live->ha_enabled);
+            cJSON_AddStringToObject(current_json, "ha_base_url",            live->ha_base_url);
+            cJSON_AddStringToObject(current_json, "ha_token",               live->ha_token);
+            cJSON_AddNumberToObject(current_json, "ha_update_interval_s",   live->ha_update_interval_s);
+            cJSON_AddStringToObject(current_json, "ha_tiles_config",        app_config_get_ha_tiles());
         }
 
         cJSON *preview = build_restore_preview(backup, current_json);
@@ -1780,6 +1939,83 @@ esp_err_t restore_post_handler(httpd_req_t *req)
             }
         }
 
+        /* JSON Display + Home Assistant page config. parse_config_from_json()
+         * carries none of it: the eight scalars are not SETTINGS_TABLE rows, and
+         * the tile layouts are not even in app_config_t. Apply the scalars onto
+         * new_cfg (picked up by the app_config_save() below, whose
+         * validate_config() clamps both intervals to 5..300 and NUL-terminates
+         * the char arrays), and persist the layouts through their own setters,
+         * which clamp to MAX-1 and refresh the getter cache.
+         *
+         * An absent key leaves the current value untouched, so a backup taken
+         * before these fields existed neither blanks a URL nor drops a token.
+         * strip_masked_secrets() (run inside parse_config_from_json above) has
+         * already deleted any "********" value, so a redacted backup cannot
+         * overwrite a live credential with literal asterisks.
+         *
+         * Change detection compares against the LIVE config, which is still
+         * pre-restore at this point; the tiles comparison must happen BEFORE the
+         * setter overwrites the cache. Each page's live-apply spine runs once,
+         * after the save, only if something on that page actually moved. */
+        bool json_page_changed = false;
+        bool ha_page_changed = false;
+        {
+            const app_config_t *live = app_config_get();
+
+            cJSON *it = cJSON_GetObjectItem(merged, "json_enabled");
+            if (cJSON_IsBool(it)) new_cfg->json_enabled = cJSON_IsTrue(it);
+            it = cJSON_GetObjectItem(merged, "json_url");
+            if (cJSON_IsString(it)) strlcpy(new_cfg->json_url, it->valuestring, sizeof(new_cfg->json_url));
+            it = cJSON_GetObjectItem(merged, "json_auth_header");
+            /* A "********" value was already deleted by strip_masked_secrets()
+             * inside parse_config_from_json above, so key-present means a real
+             * new credential; a redacted backup simply leaves the live one. */
+            if (cJSON_IsString(it)) {
+                strlcpy(new_cfg->json_auth_header, it->valuestring, sizeof(new_cfg->json_auth_header));
+            }
+            it = cJSON_GetObjectItem(merged, "json_update_interval_s");
+            if (cJSON_IsNumber(it)) new_cfg->json_update_interval_s = (uint16_t)it->valueint;
+
+            it = cJSON_GetObjectItem(merged, "ha_enabled");
+            if (cJSON_IsBool(it)) new_cfg->ha_enabled = cJSON_IsTrue(it);
+            it = cJSON_GetObjectItem(merged, "ha_base_url");
+            if (cJSON_IsString(it)) strlcpy(new_cfg->ha_base_url, it->valuestring, sizeof(new_cfg->ha_base_url));
+            it = cJSON_GetObjectItem(merged, "ha_token");
+            if (cJSON_IsString(it)) {   /* sentinel already stripped -- see above */
+                strlcpy(new_cfg->ha_token, it->valuestring, sizeof(new_cfg->ha_token));
+            }
+            it = cJSON_GetObjectItem(merged, "ha_update_interval_s");
+            if (cJSON_IsNumber(it)) new_cfg->ha_update_interval_s = (uint16_t)it->valueint;
+
+            json_page_changed =
+                (new_cfg->json_enabled != live->json_enabled) ||
+                (new_cfg->json_update_interval_s != live->json_update_interval_s) ||
+                (strcmp(new_cfg->json_url, live->json_url) != 0) ||
+                (strcmp(new_cfg->json_auth_header, live->json_auth_header) != 0);
+            ha_page_changed =
+                (new_cfg->ha_enabled != live->ha_enabled) ||
+                (new_cfg->ha_update_interval_s != live->ha_update_interval_s) ||
+                (strcmp(new_cfg->ha_base_url, live->ha_base_url) != 0) ||
+                (strcmp(new_cfg->ha_token, live->ha_token) != 0);
+
+            cJSON *jt = cJSON_GetObjectItem(merged, "json_tiles_config");
+            if (cJSON_IsString(jt) && jt->valuestring) {
+                if (strcmp(jt->valuestring, app_config_get_json_tiles()) != 0) {
+                    json_page_changed = true;
+                }
+                esp_err_t te = app_config_set_json_tiles(jt->valuestring);
+                if (te != ESP_OK) ESP_LOGW(TAG, "restore: json tiles persist failed: %s", esp_err_to_name(te));
+            }
+            cJSON *ht = cJSON_GetObjectItem(merged, "ha_tiles_config");
+            if (cJSON_IsString(ht) && ht->valuestring) {
+                if (strcmp(ht->valuestring, app_config_get_ha_tiles()) != 0) {
+                    ha_page_changed = true;
+                }
+                esp_err_t te = app_config_set_ha_tiles(ht->valuestring);
+                if (te != ESP_OK) ESP_LOGW(TAG, "restore: ha tiles persist failed: %s", esp_err_to_name(te));
+            }
+        }
+
         cJSON_Delete(merged);
         cJSON_Delete(root);
 
@@ -1797,6 +2033,19 @@ esp_err_t restore_post_handler(httpd_req_t *req)
         free(old_cfg);
         free(new_cfg);
 
+        /* Bring each tile page up to the restored config: rebuild the widget
+         * tree, show/hide per the restored enable flag, re-resolve navigation,
+         * and start the poll task if the restore just enabled the page. Run only
+         * for a page whose scalars or layout actually moved -- a rebuild is not
+         * free, and most restores touch neither. Read the enable flag back from
+         * the saved config so it reflects validate_config()'s canonicalization. */
+        if (json_page_changed) {
+            json_page_apply_live(app_config_get()->json_enabled);
+        }
+        if (ha_page_changed) {
+            ha_page_apply_live(app_config_get()->ha_enabled);
+        }
+
         /* Send success response with change count */
         cJSON *resp = cJSON_CreateObject();
         cJSON_AddStringToObject(resp, "status", "applied");
@@ -1811,4 +2060,172 @@ esp_err_t restore_post_handler(httpd_req_t *req)
         free((void *)resp_str);
         return ESP_OK;
     }
+}
+
+/* ---- Device-to-device config clone (POST /api/config/pull) ---- */
+
+/* Upstream backup cap. A backup with both tiles blobs runs ~30 KB; 64 KB leaves
+ * room for growth while bounding what one httpd worker will buffer in PSRAM. */
+#define PULL_MAX_RESPONSE  65536
+/* The source device may be on a slow power-save link (20-50 KB/s measured), so
+ * allow a generous window for a ~30 KB body before giving up. */
+#define PULL_TIMEOUT_MS    15000
+
+/* Send {"error":"<code>"} (plus "status" when @p status is non-zero) as a 200.
+ * The verdict lives in the body so the browser gets one uniform shape to switch
+ * on; transport-vs-upstream detail never leaks into the HTTP status of OUR
+ * response. Returns ESP_OK so handlers can `return pull_send_error(...)`. */
+static esp_err_t pull_send_error(httpd_req_t *req, const char *code, int status)
+{
+    char body[96];
+    if (status != 0) {
+        snprintf(body, sizeof(body), "{\"error\":\"%s\",\"status\":%d}", code, status);
+    } else {
+        snprintf(body, sizeof(body), "{\"error\":\"%s\"}", code);
+    }
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, body, HTTPD_RESP_USE_STRLEN);
+    return ESP_OK;
+}
+
+/**
+ * @brief POST /api/config/pull  -- fetch another device's backup through this
+ *        device and forward it, so one panel can be cloned from another.
+ *
+ * Body: {"host":"<hostname or ip[:port]>","password":"<source admin password>",
+ *        "sensitive":true|false}
+ *
+ * The device performs GET http://<host>/api/config/backup?include_sensitive=<0|1>
+ * with an X-Auth-Password header (check_session() on the source accepts that
+ * header as an alternative to a session cookie, and feeds it through the same
+ * login lockout). Doing the fetch here rather than in the browser avoids a CORS
+ * problem and means the source password never has to survive a cross-origin
+ * request; it is used once, never logged, and never echoed.
+ *
+ * On success the upstream body is forwarded VERBATIM (it is already exactly the
+ * backup JSON that POST /api/config/restore consumes). Failures come back as a
+ * 200 carrying {"error":...} -- see pull_send_error.
+ */
+esp_err_t config_pull_post_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+    cJSON *root = receive_json_body(req, CONFIG_MAX_PAYLOAD);
+    if (!root) return ESP_OK;  /* error already sent */
+
+    cJSON *host_item = cJSON_GetObjectItem(root, "host");
+    cJSON *pw_item   = cJSON_GetObjectItem(root, "password");
+    bool include_sensitive = cJSON_IsTrue(cJSON_GetObjectItem(root, "sensitive"));
+
+    if (!cJSON_IsString(host_item) || host_item->valuestring[0] == '\0') {
+        cJSON_Delete(root);
+        return send_400(req, "Missing 'host'");
+    }
+
+    /* Host hygiene. Only a bare host[:port] is accepted; the scheme is supplied
+     * by us, so a caller cannot redirect the fetch elsewhere by smuggling one
+     * in. A single leading "http://" is tolerated (users paste URLs) and
+     * stripped BEFORE the checks, so "https://x" and "host/path" both fail the
+     * '/' test, and "user@host" fails the '@' test. Whitespace and control
+     * characters are rejected outright -- they cannot appear in a hostname and
+     * could otherwise split the request line. */
+    char host[128];
+    {
+        const char *h = host_item->valuestring;
+        if (strncasecmp(h, "http://", 7) == 0) h += 7;
+        if (h[0] == '\0' || strlen(h) >= sizeof(host)) {
+            cJSON_Delete(root);
+            return pull_send_error(req, "bad_host", 0);
+        }
+        for (const char *p = h; *p; p++) {
+            unsigned char c = (unsigned char)*p;
+            if (c == '/' || c == '@' || c == '?' || c == '#' || c == '\\' ||
+                c <= ' ' || c == 0x7f) {
+                cJSON_Delete(root);
+                return pull_send_error(req, "bad_host", 0);
+            }
+        }
+        strlcpy(host, h, sizeof(host));
+    }
+
+    /* Password: optional (the source may have auth disabled). Capped at the
+     * admin_password capacity -- check_session() rejects anything longer, so a
+     * longer value could never authenticate anyway. */
+    char auth_hdr[64];
+    auth_hdr[0] = '\0';
+    if (cJSON_IsString(pw_item) && pw_item->valuestring[0] != '\0') {
+        if (strlen(pw_item->valuestring) >= sizeof(((app_config_t *)0)->admin_password)) {
+            cJSON_Delete(root);
+            return pull_send_error(req, "auth", 0);
+        }
+        /* auth_hdr[64] covers "X-Auth-Password: " (17) + password (<=32). */
+        snprintf(auth_hdr, sizeof(auth_hdr), "X-Auth-Password: %s", pw_item->valuestring);
+    }
+
+    /* Wipe the password out of the cJSON string before freeing it, so the only
+     * remaining copy is auth_hdr (a local, zeroed right after the fetch). cJSON
+     * frees without clearing, and the PSRAM it releases is reused by the next
+     * allocation -- receive_json_body() scrubs the raw request buffer for the
+     * same reason. */
+    if (cJSON_IsString(pw_item) && pw_item->valuestring) {
+        memset(pw_item->valuestring, 0, strlen(pw_item->valuestring));
+    }
+    cJSON_Delete(root);   /* password is now only in auth_hdr, a local */
+
+    /* url[192] covers "http://" + host[<=127] + the fixed query string (45). */
+    char url[192];
+    snprintf(url, sizeof(url), "http://%s/api/config/backup?include_sensitive=%d",
+             host, include_sensitive ? 1 : 0);
+
+    int status = 0;
+    http_fetch_opts_t opts = {
+        .timeout_ms         = PULL_TIMEOUT_MS,
+        .max_redirects      = 0,   /* a peer device never redirects; refuse to chase one */
+        .max_attempts       = 1,
+        .max_response_bytes = PULL_MAX_RESPONSE,
+        .extra_header       = (auth_hdr[0] != '\0') ? auth_hdr : NULL,
+        .status_out         = &status,
+    };
+
+    char *body = NULL;
+    size_t body_len = 0;
+    esp_err_t err = http_fetch_text(url, &opts, &body, &body_len);
+
+    /* Scrub the password from the stack copy as soon as the fetch is done. */
+    memset(auth_hdr, 0, sizeof(auth_hdr));
+
+    if (err != ESP_OK) {
+        /* status 0 == no HTTP response at all (DNS/connect/timeout). Never log
+         * the password or the header; host and status are safe. */
+        ESP_LOGW(TAG, "config pull: %s failed (status=%d, %s)",
+                 host, status, esp_err_to_name(err));
+        if (status == 0) {
+            return pull_send_error(req, "unreachable", 0);
+        }
+        if (status == 401 || status == 403) {
+            return pull_send_error(req, "auth", status);
+        }
+        return pull_send_error(req, "bad_response", status);
+    }
+
+    /* A 200 is not proof we reached a NINA display: a captive portal or a login
+     * page also answers 200. Require the body to parse and to carry the "meta"
+     * object every backup has, so the browser is never handed something the
+     * restore endpoint will reject. Parse-and-discard: the raw text is what gets
+     * forwarded, since it is already the exact restore input. */
+    cJSON *probe = cJSON_Parse(body);
+    bool looks_like_backup = (probe != NULL && cJSON_IsObject(cJSON_GetObjectItem(probe, "meta")));
+    if (probe) cJSON_Delete(probe);
+    if (!looks_like_backup) {
+        ESP_LOGW(TAG, "config pull: %s returned a non-backup body", host);
+        heap_caps_free(body);
+        return pull_send_error(req, "bad_response", status);
+    }
+
+    ESP_LOGI(TAG, "config pull: %s ok (%u bytes, secrets=%d)",
+             host, (unsigned)body_len, include_sensitive ? 1 : 0);
+
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, body, body_len);
+    heap_caps_free(body);
+    return ESP_OK;
 }

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -19,6 +19,8 @@
 
 extern const uint8_t config_html_start[] asm("_binary_config_ui_html_start");
 extern const uint8_t config_html_end[]   asm("_binary_config_ui_html_end");
+extern const uint8_t home_html_start[] asm("_binary_home_ui_html_start");
+extern const uint8_t home_html_end[]   asm("_binary_home_ui_html_end");
 extern const uint8_t setup_html_start[] asm("_binary_setup_ui_html_start");
 extern const uint8_t setup_html_end[]   asm("_binary_setup_ui_html_end");
 extern const uint8_t favicon_png_start[] asm("_binary_favicon_png_start");
@@ -171,7 +173,7 @@ static esp_err_t send_embedded_asset(httpd_req_t *req,
     return httpd_resp_send(req, (const char *)plain_start, plain_end - plain_start);
 }
 
-// Handler for root URL
+// Handler for the config UI (served at /config; "/" is the Home page below)
 esp_err_t root_get_handler(httpd_req_t *req)
 {
     if (is_setup_mode()) {
@@ -184,6 +186,22 @@ esp_err_t root_get_handler(httpd_req_t *req)
     return send_embedded_asset(req, config_html_start, config_html_end,
                                config_html_gz_start, config_html_gz_end,
                                "text/html");
+}
+
+// Handler for the Home page at "/". Mirrors root_get_handler's flow exactly:
+// the first-run setup screen wins while no WiFi is configured, and
+// unauthenticated browsers are redirected into the login flow.
+esp_err_t home_get_handler(httpd_req_t *req)
+{
+    if (is_setup_mode()) {
+        httpd_resp_set_type(req, "text/html");
+        httpd_resp_send(req, (const char *)setup_html_start,
+                        setup_html_end - setup_html_start);
+        return ESP_OK;
+    }
+    REQUIRE_AUTH(req);
+    return send_embedded_asset(req, home_html_start, home_html_end,
+                               NULL, NULL, "text/html");
 }
 
 /**

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -148,6 +148,31 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
     }
 }
 
+/**
+ * Commit a live display tweak to the in-memory config, RAM-only either way.
+ *
+ * These five endpoints (/api/brightness, /api/color-brightness, /api/theme,
+ * /api/widget-style, /api/screen-rotation) serve two very different callers: the
+ * config UI's sliders, where the change IS a pending unsaved edit and the
+ * "unsaved changes" bar is honest -- and HA automations or macro keypads driving
+ * the same routes with X-Auth-Password, where the user never opened an editor
+ * and a bar they cannot explain is a bug. A day/night theme automation firing a
+ * few minutes after boot left dash2 permanently flagged dirty with nothing
+ * actually unsaved.
+ *
+ * Split on the session cookie (see request_is_web_ui) -- an existing signal, not
+ * a new one. Persistence is unchanged and identical on both paths: neither
+ * writes NVS. Only the flag differs.
+ */
+static void apply_display_change(httpd_req_t *req, const app_config_t *cfg)
+{
+    if (request_is_web_ui(req)) {
+        app_config_apply(cfg);        /* pending web edit -> bar is correct */
+    } else {
+        app_config_apply_external(cfg);   /* commanded from outside -> no bar */
+    }
+}
+
 // Handler for live brightness adjustment (no reboot needed)
 esp_err_t brightness_post_handler(httpd_req_t *req)
 {
@@ -185,7 +210,7 @@ esp_err_t brightness_post_handler(httpd_req_t *req)
         if (cfg) {
             app_config_get_snapshot_into(cfg);
             cfg->brightness = brightness;
-            app_config_apply(cfg);
+            apply_display_change(req, cfg);
             heap_caps_free(cfg);
         }
         bsp_display_brightness_set(brightness);
@@ -239,7 +264,7 @@ esp_err_t color_brightness_post_handler(httpd_req_t *req)
         }
         app_config_get_snapshot_into(cfg);
         cfg->color_brightness = cb;
-        app_config_apply(cfg);
+        apply_display_change(req, cfg);
 
         // Re-apply theme to update static text brightness
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
@@ -300,7 +325,7 @@ esp_err_t theme_post_handler(httpd_req_t *req)
         }
         app_config_get_snapshot_into(cfg);
         cfg->theme_index = idx;
-        app_config_apply(cfg);
+        apply_display_change(req, cfg);
         heap_caps_free(cfg);
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             nina_dashboard_apply_theme(idx);
@@ -357,7 +382,7 @@ esp_err_t widget_style_post_handler(httpd_req_t *req)
         }
         app_config_get_snapshot_into(cfg);
         cfg->widget_style = (uint8_t)idx;
-        app_config_apply(cfg);
+        apply_display_change(req, cfg);
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             nina_dashboard_apply_theme(cfg->theme_index);
             bsp_display_unlock();
@@ -465,7 +490,7 @@ esp_err_t screen_rotation_post_handler(httpd_req_t *req)
         }
         app_config_get_snapshot_into(cfg);
         cfg->screen_rotation = (uint8_t)rot;
-        app_config_apply(cfg);
+        apply_display_change(req, cfg);
         heap_caps_free(cfg);
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             lv_display_set_rotation(lv_display_get_default(), rot);

--- a/main/web_handlers_ha.c
+++ b/main/web_handlers_ha.c
@@ -2,12 +2,15 @@
  * @file web_handlers_ha.c
  * @brief HTTP handlers for the Home Assistant page.
  *
- * Three routes, all ROUTE_AUTH_REQUIRED (see web_server.c) and each also
+ * Four routes, all ROUTE_AUTH_REQUIRED (see web_server.c) and each also
  * REQUIRE_AUTH() first-line (defense-in-depth):
  *   GET  /api/ha-config  -- return the 5 Home Assistant config fields
  *   POST /api/ha-config  -- validate, snapshot+save, invalidate cache, live-apply
+ *                           ("preview":true applies live WITHOUT persisting)
  *   GET  /api/ha-probe   -- one-shot fetch of ONE entity (GET {base}/api/states/
  *                           <entity_id>) with Bearer auth, forward the entity JSON
+ *   GET  /api/ha-test    -- one-shot credentials check (GET {base}/api/config),
+ *                           reports a coarse verdict instead of the raw body
  *
  * Mirrors web_handlers_json.c (config get/post + proxy). The HA page fetches
  * per-entity (GET /api/states/<entity_id>) rather than a single URL, so the
@@ -33,6 +36,45 @@
 /* POST body cap: the tiles blob is ha_tiles_config[6144]; JSON-escaped and
  * wrapped with base/token/interval fields it stays well under this. PSRAM-backed. */
 #define HA_CONFIG_MAX_PAYLOAD  16384
+
+/**
+ * @brief Apply the current Home Assistant config to the live UI, without
+ *        touching persistence.
+ *
+ * Shared spine for every path that changes HA page config: the POST handler
+ * (save and preview) and the backup restore path. Reads the values it applies
+ * from the live config (app_config_get / app_config_get_ha_tiles), so the caller
+ * must have already committed them there via app_config_save(),
+ * app_config_apply_preview(), or app_config_set_ha_tiles[_ram]().
+ *
+ * Steps, in order: drop the client's parsed-tiles cache so the next poll re-reads
+ * the config; rebuild the page widget tree to the new rows/tiles; show/hide the
+ * page per @p enabled; re-resolve navigation (the page just appeared/disappeared
+ * from the arbiter ladder); start the poll task if the page is enabled.
+ *
+ * The refresh + enable calls touch LVGL and do NOT self-lock, so they run under
+ * the display lock (matches json_page_refresh_config usage). A lock timeout is
+ * not fatal -- the next poll picks the config up.
+ */
+void ha_page_apply_live(bool enabled)
+{
+    ha_client_invalidate_config_cache();
+    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+        ha_page_refresh_config();
+        nina_dashboard_set_ha_enabled(enabled);
+        bsp_display_unlock();
+    } else {
+        ESP_LOGW(TAG, "HA config: display lock timeout; page refresh deferred to next poll");
+    }
+
+    nav_arbiter_notify_topology_changed();
+
+    /* A runtime enable must start the poll task without a reboot; idempotent
+     * (no-op when disabled or already running). */
+    if (enabled) {
+        ha_ensure_task_running();
+    }
+}
 
 /**
  * @brief GET /api/ha-config  -- return the Home Assistant config fields.
@@ -81,6 +123,17 @@ esp_err_t ha_config_get_handler(httpd_req_t *req)
  * page widget tree + show/hide the page + start the poll task). app_config_t
  * is ~7.6 KB, so the copy lives in PSRAM -- never on the httpd stack (two
  * copies overflow it -> panic).
+ *
+ * Preview: a body carrying "preview":true runs the identical validation and
+ * live-apply path but swaps both persist calls for their RAM-only twins --
+ * app_config_apply_preview() instead of app_config_save(),
+ * app_config_set_ha_tiles_ram() instead of app_config_set_ha_tiles(). Nothing
+ * reaches NVS, so the panel shows the candidate config while the saved one is
+ * untouched. The live-apply helpers read app_config_get() /
+ * app_config_get_ha_tiles(), which is exactly what those two RAM-only writes
+ * update, so preview needs no separate apply path. Neither RAM-only write
+ * touches the unsaved-changes flag, so a preview never raises the web UI's
+ * "unsaved changes" bar.
  */
 esp_err_t ha_config_post_handler(httpd_req_t *req)
 {
@@ -109,6 +162,9 @@ esp_err_t ha_config_post_handler(httpd_req_t *req)
         }
     }
 
+    /* Preview: apply live, persist nothing. Absent/false => save as before. */
+    bool preview = cJSON_IsTrue(cJSON_GetObjectItem(root, "preview"));
+
     app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
     if (!cfg) {
         cJSON_Delete(root);
@@ -129,46 +185,76 @@ esp_err_t ha_config_post_handler(httpd_req_t *req)
      * live-apply refresh below reads the new value. */
     cJSON *tiles_item = cJSON_GetObjectItem(root, "ha_tiles_config");
     if (cJSON_IsString(tiles_item) && tiles_item->valuestring) {
-        esp_err_t te = app_config_set_ha_tiles(tiles_item->valuestring);
-        if (te != ESP_OK) ESP_LOGW(TAG, "ha tiles persist failed: %s", esp_err_to_name(te));
+        esp_err_t te = preview ? app_config_set_ha_tiles_ram(tiles_item->valuestring)
+                               : app_config_set_ha_tiles(tiles_item->valuestring);
+        if (te != ESP_OK) ESP_LOGW(TAG, "ha tiles apply failed: %s", esp_err_to_name(te));
     }
 
     cJSON_Delete(root);
 
-    /* Single atomic memcpy under the config mutex + NVS persist. validate_config
-     * (inside save) clamps ha_update_interval_s to 5..300 and NUL-terminates
-     * the char arrays. */
-    app_config_save(cfg);
-
-    /* Live apply. The parsed-tiles cache in ha_client must be dropped so the
-     * next poll re-reads the new config; the page widget tree is rebuilt to the
-     * new rows/tiles; and the page is shown/hidden per ha_enabled. The refresh
-     * + enable calls touch LVGL, so they run under the display lock (they do NOT
-     * self-lock -- matches json_page_refresh_config usage). */
-    ha_client_invalidate_config_cache();
-    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        ha_page_refresh_config();
-        nina_dashboard_set_ha_enabled(cfg->ha_enabled);
-        bsp_display_unlock();
+    /* Single atomic memcpy under the config mutex, + NVS persist unless preview.
+     * validate_config (inside both save and apply) clamps ha_update_interval_s
+     * to 5..300 and NUL-terminates the char arrays. The _preview variant also
+     * leaves the unsaved-changes flag untouched. */
+    if (preview) {
+        app_config_apply_preview(cfg);
     } else {
-        ESP_LOGW(TAG, "HA config: display lock timeout; page refresh deferred to next poll");
+        app_config_save(cfg);
     }
 
-    /* Re-resolve navigation so the arbiter immediately re-evaluates the HA
-     * page's availability (it just appeared/disappeared from the ladder). */
-    nav_arbiter_notify_topology_changed();
-
-    /* A runtime enable must start the poll task without a reboot; idempotent
-     * (no-op when disabled or already running). */
-    if (cfg->ha_enabled) {
-        ha_ensure_task_running();
-    }
+    /* Live apply (cache drop + widget rebuild + show/hide + nav + task). */
+    ha_page_apply_live(cfg->ha_enabled);
 
     heap_caps_free(cfg);
 
     httpd_resp_set_type(req, "application/json");
-    httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
+    httpd_resp_send(req, preview ? "{\"success\":true,\"preview\":true}"
+                                 : "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
+}
+
+/* Buffer sizes for the resolved credentials, taken from the config fields. */
+#define HA_BASE_BUF   sizeof(((app_config_t *)0)->ha_base_url)
+#define HA_TOKEN_BUF  sizeof(((app_config_t *)0)->ha_token)
+
+/**
+ * Resolve the base URL + token for an outbound HA request: start from the saved
+ * config, then override each with the live (possibly unsaved) value sent as an
+ * X-HA-BASE / X-HA-TOKEN request header, so Probe and Test work before Save.
+ * Headers (not query params) keep the bearer token out of any request-URI log.
+ *
+ * @p base must be HA_BASE_BUF bytes, @p token HA_TOKEN_BUF bytes; both are always
+ * NUL-terminated on a true return. Returns false only when the PSRAM config copy
+ * could not be allocated (caller sends 500). The config copy is heap-allocated in
+ * PSRAM and freed before returning -- app_config_t is ~7.6 KB and must never sit
+ * on the httpd stack.
+ */
+static bool ha_resolve_credentials(httpd_req_t *req, char *base, char *token)
+{
+    app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
+    if (!cfg) {
+        return false;
+    }
+    app_config_get_snapshot_into(cfg);
+    strlcpy(base, cfg->ha_base_url, HA_BASE_BUF);
+    strlcpy(token, cfg->ha_token, HA_TOKEN_BUF);
+    heap_caps_free(cfg);
+
+    size_t hlen = httpd_req_get_hdr_value_len(req, "X-HA-BASE");
+    if (hlen > 0 && hlen < HA_BASE_BUF) {
+        char hval[HA_BASE_BUF];
+        if (httpd_req_get_hdr_value_str(req, "X-HA-BASE", hval, sizeof(hval)) == ESP_OK) {
+            strlcpy(base, hval, HA_BASE_BUF);
+        }
+    }
+    hlen = httpd_req_get_hdr_value_len(req, "X-HA-TOKEN");
+    if (hlen > 0 && hlen < HA_TOKEN_BUF) {
+        char tval[HA_TOKEN_BUF];
+        if (httpd_req_get_hdr_value_str(req, "X-HA-TOKEN", tval, sizeof(tval)) == ESP_OK) {
+            strlcpy(token, tval, HA_TOKEN_BUF);
+        }
+    }
+    return true;
 }
 
 /**
@@ -185,34 +271,11 @@ esp_err_t ha_probe_get_handler(httpd_req_t *req)
 {
     REQUIRE_AUTH(req);
 
-    app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
-    if (!cfg) {
+    char base[HA_BASE_BUF];
+    char token[HA_TOKEN_BUF];
+    if (!ha_resolve_credentials(req, base, token)) {
         httpd_resp_send_500(req);
         return ESP_FAIL;
-    }
-    app_config_get_snapshot_into(cfg);
-    char base[sizeof(cfg->ha_base_url)];
-    char token[sizeof(cfg->ha_token)];
-    strlcpy(base, cfg->ha_base_url, sizeof(base));
-    strlcpy(token, cfg->ha_token, sizeof(token));
-    heap_caps_free(cfg);
-
-    /* Override base/token with the live (possibly unsaved) values sent as
-     * request headers, so Probe works before Save. Headers (not query params)
-     * keep the bearer token out of any request-URI log. Fall back to saved. */
-    size_t hlen = httpd_req_get_hdr_value_len(req, "X-HA-BASE");
-    if (hlen > 0 && hlen < sizeof(base)) {
-        char hval[sizeof(base)];
-        if (httpd_req_get_hdr_value_str(req, "X-HA-BASE", hval, sizeof(hval)) == ESP_OK) {
-            strlcpy(base, hval, sizeof(base));
-        }
-    }
-    hlen = httpd_req_get_hdr_value_len(req, "X-HA-TOKEN");
-    if (hlen > 0 && hlen < sizeof(token)) {
-        char tval[sizeof(token)];
-        if (httpd_req_get_hdr_value_str(req, "X-HA-TOKEN", tval, sizeof(tval)) == ESP_OK) {
-            strlcpy(token, tval, sizeof(token));
-        }
     }
 
     /* Read the ?entity=<entity_id> query parameter. */
@@ -254,5 +317,101 @@ esp_err_t ha_probe_get_handler(httpd_req_t *req)
 
     free((void *)body);
     cJSON_Delete(ent);
+    return ESP_OK;
+}
+
+/**
+ * @brief GET /api/ha-test  -- verify the Home Assistant base URL + token.
+ *
+ * Fetches GET {base}/api/config (the smallest authenticated HA endpoint that
+ * identifies the server) and reports a coarse verdict instead of the raw body,
+ * so the config UI can tell the three failure modes apart: host not reachable,
+ * token rejected, and reachable-but-not-Home-Assistant. Base+token come from
+ * saved config, overridden by X-HA-BASE / X-HA-TOKEN when present, so Test works
+ * before Save (same resolution as Probe -- see ha_resolve_credentials).
+ *
+ * Always answers 200 with the verdict in the body (the one exception is an
+ * unconfigured base URL -> 400 {"error":...}, matching ha-probe):
+ *   {"ok":bool, "stage":"unreachable"|"auth"|"not_ha"|"ok",
+ *    "status":<upstream HTTP status, 0 if none>, "version":"", "location_name":""}
+ * version/location_name are populated only when stage=="ok". The token is never
+ * echoed, in the response or in a log line.
+ */
+esp_err_t ha_test_get_handler(httpd_req_t *req)
+{
+    REQUIRE_AUTH(req);
+
+    char base[HA_BASE_BUF];
+    char token[HA_TOKEN_BUF];
+    if (!ha_resolve_credentials(req, base, token)) {
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    if (base[0] == '\0') {
+        httpd_resp_set_status(req, "400 Bad Request");
+        httpd_resp_set_type(req, "application/json");
+        httpd_resp_send(req, "{\"error\":\"Home Assistant base URL not configured\"}", HTTPD_RESP_USE_STRLEN);
+        return ESP_OK;
+    }
+
+    /* status 0 == no response at all (DNS/connect/timeout). */
+    cJSON *upstream = NULL;
+    int status = ha_client_fetch_config(base, token, &upstream);
+
+    bool ok = false;
+    const char *stage = "not_ha";
+    const char *version = "";
+    const char *location_name = "";
+
+    if (status == 0) {
+        stage = "unreachable";
+    } else if (status == 401 || status == 403) {
+        stage = "auth";
+    } else if (status == 200) {
+        /* A real HA /api/config always carries "version". Anything else on 200
+         * (wrong host, captive portal, reverse proxy error page) is not_ha. */
+        cJSON *v = upstream ? cJSON_GetObjectItem(upstream, "version") : NULL;
+        if (cJSON_IsString(v) && v->valuestring != NULL && v->valuestring[0] != '\0') {
+            ok = true;
+            stage = "ok";
+            version = v->valuestring;
+            cJSON *ln = cJSON_GetObjectItem(upstream, "location_name");
+            if (cJSON_IsString(ln) && ln->valuestring != NULL) {
+                location_name = ln->valuestring;
+            }
+        }
+    }
+
+    ESP_LOGI(TAG, "HA test: %s (stage=%s, status=%d)", base, stage, status);
+
+    cJSON *root = cJSON_CreateObject();
+    if (root == NULL) {
+        if (upstream) {
+            cJSON_Delete(upstream);
+        }
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    /* AddString copies, so the borrowed pointers into `upstream` are safe here. */
+    cJSON_AddBoolToObject(root,   "ok",            ok);
+    cJSON_AddStringToObject(root, "stage",         stage);
+    cJSON_AddNumberToObject(root, "status",        status);
+    cJSON_AddStringToObject(root, "version",       version);
+    cJSON_AddStringToObject(root, "location_name", location_name);
+    if (upstream) {
+        cJSON_Delete(upstream);
+    }
+
+    const char *out = cJSON_PrintUnformatted(root);
+    if (out == NULL) {
+        cJSON_Delete(root);
+        httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+    httpd_resp_set_type(req, "application/json");
+    httpd_resp_send(req, out, HTTPD_RESP_USE_STRLEN);
+
+    free((void *)out);
+    cJSON_Delete(root);
     return ESP_OK;
 }

--- a/main/web_handlers_json.c
+++ b/main/web_handlers_json.c
@@ -6,6 +6,7 @@
  * REQUIRE_AUTH() first-line (defense-in-depth):
  *   GET  /api/json-config  -- return the 5 JSON Display config fields
  *   POST /api/json-config  -- validate, snapshot+save, invalidate cache, live-apply
+ *                             ("preview":true applies live WITHOUT persisting)
  *   GET  /api/json-proxy   -- one-shot fetch of the configured URL (with auth
  *                             header), forward the raw JSON body to the browser
  *
@@ -38,6 +39,45 @@
  * truncated; the config UI then reports a parse failure rather than the device
  * buffering megabytes on an httpd worker. */
 #define JSON_PROXY_BUF_SIZE      262144
+
+/**
+ * @brief Apply the current JSON Display config to the live UI, without touching
+ *        persistence.
+ *
+ * Shared spine for every path that changes JSON Display config: the POST handler
+ * (save and preview) and the backup restore path. Reads the values it applies
+ * from the live config (app_config_get / app_config_get_json_tiles), so the
+ * caller must have already committed them there via app_config_save(),
+ * app_config_apply_preview(), or app_config_set_json_tiles[_ram]().
+ *
+ * Steps, in order: drop the client's parsed-tiles cache so the next poll re-reads
+ * the config; rebuild the page widget tree to the new rows/tiles; show/hide the
+ * page per @p enabled; re-resolve navigation (the page just appeared/disappeared
+ * from the arbiter ladder); start the poll task if the page is enabled.
+ *
+ * The refresh + enable calls touch LVGL and do NOT self-lock, so they run under
+ * the display lock (matches allsky_page_refresh_config usage). A lock timeout is
+ * not fatal -- the next poll picks the config up.
+ */
+void json_page_apply_live(bool enabled)
+{
+    json_client_invalidate_config_cache();
+    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+        json_page_refresh_config();
+        nina_dashboard_set_json_enabled(enabled);
+        bsp_display_unlock();
+    } else {
+        ESP_LOGW(TAG, "JSON config: display lock timeout; page refresh deferred to next poll");
+    }
+
+    nav_arbiter_notify_topology_changed();
+
+    /* A runtime enable must start the poll task without a reboot; idempotent
+     * (no-op when disabled or already running). */
+    if (enabled) {
+        json_ensure_task_running();
+    }
+}
 
 /**
  * @brief GET /api/json-config  -- return the JSON Display config fields.
@@ -83,6 +123,17 @@ esp_err_t json_config_get_handler(httpd_req_t *req)
  * then live-apply (invalidate the client's parsed-tiles cache + rebuild the
  * page widget tree + show/hide the page). app_config_t is ~7.6 KB, so the copy
  * lives in PSRAM -- never on the httpd stack (two copies overflow it -> panic).
+ *
+ * Preview: a body carrying "preview":true runs the identical validation and
+ * live-apply path but swaps both persist calls for their RAM-only twins --
+ * app_config_apply_preview() instead of app_config_save(),
+ * app_config_set_json_tiles_ram() instead of app_config_set_json_tiles(). Nothing
+ * reaches NVS, so the panel shows the candidate config while the saved one is
+ * untouched. The live-apply helpers read app_config_get() /
+ * app_config_get_json_tiles(), which is exactly what those two RAM-only writes
+ * update, so preview needs no separate apply path. Neither RAM-only write
+ * touches the unsaved-changes flag, so a preview never raises the web UI's
+ * "unsaved changes" bar.
  */
 esp_err_t json_config_post_handler(httpd_req_t *req)
 {
@@ -111,6 +162,9 @@ esp_err_t json_config_post_handler(httpd_req_t *req)
         }
     }
 
+    /* Preview: apply live, persist nothing. Absent/false => save as before. */
+    bool preview = cJSON_IsTrue(cJSON_GetObjectItem(root, "preview"));
+
     app_config_t *cfg = heap_caps_malloc(sizeof(app_config_t), MALLOC_CAP_SPIRAM);
     if (!cfg) {
         cJSON_Delete(root);
@@ -131,45 +185,31 @@ esp_err_t json_config_post_handler(httpd_req_t *req)
      * the live-apply refresh below reads the new value. */
     cJSON *tiles_item = cJSON_GetObjectItem(root, "json_tiles_config");
     if (cJSON_IsString(tiles_item) && tiles_item->valuestring) {
-        esp_err_t te = app_config_set_json_tiles(tiles_item->valuestring);
-        if (te != ESP_OK) ESP_LOGW(TAG, "json tiles persist failed: %s", esp_err_to_name(te));
+        esp_err_t te = preview ? app_config_set_json_tiles_ram(tiles_item->valuestring)
+                               : app_config_set_json_tiles(tiles_item->valuestring);
+        if (te != ESP_OK) ESP_LOGW(TAG, "json tiles apply failed: %s", esp_err_to_name(te));
     }
 
     cJSON_Delete(root);
 
-    /* Single atomic memcpy under the config mutex + NVS persist. validate_config
-     * (inside save) clamps json_update_interval_s to 5..300 and NUL-terminates
-     * the char arrays. */
-    app_config_save(cfg);
-
-    /* Live apply. The parsed-tiles cache in json_client must be dropped so the
-     * next poll re-reads the new config; the page widget tree is rebuilt to the
-     * new rows/tiles; and the page is shown/hidden per json_enabled. The refresh
-     * + enable calls touch LVGL, so they run under the display lock (they do NOT
-     * self-lock -- matches allsky_page_refresh_config usage). */
-    json_client_invalidate_config_cache();
-    if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        json_page_refresh_config();
-        nina_dashboard_set_json_enabled(cfg->json_enabled);
-        bsp_display_unlock();
+    /* Single atomic memcpy under the config mutex, + NVS persist unless preview.
+     * validate_config (inside both save and apply) clamps json_update_interval_s
+     * to 5..300 and NUL-terminates the char arrays. The _preview variant also
+     * leaves the unsaved-changes flag untouched. */
+    if (preview) {
+        app_config_apply_preview(cfg);
     } else {
-        ESP_LOGW(TAG, "JSON config: display lock timeout; page refresh deferred to next poll");
+        app_config_save(cfg);
     }
 
-    /* Re-resolve navigation so the arbiter immediately re-evaluates the JSON
-     * page's availability (it just appeared/disappeared from the ladder). */
-    nav_arbiter_notify_topology_changed();
-
-    /* A runtime enable must start the poll task without a reboot; idempotent
-     * (no-op when disabled or already running). */
-    if (cfg->json_enabled) {
-        json_ensure_task_running();
-    }
+    /* Live apply (cache drop + widget rebuild + show/hide + nav + task). */
+    json_page_apply_live(cfg->json_enabled);
 
     heap_caps_free(cfg);
 
     httpd_resp_set_type(req, "application/json");
-    httpd_resp_send(req, "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
+    httpd_resp_send(req, preview ? "{\"success\":true,\"preview\":true}"
+                                 : "{\"success\":true}", HTTPD_RESP_USE_STRLEN);
     return ESP_OK;
 }
 

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -753,6 +753,7 @@ static const char *nav_level_str(nav_source_t src)
 {
     switch (src) {
         case NAV_SRC_HOLD:      return "menu";
+        case NAV_SRC_HOME_LOCK: return "lock";
         case NAV_SRC_USER:      return "override";
         case NAV_SRC_SLIDESHOW: return "slideshow";
         case NAV_SRC_SESSION:   return "session";
@@ -846,6 +847,7 @@ esp_err_t status_get_handler(httpd_req_t *req)
         cJSON_AddStringToObject(nav_obj, "level", nav_level_str(nav.level));
         cJSON_AddNumberToObject(nav_obj, "override_remaining_s", nav.grace_remaining_s);
         cJSON_AddNumberToObject(nav_obj, "grace_s", cfg->nav_grace_s);
+        cJSON_AddBoolToObject(nav_obj, "home_page_lock", cfg->home_page_lock);
         cJSON_AddNumberToObject(nav_obj, "current_page", nina_dashboard_get_active_page());
         cJSON_AddStringToObject(nav_obj, "current_page_slug",
                                 page_id_slug_or_summary(control_page_current_id()));

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -24,6 +24,9 @@
 #include "esp_timer.h"
 #include "nina_connection.h"
 #include "ui/nina_dashboard.h"
+#include "ui/nina_nav_arbiter.h"
+#include "ui/page_registry.h"
+#include "control_registry.h"   /* control_page_current_id — image-source-aware page id */
 #include "power_mgmt.h"
 #include "esp_wifi.h"
 #include "driver/temperature_sensor.h"
@@ -745,6 +748,36 @@ esp_err_t perf_reset_post_handler(httpd_req_t *req)
     return ESP_OK;
 }
 
+/* Map a nav_source_t rung to the web contract's "level" string. */
+static const char *nav_level_str(nav_source_t src)
+{
+    switch (src) {
+        case NAV_SRC_HOLD:      return "menu";
+        case NAV_SRC_USER:      return "override";
+        case NAV_SRC_SLIDESHOW: return "slideshow";
+        case NAV_SRC_SESSION:   return "session";
+        case NAV_SRC_IDLE:      return "idle";
+        case NAV_SRC_BOOT:      /* fallthrough */
+        case NAV_SRC_DEFAULT:
+        default:                return "home";
+    }
+}
+
+/* Slug for a page_ref id. Unknown/legacy ids (including the -1 Home Page
+ * sentinel) fall back to Summary's slug, matching the arbiter's home_page()
+ * Summary fallback. */
+static const char *page_id_slug_or_summary(int id)
+{
+    const page_ref_entry_t *e = NULL;
+    if (id >= 0 && id < (int)PAGE_REF_ID_MAX) {
+        e = page_ref_by_id((page_ref_t)id);
+    }
+    if (!e || !e->slug) {
+        e = page_ref_by_id(PAGE_REF_SUMMARY);
+    }
+    return (e && e->slug) ? e->slug : "summary";
+}
+
 // Handler for lightweight device status (test automation)
 esp_err_t status_get_handler(httpd_req_t *req)
 {
@@ -800,6 +833,69 @@ esp_err_t status_get_handler(httpd_req_t *req)
         cJSON_AddNullToObject(root, "wifi_rssi");
         cJSON_AddStringToObject(root, "wifi_ssid", "");
     }
+
+    // ── Navigation state (Home web page) ──
+    const app_config_t *cfg = app_config_get();
+    nav_arbiter_web_status_t nav;
+    nav_arbiter_get_web_status(&nav);
+
+    cJSON *nav_obj = cJSON_AddObjectToObject(root, "nav");
+    if (nav_obj) {
+        cJSON_AddStringToObject(nav_obj, "mode",
+                                cfg->auto_rotate_enabled ? "slideshow" : "pinned");
+        cJSON_AddStringToObject(nav_obj, "level", nav_level_str(nav.level));
+        cJSON_AddNumberToObject(nav_obj, "override_remaining_s", nav.grace_remaining_s);
+        cJSON_AddNumberToObject(nav_obj, "grace_s", cfg->nav_grace_s);
+        cJSON_AddNumberToObject(nav_obj, "current_page", nina_dashboard_get_active_page());
+        cJSON_AddStringToObject(nav_obj, "current_page_slug",
+                                page_id_slug_or_summary(control_page_current_id()));
+        cJSON_AddStringToObject(nav_obj, "home_page_slug",
+                                page_id_slug_or_summary(cfg->active_page_override));
+        cJSON_AddBoolToObject(nav_obj, "idle_enabled", cfg->idle_page_override_enabled);
+        cJSON_AddStringToObject(nav_obj, "idle_page_slug",
+                                cfg->idle_page_override_enabled
+                                    ? page_id_slug_or_summary(cfg->idle_page_override_target)
+                                    : "");
+        cJSON_AddBoolToObject(nav_obj, "auto_rotate", cfg->auto_rotate_enabled);
+        // Slideshow stop values ARE page_ref ids; skip empty/invalid entries
+        // the same way slideshow_build_candidates() does.
+        cJSON *rot = cJSON_AddArrayToObject(nav_obj, "rotation");
+        if (rot) {
+            for (int i = 0; i < ARP_ORDER_CAPACITY; i++) {
+                uint8_t bit = cfg->auto_rotate_order2[i];
+                if (bit == 0xFF || !ARP_STOP_IS_VALID(bit)) continue;
+                const page_ref_entry_t *e = page_ref_by_id((page_ref_t)bit);
+                if (e && e->slug) {
+                    cJSON_AddItemToArray(rot, cJSON_CreateString(e->slug));
+                }
+            }
+        }
+    }
+
+    // ── Integration availability (Home web page badges) ──
+    cJSON *integ = cJSON_AddObjectToObject(root, "integrations");
+    if (integ) {
+        // Live broker connection state (false when MQTT is disabled).
+        cJSON_AddBoolToObject(integ, "mqtt", mqtt_ha_is_connected());
+        cJSON_AddBoolToObject(integ, "allsky", cfg->allsky_enabled);
+        // Weather has no enable flag; "configured" mirrors the poll task's own
+        // gate (location set, plus an API key for the providers that need one).
+        bool weather_needs_key = (cfg->weather_provider == 0 || cfg->weather_provider == 2);
+        bool weather_configured = (cfg->weather_location_name[0] != '\0')
+                               && (!weather_needs_key || cfg->weather_api_key[0] != '\0');
+        cJSON_AddBoolToObject(integ, "weather", weather_configured);
+        cJSON_AddBoolToObject(integ, "spotify", cfg->spotify_enabled);
+    }
+
+    // ── Cached update-check answer only; NEVER a network call here. The cache
+    // is filled by the async worker above (check_update_json_handler); when no
+    // check has run yet this reports false. ──
+    bool upd_avail = false;
+    if (s_upd_mutex && xSemaphoreTake(s_upd_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        upd_avail = s_upd_have_result && (s_upd_result == OTA_CHECK_UPDATE_AVAILABLE);
+        xSemaphoreGive(s_upd_mutex);
+    }
+    cJSON_AddBoolToObject(root, "update_available", upd_avail);
 
     const char *json_str = cJSON_PrintUnformatted(root);
     if (!json_str) {

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -325,7 +325,7 @@ void start_web_server(void)
      * The proper long-term fix is to offload these outbound fetches off the
      * httpd worker onto a dedicated task; until then this stack must stay large. */
     config.stack_size = 40960;
-    config.max_uri_handlers = 80;
+    config.max_uri_handlers = 84;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -346,7 +346,8 @@ void start_web_server(void)
      * ROUTE_SETUP_EXEMPT below. See main/web_route_auth.h for the truth
      * table auth_gate_handler() evaluates via route_auth_allows(). */
     static const route_entry_t routes[] = {
-        { { "/",                     HTTP_GET,  root_get_handler, NULL }, ROUTE_SETUP_EXEMPT },
+        { { "/",                     HTTP_GET,  home_get_handler, NULL }, ROUTE_SETUP_EXEMPT },
+        { { "/config",               HTTP_GET,  root_get_handler, NULL }, ROUTE_SETUP_EXEMPT },
         { { "/ui/fragment",          HTTP_GET,  ui_fragment_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/favicon.ico",          HTTP_GET,  favicon_get_handler, NULL }, ROUTE_PUBLIC },
         { { "/api/config",           HTTP_GET,  config_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
@@ -424,12 +425,12 @@ void start_web_server(void)
         { { "/api/image-display/refresh", HTTP_POST, image_display_refresh_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
     };
 
-    /* Keep config.max_uri_handlers (set to 80 above) in sync with the route
+    /* Keep config.max_uri_handlers (set to 84 above) in sync with the route
      * table; a route that overflows it would be silently dropped at
-     * registration. Bump both together when adding routes. Raised 76 -> 80 when
-     * /api/ha-test and /api/config/pull filled the last two slots; the extra
-     * headroom is a few pointers per slot in the httpd handler array. */
-    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 80,
+     * registration. Bump both together when adding routes. Raised 80 -> 84 when
+     * the Home page took "/" and the config UI moved to /config (77 routes);
+     * the extra headroom is a few pointers per slot in the httpd handler array. */
+    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 84,
                    "max_uri_handlers too small for route table");
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -180,6 +180,36 @@ bool check_session(httpd_req_t *req) {
 }
 
 /**
+ * @brief True when this request plausibly came from the config UI in a browser,
+ *        rather than from a stateless API client (HA automation, macro keypad,
+ *        curl).
+ *
+ * Discriminator: the session cookie. It already exists and is already the thing
+ * that separates the two client classes -- a browser logs in once and carries
+ * the cookie; a stateless client has no session and authenticates per request
+ * with X-Auth-Password (see check_session). No new header or flag is introduced
+ * for this; if the cookie stops being the browser's credential, this stops being
+ * correct, and that is the right coupling.
+ *
+ * Used only to decide whether a live-apply counts as an unsaved WEB EDIT (raises
+ * the config UI's "unsaved changes" bar) or as an externally commanded change
+ * (must not). It is deliberately NOT a security decision -- REQUIRE_AUTH has
+ * already run by the time any handler asks -- so a wrong answer costs a
+ * cosmetic bar, never access.
+ *
+ * When auth is disabled there is no cookie and no header to tell the two apart,
+ * so this returns true: that preserves today's behavior exactly for the UI, and
+ * an open device is not the configuration this distinction was built for.
+ */
+bool request_is_web_ui(httpd_req_t *req) {
+    const app_config_t *cfg = app_config_get();
+    if (cfg && !cfg->auth_enabled) return true;   /* indistinguishable; keep old behavior */
+
+    char tok[SESSION_TOKEN_HEX_LEN + 1];
+    return session_extract_cookie(req, tok, sizeof(tok)) && session_valid(tok);
+}
+
+/**
  * @brief Send an auth-required response.
  *
  * For browser page requests (URI does not start with /api/), issue a 302 redirect

--- a/main/web_server.c
+++ b/main/web_server.c
@@ -295,7 +295,7 @@ void start_web_server(void)
      * The proper long-term fix is to offload these outbound fetches off the
      * httpd worker onto a dedicated task; until then this stack must stay large. */
     config.stack_size = 40960;
-    config.max_uri_handlers = 76;
+    config.max_uri_handlers = 80;
     config.max_open_sockets = 16;
     config.lru_purge_enable = true;
     config.keep_alive_enable = true;
@@ -336,6 +336,7 @@ void start_web_server(void)
         { { "/api/perf/reset",       HTTP_POST, perf_reset_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/config/apply",     HTTP_POST, config_apply_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/config/revert",    HTTP_POST, config_revert_handler, NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/config/pull",      HTTP_POST, config_pull_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/check-update",     HTTP_POST, check_update_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/check-update-json", HTTP_GET, check_update_json_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/ota-github",       HTTP_POST, ota_github_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
@@ -347,6 +348,7 @@ void start_web_server(void)
         { { "/api/ha-config",        HTTP_GET,  ha_config_get_handler,  NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/ha-config",        HTTP_POST, ha_config_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/ha-probe",         HTTP_GET,  ha_probe_get_handler,   NULL }, ROUTE_AUTH_REQUIRED },
+        { { "/api/ha-test",          HTTP_GET,  ha_test_get_handler,    NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/spotify/config",         HTTP_GET,  spotify_config_get_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/spotify/config",         HTTP_POST, spotify_config_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
         { { "/api/spotify/callback",       HTTP_GET,  spotify_callback_get_handler, NULL }, ROUTE_PUBLIC },
@@ -392,10 +394,12 @@ void start_web_server(void)
         { { "/api/image-display/refresh", HTTP_POST, image_display_refresh_post_handler, NULL }, ROUTE_AUTH_REQUIRED },
     };
 
-    /* Keep config.max_uri_handlers (set to 76 above) in sync with the route
+    /* Keep config.max_uri_handlers (set to 80 above) in sync with the route
      * table; a route that overflows it would be silently dropped at
-     * registration. Bump both together when adding routes. */
-    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 76,
+     * registration. Bump both together when adding routes. Raised 76 -> 80 when
+     * /api/ha-test and /api/config/pull filled the last two slots; the extra
+     * headroom is a few pointers per slot in the httpd handler array. */
+    _Static_assert(sizeof(routes) / sizeof(routes[0]) <= 80,
                    "max_uri_handlers too small for route table");
 
     for (int i = 0; i < (int)(sizeof(routes)/sizeof(routes[0])); i++) {

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -64,6 +64,13 @@ cJSON *receive_json_body(httpd_req_t *req, int max_size);
 bool check_session(httpd_req_t *req);
 esp_err_t send_auth_required(httpd_req_t *req);
 
+/* True when the request carries a valid browser SESSION COOKIE (config UI), as
+ * opposed to a stateless X-Auth-Password client (HA automation, macro keypad).
+ * Cosmetic use only -- decides whether a live-apply raises the "unsaved changes"
+ * bar. Never a security decision; REQUIRE_AUTH has already run. Returns true
+ * when auth is disabled (the two are indistinguishable then). */
+bool request_is_web_ui(httpd_req_t *req);
+
 /* Session API used by login/logout handlers */
 const char *session_create(void);
 bool session_valid(const char *token);

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -13,9 +13,16 @@
 /* Logging tag -- shared across all handler files */
 static const char *TAG __attribute__((unused)) = "web_server";
 
-/* Maximum accepted POST payload size for config endpoints */
+/* Maximum accepted POST payload size for config endpoints. Buffers are
+ * PSRAM-backed (see receive_json_body), so these are generous by design.
+ *
+ * RESTORE was 16384 until the backup gained the two tiles blobs. A restore body
+ * wraps a whole backup file: the pre-tiles config section is ~8 KB, and each
+ * tiles blob is up to 6144 bytes whose embedded quotes roughly double under JSON
+ * escaping. 49152 covers the worst case with headroom; a body at or above the
+ * cap is rejected with "Payload too large" rather than silently truncated. */
 #define CONFIG_MAX_PAYLOAD 8192
-#define CONFIG_MAX_RESTORE_PAYLOAD 16384
+#define CONFIG_MAX_RESTORE_PAYLOAD 49152
 
 /* ---- JSON extraction macros ---- */
 #define JSON_TO_STRING(root, key, dest) do { \
@@ -110,6 +117,17 @@ esp_err_t json_proxy_get_handler(httpd_req_t *req);
 esp_err_t ha_config_get_handler(httpd_req_t *req);
 esp_err_t ha_config_post_handler(httpd_req_t *req);
 esp_err_t ha_probe_get_handler(httpd_req_t *req);
+esp_err_t ha_test_get_handler(httpd_req_t *req);
+esp_err_t config_pull_post_handler(httpd_req_t *req);
+
+/* ---- Page live-apply spines (defined alongside their page-config handlers) ----
+ * Apply the CURRENT live config to the JSON Display / Home Assistant page: drop
+ * the client's parsed-tiles cache, rebuild the page widget tree, show/hide the
+ * page per @p enabled, re-resolve navigation, and ensure the poll task runs.
+ * Persistence is the caller's job -- these only read app_config_get() and the
+ * tiles getters. Used by the page-config POST handlers and by config restore. */
+void json_page_apply_live(bool enabled);
+void ha_page_apply_live(bool enabled);
 esp_err_t spotify_config_get_handler(httpd_req_t *req);
 esp_err_t spotify_config_post_handler(httpd_req_t *req);
 esp_err_t spotify_callback_get_handler(httpd_req_t *req);

--- a/main/web_server_internal.h
+++ b/main/web_server_internal.h
@@ -94,6 +94,7 @@ void auth_note_success(void);   /* clear failure counter and any lockout */
 
 /* ---- Handler forward declarations (registered by start_web_server) ---- */
 esp_err_t root_get_handler(httpd_req_t *req);
+esp_err_t home_get_handler(httpd_req_t *req);
 esp_err_t ui_fragment_get_handler(httpd_req_t *req);
 esp_err_t favicon_get_handler(httpd_req_t *req);
 esp_err_t config_get_handler(httpd_req_t *req);


### PR DESCRIPTION
### Summary
This PR introduces a new home status page at the root URL, providing device health, connection states, and navigation insights. It also adds features for device cloning, selective configuration restore, and improves the web UI for tile configuration and saving.

### Changes
*   A new home status page is available at `/`, showing device health, connection states, and a visual decision flow for why a specific page is displayed, while the configuration UI moves to `/config`.
*   Added device cloning functionality, allowing fetching another device's backup directly, and a new endpoint to test Home Assistant connection details.
*   Configuration restore now offers selective application via checkboxes for individual settings, including WiFi networks and admin password, with a live count of selected items.
*   Tile configuration in the web UI now supports page-level default colors, collapsible editor sections, and a more compact display for tile cards.
*   The save model for web UI configuration has been reworked, with page buttons applying changes live (preview-only) and a main Save button for persistence.
*   Fixed issues where external commands or inputs on the backup/restore tab would incorrectly trigger the "Unsaved changes" bar in the web UI.
*   Backup format now includes tile layouts and page source scalars (with sensitive data redacted), and the restore preview is automatically revealed after a device pull.
*   Hardened the system against CRLF header injection and XSS vulnerabilities in backup-derived strings.

---
<sub>Analyzed **10** commit(s) | Updated: 2026-08-09T02:18:39.738Z | Generated by GitHub Actions</sub>