### PR TITLE
feat: add WiFi transmit power cap setting

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -2534,6 +2534,22 @@ static void migrate_from_v57(const void *raw, size_t raw_size, app_config_t *cfg
     ESP_LOGI(TAG, "Migrated config from v57 to v%d", APP_CONFIG_VERSION);
 }
 
+/* --- v58 → v59 migration: appends wifi_max_tx_dbm (WiFi TX power cap).
+ *     Additive; an upgrading device keeps the uncapped chip default. --- */
+static void migrate_from_v58(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v58_t) ? raw_size : sizeof(app_config_v58_t);
+    memcpy(cfg, raw, copy);
+
+    /* Appended past the v58 snapshot, so memcpy(copy) never touches it; the
+     * copy may still have landed inside dest padding, so re-assign. */
+    cfg->wifi_max_tx_dbm = 0;  // no TX power cap by default
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v58 to v%d", APP_CONFIG_VERSION);
+}
+
 static void migrate_from_v36(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -3223,6 +3239,21 @@ static bool validate_config(app_config_t *cfg) {
     }
     cfg->ha_enabled = cfg->ha_enabled ? true : false;
 
+    /* WiFi TX power cap: whitelist, not a range — only the discrete dBm steps
+     * the UI offers are meaningful, and 0 means "no cap". Anything else (a
+     * stale blob byte, or a value that slipped past the settings-table range
+     * check) resets to 0 so a bad value fails toward connectivity rather than
+     * toward a silently throttled radio. Must stay AFTER settings_clamp_apply()
+     * above, whose two-sided 0..20 range would otherwise let e.g. 13 survive. */
+    switch (cfg->wifi_max_tx_dbm) {
+        case 0: case 8: case 11: case 14: case 17: case 20:
+            break;
+        default:
+            cfg->wifi_max_tx_dbm = 0;
+            fixed = true;
+            break;
+    }
+
     return fixed;
 }
 
@@ -3300,6 +3331,14 @@ void app_config_init(void) {
             nvs_commit(handle);
         }
         /* tiles_loaded stays false -> tail loads "json_tiles"/"ha_tiles" keys */
+    } else if (version_check == 58) {
+        /* v58 → v59: added wifi_max_tx_dbm (WiFi TX power cap). tiles_loaded
+         * stays false: a v58 device already keeps its tiles in the
+         * "json_tiles"/"ha_tiles" NVS keys, so the tail loads them. */
+        migrate_from_v58(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 57) {
         /* v57 → v58: added alert_voice_conn/alert_voice_disc (spoken NINA link
          * connect/disconnect announcements). tiles_loaded stays false: a v57

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -59,7 +59,7 @@ extern "C" {
 #define ARP_ORDER_CAPACITY 16   /* size of auto_rotate_order2[] */
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 58
+#define APP_CONFIG_VERSION 59
 
 /* Tiles-config blobs no longer live inside app_config_t (v52 split them out to
  * dedicated NVS string keys "json_tiles"/"ha_tiles"). These bound the value
@@ -342,6 +342,12 @@ typedef struct {
                                        // (default 1)
     uint8_t  alert_voice_disc;         // announce NINA link disconnect, 0 = off / 1 = on
                                        // (default 1)
+
+    // Added after v58 — must stay at end to preserve NVS binary compatibility
+    uint8_t  wifi_max_tx_dbm;          // WiFi TX power cap in dBm; 0 = no cap (chip
+                                       // default/maximum). Only {0,8,11,14,17,20} are
+                                       // accepted (default 0). Capping the C6 radio
+                                       // stops the rail sag that glitches the panel.
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -2331,6 +2337,159 @@ _Static_assert(offsetof(app_config_t, alert_voice_conn) ==
  * never exceed the dest. */
 _Static_assert(sizeof(app_config_v57_t) <= sizeof(app_config_t),
                "v57 snapshot must not exceed the current config struct");
+
+/* ── Version 58 config struct — used only for NVS migration to v59 ────── */
+/* Byte-identical to app_config_t minus the trailing wifi_max_tx_dbm field  */
+/* v59 appended.                                                            */
+/* Same layout as the v57 snapshot plus the alert_voice_conn and            */
+/* alert_voice_disc fields v58 appended.                                    */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+    char     custom_image_url[256];
+    uint8_t  custom_orientation;
+    uint16_t custom_update_interval_s;
+    uint8_t  auto_rotate_order2[16];
+    uint8_t  goes_vflip;
+    uint8_t  goes_hflip;
+    uint8_t  solar_vflip;
+    uint8_t  solar_hflip;
+    uint8_t  custom_vflip;
+    uint8_t  custom_hflip;
+    bool     home_page_lock;
+    bool     json_enabled;
+    char     json_url[256];
+    char     json_auth_header[256];
+    uint16_t json_update_interval_s;
+    bool     ha_enabled;
+    char     ha_base_url[256];
+    char     ha_token[256];
+    uint16_t ha_update_interval_s;
+    bool     setup_hint_dismissed;
+    uint8_t  alert_voice_enabled;
+    uint8_t  alert_voice_volume;
+    uint8_t  alert_voice_types;
+    uint8_t  alert_voice_repeat_min;
+    bool     alert_voice_muted[3];
+    uint32_t voice_notify_mask;
+    uint8_t  boot_jingle_enabled;
+    uint8_t  alert_voice_brief;
+    uint8_t  alert_voice_conn;
+    uint8_t  alert_voice_disc;
+} app_config_v58_t;
+
+/* wifi_max_tx_dbm (uint8, align 1) appends directly after alert_voice_disc
+ * (uint8, align 1), so no alignment padding can sit between them and the exact
+ * equality the v53/v54 asserts use is reliable here. */
+_Static_assert(offsetof(app_config_t, wifi_max_tx_dbm) ==
+                   offsetof(app_config_v58_t, alert_voice_disc) +
+                       sizeof(((app_config_v58_t *)0)->alert_voice_disc),
+               "app_config_v58_t snapshot drifted from app_config_t layout");
+
+/* migrate_from_v58 memcpy's sizeof(app_config_v58_t) bytes into app_config_t.
+ * Tail padding can make the two sizes equal (the new uint8 may land inside the
+ * v58 struct's trailing pad), which is why the migration re-assigns
+ * wifi_max_tx_dbm explicitly after the copy; it must never exceed the dest. */
+_Static_assert(sizeof(app_config_v58_t) <= sizeof(app_config_t),
+               "v58 snapshot must not exceed the current config struct");
 
 // v17 snapshot — AllSky fields without allsky_enabled
 typedef struct {

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -2226,6 +2226,7 @@
       data.debug_mode=!!$('debug_mode').checked;
       data.demo_mode=!!$('demo_mode').checked;
       data.wifi_power_save=!!$('wifi_power_save').checked;
+      data.wifi_max_tx_dbm=parseInt($('wifi_max_tx_dbm').value)||0;
       data.deep_sleep_enabled=!!$('deep_sleep_enabled').checked;
       data.deep_sleep_wake_timer_s=(parseInt($('deep_sleep_wake_timer').value)||0)*3600;
       data.deep_sleep_on_idle=!!$('deep_sleep_on_idle').checked;
@@ -2608,6 +2609,12 @@
       $('debug_mode').checked=!!data.debug_mode;
       $('demo_mode').checked=!!data.demo_mode;
       $('wifi_power_save').checked=data.wifi_power_save!==false;
+      /* _prev is the value txPowerChanged() restores when the user declines the
+         lockout warning; seed it here so a decline before any accepted change
+         still has somewhere to go back to. */
+      var txSel=$('wifi_max_tx_dbm');
+      txSel.value=data.wifi_max_tx_dbm||0;
+      txSel._prev=txSel.value;
       $('deep_sleep_enabled').checked=!!data.deep_sleep_enabled;
       $('deep_sleep_wake_timer').value=Math.round((data.deep_sleep_wake_timer_s||0)/3600);
       $('deep_sleep_on_idle').checked=!!data.deep_sleep_on_idle;
@@ -3597,6 +3604,36 @@
         showToast('Screenshot failed','error');
         btn.textContent='Capture Screenshot'; btn.disabled=false;
       });
+    }
+
+    /* === WiFi Transmit Power === */
+    /* Every other setting can be undone from this page. This one can lock you
+       out of it: too low a value for the distance to the router and the device
+       drops off the network mid-request. Confirm before the change reaches the
+       radio, and put the recovery step in the prompt.
+
+       A <select> fires 'input' first, so the delegated listener on .content
+       has ALREADY scheduled liveApply()'s 400 ms debounce timer before this
+       runs -- the inline onchange is not ahead of it. The decline path works
+       for a different reason: confirm() blocks the single JS thread, so that
+       timer cannot fire while the dialog is up; _prev is restored before it
+       ever gets a chance. Then the delegated 'change' listener bubbles,
+       re-enters liveApply(), and clearTimeout()s the pending timer in favour
+       of a fresh one that reads the restored value -- which diffs clean, so
+       nothing is posted, and its checkDirty() retracts the save bar the
+       'input' pass had raised. */
+    function txPowerChanged(sel){
+      if(sel.value!=='0' && !confirm(
+        'Lower the WiFi transmit power to '+sel.value+' dBm?\n\n'+
+        'This applies right away. If the device is far from your router it may '+
+        'drop off the network and this page will stop responding.\n\n'+
+        'To recover, power-cycle the device: the change is not saved yet, so it '+
+        'is discarded on restart. Only press Save once you have confirmed this '+
+        'page still works.\n\nContinue?')){
+        sel.value=sel._prev;
+        return;
+      }
+      sel._prev=sel.value;
     }
 
     /* === Dirty State Detection === */

--- a/main/fragment_system.html
+++ b/main/fragment_system.html
@@ -144,7 +144,7 @@
 
       <div class="card">
         <div class="card-title"><span class="card-title-label">Power Management <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-        <div class="help-popover"><div class="help-popover-title">Power Management</div><p>Controls deep sleep. Deep sleep powers the device down on a long-press of the BOOT button or, optionally, after extended disconnection from all NINA instances. While asleep the display is off and the device is not reachable over the network.</p><p>The wake timer sets how many hours pass before the device wakes itself from deep sleep. A value of 0 means it stays asleep until physically rebooted.</p><p>Example: leave deep sleep off for an always-mounted display so the dashboard stays reachable over the network at all times.</p></div>
+        <div class="help-popover"><div class="help-popover-title">Power Management</div><p>Controls deep sleep. Deep sleep powers the device down on a long-press of the BOOT button or, optionally, after extended disconnection from all NINA instances. While asleep the display is off and the device is not reachable over the network.</p><p>The wake timer sets how many hours pass before the device wakes itself from deep sleep. A value of 0 means it stays asleep until physically rebooted.</p><p>WiFi transmit power sets how strongly the device transmits. Maximum is the normal setting. Lowering it reduces WiFi range slightly but can fix brief teal or green screen flashes on some boards, caused by power supply noise during WiFi transmit bursts. The new value takes effect the moment you pick it, so you can judge the result before you save. If a lower setting makes the device unreachable, power-cycle it and the unsaved change is discarded.</p><p>Example: leave deep sleep off for an always-mounted display so the dashboard stays reachable over the network at all times.</p></div>
         <div class="toggle-row">
           <span class="toggle-label">Enable deep sleep (long-press BOOT to power off)</span>
           <label class="toggle"><input type="checkbox" id="deep_sleep_enabled"><span class="toggle-track"></span></label>
@@ -161,6 +161,22 @@
             <label class="toggle"><input type="checkbox" id="deep_sleep_on_idle"><span class="toggle-track"></span></label>
           </div>
           <div class="field-hint">Enter deep sleep after extended disconnection from all NINA instances. The device must be physically rebooted to wake up if the wake timer is set to 0.</div>
+        </div>
+        <div class="subsection">
+        <div class="subsection-title">WiFi Transmit Power</div>
+        <div class="field">
+          <label class="field-label">WiFi transmit power</label>
+          <select class="input" id="wifi_max_tx_dbm" onchange="txPowerChanged(this)">
+            <option value="0">Maximum</option>
+            <option value="20">20 dBm</option>
+            <option value="17">17 dBm</option>
+            <option value="14">14 dBm</option>
+            <option value="11">11 dBm</option>
+            <option value="8">8 dBm</option>
+          </select>
+          <div class="field-hint">Lowering transmit power reduces WiFi range slightly but can fix brief teal or green screen flashes on some boards, caused by power supply noise during WiFi transmit bursts. The new value takes effect as soon as you pick it, so you can check the display and this page before saving.</div>
+          <div class="field-hint">Warning: a value too low for the distance to your router can make the device unreachable and leave this page unresponsive. Power-cycle the device to discard an unsaved change, and only press Save once you have confirmed the page still works.</div>
+        </div>
         </div>
       </div>
 

--- a/main/main.c
+++ b/main/main.c
@@ -324,6 +324,57 @@ int wifi_get_current_network_index(void)
     return current_network_index;
 }
 
+void wifi_apply_tx_power(uint8_t dbm)
+{
+    /* Same whitelist validate_config() enforces, repeated here because this is
+     * the choke point every path reaches: boot, /api/config (Save),
+     * /api/config/apply (live preview, never validated), /api/config/revert,
+     * and the screen-sleep wake re-apply. An off-list value means "no cap"
+     * rather than an arbitrary number written to the radio. */
+    switch (dbm) {
+        case 0: case 8: case 11: case 14: case 17: case 20:
+            break;
+        default:
+            ESP_LOGW(TAG, "WiFi TX power %u dBm is not a legal step, treating as uncapped",
+                     (unsigned)dbm);
+            dbm = 0;
+            break;
+    }
+
+    /* There is no "remove the cap" API — uncapping means writing the chip's
+     * own default back. Capture it on the very first call, which is the one in
+     * wifi_init() right after esp_wifi_start(), i.e. before any cap exists.
+     * 0 means the probe failed (never a real max-TX value), in which case
+     * "no cap" degrades to a no-op instead of writing a bogus power. */
+    static bool s_default_probed = false;
+    static int8_t s_default_qdbm = 0;
+    if (!s_default_probed) {
+        s_default_probed = true;
+        int8_t probed = 0;
+        if (esp_wifi_get_max_tx_power(&probed) == ESP_OK && probed > 0) {
+            s_default_qdbm = probed;
+            ESP_LOGI(TAG, "WiFi TX power chip default is %d dBm", probed / 4);
+        } else {
+            ESP_LOGW(TAG, "WiFi TX power chip default unreadable; uncapping will be a no-op");
+        }
+    }
+
+    /* esp_wifi_set_max_tx_power() takes quarter-dBm units. Goes over the
+     * esp_wifi_remote RPC to the C6, same as every other esp_wifi_* call here. */
+    int8_t target = (dbm == 0) ? s_default_qdbm : (int8_t)(dbm * 4);
+    if (target == 0) {
+        return;   /* uncap requested, nothing captured to restore */
+    }
+    esp_err_t err = esp_wifi_set_max_tx_power(target);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "WiFi TX power set to %d dBm failed: %s", target / 4, esp_err_to_name(err));
+    } else if (dbm == 0) {
+        ESP_LOGI(TAG, "WiFi TX power restored to chip default (%d dBm)", target / 4);
+    } else {
+        ESP_LOGI(TAG, "WiFi TX power capped at %u dBm", (unsigned)dbm);
+    }
+}
+
 static void wifi_reconnect_cb(void *arg)
 {
     if (manual_switch_pending) {
@@ -533,6 +584,10 @@ static void event_handler(void *arg, esp_event_base_t event_base,
             esp_wifi_set_ps(WIFI_PS_NONE);
         }
 
+        /* Apply the TX power cap (0 = uncapped). Must run after the link is up,
+         * since esp_wifi_set_max_tx_power() only takes effect once WiFi started. */
+        wifi_apply_tx_power(app_config_get()->wifi_max_tx_dbm);
+
         xEventGroupSetBits(s_wifi_event_group, WIFI_CONNECTED_BIT);
     }
 }
@@ -623,6 +678,10 @@ static void wifi_init(void)
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_APSTA));
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP,  &wifi_config_ap));
     ESP_ERROR_CHECK(esp_wifi_start());
+
+    /* Cap TX power as soon as WiFi is started so AP-only sessions are capped
+     * too; the STA got-IP path re-applies it after the link comes up. */
+    wifi_apply_tx_power(app_config_get()->wifi_max_tx_dbm);
 
     ESP_LOGI(TAG, "wifi_init finished.");
 }

--- a/main/moon_sphere.cpp
+++ b/main/moon_sphere.cpp
@@ -367,8 +367,16 @@ extern "C" bool moon_sphere_init(void)
 }
 
 /* Release the decoded lunar texture (1024x512 RGB565 = 1,048,576 B PSRAM) when
- * the Image Display page is left. Held under the same mutex as init so a render
- * in flight on the other core cannot be looking at s_tex_buf while it is freed.
+ * the Image Display page is left.
+ *
+ * CALLER CONTRACT: must be called from the SAME task that runs the renders, and
+ * only when no render is in flight. The init mutex taken below does NOT make
+ * this safe against a concurrent render: the render path deliberately does not
+ * hold that mutex across drawSphere (a 720px render blocks ~300ms), so it is
+ * still sampling s_tex_buf the whole time. Calling this from another task while
+ * a render runs panics inside tgx texture sampling (confirmed crash). In this
+ * firmware the sole renderer is goes_poll_task, and it frees at its parked point
+ * on request from data_update_task — see the ownership contract in tasks.c.
  * The state is reset to "never inited", so the next moon_sphere_init() (lazy,
  * from moon_sphere_render*) re-decodes cleanly, including the current flips.
  * Safe to call when nothing was ever allocated. */

--- a/main/moon_sphere.h
+++ b/main/moon_sphere.h
@@ -8,7 +8,9 @@ extern "C" {
 /* Decode/prepare the texture into PSRAM once. Returns false on failure. */
 bool moon_sphere_init(void);
 /* Free the decoded PSRAM texture (~1 MB) and reset init state; the next render
- * re-decodes lazily. Call on Image Display page leave. Safe if never inited. */
+ * re-decodes lazily. Call on Image Display page leave. Safe if never inited.
+ * NOT safe against a concurrent render: call it only from the task that runs the
+ * moon renders (goes_poll_task here), with no render in flight. */
 void moon_sphere_deinit(void);
 /* Render a textured, sub-solar-lit sphere for `st` into a freshly malloc'd
  * RGB565 PSRAM buffer of size w*h*2 (caller frees). Returns NULL on failure. */

--- a/main/settings_table.h
+++ b/main/settings_table.h
@@ -87,6 +87,7 @@
     BOOL      (screen_sleep_enabled,         "screen_sleep_enabled",         false) \
     BOOL      (alert_flash_enabled,          "alert_flash_enabled",          true) \
     BOOL      (wifi_power_save,              "wifi_power_save",              false) \
+    INT_RESET (wifi_max_tx_dbm,              "wifi_max_tx_dbm",              0,     0,     20)    /* 0 = no cap (radio default); the only other legal values are 8/11/14/17/20. RESET, not clamp: an out-of-range byte (e.g. a stale 255) must fail toward connectivity (0 = uncapped), never toward a silent 20 dBm cap the user never chose. This row bounds the range only; the exact whitelist is enforced at the BOTTOM of validate_config() in app_config.c, which runs after settings_clamp_apply() and resets an in-range off-list survivor (e.g. 13) to 0. Strictest check last — the two compose, they do not fight */ \
     BOOL      (auto_update_check,            "auto_update_check",            1) \
     INT_RESET (update_channel,               "update_channel",               0,     0,     2) \
     /* -- Deep sleep -- */ \

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -63,6 +63,7 @@
 #include "freertos/queue.h"
 #include "ui/nina_thumbnail.h"
 #include "poll_task.h"
+#include "wifi_manager.h"   /* wifi_apply_tx_power — re-applied on screen-sleep wake */
 
 static const char *TAG = "tasks";
 
@@ -3704,6 +3705,7 @@ main_loop:
                 if (screen_asleep && screen_touch_wake) {
                     /* Restore WiFi power save mode */
                     esp_wifi_set_ps(sl_cfg->wifi_power_save ? WIFI_PS_MIN_MODEM : WIFI_PS_NONE);
+                    wifi_apply_tx_power(sl_cfg->wifi_max_tx_dbm);
                     /* Resume LVGL processing */
                     lvgl_port_lock(0);
                     lvgl_port_resume();
@@ -3777,6 +3779,7 @@ main_loop:
                 if (should_wake) {
                     /* Restore WiFi power save mode */
                     esp_wifi_set_ps(sl_cfg->wifi_power_save ? WIFI_PS_MIN_MODEM : WIFI_PS_NONE);
+                    wifi_apply_tx_power(sl_cfg->wifi_max_tx_dbm);
                     /* Resume LVGL processing */
                     lvgl_port_lock(0);
                     lvgl_port_resume();
@@ -3857,6 +3860,7 @@ main_loop:
                 /* Feature disabled while asleep — wake up */
                 /* Restore WiFi power save mode */
                 esp_wifi_set_ps(sl_cfg->wifi_power_save ? WIFI_PS_MIN_MODEM : WIFI_PS_NONE);
+                wifi_apply_tx_power(sl_cfg->wifi_max_tx_dbm);
                 /* Resume LVGL processing */
                 lvgl_port_lock(0);
                 lvgl_port_resume();

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -935,10 +935,27 @@ static uint16_t *s_drag_zbuf   = NULL;
 static uint16_t *s_ppa_out[2]  = { NULL, NULL };   /* 720x720 PPA-output ping-pong */
 static int       s_ppa_ping    = 0;                /* index PPA writes next (flips each frame) */
 
-/* Free the moon-drag scratch and PPA output buffers and NULL them. Called on
- * Image Display page leave. Safe to call when the buffers were never allocated
- * (NULL frees are no-ops). The page's own software-scale copy buffers are freed
- * separately in nina_image_display_cleanup(). */
+/* MOON BUFFER LIFETIME CONTRACT (fixes a confirmed use-after-free crash).
+ * The moon texture (moon_sphere.cpp s_tex_buf, ~1MB) and the drag scratch above
+ * are READ/WRITTEN by renders that run ONLY on goes_poll_task, and a single
+ * 720px render blocks ~300ms. data_update_task (Core 1) detects the page leave,
+ * so it must NOT free them itself: while a slideshow rotation fires the leave,
+ * goes_poll_task can be mid-drawSphere sampling s_tex_buf, and freeing it under
+ * the renderer panics inside tgx texture sampling. moon_sphere's init mutex does
+ * NOT cover this — the render path never holds it across the render, and it
+ * cannot cover the drag scratch at all.
+ * So the free is OWNERSHIP-TRANSFERRED, not locked: data_update_task only sets
+ * this request flag (AFTER nina_image_display_cleanup() has dropped the LVGL
+ * descriptor that borrows s_ppa_out), and goes_poll_task performs the actual
+ * free at its parked point, where no render can be in flight. One task renders,
+ * the same task frees; no cross-task lock, no contention, no blocked UI. */
+static _Atomic bool s_moon_release_req = false;
+
+/* Free the moon-drag scratch and PPA output buffers and NULL them. Called ONLY
+ * from goes_poll_task (see the ownership contract above). Safe to call when the
+ * buffers were never allocated (NULL frees are no-ops). The page's own
+ * software-scale copy buffers are freed separately in
+ * nina_image_display_cleanup(). */
 static void moon_drag_buffers_free(void)
 {
     if (s_drag_color) { heap_caps_free(s_drag_color); s_drag_color = NULL; }
@@ -1125,9 +1142,18 @@ void moon_overlay_info(char *age,  size_t age_sz,
  * Consume any pending prefetch request (s_prefetch_source, set by the arbiter via
  * image_source_trigger_prefetch) and build that source's frame INTO
  * goes_prefetch_data — never goes_data — so a later rotation to it can swap in a
- * ready buffer with no network round-trip. Runs at the END of each goes_poll_task
- * foreground iteration (both the moon path and the network path call it), so it
- * only ever executes in the single goes_poll_task context that owns both structs.
+ * ready buffer with no network round-trip.
+ *
+ * TWO call sites, BOTH inside goes_poll_task, so this only ever executes in the
+ * single context that owns both structs (and, for the Moon source, the only
+ * context allowed to touch the tgx texture):
+ *   1. the parked loop — serves requests scheduled from a NON-image slideshow
+ *      stop, which is when this task is suspended and used to drop them;
+ *   2. the top of the active loop body, ahead of the foreground fetch, so the
+ *      deadline-bound prefetch is never serialized behind a refresh.
+ * A missed request is not a cosmetic loss: with auto-rotate on, the loading
+ * overlay is deliberately suppressed, so an image stop that arrives without a
+ * warm frame shows a BLACK page for the whole fetch.
  *
  * On success it sets s_prefetch_ready + s_prefetch_ready_src so the swap consumer
  * at the top of the loop can install the buffer and decide whether it satisfies the
@@ -1219,8 +1245,43 @@ void goes_poll_task(void *arg)
     ESP_LOGI(TAG, "GOES poll task started");
 
     while (1) {
-        /* Suspend during OTA or when the Image Display page is not visible */
+        /* Set while parked below, so the code after the park loop can tell a
+         * page (re)entry from an ordinary refresh tick and re-show the retained
+         * frame. */
+        bool re_entered = false;
+
+        /* Suspend during OTA or when the Image Display page is not visible.
+         * This is also the ONLY safe point to release the moon texture + drag
+         * scratch: reaching here proves no render is in flight on this task (the
+         * renders all run below, in this same loop body). data_update_task hands
+         * the request over via s_moon_release_req rather than freeing them
+         * itself — see the ownership contract at moon_drag_buffers_free(). */
         while (ota_in_progress || !image_display_page_active) {
+            re_entered = true;
+            if (atomic_exchange(&s_moon_release_req, false)) {
+                moon_sphere_deinit();       /* ~1MB cached lunar texture */
+                moon_drag_buffers_free();   /* drag color/z + PPA ping-pong */
+                /* Reset drag orientation so a visit that ended mid-settle does not
+                 * carry a stale s_cur_* into the next visit (which would snap the
+                 * disc home on the first frame). */
+                moon_drag_reset();
+                ESP_LOGI(TAG, "Left Image Display: freed moon texture + drag buffers");
+            }
+            /* Serve the slideshow prefetch WHILE PARKED. The arbiter schedules the
+             * next stop's image source at every slideshow commit, including from a
+             * NON-image stop (Clock/JSON/Summary) — at which point this task is
+             * parked here. The producer used to live only after this loop, so those
+             * requests were never served and the image page arrived cold: with
+             * auto-rotate on the loading overlay is deliberately suppressed, so cold
+             * == black screen for the whole fetch. Running it here gives a full stop
+             * of lead time and makes the swap consumer below find a ready frame.
+             * Same task owns goes_prefetch_data, so the single-writer invariant and
+             * the moon-render ownership contract above are unchanged; it runs AFTER
+             * the release above so a free is never deferred behind a fetch. Skipped
+             * during OTA — that must not contend for PSRAM or the network. */
+            if (!ota_in_progress) {
+                image_prefetch_run(app_config_get());
+            }
             ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(1000));
         }
 
@@ -1232,6 +1293,34 @@ void goes_poll_task(void *arg)
          * else the persisted default. Read ONCE so a mid-iteration arbiter change
          * cannot make the fetch dispatch and the interval/label logic disagree. */
         int8_t eff_src = image_source_get_effective();
+
+        /* ── Retained-frame re-show on page (re)entry ───────────────────────────
+         * goes_data keeps its last decoded frame across page leave (nothing frees
+         * it there any more), but nina_image_display_cleanup() dropped the page's
+         * own LVGL copy, so the panel is blank until something is pushed. Push the
+         * retained frame here — before any fetch — so a slideshow stop never shows
+         * black while a slow/failing download runs. displayed_poll_ms was reset to
+         * 0 by cleanup(), so the new-image gate passes; force_redraw is belt-and-
+         * braces against a same-millisecond stamp.
+         *
+         * Gated on src_kind == eff_src: the buffer's own tag, never intent (a
+         * retained GOES frame must never be shown for a Solar stop). On a mismatch
+         * nothing is shown, has_image() stays false, and the overlay block below
+         * puts "Loading image..." up instead of leaving a black panel. */
+        if (re_entered) {
+            bool kept = false;
+            if (goes_data_lock(&goes_data, 200)) {
+                kept = (goes_data.image_buf != NULL && goes_data.src_kind == eff_src);
+                goes_data_unlock(&goes_data);
+            }
+            if (kept && image_display_page_active) {
+                if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                    nina_image_display_force_redraw();
+                    nina_image_display_update(&goes_data);
+                    bsp_display_unlock();
+                }
+            }
+        }
 
         /* A manual navigation/config change requests a fresh foreground fetch +
          * loading animation. Peek the flag here WITHOUT consuming it (the single
@@ -1322,6 +1411,24 @@ void goes_poll_task(void *arg)
                 }
             }
         }
+
+        /* ── Prefetch PRODUCER, run BEFORE the foreground fetch ─────────────────
+         * Deadline ordering, not convenience. The prefetch is the only work here
+         * with a hard deadline (the next slideshow rotation, as little as 10s);
+         * the foreground fetch below is a periodic refresh of a frame that is
+         * already on screen. Running the producer at the END of the loop body (as
+         * it used to) serialized it behind a full HTTP fetch + JPEG decode, so the
+         * next stop's frame regularly missed the rotation and that page arrived
+         * cold — black, because auto-rotate suppresses the loading overlay.
+         *
+         * It also matters on the rotation AWAY from the image page:
+         * image_display_page_active is updated by data_update_task one cycle after
+         * the arbiter commits, so the commit that schedules the next image stop
+         * still finds this task unparked. It wakes here and, with the override
+         * already cleared to -1, would otherwise burn seconds fetching the
+         * PERSISTED default source for a page we just left before ever reaching
+         * the producer. No-op when nothing is pending. */
+        image_prefetch_run(cfg);
 
         /* A pending manual fetch always forces a fresh foreground fetch this
          * iteration, even when the swap installed the right source: the manual
@@ -1820,9 +1927,9 @@ void goes_poll_task(void *arg)
                     }
                 }
             }
-            /* Prefetch the NEXT slideshow image source (if the arbiter scheduled
-             * one) before sleeping, so a rotation to it swaps in instantly. */
-            image_prefetch_run(cfg);
+            /* The NEXT slideshow image source was already prefetched near the top
+             * of this iteration (see the deadline-ordering note there), so nothing
+             * to do before sleeping. */
             /* Recompute ~every 60s once time is valid so orientation tracks the
              * sky; poll every ~3s while waiting for the clock to sync. */
             ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(time_valid ? 60000 : 3000));
@@ -1863,9 +1970,16 @@ void goes_poll_task(void *arg)
              * spurious no-op against an overlay that never appeared. */
             if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                 /* manual_fetch (config change OR manual nav) always animates. The
-                 * bare cold-image trigger is suppressed while auto-cycle is ON so a
-                 * slideshow prefetch miss stays seamless (no overlay flash). */
-                if (manual_fetch || (!nina_image_display_has_image() && !cfg->auto_rotate_enabled)) {
+                 * cold-image trigger fires whenever nothing is on screen for this
+                 * source — INCLUDING during auto-cycle. It used to be suppressed
+                 * there to keep a prefetch miss seamless, but with goes_data now
+                 * retaining its last frame across page leave, "no image" means
+                 * genuinely nothing to show, and suppressing the overlay left a
+                 * black panel as the steady state whenever the source was
+                 * unreachable. A retained frame keeps has_image() true, so the
+                 * seamless case is still seamless and a failing fetch never flashes
+                 * an overlay over a good frame. */
+                if (manual_fetch || !nina_image_display_has_image()) {
                     nina_wait_overlay_show("Loading image...", band_name);
                     nina_wait_overlay_set_progress(-1);   /* indeterminate */
                     show_wait = true;
@@ -1917,10 +2031,8 @@ void goes_poll_task(void *arg)
             nina_toast_show(TOAST_WARNING, "Failed to load image");
         }
 
-        /* Prefetch the NEXT slideshow image source (if the arbiter scheduled one)
-         * after the foreground fetch and before sleeping, so a rotation to it swaps
-         * in instantly. No-op when nothing is pending. */
-        image_prefetch_run(cfg);
+        /* The NEXT slideshow image source was already prefetched near the top of
+         * this iteration (see the deadline-ordering note there). */
 
         /* Sleep for the configured interval. The satellite sources (GOES/Solar)
          * clamp to 5min-2h to respect the image cadence; the custom source uses
@@ -2954,7 +3066,9 @@ main_loop:
             prev_on_clock = on_clock;
             clock_page_active = on_clock;
 
-            /* Image Display lifecycle — wake on entry, free buffers on leave */
+            /* Image Display lifecycle — wake on entry, free the page's own LVGL
+             * buffers on leave (the decoded frame in goes_data is retained; see
+             * the note below). */
             static bool prev_on_image_display = false;
             if (on_image_display && !prev_on_image_display && goes_task_handle) {
                 xTaskNotifyGive(goes_task_handle);
@@ -2968,18 +3082,28 @@ main_loop:
                     nina_wait_overlay_hide();
                     bsp_display_unlock();
                 }
-                goes_client_cleanup(&goes_data);
-                moon_sphere_deinit();   /* release the cached moon texture (tgx renderer) */
-                /* Free the moon drag-to-rotate render scratch (color/z). The page's
-                 * own software-scale copy buffers are freed inside
-                 * nina_image_display_cleanup() above, so each side frees only what it
-                 * owns — no leak, no double-free. */
-                moon_drag_buffers_free();
-                /* Reset drag orientation so a visit that ended mid-settle does not
-                 * carry a stale s_cur_* into the next visit (which would snap the
-                 * disc home on the first frame). */
-                moon_drag_reset();
-                ESP_LOGI(TAG, "Left Image Display: freed buffers");
+                /* goes_data.image_buf is deliberately NOT freed here. Freeing the
+                 * last decoded frame on every page leave meant every slideshow
+                 * re-entry started from nothing, so a slow or failing source (e.g.
+                 * an SDO TLS handshake that outruns the fetch timeout) showed a
+                 * black panel for the whole stop. Keeping it costs ~1-2MB of PSRAM
+                 * for one frame and lets the re-entry path in goes_poll_task put
+                 * the last good frame back instantly. It is replaced in place by
+                 * the next successful fetch/prefetch swap, and released when the
+                 * Image Display feature is disabled (image_display_apply_live).
+                 * Moon texture + drag scratch are NOT freed here either.
+                 * Synchronization
+                 * contract: they are written by renders that run only on
+                 * goes_poll_task (a 720px render blocks ~300ms and cannot be
+                 * interrupted), so freeing them from this task raced the renderer
+                 * and crashed inside tgx texture sampling. We only request the
+                 * release; goes_poll_task frees them at its parked point. The
+                 * request is issued AFTER nina_image_display_cleanup() above, so
+                 * the LVGL descriptor borrowing s_ppa_out is already dropped by the
+                 * time the owner task can free it. */
+                atomic_store(&s_moon_release_req, true);
+                if (goes_task_handle) xTaskNotifyGive(goes_task_handle);
+                ESP_LOGI(TAG, "Left Image Display: freed page buffers (frame retained)");
             }
             prev_on_image_display = on_image_display;
         }

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -542,6 +542,7 @@ static const backup_field_t s_backup_fields[] = {
     {"deep_sleep_wake_timer_s","Deep Sleep Timer",   "System", false, false},
     {"deep_sleep_on_idle",   "Sleep on Idle",        "System", false, false},
     {"wifi_power_save",      "WiFi Power Save",      "System", false, false},
+    {"wifi_max_tx_dbm",      "WiFi Transmit Power",  "System", false, false},
     {"crash_log_retention_days","Crash Log Retention","System", false, false},
 
     /* AllSky */

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -15,6 +15,7 @@
 #include "lvgl.h"
 #include "driver/jpeg_encode.h"
 #include "mqtt_ha.h"
+#include "wifi_manager.h"
 #include "weather_client.h"
 #include "ui/nina_clock.h"
 #include "ui/nina_idle_indicator.h"
@@ -38,6 +39,19 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
             nina_dashboard_apply_theme(new_cfg->theme_index);
             bsp_display_unlock();
         }
+    }
+    /* WiFi transmit power. Applied here rather than in the POST handler so all
+     * three config write paths get it: /api/config (Save), /api/config/apply
+     * (live preview, RAM only), and /api/config/revert (Discard, which calls
+     * this with the NVS values as new_cfg). Revert genuinely puts the radio
+     * back where it was, including all the way back to the chip default when
+     * the saved value is 0 — wifi_apply_tx_power() restores the power it
+     * probed at boot rather than treating 0 as "leave the cap in place". An
+     * unsaved change therefore lasts only until Discard or the next reboot,
+     * which is the lockout escape hatch the web UI's warning tells the user
+     * about. */
+    if (new_cfg->wifi_max_tx_dbm != old_cfg->wifi_max_tx_dbm) {
+        wifi_apply_tx_power(new_cfg->wifi_max_tx_dbm);
     }
     if (new_cfg->screen_rotation != old_cfg->screen_rotation) {
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -36,6 +36,14 @@ void image_display_apply_live(const app_config_t *prev, const app_config_t *cur,
         bsp_display_unlock();
     }
 
+    /* Feature turned off: this is the release point for the retained decoded
+     * frame. goes_data keeps its last frame across page leave so a slideshow
+     * re-entry is never black (see the note in tasks.c's page-leave block), so
+     * disabling the page is the only place that ~1-2MB of PSRAM comes back. */
+    if (!cur->image_display_enabled && prev->image_display_enabled) {
+        goes_client_cleanup(&goes_data);
+    }
+
     if (cur->image_display_enabled) {
         bool source_band_region_changed =
             cur->image_display_source != prev->image_display_source ||

--- a/main/wifi_manager.h
+++ b/main/wifi_manager.h
@@ -1,4 +1,13 @@
 #pragma once
 
+#include <stdint.h>
+
 void wifi_switch_to_network(int index);
 int wifi_get_current_network_index(void);
+
+/* Apply the configured WiFi TX power cap to the C6 radio.
+ * @p dbm == 0 leaves the chip default (maximum) in place; any other value is
+ * a dBm cap. Capping TX power keeps the radio's current bursts from sagging
+ * the board rail, which glitches the display panel. Safe to call on every
+ * link-up and on every screen-sleep wake. */
+void wifi_apply_tx_power(uint8_t dbm);

--- a/test/host/test_settings_table.c
+++ b/test/host/test_settings_table.c
@@ -379,6 +379,43 @@ int main(void)
         CHECK(cfg.mqtt_enabled == false, "mqtt_enabled: wrong-type value ignored");
     }
 
+    /* ── 8. wifi_max_tx_dbm: INT_RESET row over a discrete-step field ──
+     * Section 2's generated sweep already proves "21 -> def", but this field
+     * is the one where clamp-vs-reset is a behavioral difference worth
+     * pinning by name: a garbage byte must land on 0 (uncapped) and never on
+     * the nearest bound (20 dBm — a silent throttle the user never chose).
+     * Note 13 is in-range and therefore SURVIVES this layer: it is the
+     * whitelist at the bottom of validate_config() in app_config.c that
+     * resets it to 0, and app_config.c is not linked into this harness (it
+     * needs NVS), so 13 is asserted here only as "untouched by the table". */
+    printf("8. wifi_max_tx_dbm: legal steps survive, garbage resets to 0\n");
+    {
+        static const int legal[] = { 0, 8, 20 };
+        for (size_t i = 0; i < sizeof(legal) / sizeof(legal[0]); i++) {
+            app_config_t cfg;
+            memset(&cfg, 0, sizeof(cfg));
+            settings_defaults_apply(&cfg);
+            cfg.wifi_max_tx_dbm = (uint8_t)legal[i];
+            settings_clamp_apply(&cfg);
+            CHECK(cfg.wifi_max_tx_dbm == legal[i],
+                  "wifi_max_tx_dbm: %d survives the clamp pass", legal[i]);
+        }
+    }
+    {
+        app_config_t cfg;
+        memset(&cfg, 0, sizeof(cfg));
+        settings_defaults_apply(&cfg);
+
+        cfg.wifi_max_tx_dbm = 255;
+        settings_clamp_apply(&cfg);
+        CHECK(cfg.wifi_max_tx_dbm == 0, "wifi_max_tx_dbm: 255 resets to 0 (uncapped), not to 20");
+
+        cfg.wifi_max_tx_dbm = 13;
+        settings_clamp_apply(&cfg);
+        CHECK(cfg.wifi_max_tx_dbm == 13,
+              "wifi_max_tx_dbm: in-range 13 survives the table (validate_config's whitelist kills it)");
+    }
+
     printf("\n%s: %d failure(s)\n", fails == 0 ? "PASS" : "FAIL", fails);
     return fails == 0 ? 0 : 1;
 }


### PR DESCRIPTION
### Summary
This PR resolves critical slideshow issues, preventing crashes and black images for a more stable display experience. It also adds a new user-configurable setting to cap WiFi transmit power, which helps mitigate display glitches during WiFi activity.

### Changes
* Add a WiFi transmit power cap setting in the Web UI to prevent display glitches caused by WiFi activity.
* Moon texture data frees safely only when the rendering task is not actively using it, preventing crashes.
* Image prefetch requests process even when the display task is idle, stopping black images during slideshow transitions.
* The last successfully displayed image retains across page changes and shows instantly if a new image fails to load.
* The 'Loading image...' overlay now shows during auto-rotate when no image is available, providing clearer feedback.
* Display-related task priorities and DMA settings adjust for improved system stability and to aid flicker investigation.
* A DSI probe suite adds for display diagnostics, including underrun and link error detection.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-08-14T04:07:04.941Z | Generated by GitHub Actions</sub>