### PR TITLE
feat: delay page dwell until content loads

### DIFF
--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1402,8 +1402,8 @@
       var alreadyWired=c.dataset.wired==='1';
       c.innerHTML='';
       /* [id, label, stop value]. Stop values are frozen page_ref ids: 0..11
-         anchored block, plus appended JSON (24) and Home Assistant (25) —
-         keep in sync with ARP_IDX_* in app_config.h. */
+         anchored block, plus appended JSON (24), Home Assistant (25) and
+         OctoPrint (26) — keep in sync with ARP_IDX_* in app_config.h. */
       var items=[
         ['arp_summary','Summary',0],
         ['arp_nina1','NINA 1',1],
@@ -1415,6 +1415,7 @@
         ['arp_clock','Clock',7],
         ['arp_json','JSON Display',24],
         ['arp_ha','Home Assistant',25],
+        ['arp_octoprint','3D Printer',26],
         ['arp_img_goes','Img: GOES',8],
         ['arp_img_moon','Img: Moon',9],
         ['arp_img_solar','Img: Solar',10],
@@ -2079,7 +2080,8 @@
 
     /* === Rotation slideshow list === */
     /* Single ordered slideshow list: membership == order.
-       data-arp-idx equals the slideshow stop id (0..11, 24=JSON, 25=HA).
+       data-arp-idx equals the slideshow stop id (0..11, 24=JSON, 25=HA,
+       26=OctoPrint).
        Saved array holds the indices of CHECKED pills in on-screen order,
        padded to 16 slots with 0xFF (255 = unused). */
     function getRotateOrder(){

--- a/main/fragment_behavior.html
+++ b/main/fragment_behavior.html
@@ -33,7 +33,7 @@
             <div class="field">
               <label class="field-label">Interval (seconds)</label>
               <input type="number" class="input" id="auto_rotate_interval" min="4" max="3600" value="30">
-              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600.</div>
+              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600. For pages that download a picture (GOES, Solar, Custom URL, 3D Printer), the countdown starts once the picture has finished loading.</div>
             </div>
             <div class="field">
               <label class="field-label">Transition</label>
@@ -67,7 +67,7 @@
         <div class="field">
           <label class="field-label">Stay on selected page (seconds)</label>
           <input type="number" class="input" id="nav_grace_s" min="10" max="300" value="10">
-          <div class="field-hint" style="margin-top:2px">After you swipe or tap to a page, the display keeps showing it for this long, then returns on its own to the page it would normally show (the connected instance, or your Home page).</div>
+          <div class="field-hint" style="margin-top:2px">After you swipe or tap to a page, the display keeps showing it for this long, then returns on its own to the page it would normally show (the connected instance, or your Home page). For pages that download a picture, the timer starts once the picture has finished loading.</div>
         </div>
         </div>
 

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -2128,16 +2128,20 @@ main_loop:
 
         /* Slideshow-interval edge feeder. The navigation arbiter owns the actual
          * page advance; tasks.c only fires the tick when the configured interval
-         * elapses. resolve() (called once near the end of this cycle) consumes it. */
+         * elapses. resolve() (called once near the end of this cycle) consumes it.
+         * A content-ready dwell restart (picture finished loading) resets the
+         * interval so the loaded page gets its full dwell. */
         {
             app_config_t *r_cfg = app_config_get();
             if (r_cfg->auto_rotate_enabled && r_cfg->auto_rotate_interval_s > 0) {
+                if (nav_arbiter_take_dwell_restart()) last_rotate_ms = now_ms;
                 if (last_rotate_ms == 0) last_rotate_ms = now_ms;
                 if (now_ms - last_rotate_ms >= (int64_t)r_cfg->auto_rotate_interval_s * 1000) {
                     nav_arbiter_notify_slideshow_tick();
                     last_rotate_ms = now_ms;
                 }
             } else {
+                (void)nav_arbiter_take_dwell_restart();   /* drain: never leak a stale flag */
                 last_rotate_ms = 0;
             }
         }
@@ -2201,7 +2205,11 @@ main_loop:
              * rather than blocking the UI preserves lock-ordering discipline. */
             if (octoprint_client_lock(&octoprint_data, 15)) {
                 octoprint_page_update(&octoprint_data);
+                /* Any terminal image verdict (OK / no job / no thumbnail /
+                 * webcam failed) means the page has resolved what it shows. */
+                bool octo_loaded = (octoprint_data.image_status != OCTO_IMG_PENDING);
                 octoprint_client_unlock(&octoprint_data);
+                if (octo_loaded) nav_arbiter_notify_content_ready(PAGE_IDX_OCTOPRINT);
             }
         } else if (on_image) {
             /* Image page — repaint if the poller committed a newer frame (the

--- a/main/ui/nina_image_page.c
+++ b/main/ui/nina_image_page.c
@@ -12,6 +12,7 @@
 
 #include "nina_image_page.h"
 #include "nina_wait_overlay.h"
+#include "nina_nav_arbiter.h"          /* nav_arbiter_notify_content_ready */
 #include "nina_dashboard.h"            /* nina_dashboard_set_image_page_enabled (config apply, B5) */
 #include "nina_dashboard_internal.h"   /* SCREEN_SIZE, OUTER_PADDING, current_theme, PAGE_IDX_IMG_* */
 #include "image_red_remap.h"
@@ -1313,6 +1314,7 @@ void image_page_commit_frame(image_page_t *p, image_frame_t *fresh, bool force)
         if (force) image_page_force_redraw(p);
         image_page_render_frame(p);
         bsp_display_unlock();
+        nav_arbiter_notify_content_ready(p->page_idx);   /* outside the display lock */
     }
 }
 

--- a/main/ui/nina_nav_arbiter.c
+++ b/main/ui/nina_nav_arbiter.c
@@ -21,6 +21,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "tasks.h"   /* data_task_handle */
+#include <stdatomic.h>
 
 static const char *TAG = "nav_arb";
 
@@ -47,6 +48,11 @@ static struct {
                                     * (NAV_SRC_HOLD while modal-frozen). Written
                                     * by resolve() (data task), read by
                                     * nav_arbiter_get_web_status() (httpd task). */
+    _Atomic bool content_ready_armed; /* set on commit, consumed by the first
+                                       * notify_content_ready for that page:
+                                       * one dwell restart per visit */
+    _Atomic bool dwell_restart;    /* restart requested; drained by tasks.c via
+                                    * nav_arbiter_take_dwell_restart */
 } s_arb;
 
 void nav_arbiter_init(void) {
@@ -59,6 +65,8 @@ void nav_arbiter_init(void) {
     s_arb.idle_claim_active = false;
     s_arb.pinned = false;
     s_arb.last_level = (uint8_t)NAV_SRC_DEFAULT;
+    s_arb.content_ready_armed = false;
+    s_arb.dwell_restart = false;
     s_arb.current_committed = nina_dashboard_get_active_page();
     ESP_LOGI(TAG, "nav arbiter init (committed page=%d)", s_arb.current_committed);
 }
@@ -84,6 +92,23 @@ void nav_arbiter_notify_modal_close(int64_t now_ms) {
 }
 
 void nav_arbiter_notify_slideshow_tick(void) { s_arb.slideshow_advance = true; }
+
+void nav_arbiter_notify_content_ready(int page_idx) {
+    if (page_idx != s_arb.current_committed) return;
+    if (!atomic_exchange(&s_arb.content_ready_armed, false)) return;
+    atomic_store(&s_arb.dwell_restart, true);
+    /* Restamp grace only while a USER window is still running for this page;
+     * restamping an expired window would re-pin the page. */
+    int64_t now_ms = esp_timer_get_time() / 1000;
+    if (s_arb.user_page == page_idx
+        && (now_ms - s_arb.user_stamp_ms) < (int64_t)app_config_get()->nav_grace_s * 1000) {
+        s_arb.user_stamp_ms = now_ms;
+    }
+}
+
+bool nav_arbiter_take_dwell_restart(void) {
+    return atomic_exchange(&s_arb.dwell_restart, false);
+}
 
 void nav_arbiter_set_pin(bool on, int abs_page, int64_t now_ms) {
     if (on) {
@@ -384,8 +409,18 @@ void nav_arbiter_resolve(int64_t now_ms) {
                     nina_wait_overlay_set_progress(-1);
                 }
             }
+            /* Arm one content-ready dwell restart for this visit. An image page
+             * that already shows a frame on arrival (retained/warm) is fully
+             * loaded now, so disarm: no restart wanted. has_image is read here
+             * while the display lock is still held (module convention). */
+            bool loaded_on_arrival = false;
+            if (PAGE_IDX_IS_IMAGE(desired)) {
+                image_page_t *ip = image_page_by_page_idx(desired);
+                loaded_on_arrival = ip && image_page_has_image(ip);
+            }
             bsp_display_unlock();
             s_arb.current_committed = desired;
+            atomic_store(&s_arb.content_ready_armed, !loaded_on_arrival);
             ESP_LOGI(TAG, "commit page=%d src=%d", desired, (int)src);
         }
     }

--- a/main/ui/nina_nav_arbiter.h
+++ b/main/ui/nina_nav_arbiter.h
@@ -54,6 +54,16 @@ void nav_arbiter_notify_modal_close(int64_t now_ms);
 /** Advance the slideshow index on the interval timer (records an edge). */
 void nav_arbiter_notify_slideshow_tick(void);
 
+/* A page's content finished loading (image frame committed / first image
+ * pass landed). If page_idx is the page currently shown and no content-ready
+ * has been counted since it was shown, restart its dwell: request a
+ * slideshow-interval restart (consumed by tasks.c) and, if a USER grace window
+ * is currently running for that page, restamp it. At most once per page visit,
+ * so periodic refreshes cannot hold a page forever. Any task; no locks. */
+void nav_arbiter_notify_content_ready(int page_idx);
+/* tasks.c: returns true once per requested restart; caller resets last_rotate_ms. */
+bool nav_arbiter_take_dwell_restart(void);
+
 /** Re-resolve the ladder once and commit if the desired page differs from the
  *  current page. Called once per data_update_task cycle and on user/event wake.
  *  Must be called WITHOUT the LVGL lock held; the arbiter takes it internally


### PR DESCRIPTION
### Summary
This PR adds the OctoPrint page to the automatic content rotation. It also ensures that the display time for image and OctoPrint pages only begins after their content, such as a picture, has fully loaded, preventing slow downloads from cutting into the viewing time.

### Changes
*   The 3D Printer (OctoPrint) page is now available for selection in the web interface's automatic content rotation.
*   A new function allows pages to signal when their primary content, like an image, has finished loading.
*   Image pages now use this function to report when their picture has fully loaded.
*   The navigation system now restarts the slideshow dwell timer and manual navigation grace period only after a page's content is reported as ready.
*   This ensures that the full dwell time is observed, even if content loads slowly.
*   Pages that already have content present upon arrival are treated as loaded immediately, preventing unnecessary timer restarts.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-16T21:28:42.831Z | Generated by GitHub Actions</sub>