### PR TITLE
ci(host-tests): cap cppcheck install at 5 min, skip apt update unless…

### DIFF
--- a/.github/workflows/host-tests.yml
+++ b/.github/workflows/host-tests.yml
@@ -38,7 +38,8 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install cppcheck
-        run: sudo apt-get update && sudo apt-get install -y cppcheck
+        timeout-minutes: 5
+        run: sudo apt-get install -y --no-install-recommends cppcheck || (sudo apt-get update && sudo apt-get install -y --no-install-recommends cppcheck)
 
       - name: Run cppcheck against firmware sources
         run: |


### PR DESCRIPTION
… needed

apt-get update hung ~30 min on the runner's Azure mirror outage (run 32209947484). Install from the image's lists first, refresh only on a miss.