### PR TITLE
feat: add cloud cover satellite page

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ The home page shows device health at a glance, explains why the panel is on its 
   </tr>
   <tr>
     <td align="center"><em>AllSky (connection, per-quadrant field mappings)</em></td>
-    <td align="center"><em>Image pages (GOES / Moon / Solar / custom URL)</em></td>
+    <td align="center"><em>Image pages (GOES / Moon / Solar / custom URL / Weather Radar / Cloud Cover)</em></td>
   </tr>
   <tr>
     <td align="center"><img src="images/settings_logs.jpg" alt="Logs tab" width="480"></td>
@@ -390,8 +390,9 @@ Point MQTT at your broker to publish the device's own state via Home Assistant a
 
 - **AllSky** — a four-quadrant environmental panel (thermal, sky quality, ambient, power) fed from an AllSky API with configurable field mappings and thresholds.
 - **Weather** — OpenWeatherMap, Open-Meteo, or Weather Underground data on the clock page.
-- **Image pages** — four full-screen pages: GOES satellite, Moon (rendered on-device), NASA SDO/SOHO solar imagery, and a custom image URL. Each has its own enable, refresh interval, and overlay/crop settings.
+- **Image pages** — six full-screen pages: GOES satellite, Moon (rendered on-device), NASA SDO/SOHO solar imagery, a custom image URL, Weather Radar, and Cloud Cover. Each has its own enable, refresh interval, and overlay/crop settings.
 - **Weather Radar**: an animated NWS radar loop for a chosen radar site (or the nearest site to your weather location, or the whole CONUS). Choose how many frames to keep, the refresh interval, an optional caption, Crop (drops the NOAA header and legend), and Dark mode. The Map style option picks what the radar echoes are drawn over: Standard (roads and city names), State lines only (the default), or State and county lines. The two line-only styles remove roads and labels, which helps when highway markings look like heavy rain. Crop and Dark mode apply only to the Standard style; Red Night applies to all three.
+- **Cloud Cover**: an animated satellite loop of the cloud cover around your weather location, from NOAA GOES imagery served by NASA. Day: true colour. Night: infrared clouds over city lights. State and country borders and major roads are drawn over the picture. Choose the Area (about 150 km to 2500 km across), how many frames to keep, the refresh interval, and an optional caption. The location comes from the Location settings on the System tab; the satellite (GOES-East or GOES-West) is picked from your longitude. The source updates every 10 minutes and the newest frame is usually 30-45 minutes old.
 
 ---
 

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -18,7 +18,7 @@ idf_component_register(
          ui/nina_empty_state.c
          ${LV_DEMOS_SOURCES}
     INCLUDE_DIRS . ui ${LV_DEMO_DIR}
-    EMBED_TXTFILES config_ui.html home_ui.html login.html setup_ui.html fragment_logs.html fragment_backup.html fragment_api.html fragment_allsky.html fragment_json.html fragment_ha.html fragment_clock.html fragment_spotify.html fragment_image_goes.html fragment_image_moon.html fragment_image_solar.html fragment_image_custom.html fragment_image_radar.html fragment_octoprint.html fragment_nodes.html fragment_display.html fragment_behavior.html fragment_system.html fragment_voice_clips.html
+    EMBED_TXTFILES config_ui.html home_ui.html login.html setup_ui.html fragment_logs.html fragment_backup.html fragment_api.html fragment_allsky.html fragment_json.html fragment_ha.html fragment_clock.html fragment_spotify.html fragment_image_goes.html fragment_image_moon.html fragment_image_solar.html fragment_image_custom.html fragment_image_radar.html fragment_image_clouds.html fragment_octoprint.html fragment_nodes.html fragment_display.html fragment_behavior.html fragment_system.html fragment_voice_clips.html
                    # Standalone audio test page (web_test_audio.c, port 8080).
                    # Deliberately NOT in WEB_GZ_ASSETS: one small page served by
                    # a second httpd instance that has no gzip negotiation.
@@ -100,6 +100,7 @@ set(WEB_GZ_ASSETS
     fragment_image_goes.html fragment_image_moon.html
     fragment_image_solar.html fragment_image_custom.html
     fragment_image_radar.html
+    fragment_image_clouds.html
     fragment_octoprint.html
     fragment_nodes.html fragment_display.html fragment_behavior.html
     fragment_system.html fragment_voice_clips.html)

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -799,6 +799,20 @@ typedef struct {
     char     hostname[32];
 } app_config_v16_t;
 
+/* Clouds page (v66) defaults. Every field is a SETTINGS_TABLE row, so
+ * settings_defaults_apply() already sets them; this is re-asserted after the
+ * prefix memcpy in the v63/v64/v65 migrations because those snapshots' tail
+ * padding lands on top of the appended clouds bytes. One helper, four callers,
+ * so the defaults cannot drift between them. */
+static void clouds_set_defaults(app_config_t *cfg)
+{
+    cfg->clouds_enabled = false;
+    cfg->clouds_show_overlay = true;
+    cfg->clouds_update_interval_s = 600;   /* 10 min; GIBS publishes a new GOES frame every 10 min */
+    cfg->clouds_frames = 6;                /* ~1 MB PSRAM per 720x720 frame */
+    cfg->clouds_zoom = 7;                  /* ~600 km across at mid-latitudes */
+}
+
 static void set_defaults(app_config_t *cfg) {
     memset(cfg, 0, sizeof(app_config_t));
     settings_defaults_apply(cfg);   /* every "simple" field's default — see settings_table.h */
@@ -870,6 +884,10 @@ static void set_defaults(app_config_t *cfg) {
     cfg->radar_frames = 10;   // full NOAA loop; ~660 KB of PSRAM per retained frame
     cfg->radar_dark_mode = true;   // v64: dark basemap by default (night-friendly)
     cfg->radar_map_style = 1;      // v65: state lines only (0 = standard NWS picture with roads and city names)
+
+    // Clouds page defaults (v66). Centre comes from weather_lat/weather_lon at
+    // fetch time; nothing location-specific is stored here.
+    clouds_set_defaults(cfg);
 
     // Spotify client ID: secret-like sentinel, not table-driven
     cfg->spotify_client_id[0] = '\0';
@@ -2722,6 +2740,7 @@ static void migrate_from_v63(const void *raw, size_t raw_size, app_config_t *cfg
      * Re-assert it, same as migrate_from_v61 does for octoprint_overlay_visible. */
     cfg->radar_dark_mode = true;
     cfg->radar_map_style = 1;   /* v65 field also lies in the v63 snapshot's tail padding; force the default (state lines only) */
+    clouds_set_defaults(cfg);   /* v66 fields follow directly; same tail-padding reasoning */
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v63 to v%d", APP_CONFIG_VERSION);
@@ -2743,9 +2762,30 @@ static void migrate_from_v64(const void *raw, size_t raw_size, app_config_t *cfg
      * byte before the new field and its trailing padding lands on top.
      * Re-assert it, same as migrate_from_v63 does for radar_dark_mode. */
     cfg->radar_map_style = 1;
+    clouds_set_defaults(cfg);   /* v66 fields follow directly; same tail-padding reasoning */
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v64 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v65 -> v66 migration: appends the five clouds_* fields (Clouds satellite
+ *     page). Additive and at the very end, so this stays a plain prefix memcpy
+ *     like every migration around it. An upgrading device gets the page
+ *     disabled with the stock defaults; nothing else changes. --- */
+static void migrate_from_v65(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v65_t) ? raw_size : sizeof(app_config_v65_t);
+    memcpy(cfg, raw, copy);
+
+    /* The clouds block is appended past the v65 snapshot, so memcpy(copy)
+     * never touches it on purpose; the snapshot's tail padding can still land
+     * on top of the first bytes, so re-assert the defaults (same as
+     * migrate_from_v64 does for radar_map_style). */
+    clouds_set_defaults(cfg);
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v65 to v%d", APP_CONFIG_VERSION);
 }
 
 
@@ -3497,6 +3537,28 @@ static bool validate_config(app_config_t *cfg) {
         cfg->radar_map_style = 1;
         fixed = true;
     }
+    /* Clouds page (v66). The SETTINGS_TABLE rows already clamp/reset these in
+     * settings_clamp_apply(); kept explicit here as the last line of defence,
+     * like the radar block above. Interval 300-7200 s (settings_clamp_apply()
+     * has already turned a zeroed blob into 300, so no separate 0 arm here),
+     * frames 1-10 (~1 MB PSRAM each), zoom 5-9. */
+    if (cfg->clouds_update_interval_s < 300) {
+        cfg->clouds_update_interval_s = 300;
+        fixed = true;
+    } else if (cfg->clouds_update_interval_s > 7200) {
+        cfg->clouds_update_interval_s = 7200;
+        fixed = true;
+    }
+    if (cfg->clouds_frames < 1 || cfg->clouds_frames > 10) {
+        cfg->clouds_frames = 6;
+        fixed = true;
+    }
+    if (cfg->clouds_zoom < 5 || cfg->clouds_zoom > 9) {
+        cfg->clouds_zoom = 7;
+        fixed = true;
+    }
+    cfg->clouds_enabled      = cfg->clouds_enabled ? true : false;
+    cfg->clouds_show_overlay = cfg->clouds_show_overlay ? true : false;
 
     /* WiFi TX power cap: whitelist, not a range — only the discrete dBm steps
      * the UI offers are meaningful, and 0 means "no cap". Anything else (a
@@ -3590,6 +3652,18 @@ void app_config_init(void) {
             nvs_commit(handle);
         }
         /* tiles_loaded stays false -> tail loads "json_tiles"/"ha_tiles" keys */
+    } else if (version_check == 65) {
+        /* v65 -> v66: appended the five clouds_* fields. tiles_loaded stays
+         * false: a v65 device already keeps its tiles in the "json_tiles"/
+         * "ha_tiles" NVS keys, so the tail loads them.
+         * Safe to write back immediately, same reasoning as the v64 branch: a
+         * v65 blob already holds a real 24-entry auto_rotate_order2[] and real
+         * per-page image settings, so both dispatcher-tail fixups below are
+         * excluded by their literal version bounds. */
+        migrate_from_v65(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 64) {
         /* v64 -> v65: appended radar_map_style. tiles_loaded stays false: a v64
          * device already keeps its tiles in the "json_tiles"/"ha_tiles" NVS

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -39,6 +39,7 @@ extern "C" {
  *  25  ARP_IDX_HA         -> PAGE_IDX_HA (8)    (== PAGE_REF_HA)
  *  26  ARP_IDX_OCTOPRINT  -> PAGE_IDX_OCTOPRINT (9) (== PAGE_REF_OCTOPRINT)
  *  27  ARP_IDX_RADAR      -> the Weather Radar page   (== PAGE_REF_RADAR)
+ *  28  ARP_IDX_CLOUDS     -> the Clouds page          (== PAGE_REF_CLOUDS)
  * Use ARP_STOP_IS_VALID() for validation, never `< ARP_IDX_MAX` alone.
  */
 #define ARP_IDX_SUMMARY     0
@@ -58,9 +59,11 @@ extern "C" {
 #define ARP_IDX_HA         25   /* == PAGE_REF_HA (frozen registry id) */
 #define ARP_IDX_OCTOPRINT  26   /* == PAGE_REF_OCTOPRINT (frozen registry id) */
 #define ARP_IDX_RADAR      27   /* == PAGE_REF_RADAR (frozen registry id) */
+#define ARP_IDX_CLOUDS     28   /* == PAGE_REF_CLOUDS (frozen registry id) */
 /* True if @p b names a valid slideshow stop. */
 #define ARP_STOP_IS_VALID(b) ((b) < ARP_IDX_MAX || (b) == ARP_IDX_JSON || (b) == ARP_IDX_HA || \
-                              (b) == ARP_IDX_OCTOPRINT || (b) == ARP_IDX_RADAR)
+                              (b) == ARP_IDX_OCTOPRINT || (b) == ARP_IDX_RADAR || \
+                              (b) == ARP_IDX_CLOUDS)
 #define ARP_ORDER_CAPACITY 24   /* size of the LIVE auto_rotate_order2[] (v63) */
 /* Size of the RETIRED auto_rotate_order2_retired[] that still sits mid-struct at
  * its original offset. Used ONLY by the v63 migration lift in app_config.c.
@@ -75,7 +78,7 @@ extern "C" {
 #define ARP_ORDER_CAPACITY_RETIRED 16
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 65
+#define APP_CONFIG_VERSION 66
 
 /* Tiles-config blobs no longer live inside app_config_t (v52 split them out to
  * dedicated NVS string keys "json_tiles"/"ha_tiles"). These bound the value
@@ -473,6 +476,13 @@ typedef struct {
                                        // NWS map service: no banner or legend, black
                                        // background, so radar_crop and radar_dark_mode
                                        // do not apply. Values above 2 fall back to 1.
+
+    // Added after v65 (Clouds page) — must stay at end to preserve NVS binary compatibility
+    bool     clouds_enabled;           // show the Clouds satellite page (default false)
+    bool     clouds_show_overlay;      // draw the label/time strip over the picture (default true)
+    uint16_t clouds_update_interval_s; // 300-7200 s, default 600 (GIBS publishes every 10 min)
+    uint8_t  clouds_frames;            // 1-10 animation frames, default 6 (~1 MB PSRAM each)
+    uint8_t  clouds_zoom;              // 5-9 Web-Mercator zoom around weather_lat/lon, default 7
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -3659,6 +3669,190 @@ _Static_assert(offsetof(app_config_t, radar_map_style) ==
  * it must never exceed the destination. */
 _Static_assert(sizeof(app_config_v64_t) <= sizeof(app_config_t),
                "v64 snapshot must not exceed the current config struct");
+
+/* ── Version 65 config struct — used only for NVS migration to v66 ────── */
+/* Byte-identical to app_config_t minus the five trailing clouds_* fields v66 */
+/* appended. Same body as the v64 snapshot plus radar_map_style v65 at the    */
+/* end.                                                                       */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+    char     custom_image_url[256];
+    uint8_t  custom_orientation;
+    uint16_t custom_update_interval_s;
+    uint8_t  auto_rotate_order2_retired[16];   /* the RETIRED mid-struct array,
+                                        * named exactly as the live struct
+                                        * names it — see the note there */
+    uint8_t  goes_vflip;
+    uint8_t  goes_hflip;
+    uint8_t  solar_vflip;
+    uint8_t  solar_hflip;
+    uint8_t  custom_vflip;
+    uint8_t  custom_hflip;
+    bool     home_page_lock;
+    bool     json_enabled;
+    char     json_url[256];
+    char     json_auth_header[256];
+    uint16_t json_update_interval_s;
+    bool     ha_enabled;
+    char     ha_base_url[256];
+    char     ha_token[256];
+    uint16_t ha_update_interval_s;
+    bool     setup_hint_dismissed;
+    uint8_t  alert_voice_enabled;
+    uint8_t  alert_voice_volume;
+    uint8_t  alert_voice_types;
+    uint8_t  alert_voice_repeat_min;
+    bool     alert_voice_muted[3];
+    uint32_t voice_notify_mask;
+    uint8_t  boot_jingle_enabled;
+    uint8_t  alert_voice_brief;
+    uint8_t  alert_voice_conn;
+    uint8_t  alert_voice_disc;
+    uint8_t  wifi_max_tx_dbm;
+    uint8_t  octoprint_enabled;
+    char     octoprint_url[128];
+    char     octoprint_api_key[64];
+    uint16_t octoprint_update_interval_s;
+    uint8_t  octoprint_image_source;
+    uint8_t  octoprint_layout;
+    char     octoprint_snapshot_url[128];
+    bool     goes_enabled;
+    bool     moon_enabled;
+    bool     solar_enabled;
+    bool     custom_enabled;
+    uint16_t solar_update_interval_s;
+    uint16_t moon_update_interval_s;
+    bool     goes_crop;
+    bool     solar_crop;
+    bool     custom_crop;
+    bool     goes_show_overlay;
+    bool     moon_show_overlay;
+    bool     solar_show_overlay;
+    bool     custom_show_overlay;
+    bool     octoprint_overlay_visible;
+    bool     radar_enabled;
+    char     radar_token[16];
+    uint16_t radar_update_interval_s;
+    bool     radar_show_overlay;
+    uint8_t  radar_crop;
+    uint8_t  radar_frames;
+    uint8_t  auto_rotate_order2[ARP_ORDER_CAPACITY];
+    bool     radar_dark_mode;
+    uint8_t  radar_map_style;
+} app_config_v65_t;
+
+/* clouds_enabled (bool, align 1) appends directly after radar_map_style
+ * (uint8_t, align 1), so no alignment padding can sit between them. Nothing
+ * moved in v66 — the fields are a pure append — so this is the plain
+ * end-of-last-field equality the v62/v63/v64 asserts use. */
+_Static_assert(offsetof(app_config_t, clouds_enabled) ==
+                   offsetof(app_config_v65_t, radar_map_style) +
+                       sizeof(((app_config_v65_t *)0)->radar_map_style),
+               "app_config_v65_t snapshot drifted from app_config_t layout");
+
+/* migrate_from_v65 memcpy's sizeof(app_config_v65_t) bytes into app_config_t;
+ * it must never exceed the destination. */
+_Static_assert(sizeof(app_config_v65_t) <= sizeof(app_config_t),
+               "v65 snapshot must not exceed the current config struct");
 
 // v17 snapshot — AllSky fields without allsky_enabled
 typedef struct {

--- a/main/clouds_wms.h
+++ b/main/clouds_wms.h
@@ -1,0 +1,349 @@
+#pragma once
+
+/*
+ * clouds_wms.h - pure URL, geometry and time decisions for the Clouds page
+ * (NASA GIBS WMS, GOES ABI GeoColor over Reference_Features_15m).
+ *
+ * Header-only and free of ESP-IDF, FreeRTOS and LVGL, so the host test suite
+ * (test/host/test_clouds_wms.c) can exercise the parts that are easy to get
+ * wrong: the East/West pick, the Web-Mercator box, the GetMap URL shape, the
+ * DescribeDomains parser and the UTC calendar arithmetic. Same precedent as
+ * radar_wms.h, whose Mercator helpers this file reuses. Fetching and the frame
+ * ring live in image_page_poll.c and ui/nina_image_page.c.
+ *
+ * Verified against the live server 2026-08-18 (scratchpad gibs-robustness.md).
+ * Traps this header is written around:
+ *
+ *  - TIME is mandatory and must be YYYY-MM-DDThh:mm:ssZ on the 10-minute grid.
+ *    Omitting it serves whatever the (stale) capabilities default names, and
+ *    off-grid values floor silently. Never send Reference_Labels_15m: it blanks
+ *    the whole JPEG.
+ *
+ *  - A future or missing slot is NOT an error: the server answers 200 image/jpeg
+ *    with the vector overlay drawn over black. DescribeDomains (a ~320 B REST
+ *    document, cache-busted by a to-the-second window start) is the only cheap
+ *    source of the slots that exist, so the ring is fed from it, never by
+ *    blind stepping. When it fails, floor(now,10min)-50min is the fallback
+ *    newest (frames land 30-47 min behind wall clock; -50 keeps the guess at
+ *    or behind the real newest so a real list heals it instead of leaving a
+ *    blank frame stranded as "Latest" ahead of every real stamp).
+ *
+ *  - ponytail: an HTTP 200 blank JPEG for a slot that DescribeDomains listed
+ *    but the origin has not filled (or a partial frame with black quadrants)
+ *    is not detected in this version; it enters the ring like any other
+ *    frame and is only healed by the same-stamp replace on the next poll.
+ *    Upgrade path: keep a per-(layer,bbox) blank length+CRC probe at
+ *    TIME=2000-01-01T00:00:00Z and drop matching bodies.
+ *
+ * All maths is float-only (the P4 FPU is single precision); the calendar
+ * helpers are integer days-from-civil / civil-from-days, no localtime.
+ */
+
+#include <math.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "radar_wms.h"   /* radar_wms_merc_x/y, radar_wms_find */
+
+#define CLOUDS_URL_MAX        RADAR_WMS_URL_MAX   /* 512: the GetMap URL is ~330 chars */
+#define CLOUDS_TIME_MAX       21                  /* "2026-08-18T04:00:00Z" + NUL */
+#define CLOUDS_TIMES_MAX      10                  /* == max clouds_frames (ring capacity) */
+#define CLOUDS_PERIOD_S       600u                /* GOES ABI GeoColor cadence, PT10M */
+#define CLOUDS_FALLBACK_LAG_S 3000u               /* 50 min behind wall clock when the domain fetch fails */
+#define CLOUDS_PX             720                 /* frame size, native panel size */
+#define CLOUDS_ZOOM_MIN       5
+#define CLOUDS_ZOOM_MAX       9
+#define CLOUDS_DOMAIN_BACK_S  (3u * 3600u)        /* DescribeDomains window: now-3h .. now+1h */
+#define CLOUDS_DOMAIN_FWD_S   3600u
+
+#define CLOUDS_GIBS_BASE   "https://gibs.earthdata.nasa.gov/"
+#define CLOUDS_LAYER_WEST  "GOES-West_ABI_GeoColor"
+#define CLOUDS_LAYER_EAST  "GOES-East_ABI_GeoColor"
+#define CLOUDS_SPLIT_LON   (-106.2f)              /* midpoint of the two sub-satellite longitudes */
+
+/* Satellite by longitude only: west of the -75.2/-137.2 midpoint gets GOES-West. */
+static inline const char *clouds_layer(float lon)
+{
+    return (lon < CLOUDS_SPLIT_LON) ? CLOUDS_LAYER_WEST : CLOUDS_LAYER_EAST;
+}
+
+/* Half-width of the 720 px box in Web-Mercator metres at Web-Mercator zoom
+ * @p zoom (clamped 5..9): 720 px * (world circumference / (256 * 2^zoom)) / 2. */
+static inline float clouds_half_m(uint8_t zoom)
+{
+    if (zoom < CLOUDS_ZOOM_MIN) zoom = CLOUDS_ZOOM_MIN;
+    if (zoom > CLOUDS_ZOOM_MAX) zoom = CLOUDS_ZOOM_MAX;
+    return 360.0f * 40075016.686f / (256.0f * (float)(1u << zoom));
+}
+
+/* Square EPSG:3857 box centred on lat/lon. Latitude is clamped to +-85 inside
+ * radar_wms_merc_y(). (0,0) is a valid centre (Gulf of Guinea), no special case. */
+static inline void clouds_bbox(float lat, float lon, uint8_t zoom,
+                               float *minx, float *miny, float *maxx, float *maxy)
+{
+    float cx = radar_wms_merc_x(lon);
+    float cy = radar_wms_merc_y(lat);
+    float half = clouds_half_m(zoom);
+    if (minx) *minx = cx - half;
+    if (miny) *miny = cy - half;
+    if (maxx) *maxx = cx + half;
+    if (maxy) *maxy = cy + half;
+}
+
+/* ---- UTC calendar arithmetic (proleptic Gregorian, no localtime) ---- */
+
+/* Days since 1970-01-01 for a civil date (Howard Hinnant's days_from_civil). */
+static inline int64_t clouds_days_from_civil(int y, unsigned m, unsigned d)
+{
+    y -= (m <= 2) ? 1 : 0;
+    const int64_t era = (y >= 0 ? y : y - 399) / 400;
+    const unsigned yoe = (unsigned)(y - (int)era * 400);
+    const unsigned doy = (153u * (m > 2 ? m - 3u : m + 9u) + 2u) / 5u + d - 1u;
+    const unsigned doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+    return era * 146097 + (int64_t)doe - 719468;
+}
+
+/* Civil date from days since 1970-01-01 (Howard Hinnant's civil_from_days). */
+static inline void clouds_civil_from_days(int64_t z, int *y, unsigned *m, unsigned *d)
+{
+    z += 719468;
+    const int64_t era = (z >= 0 ? z : z - 146096) / 146097;
+    const unsigned doe = (unsigned)(z - era * 146097);
+    const unsigned yoe = (doe - doe / 1460u + doe / 36524u - doe / 146096u) / 365u;
+    const int64_t yy = (int64_t)yoe + era * 400;
+    const unsigned doy = doe - (365u * yoe + yoe / 4u - yoe / 100u);
+    const unsigned mp = (5u * doy + 2u) / 153u;
+    const unsigned dd = doy - (153u * mp + 2u) / 5u + 1u;
+    const unsigned mm = mp < 10u ? mp + 3u : mp - 9u;
+    if (y) *y = (int)(yy + (mm <= 2u ? 1 : 0));
+    if (m) *m = mm;
+    if (d) *d = dd;
+}
+
+/* Format @p epoch (UTC seconds) as "YYYY-MM-DDThh:mm:ssZ". @p sz >= CLOUDS_TIME_MAX. */
+static inline bool clouds_time_format(char *out, size_t sz, uint32_t epoch)
+{
+    if (out == NULL || sz == 0) return false;
+    int y; unsigned m, d;
+    clouds_civil_from_days((int64_t)(epoch / 86400u), &y, &m, &d);
+    unsigned s = epoch % 86400u;
+    int n = snprintf(out, sz, "%04d-%02u-%02uT%02u:%02u:%02uZ",
+                     y, m, d, s / 3600u, (s / 60u) % 60u, s % 60u);
+    if (n < 0 || (size_t)n >= sz) {
+        out[0] = '\0';
+        return false;
+    }
+    return true;
+}
+
+/* Parse @p n digits at @p s into *v; false on any non-digit. */
+static inline bool clouds_parse_digits(const char *s, size_t n, unsigned *v)
+{
+    unsigned acc = 0;
+    for (size_t i = 0; i < n; i++) {
+        if (s[i] < '0' || s[i] > '9') return false;
+        acc = acc * 10u + (unsigned)(s[i] - '0');
+    }
+    *v = acc;
+    return true;
+}
+
+/* Parse "YYYY-MM-DDThh:mm:ssZ" (or "YYYY-MM-DDThh:mmZ") from [s, s+len) into
+ * UTC seconds. STRICT: an entry without 'T' (a bare date) is rejected, so a
+ * caller never mistakes a date for a frame time. Trailing junk after 'Z' fails. */
+static inline bool clouds_time_parse(const char *s, size_t len, uint32_t *out)
+{
+    unsigned Y, M, D, h, mi, se = 0;
+    if (s == NULL || out == NULL) return false;
+    if (len < 17) return false;                        /* "YYYY-MM-DDThh:mmZ" */
+    if (s[4] != '-' || s[7] != '-' || s[10] != 'T' || s[13] != ':') return false;
+    if (!clouds_parse_digits(s, 4, &Y) || !clouds_parse_digits(s + 5, 2, &M) ||
+        !clouds_parse_digits(s + 8, 2, &D) || !clouds_parse_digits(s + 11, 2, &h) ||
+        !clouds_parse_digits(s + 14, 2, &mi)) return false;
+    size_t p = 16;
+    if (s[p] == ':') {
+        if (len < 20 || !clouds_parse_digits(s + 17, 2, &se)) return false;
+        p = 19;
+    }
+    if (p >= len || s[p] != 'Z' || p + 1 != len) return false;
+    if (M < 1 || M > 12 || D < 1 || D > 31 || h > 23 || mi > 59 || se > 59) return false;
+    if (Y < 1970 || Y > 2105) return false;              /* keeps the product inside uint32 */
+    int64_t days = clouds_days_from_civil((int)Y, M, D);
+    *out = (uint32_t)(days * 86400 + (int64_t)h * 3600 + (int64_t)mi * 60 + (int64_t)se);
+    return true;
+}
+
+/* Bare "YYYY-MM-DD" (exactly 10 chars) -> UTC midnight. Used only for the START
+ * of a start/end/period segment, where GIBS does write a bare date. */
+static inline bool clouds_date_parse(const char *s, size_t len, uint32_t *out)
+{
+    unsigned Y, M, D;
+    if (s == NULL || out == NULL || len != 10) return false;
+    if (s[4] != '-' || s[7] != '-') return false;
+    if (!clouds_parse_digits(s, 4, &Y) || !clouds_parse_digits(s + 5, 2, &M) ||
+        !clouds_parse_digits(s + 8, 2, &D)) return false;
+    if (M < 1 || M > 12 || D < 1 || D > 31 || Y < 1970 || Y > 2105) return false;
+    *out = (uint32_t)(clouds_days_from_civil((int)Y, M, D) * 86400);
+    return true;
+}
+
+static inline uint32_t clouds_floor_period(uint32_t t)
+{
+    return t - (t % CLOUDS_PERIOD_S);
+}
+
+/* Newest stamp to assume when DescribeDomains is unavailable. */
+static inline uint32_t clouds_fallback_newest(uint32_t now)
+{
+    uint32_t t = clouds_floor_period(now);
+    return (t > CLOUDS_FALLBACK_LAG_S) ? t - CLOUDS_FALLBACK_LAG_S : 0u;
+}
+
+/* Frame @p i (0 = newest) counted back from @p newest on the period grid. */
+static inline uint32_t clouds_time_step(uint32_t newest, int i)
+{
+    uint32_t back = (uint32_t)(i > 0 ? i : 0) * CLOUDS_PERIOD_S;
+    return (newest > back) ? newest - back : 0u;
+}
+
+/* GetMap URL for one frame. @p stamp is the frame time in UTC seconds; it is
+ * formatted here (never copied from a server string), so no query-splitting
+ * character can reach the URL. Layer order: raster first, vector overlay after.
+ * Returns false and writes "" when the result would not fit. */
+static inline bool clouds_frame_url(char *out, size_t sz, float lat, float lon,
+                                    uint8_t zoom, uint32_t stamp)
+{
+    if (out == NULL || sz == 0) return false;
+    out[0] = '\0';
+    char tstr[CLOUDS_TIME_MAX];
+    if (!clouds_time_format(tstr, sizeof(tstr), stamp)) return false;
+    float minx, miny, maxx, maxy;
+    clouds_bbox(lat, lon, zoom, &minx, &miny, &maxx, &maxy);
+    int n = snprintf(out, sz,
+                     CLOUDS_GIBS_BASE "wms/epsg3857/best/wms.cgi?SERVICE=WMS&VERSION=1.3.0"
+                     "&REQUEST=GetMap&LAYERS=%s,Reference_Features_15m&CRS=EPSG:3857"
+                     "&BBOX=%ld,%ld,%ld,%ld&WIDTH=%d&HEIGHT=%d&FORMAT=image/jpeg&TIME=%s",
+                     clouds_layer(lon),
+                     (long)lroundf(minx), (long)lroundf(miny),
+                     (long)lroundf(maxx), (long)lroundf(maxy),
+                     CLOUDS_PX, CLOUDS_PX, tstr);
+    if (n < 0 || (size_t)n >= sz) {
+        out[0] = '\0';
+        return false;
+    }
+    return true;
+}
+
+/* WMTS DescribeDomains REST URL for @p layer over [now-3h, now+1h], both ends
+ * to the second so CloudFront (max-age 1800 on this document) cannot hand back
+ * a stale copy:
+ *   https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/1.0.0/{layer}/default/1km/all/{start}--{end}.xml */
+static inline bool clouds_domains_url(char *out, size_t sz, const char *layer, uint32_t now)
+{
+    if (out == NULL || sz == 0 || layer == NULL) return false;
+    out[0] = '\0';
+    char a[CLOUDS_TIME_MAX], b[CLOUDS_TIME_MAX];
+    uint32_t start = (now > CLOUDS_DOMAIN_BACK_S) ? now - CLOUDS_DOMAIN_BACK_S : 0u;
+    if (!clouds_time_format(a, sizeof(a), start) ||
+        !clouds_time_format(b, sizeof(b), now + CLOUDS_DOMAIN_FWD_S)) return false;
+    int n = snprintf(out, sz, CLOUDS_GIBS_BASE "wmts/epsg4326/best/1.0.0/%s/default/1km/all/%s--%s.xml",
+                     layer, a, b);
+    if (n < 0 || (size_t)n >= sz) {
+        out[0] = '\0';
+        return false;
+    }
+    return true;
+}
+
+/* Trim ASCII whitespace off [a, b). */
+static inline void clouds_trim(const char **a, const char **b)
+{
+    while (*a < *b && (**a == ' ' || **a == '\t' || **a == '\r' || **a == '\n')) (*a)++;
+    while (*b > *a && ((*b)[-1] == ' ' || (*b)[-1] == '\t' || (*b)[-1] == '\r' || (*b)[-1] == '\n')) (*b)--;
+}
+
+#define CLOUDS_SEGMENTS_MAX 32   /* start/end pairs kept from one Domain list */
+
+/* Parse a DescribeDomains body: the text of <Domain>...</Domain> is a
+ * comma-separated ASCENDING list of segments, each "start/end/PT10M" or a
+ * single "YYYY-MM-DDThh:mm:ssZ". Expands them NEWEST FIRST on the period grid
+ * into @p out (UTC seconds), at most @p max_out (<= CLOUDS_TIMES_MAX). Rules:
+ *   - a single entry without 'T' (bare date) is skipped;
+ *   - a range whose END has no 'T' is skipped; a range whose START is a bare
+ *     date starts at that midnight; any other unparsable start = open (0);
+ *   - the period is CLOUDS_PERIOD_S unless the segment says PTnM (n minutes).
+ * Returns the count (0 when the element is missing or nothing parses). Every
+ * scan is bounded by @p len: the body needs no NUL terminator. */
+static inline int clouds_parse_domains(const char *xml, size_t len, uint32_t *out, int max_out)
+{
+    if (xml == NULL || out == NULL || max_out <= 0) return 0;
+    if (max_out > CLOUDS_TIMES_MAX) max_out = CLOUDS_TIMES_MAX;
+
+    const char *d = radar_wms_find(xml, len, "<Domain>");
+    if (d == NULL) return 0;
+    d += 8;
+    const char *e = radar_wms_find(d, len - (size_t)(d - xml), "</Domain>");
+    if (e == NULL) return 0;
+
+    /* Pass 1: collect (start, end, period) per segment, in document order. */
+    uint32_t seg_start[CLOUDS_SEGMENTS_MAX], seg_end[CLOUDS_SEGMENTS_MAX], seg_per[CLOUDS_SEGMENTS_MAX];
+    int nseg = 0;
+    const char *p = d;
+    while (p < e) {
+        if (nseg == CLOUDS_SEGMENTS_MAX) {        /* overflow: drop the OLDEST, keep collecting */
+            memmove(seg_start, seg_start + 1, sizeof(seg_start) - sizeof(seg_start[0]));
+            memmove(seg_end,   seg_end + 1,   sizeof(seg_end)   - sizeof(seg_end[0]));
+            memmove(seg_per,   seg_per + 1,   sizeof(seg_per)   - sizeof(seg_per[0]));
+            nseg--;
+        }
+        const char *comma = memchr(p, ',', (size_t)(e - p));
+        const char *sa = p, *sb = comma ? comma : e;
+        p = comma ? comma + 1 : e;
+        clouds_trim(&sa, &sb);
+        if (sa >= sb) continue;
+
+        const char *sl1 = memchr(sa, '/', (size_t)(sb - sa));
+        if (sl1 == NULL) {                        /* single instant */
+            uint32_t t;
+            if (clouds_time_parse(sa, (size_t)(sb - sa), &t)) {
+                seg_start[nseg] = t; seg_end[nseg] = t; seg_per[nseg] = CLOUDS_PERIOD_S; nseg++;
+            }
+            continue;
+        }
+        const char *sl2 = memchr(sl1 + 1, '/', (size_t)(sb - sl1 - 1));
+        const char *end_b = sl2 ? sl2 : sb;
+        uint32_t t_end, t_start = 0, per = CLOUDS_PERIOD_S;
+        if (!clouds_time_parse(sl1 + 1, (size_t)(end_b - sl1 - 1), &t_end)) continue;
+        if (!clouds_time_parse(sa, (size_t)(sl1 - sa), &t_start) &&
+            !clouds_date_parse(sa, (size_t)(sl1 - sa), &t_start)) t_start = 0;
+        if (sl2 != NULL) {                        /* "PT10M" */
+            const char *q = sl2 + 1;
+            if ((size_t)(sb - q) >= 4 && q[0] == 'P' && q[1] == 'T') {
+                unsigned n = 0; const char *r = q + 2;
+                while (r < sb && *r >= '0' && *r <= '9') { n = n * 10u + (unsigned)(*r - '0'); r++; }
+                if (r < sb && *r == 'M' && n > 0) per = n * 60u;
+            }
+        }
+        if (t_start > t_end) t_start = t_end;
+        seg_start[nseg] = t_start; seg_end[nseg] = t_end; seg_per[nseg] = per; nseg++;
+    }
+
+    /* Pass 2: newest segment first, each expanded end -> start. */
+    int count = 0;
+    for (int s = nseg - 1; s >= 0 && count < max_out; s--) {
+        uint32_t t = seg_end[s];
+        for (;;) {
+            if (count > 0 && out[count - 1] == t) { /* duplicate boundary between segments */
+            } else {
+                out[count++] = t;
+                if (count >= max_out) break;
+            }
+            if (t < seg_start[s] + seg_per[s]) break;
+            t -= seg_per[s];
+        }
+    }
+    return count;
+}

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1038,6 +1038,7 @@
         <button class="tab-btn" data-tab="image-solar">Solar</button>
         <button class="tab-btn" data-tab="image-custom">Custom URL</button>
         <button class="tab-btn" data-tab="image-radar">Radar</button>
+        <button class="tab-btn" data-tab="image-clouds">Cloud Cover</button>
         <button class="tab-btn" data-tab="octoprint">OctoPrint</button>
       </div>
       <div class="tab-group" data-section="device">
@@ -1095,6 +1096,7 @@
     <div id="tab-image-solar" class="tab-panel"></div>
     <div id="tab-image-custom" class="tab-panel"></div>
     <div id="tab-image-radar" class="tab-panel"></div>
+    <div id="tab-image-clouds" class="tab-panel"></div>
 
     <!-- ==================== TAB: OCTOPRINT ==================== -->
     <!-- Markup extracted to main/fragment_octoprint.html; lazily fetched by
@@ -1405,7 +1407,7 @@
       c.innerHTML='';
       /* [id, label, stop value]. Stop values are frozen page_ref ids: 0..11
          anchored block, plus appended JSON (24), Home Assistant (25),
-         OctoPrint (26) and Weather Radar (27) — keep in sync with ARP_IDX_*
+         OctoPrint (26), Weather Radar (27) and Cloud Cover (28) — keep in sync with ARP_IDX_*
          in app_config.h. */
       var items=[
         ['arp_summary','Summary',0],
@@ -1423,7 +1425,8 @@
         ['arp_img_moon','Img: Moon',9],
         ['arp_img_solar','Img: Solar',10],
         ['arp_img_custom','Img: Custom',11],
-        ['arp_img_radar','Img: Radar',27]
+        ['arp_img_radar','Img: Radar',27],
+        ['arp_img_clouds','Img: Cloud Cover',28]
       ];
       items.forEach(function(it){
         var idx=it[2];
@@ -1586,7 +1589,7 @@
        so the initial switchTab() call at boot -- which shows whichever tab
        was last active -- transparently fetches that tab's fragment first; no
        separate boot-time special case is needed for the default tab. */
-    const TAB_ORDER=['nodes','allsky','json','ha','clock','spotify','image-goes','image-moon','image-solar','image-custom','image-radar','octoprint','display','behavior','voice-clips','system','logs','backup','api'];
+    const TAB_ORDER=['nodes','allsky','json','ha','clock','spotify','image-goes','image-moon','image-solar','image-custom','image-radar','image-clouds','octoprint','display','behavior','voice-clips','system','logs','backup','api'];
     const LAZY_TABS=new Set(TAB_ORDER);
     const loadedTabs=new Set(TAB_ORDER.filter(n=>!LAZY_TABS.has(n)));
 
@@ -1772,7 +1775,7 @@
        highlights and row 2 shows the matching tab group. _lastUsedTab remembers
        the tab last visited in each section (in-memory) so a section click lands
        on a sensible default; switchTab() keeps it seeded as tabs activate. */
-    const TAB_GROUP = { nodes:'pages', allsky:'pages', json:'pages', ha:'pages', clock:'pages', spotify:'pages', 'image-goes':'pages', 'image-moon':'pages', 'image-solar':'pages', 'image-custom':'pages', 'image-radar':'pages', octoprint:'pages', display:'device', behavior:'device', 'voice-clips':'device', system:'device', logs:'tools', backup:'tools', api:'tools' };
+    const TAB_GROUP = { nodes:'pages', allsky:'pages', json:'pages', ha:'pages', clock:'pages', spotify:'pages', 'image-goes':'pages', 'image-moon':'pages', 'image-solar':'pages', 'image-custom':'pages', 'image-radar':'pages', 'image-clouds':'pages', octoprint:'pages', display:'device', behavior:'device', 'voice-clips':'device', system:'device', logs:'tools', backup:'tools', api:'tools' };
     var _lastUsedTab={};
     function highlightGroup(name){
       var sec=TAB_GROUP[name];
@@ -2085,7 +2088,7 @@
     /* === Rotation slideshow list === */
     /* Single ordered slideshow list: membership == order.
        data-arp-idx equals the slideshow stop id (0..11, 24=JSON, 25=HA,
-       26=OctoPrint, 27=Radar).
+       26=OctoPrint, 27=Radar, 28=Cloud Cover).
        Saved array holds the indices of CHECKED pills in on-screen order,
        padded to 24 slots with 0xFF (255 = unused). */
     function getRotateOrder(){
@@ -2106,9 +2109,9 @@
       var pillMap={};
       pills.forEach(function(p){ pillMap[p.getAttribute('data-arp-idx')]=p; });
       /* Members (in order) = valid stop ids (0..11, 24=JSON, 25=HA,
-         26=OctoPrint, 27=Radar) that are not the 0xFF/255 sentinel. Keep in
+         26=OctoPrint, 27=Radar, 28=Cloud Cover) that are not the 0xFF/255 sentinel. Keep in
          sync with ARP_STOP_IS_VALID in app_config.h. */
-      var members=orderArr.map(function(v){return parseInt(v);}).filter(function(v){return !isNaN(v)&&(v>=0&&v<12||v===24||v===25||v===26||v===27);});
+      var members=orderArr.map(function(v){return parseInt(v);}).filter(function(v){return !isNaN(v)&&(v>=0&&v<12||v===24||v===25||v===26||v===27||v===28);});
       /* Reorder members to the front in saved order, set their checkbox on. */
       members.forEach(function(idx){
         var p=pillMap[idx];
@@ -2276,6 +2279,13 @@
       data.radar_token=$('radar_token').value;
       data.radar_update_interval_s=parseInt($('radar_update_interval_s').value,10)||900;
       data.radar_frames=parseInt($('radar_frames').value,10)||10;
+    }
+    function collectTab_image_clouds(data){
+      data.clouds_enabled=!!$('clouds_enabled').checked;
+      data.clouds_show_overlay=!!$('clouds_show_overlay').checked;
+      data.clouds_zoom=parseInt($('clouds_zoom').value,10)||7;
+      data.clouds_update_interval_s=parseInt($('clouds_update_interval_s').value,10)||600;
+      data.clouds_frames=parseInt($('clouds_frames').value,10)||6;
     }
 
     function collectTab_octoprint(data){
@@ -2448,6 +2458,7 @@
       'image-solar': collectTab_image_solar,
       'image-custom': collectTab_image_custom,
       'image-radar': collectTab_image_radar,
+      'image-clouds': collectTab_image_clouds,
       octoprint: collectTab_octoprint,
       display: collectTab_display,
       behavior: collectTab_behavior,
@@ -2716,6 +2727,19 @@
       if($('radar_frames')) $('radar_frames').value=String(data.radar_frames||10);
       updateImagePageEnabledUI('image-radar');
     }
+    function populateTab_image_clouds(data){
+      if($('clouds_enabled')) $('clouds_enabled').checked=!!data.clouds_enabled;
+      /* Overlay defaults on, so only an explicit false clears it (missing key
+         on older firmware keeps the default). */
+      if($('clouds_show_overlay')) $('clouds_show_overlay').checked=(data.clouds_show_overlay!==false);
+      if($('clouds_zoom')){
+        var cz=parseInt(data.clouds_zoom,10)||7;
+        $('clouds_zoom').value=String((cz>=5&&cz<=9)?cz:7);
+      }
+      if($('clouds_update_interval_s')) $('clouds_update_interval_s').value=String(data.clouds_update_interval_s||600);
+      if($('clouds_frames')) $('clouds_frames').value=String(data.clouds_frames||6);
+      updateImagePageEnabledUI('image-clouds');
+    }
 
     function populateTab_octoprint(data){
       if($('octoprint_enabled')) $('octoprint_enabled').checked=!!data.octoprint_enabled;
@@ -2918,6 +2942,7 @@
       'image-solar': populateTab_image_solar,
       'image-custom': populateTab_image_custom,
       'image-radar': populateTab_image_radar,
+      'image-clouds': populateTab_image_clouds,
       octoprint: populateTab_octoprint,
       display: populateTab_display,
       behavior: populateTab_behavior,
@@ -4441,7 +4466,8 @@
       'image-moon':   {en:'moon_enabled',   fields:'moonFields',   src:1},
       'image-solar':  {en:'solar_enabled',  fields:'solarFields',  src:2},
       'image-custom': {en:'custom_enabled', fields:'customFields', src:3},
-      'image-radar':  {en:'radar_enabled',  fields:'radarFields',  src:4}
+      'image-radar':  {en:'radar_enabled',  fields:'radarFields',  src:4},
+      'image-clouds': {en:'clouds_enabled', fields:'cloudsFields', src:5}
     };
 
     function updateImagePageEnabledUI(name){

--- a/main/fragment_api.html
+++ b/main/fragment_api.html
@@ -582,7 +582,7 @@
 
         <div class="api-ep">
           <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/image-display-config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the settings for the four image pages (GOES, Moon, Solar, Custom URL). Returns the full current value of every persisted parameter listed in the POST table below (force_fetch is not part of the output).</p>
+          <p class="api-purpose">Read the settings for the six image pages (GOES, Moon, Solar, Custom URL, Weather Radar, Cloud Cover). Returns the full current value of every persisted parameter listed in the POST table below (force_fetch is not part of the output).</p>
           <div class="api-snip-label">Request</div>
           <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/image-display-config">
             <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
@@ -603,7 +603,7 @@
             <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
             <pre>curl -b cookies.txt -X POST http://<span class="api-host">HOST</span>/api/image-display-config -d '{"source":2,"solar_band":5}'</pre>
           </div>
-          <p class="api-purpose">Send any subset of keys; <code>source</code> (0=GOES, 1=Moon, 2=Solar, 3=Custom) selects which page's last fetch error is echoed in the response.</p>
+          <p class="api-purpose">Send any subset of keys; <code>source</code> (0=GOES, 1=Moon, 2=Solar, 3=Custom, 4=Weather Radar, 5=Cloud Cover) selects which page's last fetch error is echoed in the response.</p>
           <div class="api-snip-label">Request (force a refresh)</div>
           <div class="api-snip" data-curl="curl -b cookies.txt -X POST http://HOST/api/image-display-config -d '{&quot;force_fetch&quot;:true}'">
             <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
@@ -627,7 +627,7 @@
                 <tr><td>custom_crop</td><td>bool</td><td>true / false</td><td>Crop vs full-frame; re-renders the cached frame locally (no re-download).</td></tr>
                 <tr><td>solar_update_interval_s</td><td>int</td><td>300 to 7200 (clamped)</td><td>Solar refresh interval in seconds.</td></tr>
                 <tr><td>moon_update_interval_s</td><td>int</td><td>10 to 3600 (clamped)</td><td>Moon re-render interval in seconds.</td></tr>
-                <tr><td>source</td><td>int</td><td>0=GOES, 1=Moon, 2=Solar, 3=Custom</td><td>Action only, not persisted. Selects which page's last fetch error is echoed in the response. The same key is accepted by <code>POST /api/image-display/refresh</code> as <code>{"source":n}</code>.</td></tr>
+                <tr><td>source</td><td>int</td><td>0=GOES, 1=Moon, 2=Solar, 3=Custom, 4=Weather Radar, 5=Cloud Cover</td><td>Action only, not persisted. Selects which page's last fetch error is echoed in the response. The same key is accepted by <code>POST /api/image-display/refresh</code> as <code>{"source":n}</code>.</td></tr>
                 <tr><td>goes_region</td><td>string</td><td>region code</td><td>GOES region id.</td></tr>
                 <tr><td>goes_update_interval_s</td><td>int</td><td>300 to 7200 (clamped)</td><td>GOES refresh interval in seconds.</td></tr>
                 <tr><td>goes_orientation</td><td>int</td><td>0 to 3</td><td>Rotation quadrant (0/90/180/270 degrees).</td></tr>
@@ -811,7 +811,7 @@
 
         <div class="api-ep">
           <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/image-display/refresh</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Force an immediate re-fetch of one image page with the loading overlay. With no body it refreshes the image page currently on screen; pass {"source":0..3} (0=GOES, 1=Moon, 2=Solar, 3=Custom) to refresh a specific page. This works for all four pages, unlike the force_fetch flag on /api/image-display-config which forces a download only for the Custom URL page.</p>
+          <p class="api-purpose">Force an immediate re-fetch of one image page with the loading overlay. With no body it refreshes the image page currently on screen; pass {"source":0..5} (0=GOES, 1=Moon, 2=Solar, 3=Custom, 4=Weather Radar, 5=Cloud Cover) to refresh a specific page. This works for all six pages, unlike the force_fetch flag on /api/image-display-config which forces a download only for the Custom URL page.</p>
           <div class="api-snip-label">Request (page on screen)</div>
           <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://HOST/api/image-display/refresh">
             <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>

--- a/main/fragment_behavior.html
+++ b/main/fragment_behavior.html
@@ -33,7 +33,7 @@
             <div class="field">
               <label class="field-label">Interval (seconds)</label>
               <input type="number" class="input" id="auto_rotate_interval" min="4" max="3600" value="30">
-              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600. For pages that download a picture (GOES, Solar, Custom URL, OctoPrint), the countdown starts once the picture has finished loading.</div>
+              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600. For pages that download a picture (GOES, Solar, Custom URL, Weather Radar, Cloud Cover, OctoPrint), the countdown starts once the picture has finished loading.</div>
             </div>
             <div class="field">
               <label class="field-label">Transition</label>
@@ -57,7 +57,7 @@
             <div style="font-size:0.72rem;color:var(--text-muted);margin:-8px 0 10px;opacity:0.7">Drag to reorder</div>
             <div class="pn-pill-grid reorderable" id="arp-container"></div>
             <div class="field-hint">Pick which pages and image sources rotate, and drag to set the order.</div>
-            <div class="field-hint">Note: Image pages (GOES, Solar, and Custom URL) download a fresh image from their source each time the rotation reaches them, even if their refresh interval has not elapsed yet. Shorter rotation intervals mean more frequent downloads from those image servers.</div>
+            <div class="field-hint">Note: Image pages (GOES, Solar, Custom URL, Weather Radar, and Cloud Cover) download a fresh image from their source each time the rotation reaches them, even if their refresh interval has not elapsed yet. Shorter rotation intervals mean more frequent downloads from those image servers.</div>
           </div>
         </div>
         </div>

--- a/main/fragment_image_clouds.html
+++ b/main/fragment_image_clouds.html
@@ -1,0 +1,59 @@
+        <div class="card">
+          <div class="card-title"><span class="card-title-label">Cloud Cover <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+          <div class="help-popover"><div class="help-popover-title">Cloud Cover page</div><p>Live satellite picture of cloud cover around your location, from NOAA GOES imagery served by NASA. Day: true colour. Night: infrared clouds over city lights. Updates every 10 minutes at the source; the newest frame is usually 30-45 minutes old. Location comes from the System tab's location settings.</p><p>Coverage is the Americas and the surrounding oceans (GOES East and West).</p></div>
+          <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
+            <span class="toggle-label">Enable Cloud Cover page</span>
+            <label class="toggle"><input type="checkbox" id="clouds_enabled" onchange="updateImagePageEnabledUI('image-clouds');applyImagePage('image-clouds');checkDirty()"><span class="toggle-track"></span></label>
+          </div>
+          <div class="field-hint">Adds the Cloud Cover page and starts fetching satellite pictures around your location.</div>
+          <div id="cloudsFields">
+            <div class="toggle-row" style="margin-top:16px">
+              <span class="toggle-label">Show Overlay</span>
+              <label class="toggle"><input type="checkbox" id="clouds_show_overlay" onchange="applyImagePage('image-clouds');checkDirty()"><span class="toggle-track"></span></label>
+            </div>
+            <div class="field-hint">Satellite name and picture time overlay on the display</div>
+            <div class="field" style="margin-top:16px">
+              <label class="field-label">Area</label>
+              <select class="input" id="clouds_zoom" onchange="applyImagePage('image-clouds');checkDirty()">
+                <option value="5">Region, about 2500 km across</option>
+                <option value="6">About 1200 km across</option>
+                <option value="7" selected>About 600 km across</option>
+                <option value="8">About 300 km across</option>
+                <option value="9">About 150 km across</option>
+              </select>
+              <div class="field-hint">How much of the map fits on the screen, centred on the location set on the System tab (widths quoted at mid-latitudes).</div>
+            </div>
+            <div class="card">
+              <div class="card-title"><span class="card-title-label">Animation <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+              <div class="help-popover"><div class="help-popover-title">Animation</div><p>Update Interval sets how often the page checks for a new satellite picture. The source publishes a new picture every 10 minutes, so checking more often than that gains nothing.</p><p>Animation length sets how many recent pictures the page plays back. Pictures are 10 minutes apart, so 6 frames is roughly the last hour; 1 frame is a still picture that never animates. Each frame takes about 1 MB of memory, so pick a shorter animation if the device is short on room.</p></div>
+            <div class="field" style="margin-top:16px">
+              <label class="field-label">Update Interval</label>
+              <select class="input" id="clouds_update_interval_s" onchange="applyImagePage('image-clouds');checkDirty()">
+                <option value="300">5 minutes</option>
+                <option value="600" selected>10 minutes</option>
+                <option value="900">15 minutes</option>
+                <option value="1800">30 minutes</option>
+                <option value="3600">1 hour</option>
+                <option value="7200">2 hours</option>
+              </select>
+              <div class="field-hint">How often a new satellite picture is fetched.</div>
+            </div>
+            <div class="field" style="margin-top:16px">
+              <label class="field-label">Animation length</label>
+              <select class="input" id="clouds_frames" onchange="applyImagePage('image-clouds');checkDirty()">
+                <option value="1">1 frame - still picture, no animation</option>
+                <option value="2">2 frames - about 20 minutes</option>
+                <option value="3">3 frames - about 30 minutes</option>
+                <option value="4">4 frames - about 40 minutes</option>
+                <option value="5">5 frames - about 50 minutes</option>
+                <option value="6" selected>6 frames - about 1 hour</option>
+                <option value="7">7 frames - about 70 minutes</option>
+                <option value="8">8 frames - about 80 minutes</option>
+                <option value="9">9 frames - about 90 minutes</option>
+                <option value="10">10 frames - about 100 minutes</option>
+              </select>
+              <div class="field-hint">How many recent pictures the page plays back; 1 is a still picture. About 1 MB memory per frame.</div>
+            </div>
+            </div>
+          </div>
+        </div>

--- a/main/home_ui.html
+++ b/main/home_ui.html
@@ -264,6 +264,9 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
    <a class="nav-tab" href="/config#image-moon">Moon</a>
    <a class="nav-tab" href="/config#image-solar">Solar</a>
    <a class="nav-tab" href="/config#image-custom">Custom URL</a>
+   <a class="nav-tab" href="/config#image-radar">Radar</a>
+   <a class="nav-tab" href="/config#image-clouds">Cloud Cover</a>
+   <a class="nav-tab" href="/config#octoprint">OctoPrint</a>
   </div>
   <div class="tab-group" data-section="device">
    <a class="nav-tab" href="/config#display">Display</a>
@@ -477,7 +480,9 @@ var ICONS = { summary: 'i-grid', sysinfo: 'i-chip', allsky: 'i-sun', spotify: 'i
 var SUBS  = { summary: 'All computers', sysinfo: 'Device status', allsky: 'Sky conditions',
               spotify: 'Music player', clock: 'Time and weather', json: 'Custom tiles',
               ha: 'Entity tiles', 'image.goes': 'Satellite view', 'image.moon': 'Moon phase',
-              'image.solar': 'Solar view', 'image.custom': 'Your image' };
+              'image.solar': 'Solar view', 'image.custom': 'Your image',
+              'image.radar': 'Weather radar', 'image.clouds': 'Satellite cloud cover',
+              octoprint: '3D printer' };
 function iconFor(slug) {
  if (slug.indexOf('nina.') === 0) return 'i-star';
  if (slug.indexOf('image') === 0) return 'i-image';

--- a/main/image_page_poll.c
+++ b/main/image_page_poll.c
@@ -1,9 +1,9 @@
 /**
  * @file image_page_poll.c
- * @brief Pollers for the five image pages, on the poll_task spine. One task
- *        per ENABLED source ("img_goes" .. "img_radar", 12288 B PSRAM stack,
+ * @brief Pollers for the six image pages, on the poll_task spine. One task
+ *        per ENABLED source ("img_goes" .. "img_clouds", 12288 B PSRAM stack,
  *        prio 3, Core 0), gated by image_page_t.poll_gate (active || warm).
- *        GOES/Solar/Custom/Radar share net_poll_once(); the Moon renders locally in
+ *        GOES/Solar/Custom/Radar/Clouds share net_poll_once(); the Moon renders locally in
  *        moon_poll_once() (ported from the former goes_poll_task moon branch)
  *        and releases its texture/scratch in moon_on_park().
  */
@@ -14,8 +14,9 @@
 #include "poll_task.h"
 #include "radar_play.h"            /* radar_frame_is_stale (ring generation) */
 #include "radar_wms.h"             /* styles 1/2: GeoServer WMS URL builder + caps TIME parser */
+#include "clouds_wms.h"            /* Clouds: GIBS GetMap URL, DescribeDomains parser, UTC time helpers */
 #include "radar_sites.h"           /* radar_site_coords (WMS site bbox centre) */
-#include "http_fetch.h"            /* http_fetch_text (WMS GetCapabilities) */
+#include "http_fetch.h"            /* http_fetch_text (WMS GetCapabilities / WMTS DescribeDomains) */
 #include "tasks.h"                 /* s_wifi_event_group, WIFI_CONNECTED_BIT, ota_in_progress */
 #include "app_config.h"
 #include "display_defs.h"
@@ -319,9 +320,9 @@ static uint32_t interval_cb(void *arg)
 {
     image_page_t *p = (image_page_t *)arg;
     uint32_t interval = image_page_interval_ms(p);
-    /* Moon renders every call; radar keeps its frames in the ring rather than
-     * p->frame, so neither has a p->frame age to shorten the sleep by. */
-    if (p->src == IMG_SRC_MOON || p->src == IMG_SRC_RADAR) return interval;
+    /* Moon renders every call; the animated pages keep their frames in the ring
+     * rather than p->frame, so none has a p->frame age to shorten the sleep by. */
+    if (p->src == IMG_SRC_MOON || image_src_is_animated(p->src)) return interval;
     int64_t age_ms = -1;
     if (xSemaphoreTake(p->frame_mux, pdMS_TO_TICKS(100)) == pdTRUE) {
         if (p->frame.buf) age_ms = esp_timer_get_time() / 1000 - p->frame.stamp_ms;
@@ -332,7 +333,7 @@ static uint32_t interval_cb(void *arg)
     return interval - (uint32_t)age_ms;                 /* remaining */
 }
 
-/* One image download+decode in flight across ALL five pollers (today's single
+/* One image download+decode in flight across ALL six pollers (today's single
  * goes task never ran two fetches at once; two concurrent 1 MB JPEG + 2 MB
  * decode transients would exceed the PSRAM budget and double the outbound
  * TLS sockets). A mutex is the right binary gate here (only the taker gives).
@@ -357,7 +358,7 @@ static void moon_commit(image_page_t *p, uint16_t *img, int w, int h)
     image_page_commit_frame(p, &f, true);
 }
 
-/* ---- GOES / Solar / Custom / Radar ---- */
+/* ---- GOES / Solar / Custom / Radar / Clouds ---- */
 
 /* Build a RIDGE still URL (radar_map_style 0). `token` is a char[16] and
  * `frame` is 0..9, so the longest possible result is 41 + 15 + 1 + 6 + NUL = 64
@@ -379,16 +380,34 @@ static void radar_frame_url(char *url, size_t sz, const char token[16], int fram
     snprintf(url, sz, "https://radar.weather.gov/ridge/standard/%s_%d.gif", token, frame);
 }
 
-/* Time of the last successful newest-frame push, so the freshness check below
- * can skip a download. Touched only by this task. */
-static int64_t s_radar_last_push_ms = 0;
+/* Per-instance poller state for the ANIMATED sources (image_src_is_animated),
+ * indexed by src; the single-frame sources' entries are never touched.
+ *   last_push_ms  time of the last successful newest-frame push, so the
+ *                 freshness check can skip a download;
+ *   times[]       advertised TIME stamps NEWEST FIRST, verbatim as the radar
+ *                 WMS caps list them (styles 1/2; empty on style 0);
+ *   stamps[]      the same list as UTC seconds for a source whose stamps are
+ *                 parsed (Clouds; 0 for radar = unknown, hash-only dedupe).
+ * Touched only by that page's poll task (net_poll_once and anim_backfill run on
+ * it sequentially). File-scope on purpose: the string table is 320 B per source
+ * and does not belong on the 12288 B poller stack. */
+typedef struct {
+    int64_t  last_push_ms;
+    int      ntimes;
+    char     times[RADAR_WMS_TIMES_MAX][RADAR_WMS_TIME_MAX];
+    uint32_t stamps[RADAR_WMS_TIMES_MAX];
+} anim_state_t;
+static anim_state_t s_anim[IMG_SRC_COUNT];
+/* The ring indexes stamps[]/times[] up to its capacity, so the two times lists
+ * must be at least as long as the largest ring. */
+_Static_assert(RADAR_WMS_TIMES_MAX >= RADAR_RING_MAX, "radar times list shorter than the ring");
+_Static_assert(CLOUDS_TIMES_MAX >= RADAR_RING_MAX, "clouds times list shorter than the ring");
 
-/* Advertised TIME stamps of the radar layer for styles 1/2 (GeoServer WMS),
- * NEWEST FIRST, refreshed on every newest-frame fetch. Touched only by the
- * radar poll task (net_poll_once and radar_backfill run on it sequentially).
- * File-scope on purpose: 320 B does not belong on the 12288 B poller stack. */
-static char s_radar_times[RADAR_WMS_TIMES_MAX][RADAR_WMS_TIME_MAX];
-static int  s_radar_ntimes = 0;
+static inline uint32_t anim_stamp(image_page_t *p, int i)
+{
+    anim_state_t *a = &s_anim[p->src];
+    return (i >= 0 && i < a->ntimes) ? a->stamps[i] : 0;
+}
 
 /* Build the WMS GetMap URL for `token` under styles 1/2. `token` has already
  * passed image_page_radar_token() (A-Z0-9 only) and radar_wms_frame_url()
@@ -403,74 +422,185 @@ static bool radar_wms_url_for(char *url, size_t sz, const app_config_t *cfg,
     return radar_wms_frame_url(url, sz, cfg->radar_map_style, token, lat, lon, stamp);
 }
 
-/* Refresh s_radar_times from the namespace-scoped GetCapabilities document.
- * Blind time stepping does not work (the newest frame lags wall clock by a
- * variable amount and out-of-range TIME returns a valid near-black GIF), so
- * the advertised list is the only safe source of stamps. Empty on any failure:
- * the newest fetch then omits TIME (server default = newest) and backfill
- * stops. KHDC is the standing case: its namespace GetCapabilities advertises
- * zero layers (so no time list) although its GetMap serves a live picture, so
- * on styles 1/2 it shows the newest picture only, with no history. */
-static void radar_wms_refresh_times(const char *token)
+/* One small text document (WMS caps / WMTS DescribeDomains), TLS bundle, capped
+ * at @p cap bytes. Body is PSRAM, caller frees. */
+static bool anim_fetch_small(const char *url, size_t cap, char **body, size_t *len)
 {
-    char url[128];
-    char layer[32];
-    s_radar_ntimes = 0;
-    if (!radar_wms_caps_url(url, sizeof(url), token) ||
-        !radar_wms_layer_name(layer, sizeof(layer), token)) return;
     http_fetch_opts_t opts = {
         .timeout_ms = 10000,
         .use_tls_bundle = true,
-        .max_response_bytes = 65536,
+        .max_response_bytes = cap,
         .user_agent = "NINA-Display/1.0 (ESP32-P4 dashboard)",
     };
+    return http_fetch_text(url, &opts, body, len) == ESP_OK;
+}
+
+/* Refresh the radar times list from the namespace-scoped GetCapabilities
+ * document (styles 1/2). Blind time stepping does not work (the newest frame
+ * lags wall clock by a variable amount and out-of-range TIME returns a valid
+ * near-black GIF), so the advertised list is the only safe source of stamps.
+ * Empty on any failure: the newest fetch then omits TIME (server default =
+ * newest) and backfill stops. KHDC is the standing case: its namespace
+ * GetCapabilities advertises zero layers (so no time list) although its GetMap
+ * serves a live picture, so on styles 1/2 it shows the newest picture only,
+ * with no history. */
+static void radar_wms_refresh_times(anim_state_t *a, const char *token)
+{
+    char url[128];
+    char layer[32];
+    a->ntimes = 0;
+    if (!radar_wms_caps_url(url, sizeof(url), token) ||
+        !radar_wms_layer_name(layer, sizeof(layer), token)) return;
     char *body = NULL;
     size_t len = 0;
-    if (http_fetch_text(url, &opts, &body, &len) != ESP_OK) {
+    if (!anim_fetch_small(url, 65536, &body, &len)) {
         ESP_LOGW(TAG, "radar caps fetch failed for %s; newest only", token);
         return;
     }
-    s_radar_ntimes = radar_wms_parse_times(body, len, layer, s_radar_times, RADAR_WMS_TIMES_MAX);
+    a->ntimes = radar_wms_parse_times(body, len, layer, a->times, RADAR_WMS_TIMES_MAX);
     heap_caps_free(body);
-    if (s_radar_ntimes == 0) ESP_LOGW(TAG, "no advertised radar times for %s; newest only", token);
+    memset(a->stamps, 0, sizeof(a->stamps));   /* radar stamps stay unknown */
+    if (a->ntimes == 0) ESP_LOGW(TAG, "no advertised radar times for %s; newest only", token);
+}
+
+/* Refresh the Clouds times list from WMTS DescribeDomains (~320 B): the slots
+ * GIBS actually holds for the picked satellite over the last three hours,
+ * newest first, at most clouds_frames. A missing or empty answer falls back to
+ * floor(now,10min)-50min as the single newest slot (frames land 30-47 min
+ * behind wall clock; -50 keeps the guess at or behind the real newest, so it
+ * is healed rather than stranded ahead of every real stamp), so the page still
+ * shows a picture during a GIBS wobble. */
+static void clouds_refresh_times(image_page_t *p, anim_state_t *a, const app_config_t *cfg)
+{
+    time_t now_t;
+    time(&now_t);
+    uint32_t now = (uint32_t)now_t;
+    int cap = image_page_ring_capacity(p);
+    a->ntimes = 0;
+
+    char url[160];
+    if (clouds_domains_url(url, sizeof(url), clouds_layer(cfg->weather_lon), now)) {
+        char *body = NULL;
+        size_t len = 0;
+        if (anim_fetch_small(url, 4096, &body, &len)) {
+            a->ntimes = clouds_parse_domains(body, len, a->stamps, cap);
+            heap_caps_free(body);
+        }
+    }
+    if (a->ntimes == 0) {
+        ESP_LOGW(TAG, "clouds: no GIBS time list; assuming newest = now - 50 min");
+        a->stamps[0] = clouds_fallback_newest(now);
+        a->ntimes = 1;
+    }
+    for (int i = 0; i < a->ntimes; i++) {
+        clouds_time_format(a->times[i], sizeof(a->times[i]), a->stamps[i]);
+    }
+}
+
+/* Per-source hook: refresh the advertised times list before the newest fetch.
+ * A network op, so it runs inside s_fetch_gate with the frame fetch. */
+static void anim_refresh_times(image_page_t *p, const app_config_t *cfg, const char *token)
+{
+    anim_state_t *a = &s_anim[p->src];
+    if (p->src == IMG_SRC_CLOUDS) {
+        clouds_refresh_times(p, a, cfg);
+    } else if (cfg->radar_map_style != 0) {
+        radar_wms_refresh_times(a, token);
+    } else {
+        a->ntimes = 0;                          /* RIDGE stills: indexed, no time list */
+    }
+}
+
+/* Per-source hook: URL of history frame @p i (0 = newest). false when there is
+ * no such frame (list exhausted, unknown radar token) — the history ends there.
+ * Radar style 0 indexes RIDGE's _i.gif; styles 1/2 and Clouds index the times
+ * list newest-first, so frame i is the i-th newest, which is what _i.gif means. */
+static bool anim_frame_url(image_page_t *p, const app_config_t *cfg, const char *token,
+                           int i, char *url, size_t sz)
+{
+    anim_state_t *a = &s_anim[p->src];
+    if (p->src == IMG_SRC_CLOUDS) {
+        if (i >= a->ntimes) return false;
+        return clouds_frame_url(url, sz, cfg->weather_lat, cfg->weather_lon,
+                                cfg->clouds_zoom, a->stamps[i]);
+    }
+    if (cfg->radar_map_style == 0) {
+        radar_frame_url(url, sz, token, i);
+        return true;
+    }
+    /* Newest = advertised stamp [0], or the server default (= newest) when none
+     * were advertised (KHDC). Older frames need a stamp. */
+    if (i > 0 && i >= a->ntimes) return false;
+    return radar_wms_url_for(url, sz, cfg, token, a->ntimes > 0 ? a->times[i] : NULL);
+}
+
+/* Fetch history frame @p i under generation @p gen and hand it to the ring
+ * (accepted or rejected, the ring owns both buffers). Serialised on the fetch
+ * gate. false when the fetch failed (older frames are optional). */
+static bool anim_fetch_index(image_page_t *p, const app_config_t *cfg, const char *token,
+                             int i, uint32_t gen)
+{
+    char url[RADAR_WMS_URL_MAX];
+    if (!anim_frame_url(p, cfg, token, i, url, sizeof(url))) return false;
+    image_frame_t old = {0};
+    uint8_t *src = NULL;
+    size_t   src_len = 0;
+    xSemaphoreTake(s_fetch_gate, portMAX_DELAY);
+    esp_err_t e = image_fetch_custom_retain(url, &old, &src, &src_len);
+    xSemaphoreGive(s_fetch_gate);
+    if (e != ESP_OK) {
+        if (old.buf) heap_caps_free(old.buf);
+        /* src is NULL on every error return (see image_fetch_custom_retain). */
+        return false;
+    }
+    image_page_ring_add(p, &old, false, gen, src, src_len, anim_stamp(p, i));
+    return true;
 }
 
 /* Rebuild the history behind the newest frame after a page activation: fetch
- * {TOKEN}_1.gif upward (style 0) or the advertised WMS stamps from the second
- * newest down (styles 1/2) and APPEND each at the tail, so the ring stays
- * newest-first without ever reordering. Frames are STAGGERED ~1 s apart rather
- * than run back to back: this board glitches the panel under sustained radio
- * transmission (see wifi_max_tx_dbm), and nine rapid TLS downloads are exactly
- * that profile. Stops early when the ring fills, a fetch fails (older frames
- * are optional), or the page is left mid-backfill. */
+ * frame 1 upward through the frame_url hook and hand each to the ring (tail
+ * append for radar; placed by stamp for Clouds), so the ring stays newest-first
+ * without ever reordering. Frames are STAGGERED ~1 s apart rather than run back
+ * to back: this board glitches the panel under sustained radio transmission
+ * (see wifi_max_tx_dbm), and nine rapid TLS downloads are exactly that profile.
+ * Stops early when the ring fills, a fetch fails (older frames are optional),
+ * or the page is left mid-backfill. */
 #define RADAR_BACKFILL_GAP_MS 1000
 
-static void radar_backfill(image_page_t *p, const app_config_t *cfg)
+static void anim_backfill(image_page_t *p, const app_config_t *cfg)
 {
-    int cap = image_page_radar_capacity();
-    if (cap <= 1) return;                       /* radar_frames == 1: a still, no ring */
+    int cap = image_page_ring_capacity(p);
+    if (cap <= 1) return;                       /* frames == 1: a still, no ring */
 
     /* Generation FIRST, token second: the config write lands before the ring
      * reset bumps the generation, so this order can never pair an old token
      * with the new generation (see radar_frame_is_stale in radar_play.h). */
-    uint32_t gen = image_page_radar_gen();
+    uint32_t gen = image_page_ring_gen(p);
     char token[16];
     image_page_radar_token(cfg, token, sizeof(token));
-    uint8_t style = cfg->radar_map_style;
 
     for (int i = 1; i < cap; i++) {
         if (!atomic_load(&p->poll_gate)) break;             /* page left / un-warmed */
-        if (image_page_radar_count() >= cap) break;         /* ring full */
+        if (image_page_ring_count(p) >= cap) break;         /* ring full */
+        /* A stamped frame the ring already holds (Clouds re-entry after a
+         * partial teardown, or the times[1] repair fetch below) costs no
+         * download. */
+        if (image_page_ring_has_stamp(p, anim_stamp(p, i))) continue;
+        /* Times list exhausted (short clouds list, KHDC on styles 1/2): the
+         * history simply ends here. Checked BEFORE the delay, no warning.
+         * Radar style 0 (RIDGE _i.gif) has no list and is never exhausted. */
+        if (!(p->src == IMG_SRC_RADAR && cfg->radar_map_style == 0) &&
+            i >= s_anim[p->src].ntimes) break;
         vTaskDelay(pdMS_TO_TICKS(RADAR_BACKFILL_GAP_MS));
         /* Superseded mid-backfill (region/frame-count/crop change, page leave).
-         * image_page_radar_add() would reject these frames anyway; bailing here
+         * image_page_ring_add() would reject these frames anyway; bailing here
          * stops us DOWNLOADING them. This loop lives ~9 s, so without it a
-         * region switch costs up to eight more 32 KB TLS fetches for a region
-         * nobody is looking at — and sustained radio transmission is what
-         * glitches this panel (see wifi_max_tx_dbm). Placed after the delay so
-         * it gates every fetch, including the first. */
-        if (radar_frame_is_stale(gen, image_page_radar_gen())) {
-            ESP_LOGI(TAG, "radar backfill superseded at frame %d", i);
+         * region switch costs up to eight more TLS fetches for a region nobody
+         * is looking at — and sustained radio transmission is what glitches
+         * this panel (see wifi_max_tx_dbm). Placed after the delay so it gates
+         * every fetch, including the first. */
+        if (radar_frame_is_stale(gen, image_page_ring_gen(p))) {
+            ESP_LOGI(TAG, "%s backfill superseded at frame %d", p->name, i);
             return;
         }
 
@@ -486,36 +616,14 @@ static void radar_backfill(image_page_t *p, const app_config_t *cfg)
          * remaining frame is still fetched, in order, and each is baked live
          * under the settings that just won. Safe to call from here: it runs on
          * this task, and no insert is in flight at this point in the loop. */
-        image_page_radar_retransform_if_requested(p);
+        image_page_ring_retransform_if_requested(p);
 
-        char url[RADAR_WMS_URL_MAX];
-        if (style == 0) {
-            radar_frame_url(url, sizeof(url), token, i);
-        } else {
-            /* Styles 1/2 index the advertised stamp list newest-first, so
-             * frame i is the i-th newest -- what RIDGE's _i.gif means on
-             * style 0. No more stamps (KHDC advertises none, parse failure,
-             * short list) or an unknown token: the history simply ends here. */
-            if (i >= s_radar_ntimes) break;
-            if (!radar_wms_url_for(url, sizeof(url), cfg, token, s_radar_times[i])) break;
-        }
-
-        image_frame_t old = {0};
-        uint8_t *src = NULL;
-        size_t   src_len = 0;
-        xSemaphoreTake(s_fetch_gate, portMAX_DELAY);
-        esp_err_t e = image_fetch_custom_retain(url, &old, &src, &src_len);
-        xSemaphoreGive(s_fetch_gate);
-        if (e != ESP_OK) {
-            if (old.buf) heap_caps_free(old.buf);
-            /* src is NULL on every error return (see image_fetch_custom_retain). */
-            ESP_LOGW(TAG, "radar backfill stopped at frame %d", i);
+        if (!anim_fetch_index(p, cfg, token, i, gen)) {
+            ESP_LOGW(TAG, "%s backfill stopped at frame %d", p->name, i);
             break;
         }
-        /* Takes both buffers, accepted or rejected. */
-        image_page_radar_add(p, &old, false, gen, src, src_len);   /* append at the tail */
     }
-    ESP_LOGI(TAG, "radar ring: %d/%d frames", image_page_radar_count(), cap);
+    ESP_LOGI(TAG, "%s ring: %d/%d frames", p->name, image_page_ring_count(p), cap);
 }
 
 static bool net_poll_once(void *arg)
@@ -523,9 +631,11 @@ static bool net_poll_once(void *arg)
     image_page_t *p = (image_page_t *)arg;
     const app_config_t *cfg = app_config_get();
     bool manual = atomic_exchange(&p->manual_fetch, false);
+    bool animated = image_src_is_animated(p->src);
 
-    /* Radar, in this order and BEFORE anything can insert a frame this pass:
-     *   1. a ring teardown image_page_radar_invalidate() had to defer because the
+    /* Animated pages, in this order and BEFORE anything can insert a frame this
+     * pass:
+     *   1. a ring teardown image_page_ring_invalidate() had to defer because the
      *      display lock was busy (the generation bump already landed, so the ring
      *      is only stale, never mixed) — running it here, ahead of the fetch
      *      below, is what keeps a frame under the NEW settings from joining old
@@ -534,11 +644,9 @@ static bool net_poll_once(void *arg)
      *      ring from each frame's retained compressed bytes. Runs BEFORE the
      *      freshness early-return below (a full, fresh ring is exactly when it is
      *      needed) and costs no network.
-     * Both are no-ops for the other four sources. */
-    if (p->src == IMG_SRC_RADAR) {
-        image_page_radar_reset_if_requested(p);
-        image_page_radar_retransform_if_requested(p);
-    }
+     * Both are no-ops for the single-frame sources. */
+    image_page_ring_reset_if_requested(p);
+    image_page_ring_retransform_if_requested(p);
 
     /* A frame that is still within its interval (a warm/prefetched frame on
      * page entry, or a wake that was not a manual/config request) needs no
@@ -546,12 +654,12 @@ static bool net_poll_once(void *arg)
     int64_t now_ms = esp_timer_get_time() / 1000;
     int64_t age_ms = 0;
     bool have = false;
-    if (p->src == IMG_SRC_RADAR) {
-        /* Radar's frames live in the ring, not p->frame. "Have" means the ring
-         * is FULL: a partly-built ring must keep polling so the backfill below
+    if (animated) {
+        /* Ring frames live in the ring, not p->frame. "Have" means the ring is
+         * FULL: a partly-built ring must keep polling so the backfill below
          * gets its chance, whatever the interval says. */
-        have = image_page_radar_count() >= image_page_radar_capacity();
-        age_ms = now_ms - s_radar_last_push_ms;
+        have = image_page_ring_count(p) >= image_page_ring_capacity(p);
+        age_ms = now_ms - s_anim[p->src].last_push_ms;
     } else if (xSemaphoreTake(p->frame_mux, pdMS_TO_TICKS(200)) == pdTRUE) {
         have = (p->frame.buf != NULL);
         age_ms = now_ms - p->frame.stamp_ms;
@@ -575,17 +683,21 @@ static bool net_poll_once(void *arg)
 
     image_frame_t fresh = {0};
     esp_err_t err;
-    /* Ring generation for a radar fetch, captured BEFORE the token is resolved
-     * below and handed to image_page_radar_add() so a frame that finishes
-     * downloading after a region switch is rejected instead of mixed into the
-     * new ring. Unused by the other four sources. */
-    uint32_t radar_gen = image_page_radar_gen();
-    /* Radar retains its compressed source bytes so the ring can be re-derived
-     * locally on a crop/dark-mode/theme change. Ownership passes to
-     * image_page_radar_add(); NULL on every non-radar path and on any error. */
-    uint8_t *radar_src = NULL;
-    size_t   radar_src_len = 0;
-    /* Serialize the fetch+decode across the five pollers (see s_fetch_gate).
+    /* Ring generation for an animated fetch, captured BEFORE the token/times
+     * are resolved below and handed to image_page_ring_add() so a frame that
+     * finishes downloading after a region switch is rejected instead of mixed
+     * into the new ring. Unused by the single-frame sources. */
+    uint32_t ring_gen = image_page_ring_gen(p);
+    /* Animated pages retain their compressed source bytes so the ring can be
+     * re-derived locally on a crop/dark-mode/theme change. Ownership passes to
+     * image_page_ring_add(); NULL on every other path and on any error. */
+    uint8_t *ring_src = NULL;
+    size_t   ring_src_len = 0;
+    /* Token resolved per fetch and never written back to config (a poll task
+     * must not persist config). Radar only; "" for the others. */
+    char token[16] = "";
+    if (p->src == IMG_SRC_RADAR) image_page_radar_token(cfg, token, sizeof(token));
+    /* Serialize the fetch+decode across the six pollers (see s_fetch_gate).
      * A page that was left/un-warmed while we waited needs no extra test here:
      * image_page_commit_frame() retains the frame either way, and the resident
      * cap frees it if the budget is exceeded. */
@@ -597,29 +709,31 @@ static bool net_poll_once(void *arg)
         case IMG_SRC_SOLAR:
             err = image_fetch_solar(cfg->solar_band, &fresh);
             break;
-        case IMG_SRC_RADAR: {
-            /* Token resolved per fetch and never written back to config (a poll
-             * task must not persist config). Frame 0 is the newest still. */
-            char token[16];
-            image_page_radar_token(cfg, token, sizeof(token));
+        case IMG_SRC_RADAR:
+        case IMG_SRC_CLOUDS: {
+            /* The times refresh is a network op, so it stays inside s_fetch_gate
+             * with the frame fetch. Frame 0 is the newest. The radar token
+             * passed image_page_radar_token() and radar_wms_frame_url()
+             * re-checks its alphabet, so the _loop.gif ban holds on this path. */
             char url[RADAR_WMS_URL_MAX];
-            if (cfg->radar_map_style == 0) {
-                radar_frame_url(url, sizeof(url), token, 0);
-                err = image_fetch_custom_retain(url, &fresh, &radar_src, &radar_src_len);
+            /* Clouds stamps are derived from wall clock; before SNTP has
+             * answered the DescribeDomains window and the fallback would both
+             * be 1970 and GIBS would serve a blank frame filed as unstamped.
+             * Fail the poll instead (the spine backoff retries). Same
+             * threshold as the Moon page's clock test. */
+            if (p->src == IMG_SRC_CLOUDS && time(NULL) <= (time_t)1577836800) {
+                strlcpy(fresh.error_msg, "Waiting for clock", sizeof(fresh.error_msg));
+                err = ESP_ERR_INVALID_STATE;
                 break;
             }
-            /* Styles 1/2: the caps fetch is a network op, so it stays inside
-             * s_fetch_gate with the frame fetch. Newest = advertised stamp [0],
-             * or the server default (= newest) when none were advertised. The
-             * token passed image_page_radar_token() and radar_wms_frame_url()
-             * re-checks its alphabet, so the _loop.gif ban holds on this path. */
-            radar_wms_refresh_times(token);
-            if (!radar_wms_url_for(url, sizeof(url), cfg, token,
-                                   s_radar_ntimes > 0 ? s_radar_times[0] : NULL)) {
-                strlcpy(fresh.error_msg, "Unknown radar area", sizeof(fresh.error_msg));
+            anim_refresh_times(p, cfg, token);
+            if (!anim_frame_url(p, cfg, token, 0, url, sizeof(url))) {
+                strlcpy(fresh.error_msg, p->src == IMG_SRC_RADAR ? "Unknown radar area"
+                                                                  : "No satellite frames",
+                        sizeof(fresh.error_msg));
                 err = ESP_ERR_INVALID_ARG;
             } else {
-                err = image_fetch_custom_retain(url, &fresh, &radar_src, &radar_src_len);
+                err = image_fetch_custom_retain(url, &fresh, &ring_src, &ring_src_len);
             }
             break;
         }
@@ -638,20 +752,28 @@ static bool net_poll_once(void *arg)
     xSemaphoreGive(s_fetch_gate);
 
     if (err == ESP_OK) {
-        if (p->src == IMG_SRC_RADAR) {
+        if (animated) {
             /* Newest frame at the head; a re-served identical still is deduped
              * inside _add. Only then rebuild the history (outside the fetch
              * gate, which the backfill re-takes per download). */
-            image_page_radar_add(p, &fresh, true, radar_gen, radar_src, radar_src_len);
-            /* Radar never goes through image_page_commit_frame(), which is what
-             * clears p->frame.error_msg for every other source (it assigns the
-             * whole zeroed `fresh`). Without this, one transient failure latches
-             * the error caption forever: image_page_render_frame() checks the
-             * error branch BEFORE the ring branch, so every later activation
-             * repaints the stale reason until the first frame lands. */
+            image_page_ring_add(p, &fresh, true, ring_gen, ring_src, ring_src_len, anim_stamp(p, 0));
+            /* Ring pages never go through image_page_commit_frame(), which is
+             * what clears p->frame.error_msg for every other source (it assigns
+             * the whole zeroed `fresh`). Without this, one transient failure
+             * latches the error caption forever: image_page_render_frame()
+             * checks the error branch BEFORE the ring branch, so every later
+             * activation repaints the stale reason until the first frame lands. */
             image_page_set_error(p, "");
-            s_radar_last_push_ms = esp_timer_get_time() / 1000;
-            if (image_page_radar_backfill_take()) radar_backfill(p, cfg);
+            s_anim[p->src].last_push_ms = esp_timer_get_time() / 1000;
+            /* Clouds: GIBS serves the newest one or two slots partially at
+             * first (black quadrants until every tile is ingested), so the
+             * second-newest is re-fetched on every poll too; the ring replaces
+             * a held stamp whose bytes changed and drops it when identical. */
+            if (p->src == IMG_SRC_CLOUDS && atomic_load(&p->poll_gate)) {
+                vTaskDelay(pdMS_TO_TICKS(RADAR_BACKFILL_GAP_MS));   /* same radio stagger as the backfill */
+                anim_fetch_index(p, cfg, token, 1, ring_gen);
+            }
+            if (image_page_ring_backfill_take(p)) anim_backfill(p, cfg);
         } else {
             image_page_commit_frame(p, &fresh, false);
         }
@@ -663,22 +785,26 @@ static bool net_poll_once(void *arg)
             nina_wait_overlay_hide();
             bsp_display_unlock();
         }
-        nina_toast_show(TOAST_WARNING, "Failed to load image");
+        /* A not-yet-synced clock is expected right after boot, not a failure
+         * worth a toast; the caption already says "Waiting for clock". */
+        if (err != ESP_ERR_INVALID_STATE) {
+            nina_toast_show(TOAST_WARNING, "Failed to load image");
+        }
     }
     return false;
 }
 
-/* Radar park point. The other consumption site for a deferred ring teardown is
- * the top of net_poll_once(), which only runs while the page is gated ON — and
- * the invalidate that had to defer often comes from image_page_disable(), which
- * closes that gate immediately. Without this hook a lock timeout on the disable
- * path would hold the whole ring (up to ~6.6 MB of PSRAM) until the page was
- * enabled again. Blocking here is free: nothing renders on this task while
- * parked, and no insert can be in flight (image_page_radar_add runs only on
- * this task, and only from net_poll_once). */
-static void radar_on_park(void *arg)
+/* Animated-page park point. The other consumption site for a deferred ring
+ * teardown is the top of net_poll_once(), which only runs while the page is
+ * gated ON — and the invalidate that had to defer often comes from
+ * image_page_disable(), which closes that gate immediately. Without this hook a
+ * lock timeout on the disable path would hold the whole ring (6-10 MB of PSRAM)
+ * until the page was enabled again. Blocking here is free: nothing renders on
+ * this task while parked, and no insert can be in flight (image_page_ring_add
+ * runs only on this task, and only from net_poll_once). */
+static void anim_on_park(void *arg)
 {
-    image_page_radar_reset_if_requested((image_page_t *)arg);
+    image_page_ring_reset_if_requested((image_page_t *)arg);
 }
 
 /* ---- Moon ---- */
@@ -1145,12 +1271,13 @@ void image_page_poll_task(void *arg)
     bool is_moon = (p->src == IMG_SRC_MOON);
     ESP_LOGI(TAG, "%s poll task started", p->name);
 
-    /* Park hooks: the Moon releases its texture and drag scratch; radar services
-     * a ring teardown that could not get the display lock (see radar_on_park).
-     * The other three sources hold nothing that a park should release. */
+    /* Park hooks: the Moon releases its texture and drag scratch; an animated
+     * page services a ring teardown that could not get the display lock (see
+     * anim_on_park). The other three sources hold nothing that a park should
+     * release. */
     void (*park_cb)(void *) = NULL;
-    if (is_moon)                        park_cb = moon_on_park;
-    else if (p->src == IMG_SRC_RADAR)   park_cb = radar_on_park;
+    if (is_moon)                             park_cb = moon_on_park;
+    else if (image_src_is_animated(p->src))  park_cb = anim_on_park;
 
     /* Network sources: a failed first fetch on page entry (transient DNS/TLS)
      * must not leave the page black for a full 5-120 min interval; the spine's

--- a/main/settings_table.h
+++ b/main/settings_table.h
@@ -207,7 +207,13 @@
     INT       (radar_update_interval_s,      "radar_update_interval_s",      900,   120,   7200)  /* 15 min default. True clamp, matching the image POST handler's clamp-to-bound (both write paths agree). validate_config()'s extra "0 -> 900" case for a zeroed blob now lands on 120 instead; both are legal intervals */ \
     INT_RESET (radar_frames,                 "radar_frames",                 10,    1,     10)    /* how many radar images the page animates. RESET reproduces validate_config() exactly: both 0 (unset blob) and >10 fall back to the full 10-frame loop, never to the opposite bound */ \
     BOOL      (radar_dark_mode,              "radar_dark_mode",              true)  /* v64: true = dark basemap (the pre-v64 behaviour, and the default), false = the NWS image as published */ \
-    INT_RESET (radar_map_style,              "radar_map_style",              1,     0,     2)     /* v65: which map the radar echoes are drawn over: 0 = standard NWS picture with roads and city names (the pre-v65 behaviour), 1 = state lines only (the default), 2 = state and county lines. RESET, not clamp: an unknown value (stale blob byte, or a future style this firmware does not know) falls back to state lines only rather than the nearest bound */
+    INT_RESET (radar_map_style,              "radar_map_style",              1,     0,     2)     /* v65: which map the radar echoes are drawn over: 0 = standard NWS picture with roads and city names (the pre-v65 behaviour), 1 = state lines only (the default), 2 = state and county lines. RESET, not clamp: an unknown value (stale blob byte, or a future style this firmware does not know) falls back to state lines only rather than the nearest bound */ \
+    /* -- Clouds page (v66): NASA GIBS GOES GeoColor around weather_lat/lon -- */ \
+    BOOL      (clouds_enabled,               "clouds_enabled",               false) \
+    BOOL      (clouds_show_overlay,          "clouds_show_overlay",          true) \
+    INT       (clouds_update_interval_s,     "clouds_update_interval_s",     600,   300,   7200)  /* 10 min default (GIBS publishes every 10 min). True clamp, matching the image POST handler's clamp-to-bound */ \
+    INT_RESET (clouds_frames,                "clouds_frames",                6,     1,     10)    /* animation depth, ~1 MB PSRAM per 720x720 frame. RESET: 0 (unset blob) and >10 both fall back to the default */ \
+    INT_RESET (clouds_zoom,                  "clouds_zoom",                  7,     5,     9)     /* Web-Mercator zoom of the 720 px picture: 5 ~2500 km wide .. 9 ~150 km. RESET: an unknown value falls back to the default, never to a bound */
 
 /* Apply every row's default value to *cfg. Called from set_defaults()
  * immediately after the memset(). Does not touch excluded/complex fields

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -1760,10 +1760,11 @@ main_loop:
          *   PAGE_IDX_IMG_SOLAR     (5)                  = Solar image page
          *   PAGE_IDX_IMG_CUSTOM    (6)                  = Custom URL image page
          *   PAGE_IDX_IMG_RADAR     (7)                  = Weather Radar image page
-         *   PAGE_IDX_JSON          (8)                  = JSON Display page
-         *   PAGE_IDX_HA            (9)                  = Home Assistant page
-         *   PAGE_IDX_OCTOPRINT     (10)                 = OctoPrint 3D Printer page
-         *   PAGE_IDX_SUMMARY       (11)                 = summary page
+         *   PAGE_IDX_IMG_CLOUDS    (8)                  = Clouds satellite image page
+         *   PAGE_IDX_JSON          (9)                  = JSON Display page
+         *   PAGE_IDX_HA            (10)                 = Home Assistant page
+         *   PAGE_IDX_OCTOPRINT     (11)                 = OctoPrint 3D Printer page
+         *   PAGE_IDX_SUMMARY       (12)                 = summary page
          *   NINA_PAGE_OFFSET .. NINA_PAGE_OFFSET+pc-1   = NINA instance pages
          *   SETTINGS_PAGE_IDX(pc)                       = settings page
          *   SYSINFO_PAGE_IDX(pc)                        = sysinfo page

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -161,7 +161,7 @@ static const page_ops_t s_clock_page_ops = {
     .is_available = NULL,   /* NULL = derive from get_obj() != NULL (always available) */
 };
 
-/* ── Image pages — PAGE_IDX_IMG_GOES..PAGE_IDX_IMG_RADAR, one spine, five
+/* ── Image pages — PAGE_IDX_IMG_GOES..PAGE_IDX_IMG_CLOUDS, one spine, six
  * instances (ui/nina_image_page.h). Same NULL-when-disabled pattern as the
  * other optional pages: img_obj[s] is NULL while the source is disabled,
  * img_created[s] is NULL until its first enable. The registry ops show/hide
@@ -188,17 +188,19 @@ IMG_PAGE_OPS(img_moon,   IMG_SRC_MOON,   NULL)
 IMG_PAGE_OPS(img_solar,  IMG_SRC_SOLAR,  NULL)
 IMG_PAGE_OPS(img_custom, IMG_SRC_CUSTOM, img_custom_available)
 IMG_PAGE_OPS(img_radar,  IMG_SRC_RADAR,  NULL)
+IMG_PAGE_OPS(img_clouds, IMG_SRC_CLOUDS, NULL)
 #undef IMG_PAGE_OPS
 
 static const page_ops_t *const s_img_ops[IMG_SRC_COUNT] = {
-    &img_goes_ops, &img_moon_ops, &img_solar_ops, &img_custom_ops, &img_radar_ops
+    &img_goes_ops, &img_moon_ops, &img_solar_ops, &img_custom_ops, &img_radar_ops,
+    &img_clouds_ops
 };
 static const page_ref_t s_img_ref[IMG_SRC_COUNT] = {
     PAGE_REF_IMG_GOES, PAGE_REF_IMG_MOON, PAGE_REF_IMG_SOLAR, PAGE_REF_IMG_CUSTOM,
-    PAGE_REF_RADAR
+    PAGE_REF_RADAR, PAGE_REF_CLOUDS
 };
 
-/* Summary page — at PAGE_IDX_SUMMARY (7), excluded from indicators */
+/* Summary page — at PAGE_IDX_SUMMARY, excluded from indicators */
 static lv_obj_t *summary_obj = NULL;
 
 /* ── Summary page registry ops (Task 4.7 wave P7b) ──
@@ -245,7 +247,7 @@ static const page_ops_t s_sysinfo_page_ops = {
     .apply_theme  = sysinfo_page_apply_theme,
     .is_available = NULL,
 };
-int total_page_count = 0;   /* page_count + EXTRA_PAGES (allsky + spotify + clock + 5 image pages + json + ha + octoprint + summary + settings + sysinfo) */
+int total_page_count = 0;   /* page_count + EXTRA_PAGES (allsky + spotify + clock + 6 image pages + json + ha + octoprint + summary + settings + sysinfo) */
 
 /* Private state */
 static lv_obj_t *scr_dashboard = NULL;
@@ -335,10 +337,11 @@ lv_obj_t *create_value_label(lv_obj_t *parent) {
  *   PAGE_IDX_IMG_SOLAR     (5)                  = Image page: Solar
  *   PAGE_IDX_IMG_CUSTOM    (6)                  = Image page: Custom URL
  *   PAGE_IDX_IMG_RADAR     (7)                  = Image page: Weather Radar
- *   PAGE_IDX_JSON          (8)                  = JSON Display page
- *   PAGE_IDX_HA            (9)                  = Home Assistant page
- *   PAGE_IDX_OCTOPRINT     (10)                 = OctoPrint 3D Printer page
- *   PAGE_IDX_SUMMARY       (11)                 = summary page
+ *   PAGE_IDX_IMG_CLOUDS    (8)                  = Image page: Clouds (GOES GeoColor)
+ *   PAGE_IDX_JSON          (9)                  = JSON Display page
+ *   PAGE_IDX_HA            (10)                 = Home Assistant page
+ *   PAGE_IDX_OCTOPRINT     (11)                 = OctoPrint 3D Printer page
+ *   PAGE_IDX_SUMMARY       (12)                 = summary page
  *   NINA_PAGE_OFFSET .. NINA_PAGE_OFFSET+pc-1   = NINA instance pages  (pages[idx - NINA_PAGE_OFFSET])
  *   SETTINGS_PAGE_IDX(pc)                       = settings page
  *   SYSINFO_PAGE_IDX(pc)                        = sysinfo page
@@ -1335,7 +1338,7 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
     clock_obj = s_clock_page_ops.create(main_cont);
     lv_obj_add_flag(clock_obj, LV_OBJ_FLAG_HIDDEN);
 
-    /* Image pages — PAGE_IDX_IMG_GOES..PAGE_IDX_IMG_RADAR. One ops table per
+    /* Image pages — PAGE_IDX_IMG_GOES..PAGE_IDX_IMG_CLOUDS. One ops table per
      * instance, registered under its own frozen id; created only if enabled. */
     for (int s = 0; s < IMG_SRC_COUNT; s++) {
         page_registry_set_ops(s_img_ref[s], s_img_ops[s]);
@@ -1375,7 +1378,7 @@ void create_nina_dashboard(lv_obj_t *parent, int instance_count) {
     page_registry_set_ops(PAGE_REF_SYSINFO, &s_sysinfo_page_ops);
     sysinfo_obj = s_sysinfo_page_ops.create(main_cont);
     lv_obj_add_flag(sysinfo_obj, LV_OBJ_FLAG_HIDDEN);
-    total_page_count = page_count + EXTRA_PAGES;  /* allsky + spotify + clock + 5 image pages + json + ha + octoprint + summary + NINA pages + settings + sysinfo */
+    total_page_count = page_count + EXTRA_PAGES;  /* allsky + spotify + clock + 6 image pages + json + ha + octoprint + summary + NINA pages + settings + sysinfo */
 
     /* Page indicator dots — one dot per available NINA slot (not allsky, spotify, summary, settings, or sysinfo) */
     create_page_indicator(scr_dashboard, nina_available_count);

--- a/main/ui/nina_dashboard_internal.h
+++ b/main/ui/nina_dashboard_internal.h
@@ -25,23 +25,24 @@
  *   PAGE_IDX_IMG_SOLAR      (5)  = Solar image page
  *   PAGE_IDX_IMG_CUSTOM     (6)  = Custom URL image page
  *   PAGE_IDX_IMG_RADAR      (7)  = Weather Radar image page
- *   PAGE_IDX_JSON           (8)  = JSON Display page
- *   PAGE_IDX_HA             (9)  = Home Assistant page
- *   PAGE_IDX_OCTOPRINT      (10) = OctoPrint 3D Printer page
- *   PAGE_IDX_SUMMARY        (11) = Summary page
- *   NINA_PAGE_OFFSET        (12) .. NINA_PAGE_OFFSET + page_count - 1 = NINA instance pages
- *   page_count + NINA_PAGE_OFFSET     = settings page  (15)
- *   page_count + NINA_PAGE_OFFSET + 1 = sysinfo page   (16)
- *   total_page_count = page_count + EXTRA_PAGES        (17)
+ *   PAGE_IDX_IMG_CLOUDS     (8)  = Clouds (GOES GeoColor satellite) image page
+ *   PAGE_IDX_JSON           (9)  = JSON Display page
+ *   PAGE_IDX_HA             (10) = Home Assistant page
+ *   PAGE_IDX_OCTOPRINT      (11) = OctoPrint 3D Printer page
+ *   PAGE_IDX_SUMMARY        (12) = Summary page
+ *   NINA_PAGE_OFFSET        (13) .. NINA_PAGE_OFFSET + page_count - 1 = NINA instance pages
+ *   page_count + NINA_PAGE_OFFSET     = settings page  (16)
+ *   page_count + NINA_PAGE_OFFSET + 1 = sysinfo page   (17)
+ *   total_page_count = page_count + EXTRA_PAGES        (18)
  *
  * These are INTERNAL absolute indices and may shift when an optional page is
  * inserted; nothing persists them. The stable external identity is the
  * page_ref_t id / slug in page_registry.h, which is what NVS and the web API
  * exchange. Every consumer must use the macros below, never a literal.
  *
- * The five image pages are contiguous and ordered as image_src_t
- * (ui/nina_image_page.h): GOES=0, Moon=1, Solar=2, Custom=3, Radar=4, so the
- * page index encodes the source (PAGE_IDX_TO_IMG_SRC).
+ * The six image pages are contiguous and ordered as image_src_t
+ * (ui/nina_image_page.h): GOES=0, Moon=1, Solar=2, Custom=3, Radar=4, Clouds=5,
+ * so the page index encodes the source (PAGE_IDX_TO_IMG_SRC).
  */
 #define PAGE_IDX_ALLSKY          0
 #define PAGE_IDX_SPOTIFY         1
@@ -51,15 +52,16 @@
 #define PAGE_IDX_IMG_SOLAR       5
 #define PAGE_IDX_IMG_CUSTOM      6
 #define PAGE_IDX_IMG_RADAR       7
-#define PAGE_IDX_JSON            8
-#define PAGE_IDX_HA              9
-#define PAGE_IDX_OCTOPRINT       10
-#define PAGE_IDX_SUMMARY         11
-#define NINA_PAGE_OFFSET         12  /* first NINA page index */
-#define EXTRA_PAGES              14  /* allsky+spotify+clock+5 image+json+ha+octoprint+summary+settings+sysinfo */
+#define PAGE_IDX_IMG_CLOUDS      8
+#define PAGE_IDX_JSON            9
+#define PAGE_IDX_HA              10
+#define PAGE_IDX_OCTOPRINT       11
+#define PAGE_IDX_SUMMARY         12
+#define NINA_PAGE_OFFSET         13  /* first NINA page index */
+#define EXTRA_PAGES              15  /* allsky+spotify+clock+6 image+json+ha+octoprint+summary+settings+sysinfo */
 
-/* Image page helpers: contiguous band [PAGE_IDX_IMG_GOES, PAGE_IDX_IMG_RADAR]. */
-#define PAGE_IDX_IS_IMAGE(i)     ((i) >= PAGE_IDX_IMG_GOES && (i) <= PAGE_IDX_IMG_RADAR)
+/* Image page helpers: contiguous band [PAGE_IDX_IMG_GOES, PAGE_IDX_IMG_CLOUDS]. */
+#define PAGE_IDX_IS_IMAGE(i)     ((i) >= PAGE_IDX_IMG_GOES && (i) <= PAGE_IDX_IMG_CLOUDS)
 #define PAGE_IDX_TO_IMG_SRC(i)   ((i) - PAGE_IDX_IMG_GOES)   /* valid only when PAGE_IDX_IS_IMAGE(i) */
 
 /* Derived page index helpers (use these instead of hardcoded arithmetic) */

--- a/main/ui/nina_image_page.c
+++ b/main/ui/nina_image_page.c
@@ -1,7 +1,7 @@
 /**
  * @file nina_image_page.c
- * @brief Image page spine: rendering + lifecycle for the five image pages
- *        (GOES / Moon / Solar / Custom / Radar). Ported from nina_image_display.c;
+ * @brief Image page spine: rendering + lifecycle for the six image pages
+ *        (GOES / Moon / Solar / Custom / Radar / Clouds). Ported from nina_image_display.c;
  *        every former module-level static is now a field of image_page_t.
  *
  * Threading: every LVGL call below runs under the display lock held by the
@@ -37,33 +37,16 @@ static const char *TAG = "image_page";
 
 extern const lv_font_t lv_font_overpass_27;
 
-/* The five instances. Identity fields are filled by image_page_init(). */
+/* The six instances. Identity fields are filled by image_page_init(). */
 static image_page_t s_pages[IMG_SRC_COUNT];
 
-/* Weather Radar animation ring — implementation further down, forward-declared
+/* Animation ring (Radar, Clouds) — implementation further down, forward-declared
  * here because the render/lifecycle functions above it dispatch into the ring
- * for IMG_SRC_RADAR. All three require the display lock held by the caller. */
-static void radar_show_idx(image_page_t *p, int idx);
-static void radar_timer_sync(image_page_t *p);
-
-/* Pending-backfill request. Declared HERE, not with the rest of the ring state
- * further down, because image_page_set_active() (above the ring block) raises it
- * on every activation. Atomic: set from the UI task, consumed by the poll task
- * via image_page_radar_backfill_take(). */
-static _Atomic bool s_radar_backfill_req;
-
-/* Pending local re-transform request (crop / dark-mode / Red Night change).
- * Declared here for the same reason as s_radar_backfill_req: image_page_apply_theme()
- * sits above the ring block and raises it. Set from the UI or httpd task,
- * consumed by the radar poll task in image_page_radar_retransform_if_requested(). */
-static _Atomic bool s_radar_retransform_req;
-
-/* Red Night state the RESIDENT radar ring was recoloured with. Radar frames are
- * recoloured once, at insert (image_page_radar_add), so image_page_apply_theme()
- * — which sits above the ring block — needs this to tell a theme switch that
- * changes radar pixels from one that does not. Plain bool: written and read only
- * under the display lock. */
-static bool s_radar_ring_red;
+ * for the animated sources. All require the display lock held by the caller. */
+static void ring_show_idx(image_page_t *p, int idx);
+static void ring_timer_sync(image_page_t *p);
+static void ring_request_backfill(image_page_t *p);
+static bool ring_red_mismatch(image_page_t *p);
 
 static inline void set_label_if_changed(lv_obj_t *label, const char *text)
 {
@@ -472,9 +455,10 @@ void image_page_render_frame(image_page_t *p)
      * other frame read here), and when a reason is present render it as the
      * caption text and bail. A successful fetch clears error_msg, so the normal
      * swap path below runs and overwrites the caption — no stale error. Scoped to
-     * the two user-addressed sources (Custom URL and Radar, whose site token can
-     * be mistyped into a 404), so GOES/Solar/Moon are visually unchanged. */
-    if ((p->src == IMG_SRC_CUSTOM || p->src == IMG_SRC_RADAR) && p->frame.error_msg[0] != '\0') {
+     * the sources whose failures are user-visible (Custom URL, Radar whose site
+     * token can be mistyped into a 404, Clouds behind a GIBS outage), so
+     * GOES/Solar/Moon are visually unchanged. */
+    if (image_page_shows_error(p->src) && p->frame.error_msg[0] != '\0') {
         char err_copy[48];
         strlcpy(err_copy, p->frame.error_msg, sizeof(err_copy));
         frame_unlock(p);
@@ -487,14 +471,14 @@ void image_page_render_frame(image_page_t *p)
         return;
     }
 
-    /* Radar keeps its decoded frames in the animation ring, never in p->frame,
+    /* An animated page keeps its decoded frames in the ring, never in p->frame,
      * so the whole copy/crop/crossfade path below does not apply: re-show the
-     * frame the playback cursor is on (the ring stores them already cropped)
+     * frame the playback cursor is on (the ring stores them already baked)
      * and make sure the playback timer matches the current ring state. */
-    if (p->src == IMG_SRC_RADAR) {
+    if (image_src_is_animated(p->src)) {
         frame_unlock(p);
-        radar_show_idx(p, -1);          /* -1 = whatever the cursor is on */
-        radar_timer_sync(p);
+        ring_show_idx(p, -1);           /* -1 = whatever the cursor is on */
+        ring_timer_sync(p);
         nina_wait_overlay_hide();
         return;
     }
@@ -1096,9 +1080,9 @@ void image_page_apply_theme(image_page_t *p)
     if (p->lbl_moon_rise) apply_chip_style(p->lbl_moon_rise);
     if (p->lbl_moon_set)  apply_chip_style(p->lbl_moon_set);
 
-    /* Radar pixels are recoloured once, at insert, so restyling labels is not
-     * enough here: crossing the Red Night boundary changes both the remap AND
-     * (see image_page_radar_add) whether the dark treatment is forced, and
+    /* Ring pixels (Radar, Clouds) are recoloured once, at insert, so restyling
+     * labels is not enough here: crossing the Red Night boundary changes both
+     * the remap AND (see ring_bake) whether the radar dark treatment is forced, and
      * neither is reversible in place — the remap is lossy. Without this, a
      * switch INTO Red Night would leave up to ten bright frames looping for as
      * long as it takes the ring to roll over, on the one theme that must not put
@@ -1106,19 +1090,16 @@ void image_page_apply_theme(image_page_t *p)
      *
      * The fix is LOCAL: every slot keeps its compressed source bytes, so the
      * ring is re-derived from them under the new theme with no network. Request
-     * it and return; the radar poll task does the work.
+     * it and return; the page's poll task does the work.
      *
      * Gated on the state actually flipping: a switch between two non-red themes
-     * changes no radar pixel and must not rebuild anything. */
-    if (p->src == IMG_SRC_RADAR && image_page_radar_count() > 0 &&
-        s_radar_ring_red != image_red_remap_active()) {
-        image_page_radar_request_retransform(p);
-    }
+     * changes no ring pixel and must not rebuild anything. */
+    if (ring_red_mismatch(p)) image_page_ring_request_retransform(p);
 }
 
 /* ─────────────────────────── instances & gates ─────────────────────────── */
 
-static const char *const s_names[IMG_SRC_COUNT] = { "img_goes", "img_moon", "img_solar", "img_custom", "img_radar" };
+static const char *const s_names[IMG_SRC_COUNT] = { "img_goes", "img_moon", "img_solar", "img_custom", "img_radar", "img_clouds" };
 
 image_page_t *image_page_get(image_src_t src)
 {
@@ -1217,10 +1198,10 @@ void image_page_set_active(image_page_t *p, bool active)
     update_gate(p);
     if (active) {
         p->last_shown_ms = esp_timer_get_time() / 1000;   /* eviction order (LRU) */
-        /* Radar frees its whole ring on leave (see the ring block), so every
-         * activation asks the poller to rebuild the history behind the newest
-         * frame. The request is a no-op once the ring is full. */
-        if (p->src == IMG_SRC_RADAR) atomic_store(&s_radar_backfill_req, true);
+        /* An animated page frees its whole ring on leave (see the ring block),
+         * so every activation asks the poller to rebuild the history behind the
+         * newest frame. The request is a no-op once the ring is full. */
+        ring_request_backfill(p);
         image_page_ensure_task_running(p);
         image_page_render_frame(p);   /* a retained or warm frame shows instantly; no-op when empty */
         image_page_wake(p);
@@ -1232,11 +1213,12 @@ void image_page_set_active(image_page_t *p, bool active)
      * by image_page_evict_if_over_cap on later commits). Poke the poller so it
      * parks (Moon frees its texture in on_park unless it is still warm). */
     image_page_release_lvgl(p);
-    /* A full radar ring is ~6.6 MB — far past what the retained-frame budget
-     * was sized for, and it is never counted by image_page_evict_if_over_cap
-     * (which looks at p->frame, always NULL for radar). Free it outright here
-     * rather than let a parked page sit on it; the next activation backfills. */
-    if (p->src == IMG_SRC_RADAR) image_page_radar_reset(p);
+    /* A full ring is 6-10 MB — far past what the retained-frame budget was
+     * sized for, and it is never counted by image_page_evict_if_over_cap (which
+     * looks at p->frame, always NULL for an animated page). Free it outright
+     * here rather than let a parked page sit on it; the next activation
+     * backfills. No-op for the single-frame sources. */
+    image_page_ring_reset(p);
     nina_wait_overlay_hide();
     image_page_wake(p);
 }
@@ -1266,9 +1248,10 @@ void image_page_disable(image_page_t *p)
     atomic_store(&p->warm, false);
     update_gate(p);
     frame_drop(p);
-    /* Radar holds its frames in the ring, not p->frame; take the display lock
-     * (this function is called without it) and drop the whole ring. */
-    if (p->src == IMG_SRC_RADAR) image_page_radar_invalidate(p);
+    /* An animated page holds its frames in the ring, not p->frame; take the
+     * display lock (this function is called without it) and drop the whole
+     * ring. No-op for the single-frame sources. */
+    image_page_ring_invalidate(p);
     image_page_wake(p);
 }
 
@@ -1315,6 +1298,7 @@ bool image_page_config_enabled(const app_config_t *c, image_src_t src)
         case IMG_SRC_SOLAR:  return c->solar_enabled;
         case IMG_SRC_CUSTOM: return c->custom_enabled;
         case IMG_SRC_RADAR:  return c->radar_enabled;
+        case IMG_SRC_CLOUDS: return c->clouds_enabled;
         default:             return false;
     }
 }
@@ -1327,6 +1311,7 @@ bool image_page_config_overlay(const app_config_t *c, image_src_t src)
         case IMG_SRC_SOLAR:  return c->solar_show_overlay;
         case IMG_SRC_CUSTOM: return c->custom_show_overlay;
         case IMG_SRC_RADAR:  return c->radar_show_overlay;
+        case IMG_SRC_CLOUDS: return c->clouds_show_overlay;
         default:             return true;
     }
 }
@@ -1344,7 +1329,7 @@ bool image_page_config_crop(const app_config_t *c, image_src_t src)
          * radar_map_style gate lives; mirrored here so the predicate never
          * claims a crop that the bake would not apply. */
         case IMG_SRC_RADAR:  return c->radar_map_style == 0 && c->radar_crop != 0;
-        default:             return false;   /* Moon never crops */
+        default:             return false;   /* Moon and Clouds never crop */
     }
 }
 
@@ -1373,6 +1358,13 @@ uint32_t image_page_interval_ms(image_page_t *p)
              * config clamp also enforces, so a stale blob cannot poll faster. */
             s = c->radar_update_interval_s;
             if (s < 120) s = 120;
+            if (s > 7200) s = 7200;
+            break;
+        case IMG_SRC_CLOUDS:
+            /* GIBS publishes a GeoColor frame every 10 min; 300 s is the floor
+             * the config clamp also enforces. */
+            s = c->clouds_update_interval_s;
+            if (s < 300) s = 300;
             if (s > 7200) s = 7200;
             break;
         default: {   /* Moon: fast retry until SNTP sets the clock, then the configured cadence */
@@ -1452,6 +1444,7 @@ void image_page_label(image_page_t *p, char *out, size_t sz)
             strlcat(out, token, sz);
             break;
         }
+        case IMG_SRC_CLOUDS: strlcpy(out, "Cloud Cover", sz); break;
         default: break;
     }
 }
@@ -1467,36 +1460,46 @@ bool image_page_get_error(image_page_t *p, char *out, size_t sz)
     return out[0] != '\0';
 }
 
-/* ───────────────────────── Weather Radar animation ring ─────────────────────
+/* ───────────────────────── animation ring (Radar, Clouds) ────────────────────
  *
- * The radar page keeps up to radar_frames decoded stills (index 0 = newest) and
- * plays them oldest -> newest on an LVGL timer, holding longer on the newest.
- * Everything else on this page is unchanged; the ring simply replaces p->frame
- * as the storage, which is why image_page_render_frame() dispatches here.
+ * An ANIMATED image page (image_src_is_animated: Weather Radar, Clouds) keeps up
+ * to N decoded stills (index 0 = newest) and plays them oldest -> newest on an
+ * LVGL timer, holding longer on the newest. Everything else on such a page is
+ * unchanged; the ring simply replaces p->frame as the storage, which is why
+ * image_page_render_frame() dispatches here. One ring per instance
+ * (s_rings[src]); the two animated pages never share state.
  *
  * LOCKING: the ring is guarded by the DISPLAY LOCK alone — no second mutex.
  * Every reader/mutator either runs on the UI task with the lock already held
  * (render, playback timer, set_active) or takes it itself (the poller's
- * image_page_radar_add / _invalidate). Never hold frame_mux across these.
+ * image_page_ring_add / _invalidate). Never hold frame_mux across these.
  *
  * OWNERSHIP: the LVGL descriptor BORROWS a ring slot's buffer (release_dsc
- * skips borrowed slots), so s_radar_shown must be detached before that buffer
+ * skips borrowed slots), so ring->shown must be detached before that buffer
  * is freed — ring_free_slot() does exactly that.
  *
- * MEMORY: a full ten-frame ring of 600x550 tiles is ~6.6 MB, several times what
- * a normal image page holds, so IMAGE_PAGE_MAX_RESIDENT (which counts p->frame
- * and therefore never counts radar) is not the right control. Instead the whole
- * ring is freed when the page is deactivated or disabled and rebuilt by the
- * backfill on the next activation.
+ * MEMORY: a full ten-frame ring is ~6.6 MB (radar, 600x550) or ~10 MB (clouds,
+ * 720x720), several times what a normal image page holds, so
+ * IMAGE_PAGE_MAX_RESIDENT (which counts p->frame and therefore never counts a
+ * ring) is not the right control. Instead the whole ring is freed when the
+ * page is deactivated or disabled and rebuilt by the backfill on the next
+ * activation. Two animated pages are never both resident: leaving one frees it.
  *
- * RETAINED SOURCE BYTES: each slot also keeps the frame's COMPRESSED GIF (~37 KB,
- * ~370 KB for ten, against ~23 MB free PSRAM). The pixels carry the crop and the
- * night-invert baked in, so without the source the only way to re-derive them
- * was to re-download the whole ring — ~370 KB and ~9 s of staggered radio on a
- * board whose panel glitches under sustained transmission. With them,
- * image_page_radar_retransform_if_requested() rebuilds the ring locally. A slot
- * therefore owns TWO allocations and radar_free_slot() is the single place both
- * are released.
+ * RETAINED SOURCE BYTES: each slot also keeps the frame's COMPRESSED source
+ * (~37 KB radar GIF, ~90 KB clouds JPEG). The pixels carry the per-source bake
+ * (radar: crop + night invert; both: the Red Night remap), so without the
+ * source the only way to re-derive them was to re-download the whole ring.
+ * With them, image_page_ring_retransform_if_requested() rebuilds the ring
+ * locally. A slot therefore owns TWO allocations and ring_free_slot() is the
+ * single place both are released.
+ *
+ * STAMPS: a slot may carry the frame's own time (uint32 UTC seconds, 0 =
+ * unknown). Radar frames carry none (RIDGE stills have no per-frame time we
+ * parse) and are ordered by insertion (head push / tail append). Clouds frames
+ * carry the GIBS TIME they were fetched for: a stamped insert is placed by
+ * time (newest first, whatever the caller's at_head hint), and a stamp already
+ * held REPLACES that slot when the bytes differ (GIBS serves the newest one or
+ * two frames partially at first) or is dropped as a duplicate when they match.
  */
 
 typedef struct {
@@ -1505,89 +1508,135 @@ typedef struct {
     uint32_t hash;         /* FNV-1a over src (falls back to buf); dedupe key */
     uint8_t *src;          /* compressed source bytes, PSRAM, owned by the ring; NULL = not retained */
     size_t   src_len;
-    uint32_t bake_gen;     /* s_radar_bake_gen these PIXELS were produced under */
-} radar_slot_t;
+    uint32_t bake_gen;     /* ring->bake_gen these PIXELS were produced under */
+    uint32_t stamp;        /* frame time, UTC seconds; 0 = unknown */
+} ring_slot_t;
 
-static radar_slot_t   s_radar_ring[RADAR_RING_MAX];
-static _Atomic int    s_radar_count;        /* resident frames; read lock-free by the poller */
-static int            s_radar_play_idx;     /* ring index currently on screen */
-static const uint8_t *s_radar_shown;        /* buffer the LVGL descriptor borrows, or NULL */
-static lv_timer_t    *s_radar_timer;        /* playback timer; NULL when not animating */
-/* BAKE generation — distinct from the ring generation below, and answering a
- * different question. The ring generation asks "is this frame's CONTENT still
- * wanted?" (region / frame count); this one asks "were these PIXELS produced
- * under the settings in force now?" (crop, dark mode, Red Night).
- *
- * Bumped at the moment such a change is REQUESTED (the single funnel is
- * image_page_radar_request_retransform), recorded per slot by
- * image_page_radar_add() and re-stamped slot by slot as the re-transform pass
- * converts them. Playback advances only to matching slots (radar_play_next_baked),
- * so a ring that is momentarily half converted can never DISPLAY two geometries
- * — which is the property that makes the pumping structurally impossible rather
- * than merely unlikely. It replaces the old whole-pass playback hold: one
- * mechanism, per slot, instead of a global freeze that had to be raised and
- * lowered at exactly the right moments (and was not).
- *
- * uint32_t for the same reason as s_radar_gen: the esp-14.2.0 RISC-V subword
- * atomic sequence clobbers neighbouring bytes on narrow signed types. */
-static _Atomic uint32_t s_radar_bake_gen;
-/* Bake generation the "N slots stale" line was last logged for, so the count is
- * reported once per change rather than every 400 ms tick. UI task only. */
-static uint32_t       s_radar_bake_logged;
-/* Ring generation: bumped by every reset (image_page_radar_reset, which
- * _invalidate, page leave and page disable all route through). A producer
- * captures it before resolving the token and hands it back to
- * image_page_radar_add(), which drops any frame carrying an older value. That
- * is what stops an in-flight backfill for the OLD region from repopulating the
- * ring a region switch just cleared. uint32_t, never a narrow signed type: the
- * esp-14.2.0 RISC-V subword atomic sequence clobbers neighbouring bytes. */
-static _Atomic uint32_t s_radar_gen;
-/* Deferred ring teardown. Raised when image_page_radar_invalidate() could not get
- * the display lock in time: the generation bump has already landed (so nothing in
- * flight can enter the ring), but the ring itself still holds frames baked under
- * the superseded settings and they have to go. Consumed by the radar poll task,
- * which CAN block for the lock — same hand-off shape as s_radar_retransform_req.
- * Cleared by image_page_radar_reset() too, so a reset that happens by another
- * route (page leave, disable) cannot leave a stale request to wipe a later ring. */
-static _Atomic bool s_radar_reset_req;
-/* s_radar_backfill_req is declared at the top of this file — image_page_set_active()
- * sits above this block and raises it. */
+typedef struct {
+    ring_slot_t     slots[RADAR_RING_MAX];
+    _Atomic int     count;          /* resident frames; read lock-free by the poller */
+    int             play_idx;       /* ring index currently on screen */
+    const uint8_t  *shown;          /* buffer the LVGL descriptor borrows, or NULL */
+    lv_timer_t     *timer;          /* playback timer; NULL when not animating */
+    /* BAKE generation — distinct from the ring generation below, and answering a
+     * different question. The ring generation asks "is this frame's CONTENT still
+     * wanted?" (region / frame count); this one asks "were these PIXELS produced
+     * under the settings in force now?" (crop, dark mode, Red Night).
+     *
+     * Bumped at the moment such a change is REQUESTED (the single funnel is
+     * image_page_ring_request_retransform), recorded per slot by
+     * image_page_ring_add() and re-stamped slot by slot as the re-transform pass
+     * converts them. Playback advances only to matching slots (radar_play_next_baked),
+     * so a ring that is momentarily half converted can never DISPLAY two geometries
+     * — which is the property that makes the pumping structurally impossible rather
+     * than merely unlikely.
+     *
+     * uint32_t for the same reason as gen: the esp-14.2.0 RISC-V subword atomic
+     * sequence clobbers neighbouring bytes on narrow signed types. */
+    _Atomic uint32_t bake_gen;
+    uint32_t        bake_logged;    /* bake gen the "N slots stale" line was last logged for (UI task) */
+    /* Ring generation: bumped by every reset (image_page_ring_reset, which
+     * _invalidate, page leave and page disable all route through). A producer
+     * captures it before resolving the token/times and hands it back to
+     * image_page_ring_add(), which drops any frame carrying an older value. That
+     * is what stops an in-flight backfill for the OLD region from repopulating the
+     * ring a region switch just cleared. */
+    _Atomic uint32_t gen;
+    /* Deferred ring teardown. Raised when image_page_ring_invalidate() could not get
+     * the display lock in time: the generation bump has already landed (so nothing in
+     * flight can enter the ring), but the ring itself still holds frames baked under
+     * the superseded settings and they have to go. Consumed by the poll task, which
+     * CAN block for the lock. Cleared by image_page_ring_reset() too. */
+    _Atomic bool    reset_req;
+    /* Pending-backfill request: set on every activation by the UI task, consumed
+     * by the poll task via image_page_ring_backfill_take(). */
+    _Atomic bool    backfill_req;
+    /* Pending local re-transform request (crop / dark-mode / Red Night change).
+     * Set from the UI or httpd task, consumed by the poll task. */
+    _Atomic bool    retransform_req;
+    /* Red Night state the RESIDENT ring was recoloured with. Frames are recoloured
+     * once, at insert, so image_page_apply_theme() needs this to tell a theme switch
+     * that changes ring pixels from one that does not. Written and read only under
+     * the display lock. */
+    bool            ring_red;
+} image_ring_t;
 
-int image_page_radar_capacity(void)
+static image_ring_t s_rings[IMG_SRC_COUNT];   /* only the animated sources' entries are ever touched */
+
+static inline image_ring_t *ring_of(image_page_t *p)
 {
-    uint8_t n = app_config_get()->radar_frames;
+    return (p && image_src_is_animated(p->src)) ? &s_rings[p->src] : NULL;
+}
+
+/* Raise the pending-backfill request (UI task, page activation). No-op for a
+ * single-frame source. */
+static void ring_request_backfill(image_page_t *p)
+{
+    image_ring_t *r = ring_of(p);
+    if (r) atomic_store(&r->backfill_req, true);
+}
+
+/* True when a resident ring was baked under a different Red Night state than
+ * the theme now active (image_page_apply_theme). Display lock held. */
+static bool ring_red_mismatch(image_page_t *p)
+{
+    image_ring_t *r = ring_of(p);
+    return r && atomic_load(&r->count) > 0 && r->ring_red != image_red_remap_active();
+}
+
+int image_page_ring_capacity(image_page_t *p)
+{
+    const app_config_t *c = app_config_get();
+    uint8_t n = (p && p->src == IMG_SRC_CLOUDS) ? c->clouds_frames : c->radar_frames;
     if (n < 1) n = 1;
     if (n > RADAR_RING_MAX) n = RADAR_RING_MAX;
     return (int)n;
 }
 
-int image_page_radar_count(void)
+int image_page_ring_count(image_page_t *p)
 {
-    return atomic_load(&s_radar_count);
+    image_ring_t *r = ring_of(p);
+    return r ? atomic_load(&r->count) : 0;
 }
 
-bool image_page_radar_backfill_take(void)
+bool image_page_ring_backfill_take(image_page_t *p)
 {
-    return atomic_exchange(&s_radar_backfill_req, false);
+    image_ring_t *r = ring_of(p);
+    return r ? atomic_exchange(&r->backfill_req, false) : false;
 }
 
-uint32_t image_page_radar_gen(void)
+uint32_t image_page_ring_gen(image_page_t *p)
 {
-    return atomic_load(&s_radar_gen);
+    image_ring_t *r = ring_of(p);
+    return r ? atomic_load(&r->gen) : 0;
+}
+
+/* Lock-free scan for a held stamp: only the poll task inserts and only resets
+ * clear, so a torn read costs at most one redundant fetch. 0 never matches. */
+bool image_page_ring_has_stamp(image_page_t *p, uint32_t stamp)
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || stamp == 0) return false;
+    int n = atomic_load(&r->count);
+    if (n > RADAR_RING_MAX) n = RADAR_RING_MAX;
+    for (int i = 0; i < n; i++) {
+        if (r->slots[i].stamp == stamp) return true;
+    }
+    return false;
 }
 
 /* Free one slot — BOTH its allocations, the decoded pixels and the retained
  * compressed source. Display lock held. Detaches the LVGL descriptors first if
  * they borrow this slot's buffer, so the free can never leave LVGL on freed
- * memory. Every ring teardown routes through here (image_page_radar_reset over
- * all RADAR_RING_MAX slots, and the oldest-end eviction in _add), so there is
- * one place to get the pairing right. */
-static void radar_free_slot(image_page_t *p, int i)
+ * memory. Every ring teardown routes through here (image_page_ring_reset over
+ * all RADAR_RING_MAX slots, the oldest-end eviction and the same-stamp replace
+ * in _add), so there is one place to get the pairing right. */
+static void ring_free_slot(image_page_t *p, image_ring_t *r, int i)
 {
-    radar_slot_t *s = &s_radar_ring[i];
-    if (s->buf && (const uint8_t *)s->buf == s_radar_shown) {
+    ring_slot_t *s = &r->slots[i];
+    if (s->buf && (const uint8_t *)s->buf == r->shown) {
         image_page_release_lvgl(p);      /* drops both descriptors + borrowed flags */
-        s_radar_shown = NULL;
+        r->shown = NULL;
     }
     if (s->buf) heap_caps_free(s->buf);
     if (s->src) heap_caps_free(s->src);
@@ -1596,29 +1645,37 @@ static void radar_free_slot(image_page_t *p, int i)
 
 /* Put ring slot @p idx on screen (idx < 0 = the current cursor). Display lock
  * held. No-op when the page has no LVGL objects or the slot is empty. */
-static void radar_show_idx(image_page_t *p, int idx)
+static void ring_show_idx(image_page_t *p, int idx)
 {
-    int count = atomic_load(&s_radar_count);
-    if (idx < 0) idx = s_radar_play_idx;
+    image_ring_t *r = ring_of(p);
+    if (!r) return;
+    int count = atomic_load(&r->count);
+    if (idx < 0) idx = r->play_idx;
     if (idx < 0 || idx >= count) return;
 
-    radar_slot_t *s = &s_radar_ring[idx];
+    ring_slot_t *s = &r->slots[idx];
     if (!s->buf || !p->root || s->w == 0 || s->h == 0) return;
 
     swap_borrowed_buf(p, (const uint16_t *)s->buf, (int)s->w, (int)s->h);
-    s_radar_shown   = s->buf;
-    s_radar_play_idx = idx;
+    r->shown    = s->buf;
+    r->play_idx = idx;
 
     char label[48];
     image_page_label(p, label, sizeof(label));
     set_label_if_changed(p->lbl_region, label);
 
-    /* The newest frame is stamped with the wall clock; the history frames have
-     * no per-frame time (the RIDGE stills carry none we parse), so they show
-     * their position in the loop instead of a time we would be inventing. */
+    /* A stamped frame shows its own time (local clock); the newest carries the
+     * "Latest" prefix. Unstamped rings (radar): the newest frame is stamped with
+     * the wall clock and the history frames show their position in the loop
+     * instead of a time we would be inventing. */
     char ts[32];
-    if (idx == 0) {
-        time_t now; struct tm ti; time(&now); localtime_r(&now, &ti);
+    struct tm ti;
+    if (s->stamp != 0) {
+        time_t t = (time_t)s->stamp;
+        localtime_r(&t, &ti);
+        strftime(ts, sizeof(ts), idx == 0 ? "Latest %H:%M" : "%H:%M", &ti);
+    } else if (idx == 0) {
+        time_t now; time(&now); localtime_r(&now, &ti);
         strftime(ts, sizeof(ts), "Latest %H:%M", &ti);
     } else {
         snprintf(ts, sizeof(ts), "Loop %d/%d", count - idx, count);
@@ -1628,17 +1685,19 @@ static void radar_show_idx(image_page_t *p, int idx)
 
 /* True if slot @p i holds pixels baked under the settings in force now. Display
  * lock held. Out-of-range answers false so a caller can use it as a guard. */
-static bool radar_slot_current(int i)
+static bool ring_slot_current(image_ring_t *r, int i)
 {
-    if (i < 0 || i >= atomic_load(&s_radar_count)) return false;
-    return s_radar_ring[i].bake_gen == atomic_load(&s_radar_bake_gen);
+    if (i < 0 || i >= atomic_load(&r->count)) return false;
+    return r->slots[i].bake_gen == atomic_load(&r->bake_gen);
 }
 
-static void radar_tick_cb(lv_timer_t *t)
+static void ring_tick_cb(lv_timer_t *t)
 {
     image_page_t *p = lv_timer_get_user_data(t);
-    int count = atomic_load(&s_radar_count);
-    if (!p || count <= 1 || !atomic_load(&p->active)) return;
+    image_ring_t *r = ring_of(p);
+    if (!r) return;
+    int count = atomic_load(&r->count);
+    if (count <= 1 || !atomic_load(&p->active)) return;
 
     /* Advance only to a slot baked under the CURRENT settings. Mid-re-transform
      * the rest still hold the old crop / dark treatment, and showing them is
@@ -1647,55 +1706,59 @@ static void radar_tick_cb(lv_timer_t *t)
      * anywhere, so hold on what is displayed rather than blank the page. */
     uint32_t gens[RADAR_RING_MAX];
     if (count > RADAR_RING_MAX) count = RADAR_RING_MAX;
-    for (int i = 0; i < count; i++) gens[i] = s_radar_ring[i].bake_gen;
-    uint32_t cur_gen = atomic_load(&s_radar_bake_gen);
+    for (int i = 0; i < count; i++) gens[i] = r->slots[i].bake_gen;
+    uint32_t cur_gen = atomic_load(&r->bake_gen);
 
     /* One line per bake change, not per tick: how much of the ring is waiting on
      * the re-transform. Makes the skip visible from /api/logs. */
-    if (cur_gen != s_radar_bake_logged) {
-        s_radar_bake_logged = cur_gen;
-        ESP_LOGI(TAG, "radar playback: %d/%d slots stale after bake change (skipped)",
-                 radar_stale_count(gens, count, cur_gen), count);
+    if (cur_gen != r->bake_logged) {
+        r->bake_logged = cur_gen;
+        ESP_LOGI(TAG, "%s playback: %d/%d slots stale after bake change (skipped)",
+                 p->name, radar_stale_count(gens, count, cur_gen), count);
     }
 
-    int next = radar_play_next_baked(s_radar_play_idx, count, gens, cur_gen);
-    if (next == s_radar_play_idx) return;
-    radar_show_idx(p, next);
+    int next = radar_play_next_baked(r->play_idx, count, gens, cur_gen);
+    if (next == r->play_idx) return;
+    ring_show_idx(p, next);
     lv_timer_set_period(t, radar_play_period_ms(next));
 }
 
 /* Create or delete the playback timer to match the current state. Display lock
- * held. A single still (radar_frames == 1, or a ring that has not filled past
- * one frame) never animates, matching the other image pages. */
-static void radar_timer_sync(image_page_t *p)
+ * held. A single still (frames == 1, or a ring that has not filled past one
+ * frame) never animates, matching the other image pages. */
+static void ring_timer_sync(image_page_t *p)
 {
+    image_ring_t *r = ring_of(p);
+    if (!r) return;
     bool want = atomic_load(&p->active) &&
-                image_page_radar_capacity() > 1 &&
-                atomic_load(&s_radar_count) > 1;
-    if (want && !s_radar_timer) {
-        s_radar_timer = lv_timer_create(radar_tick_cb, RADAR_PLAY_FRAME_MS, p);
-    } else if (!want && s_radar_timer) {
-        lv_timer_delete(s_radar_timer);
-        s_radar_timer = NULL;
+                image_page_ring_capacity(p) > 1 &&
+                atomic_load(&r->count) > 1;
+    if (want && !r->timer) {
+        r->timer = lv_timer_create(ring_tick_cb, RADAR_PLAY_FRAME_MS, p);
+    } else if (!want && r->timer) {
+        lv_timer_delete(r->timer);
+        r->timer = NULL;
     }
 }
 
-void image_page_radar_reset(image_page_t *p)
+void image_page_ring_reset(image_page_t *p)
 {
-    if (s_radar_timer) {
-        lv_timer_delete(s_radar_timer);
-        s_radar_timer = NULL;
+    image_ring_t *r = ring_of(p);
+    if (!r) return;
+    if (r->timer) {
+        lv_timer_delete(r->timer);
+        r->timer = NULL;
     }
-    for (int i = 0; i < RADAR_RING_MAX; i++) radar_free_slot(p, i);
-    atomic_store(&s_radar_count, 0);
-    s_radar_play_idx = 0;
-    s_radar_shown    = NULL;
+    for (int i = 0; i < RADAR_RING_MAX; i++) ring_free_slot(p, r, i);
+    atomic_store(&r->count, 0);
+    r->play_idx = 0;
+    r->shown    = NULL;
     /* Nothing left to re-transform; a request raised against the ring we just
      * freed would otherwise run one no-op pass later. Same for a deferred
      * teardown: the ring is gone, so honouring it later could only free a ring
      * built AFTER the change that asked for it. */
-    atomic_store(&s_radar_retransform_req, false);
-    atomic_store(&s_radar_reset_req, false);
+    atomic_store(&r->retransform_req, false);
+    atomic_store(&r->reset_req, false);
     /* The bake generation is deliberately NOT reset: it is a monotonic counter,
      * and every slot of the ring being freed here goes with it. The next ring's
      * frames stamp themselves with whatever it reads then, so they agree with
@@ -1704,60 +1767,62 @@ void image_page_radar_reset(image_page_t *p)
      * reason for the reset: a region/frame-count/crop change (via _invalidate),
      * a page leave, or a page disable. Bumping here rather than at each of
      * those call sites means a future reset path cannot forget it. Runs with
-     * the display lock held, the same lock image_page_radar_add() tests it
+     * the display lock held, the same lock image_page_ring_add() tests it
      * under, so there is no window between the bump and the free. */
-    atomic_fetch_add(&s_radar_gen, 1);
+    atomic_fetch_add(&r->gen, 1);
 }
 
-void image_page_radar_invalidate(image_page_t *p)
+void image_page_ring_invalidate(image_page_t *p)
 {
-    if (!p) return;
+    image_ring_t *r = ring_of(p);
+    if (!r) return;
     /* Bump the generation FIRST, UNCONDITIONALLY, and OUTSIDE the display lock.
      * It is an atomic and needs no lock, and it is the half that actually
      * guarantees correctness: every producer captured the old value before it
-     * started, so image_page_radar_add() drops every frame already in flight
+     * started, so image_page_ring_add() drops every frame already in flight
      * under the superseded settings. Doing this inside the lock (as it was)
      * meant a 1 s lock timeout skipped BOTH the bump and the clear, leaving a
-     * ring that could genuinely mix old and new content — the only path in the
-     * codebase that produced one. image_page_radar_reset() bumps again below;
-     * a double bump is harmless, the frame check is an inequality, not a delta. */
-    atomic_fetch_add(&s_radar_gen, 1);
+     * ring that could genuinely mix old and new content. image_page_ring_reset()
+     * bumps again below; a double bump is harmless, the frame check is an
+     * inequality, not a delta. */
+    atomic_fetch_add(&r->gen, 1);
     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        image_page_radar_reset(p);
+        image_page_ring_reset(p);
         bsp_display_unlock();
     } else {
-        /* Hand the teardown to the radar poll task, which can block for the lock.
+        /* Hand the teardown to the poll task, which can block for the lock.
          * Until it runs, the ring keeps showing the OLD frames: stale, never
          * mixed. Worth a line in /api/logs — a silent 1 s lock timeout is exactly
          * the kind of thing that should leave a trace. */
-        ESP_LOGW(TAG, "radar invalidate: display lock timeout, deferring ring reset");
-        atomic_store(&s_radar_reset_req, true);
+        ESP_LOGW(TAG, "%s invalidate: display lock timeout, deferring ring reset", p->name);
+        atomic_store(&r->reset_req, true);
         image_page_wake(p);
     }
-    atomic_store(&s_radar_backfill_req, true);
+    atomic_store(&r->backfill_req, true);
 }
 
-/* Service a teardown image_page_radar_invalidate() had to defer.
+/* Service a teardown image_page_ring_invalidate() had to defer.
  *
- * RADAR POLL TASK ONLY, and only at a point where no insert is in flight: the
- * top of net_poll_once() (before any image_page_radar_add() this pass) and the
- * park hook. image_page_radar_add() is called only from that same task, so
+ * THIS PAGE'S POLL TASK ONLY, and only at a point where no insert is in flight:
+ * the top of net_poll_once() (before any image_page_ring_add() this pass) and
+ * the park hook. image_page_ring_add() is called only from that same task, so
  * "no concurrent insert" is structural, not a timing argument.
  *
  * The generation was already bumped by the invalidate, so this is a pure free of
  * frames nothing will show again — a no-op on an already-empty ring. A second
  * lock timeout re-raises the request rather than dropping it; nothing was freed,
  * so retrying can neither leak nor double free. */
-void image_page_radar_reset_if_requested(image_page_t *p)
+void image_page_ring_reset_if_requested(image_page_t *p)
 {
-    if (!p || !atomic_exchange(&s_radar_reset_req, false)) return;
+    image_ring_t *r = ring_of(p);
+    if (!r || !atomic_exchange(&r->reset_req, false)) return;
     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        image_page_radar_reset(p);
+        image_page_ring_reset(p);
         bsp_display_unlock();
         return;
     }
-    ESP_LOGW(TAG, "radar deferred ring reset: display lock still busy, retrying");
-    atomic_store(&s_radar_reset_req, true);
+    ESP_LOGW(TAG, "%s deferred ring reset: display lock still busy, retrying", p->name);
+    atomic_store(&r->reset_req, true);
 }
 
 /* Center-crop a decoded radar frame in place-of-allocation: returns a fresh
@@ -1797,98 +1862,102 @@ static bool radar_crop_frame(image_frame_t *f, uint8_t mode)
     return true;
 }
 
-/* Apply every display transform a radar frame carries: the centred crop, the
- * night invert and the Red Night remap, in that order. THE ONE PLACE these are
- * applied — both the insert path below and the local re-transform call it, so
- * a frame re-derived from its source bytes is pixel-identical to one that came
- * off the wire under the same settings.
+/* Per-source display transforms a ring frame carries — THE ONE PLACE these are
+ * applied. Both the insert path and the local re-transform call it, so a frame
+ * re-derived from its source bytes is pixel-identical to one that came off the
+ * wire under the same settings.
  *
- * The parameters are passed in rather than read from config here so the
- * re-transform can bake a whole ring from ONE snapshot of the settings, and so
- * `dark` already folds in the Red Night override.
+ * Radar: the centred crop, the night invert and the Red Night remap, in that
+ * order. Night readability: invert the RIDGE tile's greyscale basemap (white
+ * sheet -> black, dark state lines -> light) and leave every chromatic pixel —
+ * the whole dBZ echo ramp — untouched (image_night_invert.h). Gated on
+ * radar_dark_mode (default true, v64) EXCEPT under Red Night, which forces the
+ * dark treatment whatever the toggle says: the red remap maps luma to red
+ * WITHOUT lowering it, so the light basemap would come out a BRIGHT red panel,
+ * precisely what that theme exists to prevent. Invert BEFORE the remap: the
+ * remap collapses luma to red shades and would destroy the neutral/chromatic
+ * distinction the invert keys on. Map styles 1/2 come from a different NWS
+ * service (black background, no banner, no legend): the crop has nothing to
+ * trim and the invert would turn that black sheet WHITE, so both are skipped
+ * by design there, Red Night included; the theme-gated remap still runs.
  *
- * `mode` is read as the 0..2 fit mode, not a boolean: radar_fit_rect() is a
- * no-op for 0, so no separate gate is needed.
+ * Clouds: no crop, no invert (GIBS GeoColor is already a dark night picture);
+ * only the theme-gated Red Night remap.
+ *
+ * `cfg` and `red` are passed in rather than read here so the re-transform can
+ * bake a whole ring from ONE snapshot of the settings.
  *
  * NOT ACCELERATED, deliberately: the PPA offers SRM (scale/rotate/mirror),
  * BLEND and FILL only — there is no colour-transform unit for the invert — and
  * the crop is already a row-wise memcpy. Software is correct for both. */
-static void radar_bake(image_frame_t *f, uint8_t mode, bool dark)
+static void ring_bake(image_page_t *p, image_frame_t *f, const app_config_t *cfg, bool red)
 {
-    radar_crop_frame(f, mode);            /* best-effort; keeps the frame either way */
-    size_t px = (size_t)f->w * f->h;
-    if (dark) image_night_invert_rgb565((uint16_t *)f->buf, px);
-    image_red_remap_rgb565((uint16_t *)f->buf, px);   /* self-gated on the active theme */
+    if (p->src == IMG_SRC_RADAR) {
+        bool    dark = cfg->radar_map_style == 0 && (cfg->radar_dark_mode || red);
+        uint8_t mode = cfg->radar_map_style ? 0 : cfg->radar_crop;
+        radar_crop_frame(f, mode);            /* best-effort; keeps the frame either way */
+        if (dark) image_night_invert_rgb565((uint16_t *)f->buf, (size_t)f->w * f->h);
+    }
+    image_red_remap_rgb565((uint16_t *)f->buf, (size_t)f->w * f->h);   /* self-gated on the active theme */
 }
 
 /* Free everything a rejected frame owns. Both allocations are taken over by
- * image_page_radar_add() on entry, so every one of its reject paths must land
+ * image_page_ring_add() on entry, so every one of its reject paths must land
  * here — one helper instead of five hand-paired frees. */
-static void radar_drop(image_frame_t *f, uint8_t *src)
+static void ring_drop(image_frame_t *f, uint8_t *src)
 {
     if (f && f->buf) { heap_caps_free(f->buf); f->buf = NULL; }
     if (src) heap_caps_free(src);
 }
 
-void image_page_radar_add(image_page_t *p, image_frame_t *fresh, bool at_head, uint32_t gen,
-                          uint8_t *src, size_t src_len)
+/* Move a fresh frame's allocations into slot @p i (which must be empty or already
+ * freed). Display lock held. */
+static void ring_fill_slot(image_ring_t *r, int i, image_frame_t *fresh, uint32_t hash,
+                           uint8_t *src, size_t src_len, uint32_t bake_gen, uint32_t stamp)
 {
-    if (!p || !fresh || !fresh->buf) {
-        radar_drop(fresh, src);
+    r->slots[i].buf      = fresh->buf;
+    r->slots[i].w        = fresh->w;
+    r->slots[i].h        = fresh->h;
+    r->slots[i].hash     = hash;
+    r->slots[i].src      = src;      /* ownership moves into the slot */
+    r->slots[i].src_len  = src_len;
+    r->slots[i].bake_gen = bake_gen;
+    r->slots[i].stamp    = stamp;
+    fresh->buf = NULL;
+}
+
+void image_page_ring_add(image_page_t *p, image_frame_t *fresh, bool at_head, uint32_t gen,
+                         uint8_t *src, size_t src_len, uint32_t stamp)
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || !fresh || !fresh->buf) {
+        ring_drop(fresh, src);
         return;
     }
 
-    /* Night readability: invert the RIDGE tile's greyscale basemap (white sheet
-     * -> black, dark state lines -> light) and leave every chromatic pixel — the
-     * whole dBZ echo ramp — untouched. See image_night_invert.h for the measured
-     * colour distribution this is built on. Gated on radar_dark_mode (default
-     * true, v64): the raw tile is 90% near-white and unusable in a dark
-     * observatory, but with the toggle off it stays exactly as NWS published it.
-     *
-     * ...EXCEPT under Red Night, which forces the dark treatment whatever the
-     * toggle says. That theme exists for star parties under light restrictions,
-     * and the red remap below maps luma to red WITHOUT lowering it — so the
-     * light basemap would come out a BRIGHT red full-screen panel, precisely
-     * what the theme is there to prevent. Dark is the only correct answer there,
-     * so the setting does not get a say.
-     *
-     * ORDER: invert BEFORE the red remap. The remap collapses luma to red
-     * shades, so running it first would destroy the neutral/chromatic
-     * distinction the invert keys on. Inverting first means Red Night renders a
-     * DARK RED radar map, which is the ideal observatory case.
-     *
-     * SEAM: this is the radar equivalent of the invert+remap block in
-     * image_page_render_frame() — radar returns early from that function
-     * because its frames live in the ring, not p->frame. Here is the only place
-     * a radar frame is committed, it runs once per FETCHED frame on the poll
-     * task (image_page_poll.c net_poll_once / radar_backfill), outside the
-     * display lock. It is baked into the pixels, like the crop — but the
+    /* SEAM: this is the ring equivalent of the invert+remap block in
+     * image_page_render_frame() — animated pages return early from that
+     * function because their frames live in the ring, not p->frame. Here is
+     * the only place a ring frame is committed; it runs once per FETCHED frame
+     * on the poll task (image_page_poll.c net_poll_once / anim_backfill),
+     * outside the display lock. The bake is applied to the pixels — but the
      * compressed source is kept alongside, so a crop / dark-mode / Red-Night
-     * change re-bakes the ring locally (image_page_radar_retransform_if_requested)
-     * instead of re-downloading it. Only a token or frame-count change, which
-     * genuinely means different images, still rebuilds over the network. */
+     * change re-bakes the ring locally (image_page_ring_retransform_if_requested)
+     * instead of re-downloading it. Only a token / area / frame-count change,
+     * which genuinely means different images, still rebuilds over the network. */
     /* ORDERING CONTRACT, same shape as the ring generation: read the bake
      * generation BEFORE the settings it labels. The writer changes the setting
      * first and bumps second, so gen-then-settings can only ever pair OLD pixels
      * with an OLD generation (skipped by playback until the pass re-bakes them,
      * conservative and correct) or NEW pixels with a NEW one. Settings-then-gen
      * could label old pixels as current — which is the pumping bug. */
-    uint32_t bake_gen = atomic_load(&s_radar_bake_gen);
-    /* Map styles 1/2 (state / county lines) come from a different NWS service:
-     * black background, no banner, no legend. The crop has nothing to trim and
-     * the invert would turn that black sheet WHITE (and, under Red Night,
-     * bright red) — the exact failure the invert exists to prevent on style 0.
-     * So both are skipped by design there, Red Night included: the red remap
-     * inside radar_bake() is theme-gated and still runs, mapping the black
-     * ground to black and the lines/echoes to red shades. */
+    uint32_t bake_gen = atomic_load(&r->bake_gen);
     const app_config_t *cfg = app_config_get();
-    bool    red  = image_red_remap_active();
-    bool    dark = cfg->radar_map_style == 0 && (cfg->radar_dark_mode || red);
-    uint8_t mode = cfg->radar_map_style ? 0 : cfg->radar_crop;
-    radar_bake(fresh, mode, dark);
+    bool red = image_red_remap_active();
+    ring_bake(p, fresh, cfg, red);
 
-    /* Dedupe on the COMPRESSED bytes when they were retained: 37 KB hashed
-     * instead of 660 KB, and — the reason it matters — the key is invariant
+    /* Dedupe on the COMPRESSED bytes when they were retained: kilobytes hashed
+     * instead of a megabyte, and — the reason it matters — the key is invariant
      * under the transforms above, so a local re-transform never has to
      * recompute it. Falls back to the pixel hash if a caller did not retain. */
     uint32_t hash = src ? radar_fnv1a(src, src_len)
@@ -1896,76 +1965,107 @@ void image_page_radar_add(image_page_t *p, image_frame_t *fresh, bool at_head, u
 
     bool notify = false;
     if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        radar_drop(fresh, src);
+        ring_drop(fresh, src);
         return;
     }
 
-    /* STALENESS CHOKE POINT. Every radar frame that ever enters the ring passes
-     * through here, so this is the one place a frame fetched for a region (or
-     * crop, or frame count) the user has already left can be rejected. Tested
-     * INSIDE the display lock because that is the lock image_page_radar_reset()
-     * bumps the generation under; testing it before the lock would leave the
-     * original race in a smaller window. The producers' own abort checks are a
-     * bandwidth optimisation on top of this, never a substitute. */
-    if (radar_frame_is_stale(gen, atomic_load(&s_radar_gen))) {
+    /* STALENESS CHOKE POINT. Every ring frame that ever enters passes through
+     * here, so this is the one place a frame fetched for a region (or crop, or
+     * frame count) the user has already left can be rejected. Tested INSIDE the
+     * display lock because that is the lock image_page_ring_reset() bumps the
+     * generation under; testing it before the lock would leave the original
+     * race in a smaller window. The producers' own abort checks are a bandwidth
+     * optimisation on top of this, never a substitute. */
+    if (radar_frame_is_stale(gen, atomic_load(&r->gen))) {
         bsp_display_unlock();
-        radar_drop(fresh, src);
+        ring_drop(fresh, src);
         return;
     }
 
-    int count = atomic_load(&s_radar_count);
-    int cap   = image_page_radar_capacity();
+    int count = atomic_load(&r->count);
+    int cap   = image_page_ring_capacity(p);
 
-    /* Dedupe against the entry this frame would sit next to: the head for a
-     * newest-frame push, the tail for a backfill append. RIDGE re-serves the
-     * same still between updates, so this is the common case, not an edge. */
-    uint32_t neighbour = count > 0 ? s_radar_ring[at_head ? 0 : count - 1].hash : 0;
-    if (radar_frame_is_dup(neighbour, count, hash)) {
-        bsp_display_unlock();
-        radar_drop(fresh, src);
-        return;
-    }
-
-    /* Past every reject path, so this frame is going in: record the Red Night
-     * state its pixels were baked with. Every frame in the ring shares it (a
+    /* Past every reject path that depends on content, so record the Red Night
+     * state these pixels were baked with. Every frame in the ring shares it (a
      * flip clears the ring), so one flag covers the whole ring. Display lock
      * held, which is the lock image_page_apply_theme() reads it under. */
-    s_radar_ring_red = red;
+    r->ring_red = red;
 
-    if (at_head) {
-        /* Make room at the head, evicting from the oldest end. */
-        while (count >= cap) {
-            radar_free_slot(p, count - 1);
-            count--;
-        }
-        for (int i = count; i > 0; i--) s_radar_ring[i] = s_radar_ring[i - 1];
-        /* Everything shifted down one slot, so did the frame on screen. */
-        if (s_radar_play_idx + 1 < cap) s_radar_play_idx++;
-        count++;
-        s_radar_ring[0].buf     = fresh->buf;
-        s_radar_ring[0].w       = fresh->w;
-        s_radar_ring[0].h       = fresh->h;
-        s_radar_ring[0].hash    = hash;
-        s_radar_ring[0].src     = src;      /* ownership moves into the slot */
-        s_radar_ring[0].src_len = src_len;
-        s_radar_ring[0].bake_gen = bake_gen;
-    } else {
-        if (count >= cap) {            /* ring already full: nothing to backfill */
+    int pos;   /* slot the frame lands in */
+    if (stamp != 0) {
+        /* Stamped: same stamp already held -> replace when the bytes differ
+         * (a partial frame healed), drop when identical. Otherwise insert by
+         * time so the ring stays newest-first even when a gap fills in later. */
+        int same = -1;
+        for (int i = 0; i < count; i++) if (r->slots[i].stamp == stamp) { same = i; break; }
+        if (same >= 0) {
+            if (r->slots[same].hash == hash) {
+                bsp_display_unlock();
+                ring_drop(fresh, src);
+                return;
+            }
+            bool was_shown = (r->slots[same].buf && (const uint8_t *)r->slots[same].buf == r->shown);
+            ring_free_slot(p, r, same);           /* detaches LVGL if it was on screen */
+            ring_fill_slot(r, same, fresh, hash, src, src_len, bake_gen, stamp);
+            if (atomic_load(&p->active)) {
+                /* Re-show only if the healed slot was on screen (its buffer is
+                 * gone) or nothing is up yet; otherwise playback carries on. */
+                if (was_shown || !r->shown) ring_show_idx(p, was_shown ? same : -1);
+                ring_timer_sync(p);
+                notify = true;
+            }
             bsp_display_unlock();
-            radar_drop(fresh, src);
+            if (notify) nav_arbiter_notify_content_ready(p->page_idx);
             return;
         }
-        s_radar_ring[count].buf     = fresh->buf;
-        s_radar_ring[count].w       = fresh->w;
-        s_radar_ring[count].h       = fresh->h;
-        s_radar_ring[count].hash    = hash;
-        s_radar_ring[count].src     = src;  /* ownership moves into the slot */
-        s_radar_ring[count].src_len = src_len;
-        s_radar_ring[count].bake_gen = bake_gen;
-        count++;
+        pos = 0;
+        while (pos < count && r->slots[pos].stamp > stamp) pos++;
+        if (pos >= cap) {                          /* older than everything a full ring holds */
+            bsp_display_unlock();
+            ring_drop(fresh, src);
+            return;
+        }
+        /* Neighbour dedupe as for the unstamped path: two consecutive slots
+         * with identical bytes (a re-served or blank frame) are one frame. */
+        uint32_t neighbour = (pos > 0) ? r->slots[pos - 1].hash
+                           : (count > 0 ? r->slots[0].hash : 0);
+        if (radar_frame_is_dup(neighbour, count, hash)) {
+            bsp_display_unlock();
+            ring_drop(fresh, src);
+            return;
+        }
+    } else {
+        /* Unstamped (radar): dedupe against the entry this frame would sit next
+         * to — the head for a newest-frame push, the tail for a backfill append.
+         * RIDGE re-serves the same still between updates, so this is the common
+         * case, not an edge. */
+        uint32_t neighbour = count > 0 ? r->slots[at_head ? 0 : count - 1].hash : 0;
+        if (radar_frame_is_dup(neighbour, count, hash)) {
+            bsp_display_unlock();
+            ring_drop(fresh, src);
+            return;
+        }
+        if (!at_head && count >= cap) {            /* ring already full: nothing to backfill */
+            bsp_display_unlock();
+            ring_drop(fresh, src);
+            return;
+        }
+        pos = at_head ? 0 : count;
     }
-    fresh->buf = NULL;
-    atomic_store(&s_radar_count, count);
+
+    /* Make room: evict from the oldest end while full (a head/mid insert into a
+     * full ring pushes the tail out; pos < cap is guaranteed above). */
+    while (count >= cap) {
+        ring_free_slot(p, r, count - 1);
+        count--;
+    }
+    for (int i = count; i > pos; i--) r->slots[i] = r->slots[i - 1];
+    memset(&r->slots[pos], 0, sizeof(r->slots[pos]));
+    /* Everything from pos on shifted down one slot, so did the frame on screen. */
+    if (r->play_idx >= pos && r->play_idx + 1 < cap) r->play_idx++;
+    count++;
+    ring_fill_slot(r, pos, fresh, hash, src, src_len, bake_gen, stamp);
+    atomic_store(&r->count, count);
 
     if (atomic_load(&p->active)) {
         /* Show the newest frame immediately when nothing is up yet (page entry,
@@ -1977,20 +2077,24 @@ void image_page_radar_add(image_page_t *p, image_frame_t *fresh, bool at_head, u
          * frame just inserted was baked live, so it is the one slot guaranteed
          * current: jumping to it is what ends that hold at the first opportunity
          * instead of waiting for the pass. */
-        radar_show_idx(p, (s_radar_shown && radar_slot_current(s_radar_play_idx)) ? -1 : 0);
-        radar_timer_sync(p);
+        ring_show_idx(p, (r->shown && ring_slot_current(r, r->play_idx)) ? -1 : pos);
+        ring_timer_sync(p);
         notify = true;
     }
     bsp_display_unlock();
+    /* Content-ready dwell for the slideshow: the first frame that lands while
+     * the page is on screen is what the arbiter waits for. Same call
+     * image_page_commit_frame() makes for the single-frame pages. */
     if (notify) nav_arbiter_notify_content_ready(p->page_idx);
 }
 
-void image_page_radar_request_retransform(image_page_t *p)
+void image_page_ring_request_retransform(image_page_t *p)
 {
-    if (!p || p->src != IMG_SRC_RADAR) return;
+    image_ring_t *r = ring_of(p);
+    if (!r) return;
 
-    /* THE SINGLE FUNNEL for every pixel-affecting radar setting: the crop and
-     * dark-mode toggles (radar_local_params_changed, image_page_config_apply_live)
+    /* THE SINGLE FUNNEL for every pixel-affecting ring setting: the radar crop
+     * and dark-mode toggles (radar_local_params_changed, image_page_config_apply_live)
      * and the Red Night theme flip (image_page_apply_theme) both land here. So
      * this is the one place the bake generation has to be bumped, and a future
      * pixel-affecting setting gets the skip for free by routing here too.
@@ -2003,72 +2107,64 @@ void image_page_radar_request_retransform(image_page_t *p)
      *
      * Unconditional, ahead of the empty-ring return below: it is a monotonic
      * counter, and stamping later inserts with the newer value is exactly right. */
-    atomic_fetch_add(&s_radar_bake_gen, 1);
+    atomic_fetch_add(&r->bake_gen, 1);
 
     /* Nothing resident means nothing to re-derive: the next fetch already bakes
-     * the new settings in (image_page_radar_add reads them live). Without this,
+     * the new settings in (image_page_ring_add reads them live). Without this,
      * a change made while the page is away would re-bake the frames the backfill
      * has only just fetched under exactly those settings. */
-    if (image_page_radar_count() == 0) return;
-    atomic_store(&s_radar_retransform_req, true);
+    if (atomic_load(&r->count) == 0) return;
+    atomic_store(&r->retransform_req, true);
     image_page_wake(p);
 }
 
 /* Re-derive the whole ring from the retained compressed bytes under the CURRENT
- * crop mode and dark/Red-Night treatment. Replaces the ~370 KB / ~9 s staggered
- * re-download a crop or dark-mode change used to cost, on a board that glitches
- * its panel under sustained radio transmission.
+ * settings and theme. Replaces the staggered re-download a crop, dark-mode or
+ * theme change used to cost, on a board that glitches its panel under sustained
+ * radio transmission.
  *
- * RUNS ON THE RADAR POLL TASK (it blocks and allocates megabytes), never on the
+ * RUNS ON THE PAGE'S POLL TASK (it blocks and allocates megabytes), never on the
  * LVGL timer. ONE FRAME AT A TIME: peak extra memory is a single decode plus its
- * crop output (~1.3 MB), not ten.
+ * crop output, not ten.
  *
  * LOCKING: the display lock is taken only to detach the source, and again to
  * swap the pixel pointer in — never around the decode. A slot's `src` is
  * detached (set NULL) for the duration of its decode, so a concurrent
- * image_page_radar_reset() frees the slot's pixels but not the source we are
+ * image_page_ring_reset() frees the slot's pixels but not the source we are
  * reading; the generation check on re-attach then tells us the slot is gone and
  * we free both allocations ourselves. The playback timer can never see a
  * half-swapped slot: it runs on the UI task, which needs the same lock, and the
  * slot's old buffer stays valid and displayed until the swap completes.
  *
- * NO CONCURRENT INSERT is possible: image_page_radar_add() is called only from
- * this same task (net_poll_once / radar_backfill), so nothing can shift the ring
- * under a slot index while this runs. Only resets race, and the generation
- * covers those.
+ * NO CONCURRENT INSERT is possible: image_page_ring_add() is called only from
+ * this same task, so nothing can shift the ring under a slot index while this
+ * runs. Only resets race, and the generation covers those.
  *
  * ponytail: a frame whose decode fails keeps its OLD pixels rather than being
  * dropped and re-fetched — one stale-looking frame in the loop after an OOM,
  * which the next ring rollover clears. Dropping it would mean compacting the
- * ring mid-pass for a case that needs PSRAM exhaustion to reach. */
-/* One re-transform pass over the whole ring. Caller holds playback for the
- * duration (see image_page_radar_retransform_if_requested below).
+ * ring mid-pass for a case that needs PSRAM exhaustion to reach.
  *
  * Returns false ONLY when a display-lock timeout cut the pass short, which is
  * the one abort that can leave the ring genuinely part converted: the caller
  * re-raises the request so a later cycle finishes the job. A pass stopped by the
  * generation check returns true — that ring is being freed, not left mixed. */
-static bool radar_retransform_pass(image_page_t *p)
+static bool ring_retransform_pass(image_page_t *p, image_ring_t *r)
 {
-    int count = image_page_radar_count();
+    int count = atomic_load(&r->count);
     if (count <= 0) return true;
     bool aborted = false;
 
     /* ONE snapshot of the settings for the whole pass, so the ring cannot end up
      * half baked one way and half the other. The bake generation is read FIRST,
-     * same ordering contract as image_page_radar_add(): a change landing between
+     * same ordering contract as image_page_ring_add(): a change landing between
      * these two reads leaves this pass stamping the OLDER generation, so its
      * output reads as stale and the next pass (the request is re-raised) redoes
      * it — conservative, and it converges on the latest settings. */
-    uint32_t bake_gen = atomic_load(&s_radar_bake_gen);
+    uint32_t bake_gen = atomic_load(&r->bake_gen);
     const app_config_t *c = app_config_get();
-    /* Same style gate as image_page_radar_add(): styles 1/2 are served on a
-     * black background with no banner, so crop and invert are no-ops by design
-     * (the invert would whiten the black ground, Red Night included). */
-    uint8_t  mode = c->radar_map_style ? 0 : c->radar_crop;
     bool     red  = image_red_remap_active();
-    bool     dark = c->radar_map_style == 0 && (c->radar_dark_mode || red);
-    uint32_t gen  = image_page_radar_gen();
+    uint32_t gen  = atomic_load(&r->gen);
 
     /* Claim the Red Night state for this pass UP FRONT. image_page_apply_theme()
      * compares the live theme against it, so a second flip arriving mid-pass
@@ -2079,29 +2175,29 @@ static bool radar_retransform_pass(image_page_t *p)
      * behind the hold. */
     int start = 0;
     if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-        s_radar_ring_red = red;
-        start = s_radar_play_idx;
+        r->ring_red = red;
+        start = r->play_idx;
         bsp_display_unlock();
     }
 
     int64_t t0 = esp_timer_get_time();
     int done = 0;
-    ESP_LOGI(TAG, "radar re-transform: start, %d frames from slot %d (playback held)",
-             count, start);
+    ESP_LOGI(TAG, "%s re-transform: start, %d frames from slot %d (playback held)",
+             p->name, count, start);
     for (int k = 0; k < count; k++) {
         int i = radar_retransform_idx(start, k, count);
         if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             aborted = true;
             break;
         }
-        if (radar_frame_is_stale(gen, atomic_load(&s_radar_gen)) ||
-            i >= atomic_load(&s_radar_count)) {
+        if (radar_frame_is_stale(gen, atomic_load(&r->gen)) ||
+            i >= atomic_load(&r->count)) {
             bsp_display_unlock();
             break;
         }
-        uint8_t *src = s_radar_ring[i].src;
-        size_t   len = s_radar_ring[i].src_len;
-        s_radar_ring[i].src = NULL;          /* detached: this task owns it now */
+        uint8_t *src = r->slots[i].src;
+        size_t   len = r->slots[i].src_len;
+        r->slots[i].src = NULL;              /* detached: this task owns it now */
         bsp_display_unlock();
         if (!src) continue;                  /* nothing retained for this slot */
 
@@ -2113,90 +2209,88 @@ static bool radar_retransform_pass(image_page_t *p)
             f.buf = px;
             f.w   = (uint16_t)w;
             f.h   = (uint16_t)h;
-            radar_bake(&f, mode, dark);
+            ring_bake(p, &f, c, red);
         } else if (px) {
             heap_caps_free(px);
         }
 
         if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-            radar_drop(&f, src);
+            ring_drop(&f, src);
             aborted = true;
             break;
         }
-        if (radar_frame_is_stale(gen, atomic_load(&s_radar_gen)) ||
-            i >= atomic_load(&s_radar_count)) {
+        if (radar_frame_is_stale(gen, atomic_load(&r->gen)) ||
+            i >= atomic_load(&r->count)) {
             bsp_display_unlock();
-            radar_drop(&f, src);             /* the slot is gone; we own both */
+            ring_drop(&f, src);              /* the slot is gone; we own both */
             break;
         }
-        s_radar_ring[i].src = src;           /* hand the source back, decoded or not */
+        r->slots[i].src = src;               /* hand the source back, decoded or not */
         if (!f.buf) {
             bsp_display_unlock();
             /* Keeps its OLD pixels and, deliberately, its OLD bake generation:
              * playback skips it instead of showing a frame at the superseded
              * geometry. It rejoins the loop when the ring rolls it out or a
              * later pass decodes it. */
-            ESP_LOGW(TAG, "radar re-transform: frame %d kept its old pixels (skipped in playback)", i);
+            ESP_LOGW(TAG, "%s re-transform: frame %d kept its old pixels (skipped in playback)", p->name, i);
             continue;
         }
-        uint8_t *old = s_radar_ring[i].buf;
-        bool was_shown = (old && (const uint8_t *)old == s_radar_shown);
+        uint8_t *old = r->slots[i].buf;
+        bool was_shown = (old && (const uint8_t *)old == r->shown);
         if (was_shown) {
             image_page_release_lvgl(p);      /* stop borrowing before the free */
-            s_radar_shown = NULL;
+            r->shown = NULL;
         }
-        s_radar_ring[i].buf = f.buf;
-        s_radar_ring[i].w   = f.w;
-        s_radar_ring[i].h   = f.h;
+        r->slots[i].buf = f.buf;
+        r->slots[i].w   = f.w;
+        r->slots[i].h   = f.h;
         /* Stamped BEFORE the re-show below, so the slot is already eligible for
          * playback by the time it is on screen. */
-        s_radar_ring[i].bake_gen = bake_gen;
+        r->slots[i].bake_gen = bake_gen;
         /* .hash is over the compressed bytes, so it survives the re-bake. */
-        if (was_shown) radar_show_idx(p, i);
+        if (was_shown) ring_show_idx(p, i);
         bsp_display_unlock();
         if (old) heap_caps_free(old);
         done++;
         vTaskDelay(pdMS_TO_TICKS(10));       /* stay polite between ~50 ms decodes */
     }
-    ESP_LOGI(TAG, "radar re-transform: %d/%d frames in %d ms (no network)",
-             done, count, (int)((esp_timer_get_time() - t0) / 1000));
+    ESP_LOGI(TAG, "%s re-transform: %d/%d frames in %d ms (no network)",
+             p->name, done, count, (int)((esp_timer_get_time() - t0) / 1000));
     return !aborted;
 }
 
 /* Re-bake the ring under the current settings.
  *
- * NO PLAYBACK HOLD. There used to be one (s_radar_hold, raised here and lowered
- * at the tail) and it was the wrong shape: it covered the PASS, while the ring
- * is mixed from the moment the setting CHANGES — which in the logged failure was
- * 18.4 s earlier, the pass being stuck behind a backfill. Per-slot bake
- * generations cover the whole window by construction and need nothing raised or
- * lowered, so the hold is gone rather than kept alongside them. Two overlapping
- * mechanisms each half-solving this is how the bug survived the first fix.
+ * NO PLAYBACK HOLD. There used to be one and it was the wrong shape: it covered
+ * the PASS, while the ring is mixed from the moment the setting CHANGES. Per-slot
+ * bake generations cover the whole window by construction and need nothing
+ * raised or lowered.
  *
  * DOUBLE REQUEST: a second toggle mid-pass bumps the bake generation again and
- * re-raises s_radar_retransform_req, so the loop runs another pass with a fresh
+ * re-raises retransform_req, so the loop runs another pass with a fresh
  * settings snapshot; the slots the first pass converted now read as stale and
  * are re-converted. The ring converges on the LATEST settings, and playback
  * shows only slots that have caught up throughout. A reset clears the request,
  * which is what ends the loop when the ring goes away. */
-void image_page_radar_retransform_if_requested(image_page_t *p)
+void image_page_ring_retransform_if_requested(image_page_t *p)
 {
-    if (!p || !atomic_exchange(&s_radar_retransform_req, false)) return;
-    if (image_page_radar_count() <= 0) return;
+    image_ring_t *r = ring_of(p);
+    if (!r || !atomic_exchange(&r->retransform_req, false)) return;
+    if (atomic_load(&r->count) <= 0) return;
 
     while (1) {
-        if (!radar_retransform_pass(p)) {
+        if (!ring_retransform_pass(p, r)) {
             /* Display lock timed out mid-pass, so the ring is part converted.
              * Re-raise and wake ourselves rather than retrying inline (that
              * would spin on a jammed lock); the next poll cycle finishes the
              * ring. Playback meanwhile runs over the converted slots only, or
              * holds on the displayed frame if none converted. */
-            ESP_LOGW(TAG, "radar re-transform: display lock timeout, retrying next cycle");
-            atomic_store(&s_radar_retransform_req, true);
+            ESP_LOGW(TAG, "%s re-transform: display lock timeout, retrying next cycle", p->name);
+            atomic_store(&r->retransform_req, true);
             image_page_wake(p);
             break;
         }
-        if (!atomic_exchange(&s_radar_retransform_req, false)) break;
+        if (!atomic_exchange(&r->retransform_req, false)) break;
     }
 }
 
@@ -2243,9 +2337,10 @@ void image_page_set_error(image_page_t *p, const char *msg)
         strlcpy(p->frame.error_msg, msg ? msg : "", sizeof(p->frame.error_msg));
         frame_unlock(p);
     }
-    /* The Custom and Radar pages show the reason as their caption; render_frame()
-     * handles the error branch before the newer-frame gate, so a plain call suffices. */
-    if ((p->src == IMG_SRC_CUSTOM || p->src == IMG_SRC_RADAR) &&
+    /* The Custom, Radar and Clouds pages show the reason as their caption;
+     * render_frame() handles the error branch before the newer-frame gate, so a
+     * plain call suffices. */
+    if (image_page_shows_error(p->src) &&
         atomic_load(&p->active) && bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
         image_page_render_frame(p);
         bsp_display_unlock();
@@ -2281,6 +2376,13 @@ static bool source_params_changed(image_src_t s, const app_config_t *prev, const
             return cur->radar_token[0] == '\0' &&
                    (cur->weather_lat != prev->weather_lat ||
                     cur->weather_lon != prev->weather_lon);
+        case IMG_SRC_CLOUDS:
+            /* Area (zoom), frame count and the weather location all change
+             * which GIBS frames are fetched: DIFFERENT images, so the ring goes. */
+            return cur->clouds_zoom != prev->clouds_zoom ||
+                   cur->clouds_frames != prev->clouds_frames ||
+                   cur->weather_lat != prev->weather_lat ||
+                   cur->weather_lon != prev->weather_lon;
         default:             return false;   /* Moon: local render, handled below */
     }
 }
@@ -2301,9 +2403,10 @@ static bool radar_local_params_changed(const app_config_t *prev, const app_confi
 /* Per-source "re-render the cached frame locally" test: crop / rotation / flips. */
 static bool render_params_changed(image_src_t s, const app_config_t *prev, const app_config_t *cur)
 {
-    /* Radar is not re-rendered from p->frame (it has none); its local changes go
-     * through radar_local_params_changed() above. */
-    if (s == IMG_SRC_RADAR) return false;
+    /* Animated pages are not re-rendered from p->frame (they have none); radar's
+     * local changes go through radar_local_params_changed() above and Clouds
+     * has no local render parameters at all. */
+    if (image_src_is_animated(s)) return false;
     if (image_page_config_crop(cur, s) != image_page_config_crop(prev, s)) return true;
     switch (s) {
         case IMG_SRC_GOES:   return cur->goes_orientation != prev->goes_orientation || cur->goes_vflip != prev->goes_vflip || cur->goes_hflip != prev->goes_hflip;
@@ -2332,7 +2435,7 @@ static bool moon_params_changed(const app_config_t *prev, const app_config_t *cu
            cur->moon_lon != prev->moon_lon;
 }
 
-/* Apply image-page config changes live (preview) for all five pages, comparing
+/* Apply image-page config changes live (preview) for all six pages, comparing
  * prev to cur. Shared by the image config POST handler, the control registry
  * and config_trigger_side_effects (main Save), so live-apply lives once:
  *   - enable toggled: create/hide the page (display lock), start or park its poller;
@@ -2363,14 +2466,14 @@ void image_page_config_apply_live(const app_config_t *prev, const app_config_t *
         if (!en_cur) continue;
 
         if (source_params_changed((image_src_t)s, prev, cur, force_fetch)) {
-            /* Radar: these are DIFFERENT images (region / frame count), so the
-             * ring goes and the poller refetches. */
-            if (s == IMG_SRC_RADAR) image_page_radar_invalidate(p);
+            /* Animated pages: these are DIFFERENT images (region / area / frame
+             * count), so the ring goes and the poller refetches. No-op otherwise. */
+            image_page_ring_invalidate(p);
             image_page_request_manual_fetch(p);            /* overlay + fresh download */
         } else if (s == IMG_SRC_RADAR && radar_local_params_changed(prev, cur)) {
             /* Same images, drawn differently: re-derive the ring from the
              * retained compressed bytes. No network, no ring teardown. */
-            image_page_radar_request_retransform(p);
+            image_page_ring_request_retransform(p);
         } else if (s == IMG_SRC_MOON && moon_params_changed(prev, cur)) {
             image_page_ensure_task_running(p);
             image_page_wake(p);                              /* local re-render, no overlay */

--- a/main/ui/nina_image_page.h
+++ b/main/ui/nina_image_page.h
@@ -2,8 +2,8 @@
 
 /**
  * @file nina_image_page.h
- * @brief Image page spine: ONE implementation, FIVE instances (GOES, Moon,
- *        Solar, Custom URL, Weather Radar). Each instance is a first-class page
+ * @brief Image page spine: ONE implementation, SIX instances (GOES, Moon,
+ *        Solar, Custom URL, Weather Radar, Clouds). Each instance is a first-class page
  *        with its own runtime index (PAGE_IDX_IMG_*), LVGL page, decoded frame,
  *        poller and gates. Rendering lives in ui/nina_image_page.c; the pollers
  *        live in image_page_poll.c and are built on the poll_task spine.
@@ -13,11 +13,11 @@
  *   - warm:   the page is the NEXT slideshow stop (image_page_prefetch, arbiter).
  *   - poll_gate = active || warm: the poll_task spine gate.
  *   - The decoded frame is RETAINED on leave (manual swipe-back re-shows it
- *     instantly). Cap: at most IMAGE_PAGE_MAX_RESIDENT (3) frames across the five
+ *     instantly). Cap: at most IMAGE_PAGE_MAX_RESIDENT (3) frames across the six
  *     instances; active and warm instances are pinned, and when a commit would
  *     exceed the cap the least-recently-shown other instance's frame is evicted
  *     (image_page_evict_if_over_cap). image_page_disable() frees a frame outright.
- *   - At most one download+decode is in flight across the five pollers
+ *   - At most one download+decode is in flight across the six pollers
  *     (s_fetch_gate in image_page_poll.c), matching today's single fetch task.
  *
  * Locks: LVGL display lock OUTSIDE, frame_mux INSIDE. Every image_page_*
@@ -48,14 +48,31 @@ typedef enum {
     IMG_SRC_SOLAR  = 2,
     IMG_SRC_CUSTOM = 3,
     IMG_SRC_RADAR  = 4,
-    IMG_SRC_COUNT  = 5,
+    IMG_SRC_CLOUDS = 5,
+    IMG_SRC_COUNT  = 6,
 } image_src_t;
+
+/* Sources whose frames live in the animation ring (index 0 = newest, played
+ * oldest -> newest on an LVGL timer) instead of a single p->frame. Every ring
+ * gate in nina_image_page.c / image_page_poll.c keys off this predicate, never
+ * off a source id, so a further animated source is one enum value + hooks. */
+static inline bool image_src_is_animated(image_src_t s)
+{
+    return s == IMG_SRC_RADAR || s == IMG_SRC_CLOUDS;
+}
+
+/* Sources whose fetch failure is rendered as the page caption (user-addressed
+ * or outage-prone): Custom URL, Radar (site token) and Clouds (GIBS). */
+static inline bool image_page_shows_error(image_src_t s)
+{
+    return s == IMG_SRC_CUSTOM || image_src_is_animated(s);
+}
 
 typedef struct image_page {
     /* identity: constant after image_page_init() */
     image_src_t       src;
     int               page_idx;        /* PAGE_IDX_IMG_GOES + src */
-    const char       *name;            /* task/log name: "img_goes" .. "img_radar" */
+    const char       *name;            /* task/log name: "img_goes" .. "img_clouds" */
 
     /* decoded frame, owned here, guarded by frame_mux */
     SemaphoreHandle_t frame_mux;
@@ -80,13 +97,13 @@ typedef struct image_page {
     size_t    moon_copy_cap[2];
 } image_page_t;
 
-#define IMAGE_PAGE_MAX_RESIDENT 3   /* decoded frames resident across the five instances */
+#define IMAGE_PAGE_MAX_RESIDENT 3   /* decoded frames resident across the six instances */
 
 /* ── Instances ── */
 image_page_t *image_page_get(image_src_t src);
 image_page_t *image_page_by_page_idx(int page_idx);          /* NULL if not an image page */
 
-/* Create the five instances' identities + mutexes (spawn_pollers=false) or
+/* Create the six instances' identities + mutexes (spawn_pollers=false) or
  * additionally start a poller for every source enabled in config
  * (spawn_pollers=true). Idempotent. MUST be called once with false from
  * app_main() right after app_config_init() (before the web server and before
@@ -107,7 +124,7 @@ bool     image_page_config_enabled(const app_config_t *c, image_src_t src);
 bool     image_page_config_overlay(const app_config_t *c, image_src_t src);
 bool     image_page_config_crop(const app_config_t *c, image_src_t src);
 uint32_t image_page_interval_ms(image_page_t *p);            /* live config, clamped; Moon: 3000 while the clock is invalid */
-void     image_page_label(image_page_t *p, char *out, size_t sz);   /* region name / "Moon" / band label / "Custom" / "Radar <token>" */
+void     image_page_label(image_page_t *p, char *out, size_t sz);   /* region name / "Moon" / band label / "Custom" / "Radar <token>" / "Clouds" */
 /* Radar site token for THIS fetch, resolved fresh every time and never
  * persisted (a poll task must not write config): an explicit radar_token wins,
  * else the WSR-88D site nearest the configured weather location, else the
@@ -125,26 +142,34 @@ bool     image_page_get_error(image_page_t *p, char *out, size_t sz); /* true if
  * frame_mux cannot be taken. force=true bypasses the newer-stamp gate and
  * swaps instantly (Moon). */
 void image_page_commit_frame(image_page_t *p, image_frame_t *fresh, bool force);
-void image_page_set_error(image_page_t *p, const char *msg);   /* stores error_msg; Custom/Radar render it as the caption */
+void image_page_set_error(image_page_t *p, const char *msg);   /* stores error_msg; Custom/Radar/Clouds render it as the caption */
 
-/* ── Weather Radar animation ring (IMG_SRC_RADAR only) ──
- * The radar page stores up to radar_frames decoded stills (index 0 = newest)
- * and plays them oldest -> newest on an LVGL timer, instead of keeping a single
- * frame in p->frame (which stays NULL for radar). A full ring is ~6.6 MB, so it
- * is freed whenever the page is deactivated or disabled and rebuilt by the
- * poller's backfill on the next activation. Guarded by the display lock alone;
- * see the ring block in nina_image_page.c. */
-/* Insert a decoded frame, taking ownership of fresh->buf. at_head=true is the
- * steady-state newest-frame push (evicts the oldest when full); at_head=false
- * appends an older backfill frame at the tail (ignored when full). A frame that
- * hashes equal to the entry it would sit next to is dropped. Takes the display
+/* ── Animation ring (image_src_is_animated: Weather Radar, Clouds) ──
+ * An animated page stores up to N decoded stills (index 0 = newest; N =
+ * radar_frames / clouds_frames) and plays them oldest -> newest on an LVGL
+ * timer, instead of keeping a single frame in p->frame (which stays NULL for
+ * these sources). One ring per instance. A full ring is 6-10 MB, so it is freed
+ * whenever the page is deactivated or disabled and rebuilt by the poller's
+ * backfill on the next activation. Guarded by the display lock alone; see the
+ * ring block in nina_image_page.c. Every function is a no-op (or returns 0 /
+ * false) for a single-frame source, so callers need no source test. */
+/* Insert a decoded frame, taking ownership of fresh->buf. Takes the display
  * lock itself, so it must NOT be called with the lock held.
  *
+ * @p stamp is the frame's own time (UTC seconds) or 0 when unknown. A stamped
+ * frame is placed by time (newest first) whatever @p at_head says; a stamp the
+ * ring already holds REPLACES that slot when the bytes differ (GIBS serves the
+ * newest frames partially at first) and is dropped as a duplicate when they
+ * match. For an unstamped frame at_head=true is the steady-state newest-frame
+ * push (evicts the oldest when full); at_head=false appends an older backfill
+ * frame at the tail (ignored when full). A frame that hashes equal to the
+ * entry it would sit next to is dropped.
+ *
  * @p gen is the ring generation the fetch was issued under, from
- * image_page_radar_gen(). A frame whose generation no longer matches is FREED
+ * image_page_ring_gen(). A frame whose generation no longer matches is FREED
  * and dropped: this is the single point that keeps frames from a region the
  * user has already left out of the ring. Producers must read the generation
- * BEFORE the token they fetch with (see radar_frame_is_stale in radar_play.h).
+ * BEFORE the token/times they fetch with (see radar_frame_is_stale in radar_play.h).
  *
  * @p src / @p src_len are the frame's COMPRESSED bytes from
  * image_fetch_custom_retain() (may be NULL/0). The ring retains them so a crop,
@@ -152,25 +177,31 @@ void image_page_set_error(image_page_t *p, const char *msg);   /* stores error_m
  * re-downloading the whole ring; they also serve as the dedupe key.
  *
  * Ownership of BOTH fresh->buf and src is taken on every path, accepted or
- * rejected: the caller must not free either after this returns. */
-void image_page_radar_add(image_page_t *p, image_frame_t *fresh, bool at_head, uint32_t gen,
-                          uint8_t *src, size_t src_len);
+ * rejected: the caller must not free either after this returns.
+ *
+ * Calls nav_arbiter_notify_content_ready() when a frame lands on the visible
+ * page, so the slideshow dwell starts once the picture is up (same contract as
+ * image_page_commit_frame). */
+void image_page_ring_add(image_page_t *p, image_frame_t *fresh, bool at_head, uint32_t gen,
+                         uint8_t *src, size_t src_len, uint32_t stamp);
 /* Re-derive every resident frame from its retained compressed bytes under the
- * CURRENT crop mode and dark/Red-Night treatment. No network. Request from any
- * task (sets a flag + wakes the poller); the work runs on the radar poll task,
- * one frame at a time, taking the display lock only for the pointer swaps. */
-void image_page_radar_request_retransform(image_page_t *p);
-void image_page_radar_retransform_if_requested(image_page_t *p);   /* radar poll task only */
-void image_page_radar_reset(image_page_t *p);       /* free the ring + bump the generation; display lock HELD by the caller */
+ * CURRENT bake (radar crop / dark mode) and theme (Red Night). No network.
+ * Request from any task (sets a flag + wakes the poller); the work runs on the
+ * page's poll task, one frame at a time, taking the display lock only for the
+ * pointer swaps. */
+void image_page_ring_request_retransform(image_page_t *p);
+void image_page_ring_retransform_if_requested(image_page_t *p);   /* the page's poll task only */
+void image_page_ring_reset(image_page_t *p);        /* free the ring + bump the generation; display lock HELD by the caller */
 /* Supersede the ring: bumps the generation UNCONDITIONALLY (so no in-flight frame
  * from the old settings can enter), then frees it. Takes the display lock; if that
- * times out the teardown is deferred to image_page_radar_reset_if_requested(). */
-void image_page_radar_invalidate(image_page_t *p);
-void image_page_radar_reset_if_requested(image_page_t *p);         /* radar poll task only */
-uint32_t image_page_radar_gen(void);                /* current ring generation; read BEFORE resolving the token */
-int  image_page_radar_count(void);                  /* resident frames (lock-free) */
-int  image_page_radar_capacity(void);               /* radar_frames, clamped 1..RADAR_RING_MAX */
-bool image_page_radar_backfill_take(void);          /* consume the pending-backfill request */
+ * times out the teardown is deferred to image_page_ring_reset_if_requested(). */
+void image_page_ring_invalidate(image_page_t *p);
+void image_page_ring_reset_if_requested(image_page_t *p);          /* the page's poll task only */
+uint32_t image_page_ring_gen(image_page_t *p);      /* current ring generation; read BEFORE resolving the token/times */
+int  image_page_ring_count(image_page_t *p);        /* resident frames (lock-free) */
+int  image_page_ring_capacity(image_page_t *p);     /* radar_frames / clouds_frames, clamped 1..RADAR_RING_MAX */
+bool image_page_ring_backfill_take(image_page_t *p);   /* consume the pending-backfill request */
+bool image_page_ring_has_stamp(image_page_t *p, uint32_t stamp);   /* lock-free; a held stamp needs no re-download */
 /* Enforce IMAGE_PAGE_MAX_RESIDENT: while more than the cap are resident, free the
  * frame of the least-recently-shown instance that is neither active nor warm.
  * Called by image_page_commit_frame after every commit; no display lock. */

--- a/main/ui/page_registry.c
+++ b/main/ui/page_registry.c
@@ -66,6 +66,7 @@ static const page_ref_entry_t s_pages[] = {
     /* id 25 */ { PAGE_REF_HA,               "ha",                     "Home Assistant",   PAGE_REF_KIND_PAGE,         PAGE_REF_HA,           true,  "Ambient", PAGE_IDX_HA                            },
     /* id 26 */ { PAGE_REF_OCTOPRINT,        "octoprint",              "OctoPrint",        PAGE_REF_KIND_PAGE,         PAGE_REF_OCTOPRINT,    true,  "Ambient", PAGE_IDX_OCTOPRINT                     },
     /* id 27 */ { PAGE_REF_RADAR,     "image.radar",  "Weather Radar",  PAGE_REF_KIND_IMAGE_SOURCE, PAGE_REF_RADAR,      true, "Image", PAGE_IDX_IMG_RADAR  },
+    /* id 28 */ { PAGE_REF_CLOUDS,    "image.clouds", "Cloud Cover",       PAGE_REF_KIND_IMAGE_SOURCE, PAGE_REF_CLOUDS,     true, "Image", PAGE_IDX_IMG_CLOUDS },
 };
 
 int page_ref_count(void)
@@ -131,6 +132,9 @@ bool page_ref_is_available(page_ref_t id)
         /* No URL precondition: an empty radar_token resolves at fetch time
          * (nearest site, else the CONUS mosaic), so the page always has a target. */
         case PAGE_REF_RADAR:      avail = c->radar_enabled; break;
+        /* Same: the box is centred on the weather location, and (0,0) is still a
+         * valid (if empty) box, so the page always has a target. */
+        case PAGE_REF_CLOUDS:     avail = c->clouds_enabled; break;
         case PAGE_REF_SETTINGS:           /* settings: never a slideshow/nav-list target */
         case PAGE_REF_OVL_GRAPH:          /* overlays: not directly navigable             */
         case PAGE_REF_OVL_INFO_CAMERA:

--- a/main/ui/page_registry.h
+++ b/main/ui/page_registry.h
@@ -7,7 +7,7 @@
  * Each navigable page, image source, and detail overlay is assigned a stable
  * numeric id (page_ref_t) and a stable string slug. The registry maps these
  * external identities onto the runtime absolute page index (the value the
- * Navigation Arbiter commits). The five image sources are five distinct pages
+ * Navigation Arbiter commits). The six image sources are six distinct pages
  * (PAGE_IDX_IMG_*), so the index alone identifies the source.
  *
  * APPEND-ONLY / FROZEN-IDS CONTRACT
@@ -83,14 +83,15 @@ typedef uint8_t page_ref_t;
 #define PAGE_REF_HA                 ((page_ref_t)25)
 #define PAGE_REF_OCTOPRINT          ((page_ref_t)26)
 #define PAGE_REF_RADAR              ((page_ref_t)27)
+#define PAGE_REF_CLOUDS             ((page_ref_t)28)
 
 /** Exclusive upper bound on assigned ids. */
-#define PAGE_REF_ID_MAX ((page_ref_t)28)
+#define PAGE_REF_ID_MAX ((page_ref_t)29)
 
 /** What kind of UI surface a page_ref names. */
 typedef enum {
     PAGE_REF_KIND_PAGE         = 0,  /* a navigable top-level page                */
-    PAGE_REF_KIND_IMAGE_SOURCE = 1,  /* one of the five full-screen image pages (GOES/Moon/Solar/Custom/Radar) */
+    PAGE_REF_KIND_IMAGE_SOURCE = 1,  /* one of the six full-screen image pages (GOES/Moon/Solar/Custom/Radar/Clouds) */
     PAGE_REF_KIND_OVERLAY      = 2,  /* a modal overlay (not directly navigable)   */
 } page_ref_kind_t;
 

--- a/main/ui/settings_tab_display.c
+++ b/main/ui/settings_tab_display.c
@@ -147,7 +147,7 @@ static uint32_t home_abs_to_dd_sel(int id)
  * (nina_nav_arbiter.c: slideshow_build_candidates). Each used slot holds a
  * page_ref id (== ARP_IDX_*): 0=Summary, 1..3=NINA1..3, 4=SysInfo, 5=AllSky,
  * 6=Spotify, 7=Clock, 8..11=Image sources, 24=JSON, 25=HA, 26=OctoPrint,
- * 27=Radar; 0xFF = empty.
+ * 27=Radar, 28=Clouds; 0xFF = empty.
  * The on-device checkbox table exposes only ids 0..5 (page_names below);
  * every other id is preserved across edits since this UI cannot express it. */
 

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -59,6 +59,8 @@ extern const uint8_t fragment_image_custom_html_start[] asm("_binary_fragment_im
 extern const uint8_t fragment_image_custom_html_end[]   asm("_binary_fragment_image_custom_html_end");
 extern const uint8_t fragment_image_radar_html_start[]  asm("_binary_fragment_image_radar_html_start");
 extern const uint8_t fragment_image_radar_html_end[]    asm("_binary_fragment_image_radar_html_end");
+extern const uint8_t fragment_image_clouds_html_start[] asm("_binary_fragment_image_clouds_html_start");
+extern const uint8_t fragment_image_clouds_html_end[]   asm("_binary_fragment_image_clouds_html_end");
 extern const uint8_t fragment_octoprint_html_start[] asm("_binary_fragment_octoprint_html_start");
 extern const uint8_t fragment_octoprint_html_end[]   asm("_binary_fragment_octoprint_html_end");
 
@@ -114,6 +116,8 @@ extern const uint8_t fragment_image_custom_html_gz_start[] asm("_binary_fragment
 extern const uint8_t fragment_image_custom_html_gz_end[]   asm("_binary_fragment_image_custom_html_gz_end");
 extern const uint8_t fragment_image_radar_html_gz_start[]  asm("_binary_fragment_image_radar_html_gz_start");
 extern const uint8_t fragment_image_radar_html_gz_end[]    asm("_binary_fragment_image_radar_html_gz_end");
+extern const uint8_t fragment_image_clouds_html_gz_start[] asm("_binary_fragment_image_clouds_html_gz_start");
+extern const uint8_t fragment_image_clouds_html_gz_end[]   asm("_binary_fragment_image_clouds_html_gz_end");
 extern const uint8_t fragment_octoprint_html_gz_start[] asm("_binary_fragment_octoprint_html_gz_start");
 extern const uint8_t fragment_octoprint_html_gz_end[]   asm("_binary_fragment_octoprint_html_gz_end");
 extern const uint8_t fragment_nodes_html_gz_start[] asm("_binary_fragment_nodes_html_gz_start");
@@ -289,6 +293,8 @@ static const ui_fragment_entry_t s_ui_fragments[] = {
                        fragment_image_custom_html_gz_start,  fragment_image_custom_html_gz_end },
     { "image-radar",   fragment_image_radar_html_start,   fragment_image_radar_html_end,
                        fragment_image_radar_html_gz_start,   fragment_image_radar_html_gz_end },
+    { "image-clouds",  fragment_image_clouds_html_start,  fragment_image_clouds_html_end,
+                       fragment_image_clouds_html_gz_start,  fragment_image_clouds_html_gz_end },
     { "octoprint",     fragment_octoprint_html_start,     fragment_octoprint_html_end,
                        fragment_octoprint_html_gz_start,     fragment_octoprint_html_gz_end },
     { "nodes",         fragment_nodes_html_start,         fragment_nodes_html_end,
@@ -643,6 +649,13 @@ static const backup_field_t s_backup_fields[] = {
     {"radar_frames",               "Radar Animation Length","Radar", false, false},
     {"radar_dark_mode",            "Radar Map Appearance", "Radar", false, false},
     {"radar_map_style",            "Radar Map Style",      "Radar", false, false},
+    /* Clouds page (v66). All five are SETTINGS_TABLE rows; same reasoning as
+     * the radar block above. */
+    {"clouds_enabled",             "Cloud Cover Page Enabled",  "Cloud Cover", false, false},
+    {"clouds_show_overlay",        "Cloud Cover Show Overlay",  "Cloud Cover", false, false},
+    {"clouds_update_interval_s",   "Cloud Cover Update Interval","Cloud Cover", false, false},
+    {"clouds_frames",              "Cloud Cover Animation Length","Cloud Cover", false, false},
+    {"clouds_zoom",                "Cloud Cover Area",          "Cloud Cover", false, false},
     {"goes_region",                "GOES Region",          "GOES", false, false},
     {"goes_update_interval_s",     "GOES Update Interval", "GOES", false, false},
     {"custom_image_url",           "Custom Image URL",     "Custom URL", false, false},
@@ -1051,9 +1064,9 @@ static cJSON *build_restore_preview(const cJSON *backup_root, const cJSON *curre
     bool restore_blocked = false;
 
     /* Track which categories have changes */
-    const char *categories[] = {"Display", "Behavior", "Nodes & Data", "System", "AllSky", "Spotify", "MQTT", "OctoPrint", "GOES", "Moon", "Solar", "Custom URL", "Radar"};
-    int cat_counts[13] = {0};
-    int num_categories = 13;
+    const char *categories[] = {"Display", "Behavior", "Nodes & Data", "System", "AllSky", "Spotify", "MQTT", "OctoPrint", "GOES", "Moon", "Solar", "Custom URL", "Radar", "Cloud Cover"};
+    int cat_counts[14] = {0};
+    int num_categories = 14;
 
     for (const backup_field_t *f = s_backup_fields; f->json_key; f++) {
         /* Determine which backup section this field comes from */

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -179,14 +179,15 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
     if (new_cfg->octoprint_overlay_visible != old_cfg->octoprint_overlay_visible) {
         octoprint_page_set_overlay_visible(new_cfg->octoprint_overlay_visible);
     }
-    /* Image pages (GOES/Moon/Solar/Custom/Radar): one live-apply for all five; an
+    /* Image pages (GOES/Moon/Solar/Custom/Radar/Clouds): one live-apply for all six; an
      * enable toggle is a topology change (an optional page appeared/disappeared). */
     image_page_config_apply_live(old_cfg, new_cfg, false);
     if (new_cfg->goes_enabled != old_cfg->goes_enabled ||
         new_cfg->moon_enabled != old_cfg->moon_enabled ||
         new_cfg->solar_enabled != old_cfg->solar_enabled ||
         new_cfg->custom_enabled != old_cfg->custom_enabled ||
-        new_cfg->radar_enabled != old_cfg->radar_enabled) {
+        new_cfg->radar_enabled != old_cfg->radar_enabled ||
+        new_cfg->clouds_enabled != old_cfg->clouds_enabled) {
         topology_changed = true;
     }
     /* Weather config change — invalidate stale data and force refresh */
@@ -498,38 +499,35 @@ esp_err_t screenshot_get_handler(httpd_req_t *req)
 
     ESP_LOGI(TAG, "Snapshot captured: %lux%lu, stride=%lu", width, height, stride);
 
-    // Allocate DMA-aligned input buffer and copy pixels
-    jpeg_encode_memory_alloc_cfg_t in_mem_cfg = {
-        .buffer_direction = JPEG_ENC_ALLOC_INPUT_BUFFER,
-    };
-    size_t in_alloc_size = 0;
-    uint8_t *enc_in = (uint8_t *)jpeg_alloc_encoder_mem(raw_size, &in_mem_cfg, &in_alloc_size);
-    if (!enc_in) {
-        ESP_LOGE(TAG, "Failed to alloc JPEG encoder input buffer (%lu bytes)", raw_size);
+    // Feed the LVGL draw buffer straight to the encoder when it is already
+    // cache-line aligned and densely packed (the driver msyncs the input
+    // itself); otherwise fall back to a DMA-aligned copy.
+    uint8_t *enc_in = NULL;      // owned copy, NULL when snapshot->data is used directly
+    const uint8_t *enc_src = NULL;
+    if (((uintptr_t)snapshot->data % 128) == 0 && stride == row_size) {
+        enc_src = snapshot->data;
+    } else {
+        jpeg_encode_memory_alloc_cfg_t in_mem_cfg = {
+            .buffer_direction = JPEG_ENC_ALLOC_INPUT_BUFFER,
+        };
+        size_t in_alloc_size = 0;
+        enc_in = (uint8_t *)jpeg_alloc_encoder_mem(raw_size, &in_mem_cfg, &in_alloc_size);
+        if (!enc_in) {
+            ESP_LOGE(TAG, "Failed to alloc JPEG encoder input buffer (%lu bytes)", raw_size);
+            lv_draw_buf_destroy(snapshot);
+            httpd_resp_send_500(req);
+            return ESP_FAIL;
+        }
+        for (uint32_t y = 0; y < height; y++) {
+            memcpy(enc_in + y * row_size, snapshot->data + y * stride, row_size);
+        }
         lv_draw_buf_destroy(snapshot);
-        httpd_resp_send_500(req);
-        return ESP_FAIL;
+        snapshot = NULL;
+        enc_src = enc_in;
     }
 
-    for (uint32_t y = 0; y < height; y++) {
-        memcpy(enc_in + y * row_size, snapshot->data + y * stride, row_size);
-    }
-    lv_draw_buf_destroy(snapshot);
-
-    // Allocate DMA-aligned output buffer
-    jpeg_encode_memory_alloc_cfg_t out_mem_cfg = {
-        .buffer_direction = JPEG_ENC_ALLOC_OUTPUT_BUFFER,
-    };
-    size_t out_alloc_size = 0;
-    uint8_t *enc_out = (uint8_t *)jpeg_alloc_encoder_mem(raw_size, &out_mem_cfg, &out_alloc_size);
-    if (!enc_out) {
-        ESP_LOGE(TAG, "Failed to alloc JPEG encoder output buffer");
-        free(enc_in);
-        httpd_resp_send_500(req);
-        return ESP_FAIL;
-    }
-
-    // Encode RGB565 -> JPEG
+    // Encode RGB565 -> JPEG. Output starts at raw_size/4; a too-small output
+    // buffer surfaces as ESP_ERR_INVALID_STATE, retried once at raw_size/2.
     jpeg_encode_cfg_t enc_cfg = {
         .src_type = JPEG_ENCODE_IN_FORMAT_RGB565,
         .sub_sample = JPEG_DOWN_SAMPLING_YUV422,
@@ -537,14 +535,36 @@ esp_err_t screenshot_get_handler(httpd_req_t *req)
         .width = width,
         .height = height,
     };
+    jpeg_encode_memory_alloc_cfg_t out_mem_cfg = {
+        .buffer_direction = JPEG_ENC_ALLOC_OUTPUT_BUFFER,
+    };
+    uint8_t *enc_out = NULL;
     uint32_t jpg_size = 0;
-    esp_err_t err = jpeg_encoder_process(s_jpeg_encoder, &enc_cfg,
-        enc_in, raw_size, enc_out, out_alloc_size, &jpg_size);
-    free(enc_in);
+    esp_err_t err = ESP_FAIL;
+    for (int attempt = 0; attempt < 2; attempt++) {
+        size_t want = (attempt == 0) ? raw_size / 4 : raw_size / 2;
+        size_t out_alloc_size = 0;
+        enc_out = (uint8_t *)jpeg_alloc_encoder_mem(want, &out_mem_cfg, &out_alloc_size);
+        if (!enc_out) {
+            ESP_LOGE(TAG, "Failed to alloc JPEG encoder output buffer (%u bytes)", (unsigned)want);
+            err = ESP_ERR_NO_MEM;
+            break;
+        }
+        ESP_LOGD(TAG, "JPEG output buffer: %u bytes (attempt %d)", (unsigned)out_alloc_size, attempt);
+        jpg_size = 0;
+        err = jpeg_encoder_process(s_jpeg_encoder, &enc_cfg,
+            enc_src, raw_size, enc_out, out_alloc_size, &jpg_size);
+        if (err == ESP_OK) break;
+        free(enc_out);
+        enc_out = NULL;
+        if (err != ESP_ERR_INVALID_STATE) break;
+    }
+    if (enc_in) free(enc_in);
+    if (snapshot) lv_draw_buf_destroy(snapshot);
 
     if (err != ESP_OK || jpg_size == 0) {
         ESP_LOGE(TAG, "JPEG encode failed: %s", esp_err_to_name(err));
-        free(enc_out);
+        if (enc_out) free(enc_out);
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -28,8 +28,8 @@ static bool radar_token_is_valid(const char *tok)
 }
 
 /**
- * @brief GET /api/image-display-config -- return the config fields of all five
- *        image pages (GOES, Moon, Solar, Custom URL, Radar).
+ * @brief GET /api/image-display-config -- return the config fields of all six
+ *        image pages (GOES, Moon, Solar, Custom URL, Radar, Clouds).
  */
 esp_err_t image_display_config_get_handler(httpd_req_t *req)
 {
@@ -46,11 +46,13 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
     cJSON_AddBoolToObject(root, "solar_enabled",        cfg->solar_enabled);
     cJSON_AddBoolToObject(root, "custom_enabled",       cfg->custom_enabled);
     cJSON_AddBoolToObject(root, "radar_enabled",        cfg->radar_enabled);
+    cJSON_AddBoolToObject(root, "clouds_enabled",       cfg->clouds_enabled);
     cJSON_AddBoolToObject(root, "goes_show_overlay",    cfg->goes_show_overlay);
     cJSON_AddBoolToObject(root, "moon_show_overlay",    cfg->moon_show_overlay);
     cJSON_AddBoolToObject(root, "solar_show_overlay",   cfg->solar_show_overlay);
     cJSON_AddBoolToObject(root, "custom_show_overlay",  cfg->custom_show_overlay);
     cJSON_AddBoolToObject(root, "radar_show_overlay",   cfg->radar_show_overlay);
+    cJSON_AddBoolToObject(root, "clouds_show_overlay",  cfg->clouds_show_overlay);
     cJSON_AddBoolToObject(root, "goes_crop",            cfg->goes_crop);
     cJSON_AddBoolToObject(root, "solar_crop",           cfg->solar_crop);
     cJSON_AddBoolToObject(root, "custom_crop",          cfg->custom_crop);
@@ -69,6 +71,10 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "radar_frames", cfg->radar_frames);
     /* Empty string = "automatic: nearest site, else the national view". */
     cJSON_AddStringToObject(root, "radar_token", cfg->radar_token);
+    /* Clouds: centred on weather_lat/lon (System tab, Location card); zoom 5..9 picks the width. */
+    cJSON_AddNumberToObject(root, "clouds_update_interval_s", cfg->clouds_update_interval_s);
+    cJSON_AddNumberToObject(root, "clouds_frames", cfg->clouds_frames);
+    cJSON_AddNumberToObject(root, "clouds_zoom", cfg->clouds_zoom);
 
     cJSON_AddStringToObject(root, "goes_region", cfg->goes_region);
     cJSON_AddNumberToObject(root, "goes_update_interval_s", cfg->goes_update_interval_s);
@@ -105,7 +111,7 @@ esp_err_t image_display_config_get_handler(httpd_req_t *req)
  *        Any subset of the keys may be posted; each is applied only when
  *        present. Optional "preview" (true) applies live WITHOUT persisting;
  *        without it the values are saved to NVS as before. Optional "source"
- *        (0..3) selects which page's last fetch error to echo back; optional
+ *        (0..IMG_SRC_COUNT-1) selects which page's last fetch error to echo back; optional
  *        "force_fetch" re-downloads Custom even when nothing changed (it drives
  *        the live-apply step only, so it works in preview mode too).
  */
@@ -172,11 +178,13 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
     JSON_TO_BOOL(root, "solar_enabled",       cur->solar_enabled);
     JSON_TO_BOOL(root, "custom_enabled",      cur->custom_enabled);
     JSON_TO_BOOL(root, "radar_enabled",       cur->radar_enabled);
+    JSON_TO_BOOL(root, "clouds_enabled",      cur->clouds_enabled);
     JSON_TO_BOOL(root, "goes_show_overlay",   cur->goes_show_overlay);
     JSON_TO_BOOL(root, "moon_show_overlay",   cur->moon_show_overlay);
     JSON_TO_BOOL(root, "solar_show_overlay",  cur->solar_show_overlay);
     JSON_TO_BOOL(root, "custom_show_overlay", cur->custom_show_overlay);
     JSON_TO_BOOL(root, "radar_show_overlay",  cur->radar_show_overlay);
+    JSON_TO_BOOL(root, "clouds_show_overlay", cur->clouds_show_overlay);
     JSON_TO_BOOL(root, "goes_crop",           cur->goes_crop);
     JSON_TO_BOOL(root, "solar_crop",          cur->solar_crop);
     JSON_TO_BOOL(root, "custom_crop",         cur->custom_crop);
@@ -233,6 +241,31 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
         if (v < 1) v = 1;
         if (v > 10) v = 10;
         cur->radar_frames = (uint8_t)v;
+    }
+    /* Clouds: same bounds as validate_config() and the SETTINGS_TABLE rows.
+     * Interval 300..7200 s (GIBS publishes every 10 min), frames 1..10 (~1 MB
+     * PSRAM each, so a memory bound), zoom 5..9 (Web-Mercator level of the
+     * 720 px picture around weather_lat/lon). */
+    cJSON *cinterval = cJSON_GetObjectItem(root, "clouds_update_interval_s");
+    if (cJSON_IsNumber(cinterval)) {
+        int v = cinterval->valueint;
+        if (v < 300) v = 300;
+        if (v > 7200) v = 7200;
+        cur->clouds_update_interval_s = (uint16_t)v;
+    }
+    cJSON *cframes = cJSON_GetObjectItem(root, "clouds_frames");
+    if (cJSON_IsNumber(cframes)) {
+        int v = cframes->valueint;
+        if (v < 1) v = 1;
+        if (v > 10) v = 10;
+        cur->clouds_frames = (uint8_t)v;
+    }
+    cJSON *czoom = cJSON_GetObjectItem(root, "clouds_zoom");
+    if (cJSON_IsNumber(czoom)) {
+        int v = czoom->valueint;
+        if (v < 5) v = 5;
+        if (v > 9) v = 9;
+        cur->clouds_zoom = (uint8_t)v;
     }
     cJSON *sinterval = cJSON_GetObjectItem(root, "solar_update_interval_s");
     if (cJSON_IsNumber(sinterval)) {
@@ -350,7 +383,8 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
         cur->moon_enabled   != prev->moon_enabled   ||
         cur->solar_enabled  != prev->solar_enabled  ||
         cur->custom_enabled != prev->custom_enabled ||
-        cur->radar_enabled  != prev->radar_enabled) {
+        cur->radar_enabled  != prev->radar_enabled  ||
+        cur->clouds_enabled != prev->clouds_enabled) {
         nav_arbiter_notify_topology_changed();
     }
 
@@ -377,7 +411,7 @@ esp_err_t image_display_config_post_handler(httpd_req_t *req)
 }
 
 /**
- * @brief POST /api/image-display/refresh [{"source":0..3}] -- force an immediate
+ * @brief POST /api/image-display/refresh [{"source":0..IMG_SRC_COUNT-1}] -- force an immediate
  *        re-fetch (or Moon re-render) of ONE image page with the loading overlay,
  *        without changing any config. With no body or no "source" the currently
  *        visible image page is refreshed (no-op success if none is on screen).
@@ -398,7 +432,7 @@ esp_err_t image_display_refresh_post_handler(httpd_req_t *req)
             src = src_item->valueint;
             if (src < 0 || src >= IMG_SRC_COUNT) {
                 cJSON_Delete(root);
-                return send_400(req, "source must be 0 (GOES), 1 (Moon), 2 (Solar), 3 (Custom) or 4 (Radar)");
+                return send_400(req, "source must be 0 (GOES), 1 (Moon), 2 (Solar), 3 (Custom), 4 (Radar) or 5 (Cloud Cover)");
             }
         }
         cJSON_Delete(root);

--- a/test/host/CMakeLists.txt
+++ b/test/host/CMakeLists.txt
@@ -244,3 +244,16 @@ add_nina_host_test(test_radar_wms
 target_compile_definitions(test_radar_wms PRIVATE
     NINA_FIXTURE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/fixtures"
 )
+
+# ---------------------------------------------------------------------------
+# test_clouds_wms -- URL/geometry/time decisions for the Clouds page
+# (main/clouds_wms.h): East/West satellite pick, square Web-Mercator box from
+# lat/lon + zoom, GIBS GetMap and WMTS DescribeDomains URL shape, the
+# DescribeDomains time-list parser (start/end/PTnM segments, singles, bare
+# dates) and the UTC days-from-civil calendar helpers. Header-only, no
+# ESP-IDF dependency, no fixtures.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_clouds_wms
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_clouds_wms.c
+)

--- a/test/host/test_clouds_wms.c
+++ b/test/host/test_clouds_wms.c
@@ -1,0 +1,272 @@
+/* Host test for main/clouds_wms.h -- the pure URL/geometry/time decisions behind
+ * the Clouds page (NASA GIBS WMS, GOES ABI GeoColor): satellite pick, square
+ * Web-Mercator box, GetMap and DescribeDomains URL shape, the DescribeDomains
+ * time-list parser and the UTC calendar arithmetic. Header-only, no ESP-IDF
+ * dependency; assert-style like test/host/test_radar_wms.c. */
+#include "clouds_wms.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int fails = 0;
+
+static void check_int(const char *label, long got, long expect) {
+    printf("%-64s got=%-12ld expect=%-12ld %s\n", label, got, expect,
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+static void check_bool(const char *label, bool got, bool expect) {
+    printf("%-64s got=%-6s expect=%-6s %s\n", label,
+           got ? "true" : "false", expect ? "true" : "false",
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+static void check_str(const char *label, const char *got, const char *expect) {
+    int ok = (got != NULL) && (strcmp(got, expect) == 0);
+    printf("%-64s %s\n    got=%s\n", label, ok ? "OK" : "FAIL", got ? got : "(null)");
+    if (!ok) fails++;
+}
+
+static void check_contains(const char *label, const char *hay, const char *needle, bool expect) {
+    bool got = (hay != NULL) && (strstr(hay, needle) != NULL);
+    printf("%-64s got=%-6s expect=%-6s %s\n", label,
+           got ? "true" : "false", expect ? "true" : "false",
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+/* |got - expect| <= tol, printed as long so no %f is needed */
+static void check_near(const char *label, float got, float expect, float tol) {
+    float d = got - expect;
+    if (d < 0.0f) d = -d;
+    bool ok = d <= tol;
+    printf("%-64s got=%-10ld expect=%-10ld %s\n", label,
+           (long)lroundf(got), (long)lroundf(expect), ok ? "OK" : "FAIL");
+    if (!ok) fails++;
+}
+
+/* Parse "&BBOX=a,b,c,d" out of a URL. */
+static bool url_bbox(const char *url, long *a, long *b, long *c, long *d) {
+    const char *p = strstr(url, "&BBOX=");
+    if (!p) return false;
+    return sscanf(p + 6, "%ld,%ld,%ld,%ld", a, b, c, d) == 4;
+}
+
+/* Position of needle in hay, or -1. Used to assert query parameter order. */
+static long pos_of(const char *hay, const char *needle) {
+    const char *p = strstr(hay, needle);
+    return p ? (long)(p - hay) : -1;
+}
+
+/* Three ascending segments (the GOES-West shape observed 2026-08-18: two gaps),
+ * plus a bare-date single entry that must be skipped, plus whitespace. */
+static const char sample_domains[] =
+    "<Domains xmlns:ows='http://www.opengis.net/ows/1.1'><SpaceDomain>"
+    "<BoundingBox miny='-90' maxx='180' crs='urn:ogc:def:crs:OGC:2:84' maxy='90' minx='-180'/>"
+    "</SpaceDomain><DimensionDomain><ows:Identifier>time</ows:Identifier>"
+    "<Domain>2026-08-17, 2026-08-18T01:40:00Z/2026-08-18T01:50:00Z/PT10M,\n"
+    " 2026-08-18T02:10:00Z/2026-08-18T02:20:00Z/PT10M ,"
+    "2026-08-18T02:40:00Z/2026-08-18T03:00:00Z/PT10M</Domain>"
+    "<Size>4</Size></DimensionDomain></Domains>";
+
+int main(void) {
+    char url[CLOUDS_URL_MAX];
+    char ts[CLOUDS_TIME_MAX];
+    uint32_t times[CLOUDS_TIMES_MAX];
+
+    /* -- satellite pick ---------------------------------------------------- */
+    check_str("layer: St Louis (-90.7) -> East", clouds_layer(-90.689438f), CLOUDS_LAYER_EAST);
+    check_str("layer: Denver (-105.0) -> East", clouds_layer(-105.0f), CLOUDS_LAYER_EAST);
+    check_str("layer: -106.2 exactly -> East", clouds_layer(-106.2f), CLOUDS_LAYER_EAST);
+    check_str("layer: -106.3 -> West", clouds_layer(-106.3f), CLOUDS_LAYER_WEST);
+    check_str("layer: Seattle (-122.3) -> West", clouds_layer(-122.33f), CLOUDS_LAYER_WEST);
+    check_str("layer: (0,0) -> East", clouds_layer(0.0f), CLOUDS_LAYER_EAST);
+
+    /* -- bbox -------------------------------------------------------------- */
+    {
+        const float lat = 38.758331f, lon = -90.689438f;
+        float minx, miny, maxx, maxy;
+        clouds_bbox(lat, lon, 7, &minx, &miny, &maxx, &maxy);
+        float cx = radar_wms_merc_x(lon), cy = radar_wms_merc_y(lat);
+        float half7 = 360.0f * 40075016.686f / (256.0f * 128.0f);
+        check_near("bbox z7: half-width", clouds_half_m(7), half7, 1.0f);
+        check_near("bbox z7: half-width ~440277 m", clouds_half_m(7), 440277.28f, 2.0f);
+        check_near("bbox z7: symmetric in x", (maxx - cx) - (cx - minx), 0.0f, 2.0f);
+        check_near("bbox z7: symmetric in y", (maxy - cy) - (cy - miny), 0.0f, 2.0f);
+        check_near("bbox z7: square", (maxx - minx) - (maxy - miny), 0.0f, 2.0f);
+        check_near("bbox z7: width = 2*half", maxx - minx, 2.0f * half7, 4.0f);
+        check_near("bbox z7: centre x", (minx + maxx) * 0.5f, cx, 2.0f);
+        check_near("bbox z7: centre y", (miny + maxy) * 0.5f, cy, 2.0f);
+        /* one zoom step halves the box; the clamp keeps 4 and 10 on the rails */
+        check_near("half z8 = half z7 / 2", clouds_half_m(8), half7 * 0.5f, 1.0f);
+        check_near("half z5 = half z7 * 4", clouds_half_m(5), half7 * 4.0f, 1.0f);
+        check_near("half z4 clamps to z5", clouds_half_m(4), clouds_half_m(5), 0.5f);
+        check_near("half z10 clamps to z9", clouds_half_m(10), clouds_half_m(9), 0.5f);
+        /* lat beyond +-85 is clamped inside merc_y, so no inf/nan */
+        clouds_bbox(89.0f, 0.0f, 7, &minx, &miny, &maxx, &maxy);
+        check_bool("bbox: lat 89 clamped (finite)", isfinite(miny) && isfinite(maxy), true);
+    }
+
+    /* -- GetMap URL -------------------------------------------------------- */
+    {
+        uint32_t stamp = 1787025600u;   /* 2026-08-18T04:00:00Z */
+        check_bool("url: builds", clouds_frame_url(url, sizeof(url), 38.758331f, -90.689438f, 7, stamp), true);
+        printf("    url=%s\n", url);
+        check_contains("url: https gibs host + epsg3857 endpoint", url,
+                       "https://gibs.earthdata.nasa.gov/wms/epsg3857/best/wms.cgi?", true);
+        check_contains("url: SERVICE/VERSION/REQUEST", url, "SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap", true);
+        check_contains("url: layers East + features", url,
+                       "&LAYERS=GOES-East_ABI_GeoColor,Reference_Features_15m&", true);
+        check_contains("url: never Reference_Labels", url, "Reference_Labels", false);
+        check_contains("url: CRS", url, "&CRS=EPSG:3857&", true);
+        check_contains("url: 720x720", url, "&WIDTH=720&HEIGHT=720&", true);
+        check_contains("url: jpeg", url, "&FORMAT=image/jpeg&", true);
+        check_contains("url: TIME :00Z", url, "&TIME=2026-08-18T04:00:00Z", true);
+        long a, b, c, d;
+        check_bool("url: bbox parses", url_bbox(url, &a, &b, &c, &d), true);
+        /* reference values from double maths; float-only merc is within a metre or two */
+        check_near("url: bbox minx", (float)a, -10535779.0f, 3.0f);
+        check_near("url: bbox miny", (float)b, 4246836.0f, 3.0f);
+        check_near("url: bbox maxx", (float)c, -9655225.0f, 3.0f);
+        check_near("url: bbox maxy", (float)d, 5127391.0f, 3.0f);
+        /* parameter order as the spec writes it */
+        long p_l = pos_of(url, "&LAYERS="), p_c = pos_of(url, "&CRS="), p_b = pos_of(url, "&BBOX="),
+             p_w = pos_of(url, "&WIDTH="), p_h = pos_of(url, "&HEIGHT="), p_f = pos_of(url, "&FORMAT="),
+             p_t = pos_of(url, "&TIME=");
+        check_bool("url: param order LAYERS<CRS<BBOX<WIDTH<HEIGHT<FORMAT<TIME",
+                   p_l >= 0 && p_l < p_c && p_c < p_b && p_b < p_w && p_w < p_h && p_h < p_f && p_f < p_t, true);
+        check_bool("url: TIME is last", url[strlen(url) - 1] == 'Z' && strstr(url, "&TIME=") + 6 + 20 == url + strlen(url), true);
+        /* West pick flows into the URL */
+        check_bool("url: Seattle builds", clouds_frame_url(url, sizeof(url), 47.6f, -122.33f, 6, stamp), true);
+        check_contains("url: Seattle uses West", url, "LAYERS=GOES-West_ABI_GeoColor,", true);
+        /* too small a buffer -> false and "" */
+        char tiny[64];
+        check_bool("url: tiny buffer fails", clouds_frame_url(tiny, sizeof(tiny), 1.0f, 2.0f, 7, stamp), false);
+        check_str("url: tiny buffer empty", tiny, "");
+    }
+
+    /* -- calendar / time --------------------------------------------------- */
+    {
+        check_int("days_from_civil 1970-01-01", (long)clouds_days_from_civil(1970, 1, 1), 0);
+        check_int("days_from_civil 2000-03-01", (long)clouds_days_from_civil(2000, 3, 1), 11017);
+        check_int("days_from_civil 2026-08-18", (long)clouds_days_from_civil(2026, 8, 18), 20683);
+        int y; unsigned m, d;
+        clouds_civil_from_days(20683, &y, &m, &d);
+        check_int("civil_from_days 20683 y", y, 2026);
+        check_int("civil_from_days 20683 m", m, 8);
+        check_int("civil_from_days 20683 d", d, 18);
+        clouds_civil_from_days(clouds_days_from_civil(2024, 2, 29), &y, &m, &d);
+        check_bool("leap day round trip", y == 2024 && m == 2 && d == 29, true);
+
+        check_bool("format 04:00", clouds_time_format(ts, sizeof(ts), 1787025600u), true);
+        check_str("format 2026-08-18T04:00:00Z", ts, "2026-08-18T04:00:00Z");
+        uint32_t t;
+        check_bool("parse 2026-08-18T04:00:00Z", clouds_time_parse("2026-08-18T04:00:00Z", 20, &t), true);
+        check_int("parse -> epoch", (long)t, 1787025600L);
+        check_bool("parse hh:mmZ form", clouds_time_parse("2026-08-18T04:00Z", 17, &t), true);
+        check_int("parse hh:mmZ -> epoch", (long)t, 1787025600L);
+        check_bool("parse bare date rejected", clouds_time_parse("2026-08-18", 10, &t), false);
+        check_bool("parse no Z rejected", clouds_time_parse("2026-08-18T04:00:00", 19, &t), false);
+        check_bool("parse trailing junk rejected", clouds_time_parse("2026-08-18T04:00:00Zx", 21, &t), false);
+        check_bool("parse garbage rejected", clouds_time_parse("garbage-in-here-nowZ", 20, &t), false);
+        check_bool("date parse 2026-08-18", clouds_date_parse("2026-08-18", 10, &t), true);
+        check_int("date parse -> midnight", (long)t, 20683L * 86400L);
+
+        /* stepping across midnight and a month boundary */
+        uint32_t t0;
+        clouds_time_parse("2026-09-01T00:00:00Z", 20, &t0);
+        clouds_time_format(ts, sizeof(ts), clouds_time_step(t0, 1));
+        check_str("step: 09-01 00:00 back 10 min = 08-31 23:50", ts, "2026-08-31T23:50:00Z");
+        clouds_time_format(ts, sizeof(ts), clouds_time_step(t0, 7));
+        check_str("step: back 70 min = 08-31 22:50", ts, "2026-08-31T22:50:00Z");
+        clouds_time_parse("2027-01-01T00:10:00Z", 20, &t0);
+        clouds_time_format(ts, sizeof(ts), clouds_time_step(t0, 2));
+        check_str("step: across the year = 2026-12-31 23:50", ts, "2026-12-31T23:50:00Z");
+        check_int("step: i=0 is identity", (long)clouds_time_step(t0, 0), (long)t0);
+        check_int("step: negative i is identity", (long)clouds_time_step(t0, -3), (long)t0);
+
+        /* fallback newest: floor to 10 min, minus 50 min */
+        clouds_time_parse("2026-08-18T04:17:33Z", 20, &t0);
+        clouds_time_format(ts, sizeof(ts), clouds_fallback_newest(t0));
+        check_str("fallback: 04:17:33 -> 03:20:00", ts, "2026-08-18T03:20:00Z");
+        clouds_time_parse("2026-08-18T00:05:00Z", 20, &t0);
+        clouds_time_format(ts, sizeof(ts), clouds_fallback_newest(t0));
+        check_str("fallback: 00:05 -> 23:10 previous day", ts, "2026-08-17T23:10:00Z");
+        check_int("floor_period exact", (long)clouds_floor_period(1787025600u), 1787025600L);
+        check_int("floor_period +599", (long)clouds_floor_period(1787025600u + 599u), 1787025600L);
+    }
+
+    /* -- DescribeDomains URL ---------------------------------------------- */
+    {
+        uint32_t now = 1787025600u + 150u;   /* 04:02:30Z */
+        check_bool("domains url builds", clouds_domains_url(url, sizeof(url), CLOUDS_LAYER_EAST, now), true);
+        printf("    url=%s\n", url);
+        check_str("domains url exact", url,
+                  "https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/1.0.0/GOES-East_ABI_GeoColor/default/1km/all/"
+                  "2026-08-18T01:02:30Z--2026-08-18T05:02:30Z.xml");
+        check_bool("domains url fits 160", strlen(url) < 160, true);
+        char small[100];
+        check_bool("domains url tiny fails", clouds_domains_url(small, sizeof(small), CLOUDS_LAYER_WEST, now), false);
+    }
+
+    /* -- DescribeDomains parser -------------------------------------------- */
+    {
+        int n = clouds_parse_domains(sample_domains, strlen(sample_domains), times, CLOUDS_TIMES_MAX);
+        check_int("domains: count (3+2+2, bare date skipped)", n, 7);
+        const char *expect[] = {
+            "2026-08-18T03:00:00Z", "2026-08-18T02:50:00Z", "2026-08-18T02:40:00Z",
+            "2026-08-18T02:20:00Z", "2026-08-18T02:10:00Z",
+            "2026-08-18T01:50:00Z", "2026-08-18T01:40:00Z",
+        };
+        for (int i = 0; i < n && i < 7; i++) {
+            char lbl[48];
+            snprintf(lbl, sizeof(lbl), "domains: times[%d]", i);
+            clouds_time_format(ts, sizeof(ts), times[i]);
+            check_str(lbl, ts, expect[i]);
+        }
+        /* cap */
+        n = clouds_parse_domains(sample_domains, strlen(sample_domains), times, 3);
+        check_int("domains: capped at 3", n, 3);
+        clouds_time_format(ts, sizeof(ts), times[2]);
+        check_str("domains: capped [2] = 02:40", ts, "2026-08-18T02:40:00Z");
+
+        /* the real East shape: one segment with a bare-date start */
+        const char east[] = "<Domain>2026-08-18/2026-08-18T03:50:00Z/PT10M</Domain>";
+        n = clouds_parse_domains(east, strlen(east), times, 4);
+        check_int("domains: bare-date start, 4 of many", n, 4);
+        clouds_time_format(ts, sizeof(ts), times[0]);
+        check_str("domains: newest 03:50", ts, "2026-08-18T03:50:00Z");
+        clouds_time_format(ts, sizeof(ts), times[3]);
+        check_str("domains: [3] = 03:20", ts, "2026-08-18T03:20:00Z");
+        /* bare-date start bounds the walk at midnight */
+        const char short_seg[] = "<Domain>2026-08-18/2026-08-18T00:10:00Z/PT10M</Domain>";
+        n = clouds_parse_domains(short_seg, strlen(short_seg), times, 10);
+        check_int("domains: midnight-bounded segment = 2", n, 2);
+        /* single instants and a non-default period */
+        const char singles[] = "<Domain>2026-08-18T01:00:00Z,2026-08-18T01:30:00Z/2026-08-18T02:30:00Z/PT30M</Domain>";
+        n = clouds_parse_domains(singles, strlen(singles), times, 10);
+        check_int("domains: single + PT30M range = 4", n, 4);
+        clouds_time_format(ts, sizeof(ts), times[1]);
+        check_str("domains: PT30M step [1] = 02:00", ts, "2026-08-18T02:00:00Z");
+        clouds_time_format(ts, sizeof(ts), times[3]);
+        check_str("domains: single last = 01:00", ts, "2026-08-18T01:00:00Z");
+        /* missing element / empty / bare-date only */
+        check_int("domains: no <Domain> = 0", clouds_parse_domains("<Domains></Domains>", 19, times, 10), 0);
+        check_int("domains: empty = 0", clouds_parse_domains("<Domain></Domain>", 17, times, 10), 0);
+        check_int("domains: bare date only = 0", clouds_parse_domains("<Domain>2026-08-18</Domain>", 27, times, 10), 0);
+        /* range whose end has no 'T' is skipped, the rest survives */
+        const char bad_end[] = "<Domain>2026-08-18T01:00:00Z/2026-08-18/PT10M,2026-08-18T02:00:00Z</Domain>";
+        n = clouds_parse_domains(bad_end, strlen(bad_end), times, 10);
+        check_int("domains: bad end skipped = 1", n, 1);
+        /* body without a NUL terminator: only len bytes are read */
+        char nonul[64];
+        memcpy(nonul, "<Domain>2026-08-18T05:00:00Z</Domain>XXXXXXXXXXXXXXXXXXXXXXXXXX", 64);
+        n = clouds_parse_domains(nonul, 37, times, 10);
+        check_int("domains: bounded by len", n, 1);
+    }
+
+    printf("\n%s (%d failures)\n", fails == 0 ? "ALL PASSED" : "FAILED", fails);
+    return fails == 0 ? 0 : 1;
+}


### PR DESCRIPTION
### Summary
This PR adds a new animated cloud cover satellite page, allowing users to view GOES GeoColor loops from NASA GIBS data. It also optimizes screenshot generation to prevent memory issues and refactors animated image page polling for improved robustness.

### Changes
*   Add an animated cloud cover satellite page displaying GOES GeoColor loops from NASA GIBS WMS.
*   Introduce new configuration options for the cloud page, including `clouds_enabled`, `show_overlay`, `update_interval_s`, `frames`, and `zoom`.
*   Optimize screenshot generation by encoding directly from the LVGL buffer and resizing the JPEG output, preventing PSRAM allocation failures.
*   Generalize the animated image frame ring to per-instance state shared across multiple animated pages.
*   Add a clock guard to image page polls, failing them before SNTP if the clock is not set to prevent blank frames.
*   Adjust page indices for existing pages like JSON, HA, OctoPrint, and Settings to accommodate the new cloud page.
*   Add a new test suite for the cloud WMS functionality.
*   Update the web configuration UI and handlers to manage settings for the new cloud page.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-18T13:13:01.951Z | Generated by GitHub Actions</sub>