### PR TITLE
feat: redesign ADSB Radar Scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ Setup: Pages > Solar.
 
 Full-screen JPEG fetched from any URL you supply, for example a webcam or a weather map. JPEG only, up to 1024x1024 pixels and 1 MB; PNG and WebP are not supported. A source behind a login can be reached by entering one request header line, such as `Authorization: Bearer <token>` or `X-Api-Key: <key>`; the value is stored on the device and shown masked in the web UI.
 
-Setup: Pages > Custom URL.
+Setup: Pages > Custom Image.
 
 ---
 
@@ -337,13 +337,13 @@ Each layout can show the printer camera instead of the slicer preview. On the Fl
 
 ### ADS-B
 
-Shows the aircraft your own ADS-B receiver is hearing, with the direction each connected NINA mount is pointing marked on the same picture. Data comes from a tar1090 or readsb receiver on your network; nothing is fetched from an internet flight-tracking service.
+Shows the aircraft your own ADS-B receiver is hearing, with the direction each connected NINA mount is pointing marked on the same picture. Data comes from a tar1090 or readsb receiver on your network. Aircraft positions never leave your network; the only optional internet lookup is the origin-destination route for each callsign (Route lookup toggle, on by default).
 
 Three views, cycled by tapping the page: Sky Dome draws the sky as seen looking up, with the middle of the circle directly overhead and the rim at the horizon; Radar Scope draws a flat map by distance out to a chosen range; Board is a text list of the nearest aircraft. The three nearest to a mount get a callsign and altitude tag. Aircraft are colored by altitude, military contacts are drawn as squares, and an emergency squawk gets a red halo. An elevation setting hides aircraft low on the horizon, where they are behind buildings and trees anyway; those are still counted.
 
 Dragging on the Sky Dome or Radar Scope turns the whole picture so a chosen compass direction sits at the top, which lets the screen match the view out of a window. The turn is saved, and the web field and the drag stay in step.
 
-Setup: Pages > ADS-B (receiver address such as `http://kmoofall.lan:8080`, refresh, range, minimum elevation, up direction, view).
+Setup: Pages > ADS-B (receiver address such as `http://kmoofall.lan:8080`, refresh, range, minimum elevation, up direction, view, Radar Scope labels: all aircraft, up to a number, or none).
 
 ---
 
@@ -369,7 +369,7 @@ Swipe left or right to change pages, or press the BOOT button on the board to ad
 The display picks a page on its own; a swipe or tap takes over for a configurable time (default 10 s), after which it returns to its automatic choice. Device > Behavior > Page Navigation holds the controls:
 
 - Home Page: the page the display settles on when nothing else applies. When it is a NINA instance, the display also returns there whenever that instance is online; with several online and the Home instance not among them, it shows the Summary page. An option keeps the Home Page on screen even while instances are connected.
-- Auto Cycle: rotate through a chosen, ordered list of pages on an interval with an instant, fade or slide transition, optionally skipping disconnected instances. The downloading image pages (GOES, Solar, Custom URL, Radar and Cloud Cover) fetch a fresh picture each time the rotation reaches them.
+- Auto Cycle: rotate through a chosen, ordered list of pages on an interval with an instant, fade or slide transition, optionally skipping disconnected instances. The downloading image pages (GOES, Solar, Custom Image, Radar and Cloud Cover) fetch a fresh picture each time the rotation reaches them.
 - Switch page when no connections: show a chosen page while every enabled NINA instance is disconnected.
 
 The web Home page and the API can also send the display to any page; see [Web API](#web-api).
@@ -401,7 +401,7 @@ Custom voice clips: Device > Voice Clips lets you replace any of the 47 built-in
 
 ## Web UI
 
-Open the device's address in a browser. The Home page shows device health at a glance, explains why the panel is on its current page, lists NINA connections and integrations, and lets you send the panel to any enabled page with one tap. Every setting is managed from `/config`, organized into three sections: Pages (N.I.N.A., AllSky, JSON, Home Assistant, Clock, Spotify, GOES, Moon, Solar, Custom URL, Radar, Cloud Cover, OctoPrint, ADS-B), Device (Display, Behavior, Voice Clips, System) and Tools (Logs, Backup, API). Most settings cards carry an info button that explains what those settings do. Changes apply to the display as a live preview and persist when you select Save.
+Open the device's address in a browser. The Home page shows device health at a glance, explains why the panel is on its current page, lists NINA connections and integrations, and lets you send the panel to any enabled page with one tap. Every setting is managed from `/config`, organized into three sections: Pages (N.I.N.A., AllSky, JSON, Home Assistant, Clock, Spotify, GOES, Moon, Solar, Custom Image, Radar, Cloud Cover, OctoPrint, ADS-B), Device (Display, Behavior, Voice Clips, System) and Tools (Logs, Backup, API). Most settings cards carry an info button that explains what those settings do. Changes apply to the display as a live preview and persist when you select Save.
 
 <p align="center">
   <img src="images/web_home.jpg" alt="Web UI home page" width="720">

--- a/main/adsb_client.c
+++ b/main/adsb_client.c
@@ -77,6 +77,15 @@ static bool  s_rx_valid = false;
 /* Set by adsb_client_note_config_change(), consumed at the top of a poll. */
 static _Atomic bool s_cfg_dirty = false;
 
+/* Receiver message-rate state: aircraft.json's top-level `messages` counter
+ * from the previous successful poll and when it was read. Only the poll task
+ * touches these. The counter is read as a double (it outgrows int32 in days)
+ * and kept as uint64_t; a value below the previous one means the receiver
+ * restarted, so the delta is dropped and the baseline re-armed. */
+static bool     s_msg_have_prev = false;
+static uint64_t s_msg_prev = 0;
+static int64_t  s_msg_prev_ms = 0;
+
 /* Route cache, poll-task-only (PSRAM). fetched_ms == 0 marks a free slot. */
 typedef struct {
     int64_t fetched_ms;      /**< when this callsign was last asked about */
@@ -114,8 +123,8 @@ static void  parse_one(const cJSON *item, adsb_ac_t *a, float min_el,
 static bool  better_than(const adsb_ac_t *a, const adsb_ac_t *b);
 static void  rank_contacts(adsb_data_t *d);
 static adsb_track_t *track_for(const char *hex, int64_t now_ms);
-static void  track_sample(adsb_track_t *tr, const adsb_ac_t *a, int32_t now_s);
-static void  track_expire(adsb_track_t *tr, int32_t now_s);
+static void  track_sample(adsb_track_t *tr, const adsb_ac_t *a, int32_t now_s, int32_t window_s);
+static void  track_expire(adsb_track_t *tr, int32_t now_s, int32_t window_s);
 static void  trail_update(adsb_data_t *d);
 static adsb_route_entry_t *route_cache_find(const char *cs);
 static adsb_route_entry_t *route_cache_slot(const char *cs, int64_t now);
@@ -442,11 +451,17 @@ static adsb_track_t *track_for(const char *hex, int64_t now_ms)
  * sample is only taken when the position actually moved -- or once every 10 s
  * regardless, which keeps a stationary contact's trail alive rather than
  * letting it age out and reappear as a jump. */
-static void track_sample(adsb_track_t *tr, const adsb_ac_t *a, int32_t now_s)
+static void track_sample(adsb_track_t *tr, const adsb_ac_t *a, int32_t now_s,
+                         int32_t window_s)
 {
     if (tr->n > 0) {
         bool moved = (a->lat != tr->last_lat) || (a->lon != tr->last_lon);
-        if (!moved && (now_s - tr->t_s[tr->n - 1]) < 10) return;
+        /* Space samples so the ring's slots cover the whole window (every
+         * poll at the 120 s baseline, every ~5 s at a 240 s window). */
+        int32_t min_gap = window_s / ADSB_TRAIL_MAX;
+        int32_t since   = now_s - tr->t_s[tr->n - 1];
+        if (since < min_gap) return;
+        if (!moved && since < 10) return;
     }
     if (tr->n >= ADSB_TRAIL_MAX) {
         memmove(&tr->pt[0], &tr->pt[1], (ADSB_TRAIL_MAX - 1) * sizeof(tr->pt[0]));
@@ -462,12 +477,12 @@ static void track_sample(adsb_track_t *tr, const adsb_ac_t *a, int32_t now_s)
     tr->last_lon = a->lon;
 }
 
-/* Drop samples older than ADSB_TRAIL_S. They are always at the head, so this is
+/* Drop samples older than the window. They are always at the head, so this is
  * one memmove and never a scan of the whole ring. */
-static void track_expire(adsb_track_t *tr, int32_t now_s)
+static void track_expire(adsb_track_t *tr, int32_t now_s, int32_t window_s)
 {
     int drop = 0;
-    while (drop < tr->n && (now_s - tr->t_s[drop]) > ADSB_TRAIL_S) drop++;
+    while (drop < tr->n && (now_s - tr->t_s[drop]) > window_s) drop++;
     if (drop == 0) return;
     tr->n = (uint8_t)(tr->n - drop);
     if (tr->n > 0) {
@@ -484,11 +499,21 @@ static void trail_update(adsb_data_t *d)
     int64_t now_ms = esp_timer_get_time() / 1000;
     int32_t now_s  = (int32_t)(now_ms / 1000);
 
+    /* The trail window scales with the configured range so a loop across the
+     * picture is about the same on-screen length at every range: 120 s at the
+     * 50 nm baseline, 240 s at 100 nm, clamped to [60, 600]. Sample spacing
+     * scales with it in track_sample so ADSB_TRAIL_MAX covers the window. */
+    int range = app_config_get()->flights_range_nm;
+    if (range < 10) range = 50;
+    int32_t window_s = (int32_t)ADSB_TRAIL_S * range / 50;
+    if (window_s < 60)  window_s = 60;
+    if (window_s > 600) window_s = 600;
+
     /* Recycle tracks whose aircraft has been gone longer than the trail window:
      * anything they still hold would have expired sample by sample anyway. */
     for (int i = 0; i < ADSB_MAX_AC; i++) {
         if (s_track[i].hex[0] != '\0' &&
-            (now_ms - s_track[i].seen_ms) > (int64_t)ADSB_TRAIL_S * 1000) {
+            (now_ms - s_track[i].seen_ms) > (int64_t)window_s * 1000) {
             s_track[i].hex[0] = '\0';
             s_track[i].n = 0;
         }
@@ -501,8 +526,8 @@ static void trail_update(adsb_data_t *d)
 
         adsb_track_t *tr = track_for(a->hex, now_ms);
         if (!tr) continue;
-        track_sample(tr, a, now_s);
-        track_expire(tr, now_s);
+        track_sample(tr, a, now_s, window_s);
+        track_expire(tr, now_s, window_s);
 
         if (tr->n > 0) {
             memcpy(d->trail[i], tr->pt, (size_t)tr->n * sizeof(adsb_trail_pt_t));
@@ -714,6 +739,7 @@ static bool adsb_poll_once(void *arg)
         /* The receiver reference may have moved, so every stored range/bearing
          * is now wrong: start the histories over rather than draw a kink. */
         if (s_track) memset(s_track, 0, ADSB_MAX_AC * sizeof(adsb_track_t));
+        s_msg_have_prev = false;   /* a different receiver has a different counter */
     }
 
     /* Receiver position: receiver.json, retried on every poll until it
@@ -754,6 +780,10 @@ static bool adsb_poll_once(void *arg)
         cJSON_Delete(root);
         goto fail;
     }
+    /* Top-level `messages`: readsb/tar1090 and dump1090 both publish it. */
+    const cJSON *msgs_j = cJSON_GetObjectItem(root, "messages");
+    bool have_msgs = cJSON_IsNumber(msgs_j) && msgs_j->valuedouble >= 0.0;
+    uint64_t msgs = have_msgs ? (uint64_t)msgs_j->valuedouble : 0;
 
     nina_pointing_t pts[MAX_NINA_INSTANCES];
     int npts = nina_client_get_pointings(pts, MAX_NINA_INSTANCES);
@@ -807,6 +837,23 @@ static bool adsb_poll_once(void *arg)
     d->ever_ok = true;
     d->last_ok_ms = d->now_ms;
     d->fail_count = 0;
+
+    /* Message rate: delta of the receiver's counter over the elapsed time.
+     * 0 until a baseline exists; a counter that went backwards (receiver
+     * restart) or a missing key re-arms the baseline instead of publishing
+     * a bogus burst. */
+    d->msg_rate = 0.0f;
+    if (have_msgs) {
+        int64_t dt_ms = d->now_ms - s_msg_prev_ms;
+        if (s_msg_have_prev && msgs >= s_msg_prev && dt_ms > 0) {
+            d->msg_rate = (float)(msgs - s_msg_prev) * 1000.0f / (float)dt_ms;
+        }
+        s_msg_prev = msgs;
+        s_msg_prev_ms = d->now_ms;
+        s_msg_have_prev = true;
+    } else {
+        s_msg_have_prev = false;
+    }
 
     /* Publish: swap the buffers, so the UI is never blocked behind a parse. */
     if (xSemaphoreTake(s_mux, portMAX_DELAY) == pdTRUE) {
@@ -863,6 +910,7 @@ static void adsb_poll_task(void *arg)
 {
     (void)arg;
     ESP_LOGI(TAG, "ADS-B poll task started");
+    s_msg_have_prev = false;   /* message-rate baseline starts fresh */
     poll_loop_spec_t spec = {
         .name = "adsb",
         .wifi_group = s_wifi_event_group,

--- a/main/adsb_client.c
+++ b/main/adsb_client.c
@@ -293,6 +293,7 @@ static void parse_one(const cJSON *item, adsb_ac_t *a, float min_el,
     str_of(item, "hex", a->hex, sizeof(a->hex));
     str_of(item, "flight", a->flight, sizeof(a->flight));
     str_of(item, "t", a->type, sizeof(a->type));
+    str_of(item, "category", a->cat, sizeof(a->cat));
     /* Aircraft-database extras (readsb serves these when it has a db loaded;
      * all three are simply absent on a bare dump1090 feed). */
     str_of(item, "r", a->reg, sizeof(a->reg));

--- a/main/adsb_client.h
+++ b/main/adsb_client.h
@@ -107,6 +107,12 @@ typedef struct {
     int       fail_count;
     bool      route_lookup_active; /**< mirrors flights_route_lookup so the UI can
                                      *  label "route unknown" vs "lookup off" */
+    float     msg_rate;         /**< receiver messages per second, from the delta
+                                  *  of aircraft.json's top-level `messages` counter
+                                  *  between consecutive successful polls. 0 until
+                                  *  two polls have been seen; resets on poller start
+                                  *  or when the counter goes backwards (receiver
+                                  *  restart). Unrounded: the UI formats it. */
 } adsb_data_t;
 
 /** Create the mutex and the PSRAM data block. Idempotent. */

--- a/main/adsb_client.h
+++ b/main/adsb_client.h
@@ -57,6 +57,7 @@ typedef struct {
     char     hex[8];
     char     flight[10];        /**< trimmed callsign, "" if none */
     char     type[6];           /**< readsb `t` */
+    char     cat[4];            /**< readsb `category` (A0-A7, B*, C*), "" if absent */
     float    lat, lon;          /**< valid iff has_pos */
     float    alt_ft;            /**< alt_geom else alt_baro; ground = 0 */
     bool     alt_is_geom;

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -892,7 +892,7 @@ static void set_defaults(app_config_t *cfg) {
     // v67 additions. Both are SETTINGS_TABLE rows, so settings_defaults_apply()
     // above already set them; restated here for the same reason the radar and
     // clouds blocks are, so every appended field's default reads in one place.
-    cfg->custom_image_header[0] = '\0';   // no extra header on the Custom URL fetch
+    cfg->custom_image_header[0] = '\0';   // no extra header on the Custom Image fetch
     cfg->clouds_channel = 0;               // GeoColor
 
     // v68 additions (ADS-B page). All seven are SETTINGS_TABLE rows, so
@@ -910,6 +910,9 @@ static void set_defaults(app_config_t *cfg) {
     // v69 addition (ADS-B route lookup). Also a SETTINGS_TABLE row; restated
     // here for the same reason as the block above.
     cfg->flights_route_lookup = true;   // look routes up online
+
+    // v70 addition (ADS-B Radar Scope label count). Also a SETTINGS_TABLE row.
+    cfg->flights_label_max = 64;        // 64 = label every drawn contact
 
     // Spotify client ID: secret-like sentinel, not table-driven
     cfg->spotify_client_id[0] = '\0';
@@ -2811,7 +2814,7 @@ static void migrate_from_v65(const void *raw, size_t raw_size, app_config_t *cfg
 }
 
 /* --- v66 -> v67 migration: appends custom_image_header (optional HTTP header
- *     for the Custom URL image fetch) and clouds_channel (Clouds page satellite
+ *     for the Custom Image fetch) and clouds_channel (Clouds page satellite
  *     channel). Additive and at the very end, so this stays a plain prefix
  *     memcpy like every migration around it. --- */
 static void migrate_from_v66(const void *raw, size_t raw_size, app_config_t *cfg)
@@ -2872,9 +2875,31 @@ static void migrate_from_v68(const void *raw, size_t raw_size, app_config_t *cfg
      * 4) still lands on it, so re-assert the default. Existing devices opt in
      * by default, matching a fresh install. */
     cfg->flights_route_lookup = true;
+    /* flights_label_max (v70) sits right after flights_route_lookup, inside
+     * that same tail padding, so re-assert it too. */
+    cfg->flights_label_max = 64;
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v68 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v69 -> v70 migration: appends flights_label_max, the Radar Scope's
+ *     contact-label count. Additive and at the very end, so this stays a
+ *     plain prefix memcpy like every migration around it. --- */
+static void migrate_from_v69(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v69_t) ? raw_size : sizeof(app_config_v69_t);
+    memcpy(cfg, raw, copy);
+
+    /* The field sits past the v69 snapshot, so memcpy(copy) never touches it on
+     * purpose; the snapshot's tail padding (it ends on a bool but aligns to 4)
+     * still lands on it, so re-assert the default: label every drawn contact,
+     * matching a fresh install. */
+    cfg->flights_label_max = 64;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v69 to v%d", APP_CONFIG_VERSION);
 }
 
 
@@ -3668,6 +3693,13 @@ static bool validate_config(app_config_t *cfg) {
      * validate_url_format() enforces on the web save path. */
     cfg->flights_enabled = cfg->flights_enabled ? true : false;
     cfg->flights_route_lookup = cfg->flights_route_lookup ? true : false;
+    /* flights_label_max (v70) is a SETTINGS_TABLE INT_RESET row (0-64), so
+     * settings_clamp_apply() already reset a stale byte above 64 to the
+     * default. Belt and braces: pin the ceiling explicitly too. */
+    if (cfg->flights_label_max > 64) {   /* 64 == ADSB_MAX_AC (adsb_client.h) */
+        cfg->flights_label_max = 64;
+        fixed = true;
+    }
     if (cfg->flights_url[0] != '\0' &&
         strncmp(cfg->flights_url, "http://", 7) != 0 &&
         strncmp(cfg->flights_url, "https://", 8) != 0) {
@@ -3767,6 +3799,17 @@ void app_config_init(void) {
             nvs_commit(handle);
         }
         /* tiles_loaded stays false -> tail loads "json_tiles"/"ha_tiles" keys */
+    } else if (version_check == 69) {
+        /* v69 -> v70: appended flights_label_max (ADS-B Radar Scope labels).
+         * tiles_loaded stays false: a v69 device already keeps its tiles in
+         * the "json_tiles"/"ha_tiles" NVS keys, so the tail loads them.
+         * Safe to write back immediately, same reasoning as the v68 branch:
+         * both dispatcher-tail fixups below are excluded by their literal
+         * version bounds. */
+        migrate_from_v69(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 68) {
         /* v68 -> v69: appended flights_route_lookup (ADS-B route lookup).
          * tiles_loaded stays false: a v68 device already keeps its tiles in

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -914,6 +914,9 @@ static void set_defaults(app_config_t *cfg) {
     // v70 addition (ADS-B Radar Scope label count). Also a SETTINGS_TABLE row.
     cfg->flights_label_max = 64;        // 64 = label every drawn contact
 
+    // v71 addition (ADS-B Radar Scope icon style). Also a SETTINGS_TABLE row.
+    cfg->flights_icon_style = 0;        // 0 = classic arrows
+
     // Spotify client ID: secret-like sentinel, not table-driven
     cfg->spotify_client_id[0] = '\0';
 
@@ -2875,9 +2878,11 @@ static void migrate_from_v68(const void *raw, size_t raw_size, app_config_t *cfg
      * 4) still lands on it, so re-assert the default. Existing devices opt in
      * by default, matching a fresh install. */
     cfg->flights_route_lookup = true;
-    /* flights_label_max (v70) sits right after flights_route_lookup, inside
-     * that same tail padding, so re-assert it too. */
+    /* flights_label_max (v70) and flights_icon_style (v71) sit right after
+     * flights_route_lookup, inside that same tail padding, so re-assert
+     * them too. */
     cfg->flights_label_max = 64;
+    cfg->flights_icon_style = 0;
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v68 to v%d", APP_CONFIG_VERSION);
@@ -2897,9 +2902,32 @@ static void migrate_from_v69(const void *raw, size_t raw_size, app_config_t *cfg
      * still lands on it, so re-assert the default: label every drawn contact,
      * matching a fresh install. */
     cfg->flights_label_max = 64;
+    /* flights_icon_style (v71) sits right after flights_label_max, inside
+     * that same tail padding, so re-assert it too. */
+    cfg->flights_icon_style = 0;
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v69 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v70 -> v71 migration: appends flights_icon_style, the Radar Scope's
+ *     contact-glyph choice (arrows or aircraft silhouettes). Additive and at
+ *     the very end, so this stays a plain prefix memcpy like every migration
+ *     around it. --- */
+static void migrate_from_v70(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v70_t) ? raw_size : sizeof(app_config_v70_t);
+    memcpy(cfg, raw, copy);
+
+    /* The field sits past the v70 snapshot, so memcpy(copy) never touches it on
+     * purpose; the snapshot's tail padding (it ends on a uint8_t but aligns to
+     * 4) still lands on it, so re-assert the default: classic arrows, matching
+     * a fresh install. */
+    cfg->flights_icon_style = 0;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v70 to v%d", APP_CONFIG_VERSION);
 }
 
 
@@ -3700,6 +3728,13 @@ static bool validate_config(app_config_t *cfg) {
         cfg->flights_label_max = 64;
         fixed = true;
     }
+    /* flights_icon_style (v71) is a SETTINGS_TABLE INT_RESET row (0-1), so
+     * settings_clamp_apply() already reset a stale byte above 1 to the
+     * default. Belt and braces: an unknown style falls back to arrows. */
+    if (cfg->flights_icon_style > 1) {
+        cfg->flights_icon_style = 0;
+        fixed = true;
+    }
     if (cfg->flights_url[0] != '\0' &&
         strncmp(cfg->flights_url, "http://", 7) != 0 &&
         strncmp(cfg->flights_url, "https://", 8) != 0) {
@@ -3799,6 +3834,17 @@ void app_config_init(void) {
             nvs_commit(handle);
         }
         /* tiles_loaded stays false -> tail loads "json_tiles"/"ha_tiles" keys */
+    } else if (version_check == 70) {
+        /* v70 -> v71: appended flights_icon_style (ADS-B Radar Scope glyph).
+         * tiles_loaded stays false: a v70 device already keeps its tiles in
+         * the "json_tiles"/"ha_tiles" NVS keys, so the tail loads them.
+         * Safe to write back immediately, same reasoning as the v69 branch:
+         * both dispatcher-tail fixups below are excluded by their literal
+         * version bounds. */
+        migrate_from_v70(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 69) {
         /* v69 -> v70: appended flights_label_max (ADS-B Radar Scope labels).
          * tiles_loaded stays false: a v69 device already keeps its tiles in

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -83,7 +83,7 @@ extern "C" {
 #define ARP_ORDER_CAPACITY_RETIRED 16
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 70
+#define APP_CONFIG_VERSION 71
 
 /* Tiles-config blobs no longer live inside app_config_t (v52 split them out to
  * dedicated NVS string keys "json_tiles"/"ha_tiles"). These bound the value
@@ -519,6 +519,11 @@ typedef struct {
     uint8_t  flights_label_max;        // how many Radar Scope contacts get a text label:
                                        // 0 = none, 1..63 = at most N, nearest first,
                                        // 64 (= ADSB_MAX_AC) = all drawn contacts. Default 64.
+
+    // Added after v70 (ADS-B Radar Scope icon style) — must stay at end to preserve NVS binary compatibility
+    uint8_t  flights_icon_style;       // Radar Scope contact glyph: 0 = classic arrows
+                                       // (default), 1 = aircraft silhouettes. Values
+                                       // above 1 fall back to 0.
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -4666,6 +4671,206 @@ _Static_assert(offsetof(app_config_t, flights_label_max) ==
  * it must never exceed the destination. */
 _Static_assert(sizeof(app_config_v69_t) <= sizeof(app_config_t),
                "v69 snapshot must not exceed the current config struct");
+
+/* ── Version 70 config struct — used only for NVS migration to v71 ────── */
+/* Byte-identical to app_config_t minus the trailing flights_icon_style    */
+/* field v71 appended. Same body as the v69 snapshot plus the              */
+/* flights_label_max uint8_t v70 added at the end.                         */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+    char     custom_image_url[256];
+    uint8_t  custom_orientation;
+    uint16_t custom_update_interval_s;
+    uint8_t  auto_rotate_order2_retired[16];   /* the RETIRED mid-struct array,
+                                        * named exactly as the live struct
+                                        * names it — see the note there */
+    uint8_t  goes_vflip;
+    uint8_t  goes_hflip;
+    uint8_t  solar_vflip;
+    uint8_t  solar_hflip;
+    uint8_t  custom_vflip;
+    uint8_t  custom_hflip;
+    bool     home_page_lock;
+    bool     json_enabled;
+    char     json_url[256];
+    char     json_auth_header[256];
+    uint16_t json_update_interval_s;
+    bool     ha_enabled;
+    char     ha_base_url[256];
+    char     ha_token[256];
+    uint16_t ha_update_interval_s;
+    bool     setup_hint_dismissed;
+    uint8_t  alert_voice_enabled;
+    uint8_t  alert_voice_volume;
+    uint8_t  alert_voice_types;
+    uint8_t  alert_voice_repeat_min;
+    bool     alert_voice_muted[3];
+    uint32_t voice_notify_mask;
+    uint8_t  boot_jingle_enabled;
+    uint8_t  alert_voice_brief;
+    uint8_t  alert_voice_conn;
+    uint8_t  alert_voice_disc;
+    uint8_t  wifi_max_tx_dbm;
+    uint8_t  octoprint_enabled;
+    char     octoprint_url[128];
+    char     octoprint_api_key[64];
+    uint16_t octoprint_update_interval_s;
+    uint8_t  octoprint_image_source;
+    uint8_t  octoprint_layout;
+    char     octoprint_snapshot_url[128];
+    bool     goes_enabled;
+    bool     moon_enabled;
+    bool     solar_enabled;
+    bool     custom_enabled;
+    uint16_t solar_update_interval_s;
+    uint16_t moon_update_interval_s;
+    bool     goes_crop;
+    bool     solar_crop;
+    bool     custom_crop;
+    bool     goes_show_overlay;
+    bool     moon_show_overlay;
+    bool     solar_show_overlay;
+    bool     custom_show_overlay;
+    bool     octoprint_overlay_visible;
+    bool     radar_enabled;
+    char     radar_token[16];
+    uint16_t radar_update_interval_s;
+    bool     radar_show_overlay;
+    uint8_t  radar_crop;
+    uint8_t  radar_frames;
+    uint8_t  auto_rotate_order2[ARP_ORDER_CAPACITY];
+    bool     radar_dark_mode;
+    uint8_t  radar_map_style;
+    bool     clouds_enabled;
+    bool     clouds_show_overlay;
+    uint16_t clouds_update_interval_s;
+    uint8_t  clouds_frames;
+    uint8_t  clouds_zoom;
+    char     custom_image_header[256];
+    uint8_t  clouds_channel;
+    bool     flights_enabled;
+    char     flights_url[128];
+    uint16_t flights_update_interval_s;
+    uint16_t flights_range_nm;
+    uint8_t  flights_min_el;
+    uint16_t flights_up_azimuth;
+    uint8_t  flights_mode;
+    bool     flights_route_lookup;
+    uint8_t  flights_label_max;
+} app_config_v70_t;
+
+/* flights_icon_style (uint8_t, align 1) appends directly after
+ * flights_label_max (uint8_t, align 1), so no alignment padding can sit
+ * between them. Nothing moved in v71 — the field is a pure append — so this
+ * is the plain end-of-last-field equality the v62..v69 asserts use. */
+_Static_assert(offsetof(app_config_t, flights_icon_style) ==
+                   offsetof(app_config_v70_t, flights_label_max) +
+                       sizeof(((app_config_v70_t *)0)->flights_label_max),
+               "app_config_v70_t snapshot drifted from app_config_t layout");
+
+/* migrate_from_v70 memcpy's sizeof(app_config_v70_t) bytes into app_config_t;
+ * it must never exceed the destination. */
+_Static_assert(sizeof(app_config_v70_t) <= sizeof(app_config_t),
+               "v70 snapshot must not exceed the current config struct");
 
 
 

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -83,7 +83,7 @@ extern "C" {
 #define ARP_ORDER_CAPACITY_RETIRED 16
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 69
+#define APP_CONFIG_VERSION 70
 
 /* Tiles-config blobs no longer live inside app_config_t (v52 split them out to
  * dedicated NVS string keys "json_tiles"/"ha_tiles"). These bound the value
@@ -398,7 +398,7 @@ typedef struct {
     bool     goes_enabled;             // GOES Satellite page (default false; migrated = image_display_enabled)
     bool     moon_enabled;             // Moon page (default false; migrated = image_display_enabled)
     bool     solar_enabled;            // Solar page (default false; migrated = image_display_enabled)
-    bool     custom_enabled;           // Custom URL page (default false; migrated = image_display_enabled);
+    bool     custom_enabled;           // Custom Image page (default false; migrated = image_display_enabled);
                                        // availability additionally needs custom_image_url non-empty
     uint16_t solar_update_interval_s;  // Solar poll interval 300-7200 s (default 600; migrated = goes_update_interval_s)
     uint16_t moon_update_interval_s;   // Moon re-render cadence 10-3600 s (default 60)
@@ -491,7 +491,7 @@ typedef struct {
 
     // Added after v66 — must stay at end to preserve NVS binary compatibility
     char     custom_image_header[256]; // optional raw "Name: value" header sent with the
-                                       // Custom URL image fetch ("" = none). Same shape and
+                                       // Custom Image fetch ("" = none). Same shape and
                                        // size as json_auth_header; a stored SECRET, so it is
                                        // redacted on GET /api/config and preserved on a
                                        // "********" POST (see web_handlers_config.c).
@@ -514,6 +514,11 @@ typedef struct {
     // Added after v68 (ADS-B route lookup) — must stay at end to preserve NVS binary compatibility
     bool     flights_route_lookup;     // default true: look up flight routes
                                        // (origin-destination) online for the ADS-B page
+
+    // Added after v69 (ADS-B Radar Scope labels) — must stay at end to preserve NVS binary compatibility
+    uint8_t  flights_label_max;        // how many Radar Scope contacts get a text label:
+                                       // 0 = none, 1..63 = at most N, nearest first,
+                                       // 64 (= ADSB_MAX_AC) = all drawn contacts. Default 64.
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -4462,6 +4467,205 @@ _Static_assert(offsetof(app_config_t, flights_route_lookup) ==
  * it must never exceed the destination. */
 _Static_assert(sizeof(app_config_v68_t) <= sizeof(app_config_t),
                "v68 snapshot must not exceed the current config struct");
+
+/* ── Version 69 config struct — used only for NVS migration to v70 ────── */
+/* Byte-identical to app_config_t minus the trailing flights_label_max     */
+/* field v70 appended. Same body as the v68 snapshot plus the              */
+/* flights_route_lookup bool v69 added at the end.                         */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+    char     custom_image_url[256];
+    uint8_t  custom_orientation;
+    uint16_t custom_update_interval_s;
+    uint8_t  auto_rotate_order2_retired[16];   /* the RETIRED mid-struct array,
+                                        * named exactly as the live struct
+                                        * names it — see the note there */
+    uint8_t  goes_vflip;
+    uint8_t  goes_hflip;
+    uint8_t  solar_vflip;
+    uint8_t  solar_hflip;
+    uint8_t  custom_vflip;
+    uint8_t  custom_hflip;
+    bool     home_page_lock;
+    bool     json_enabled;
+    char     json_url[256];
+    char     json_auth_header[256];
+    uint16_t json_update_interval_s;
+    bool     ha_enabled;
+    char     ha_base_url[256];
+    char     ha_token[256];
+    uint16_t ha_update_interval_s;
+    bool     setup_hint_dismissed;
+    uint8_t  alert_voice_enabled;
+    uint8_t  alert_voice_volume;
+    uint8_t  alert_voice_types;
+    uint8_t  alert_voice_repeat_min;
+    bool     alert_voice_muted[3];
+    uint32_t voice_notify_mask;
+    uint8_t  boot_jingle_enabled;
+    uint8_t  alert_voice_brief;
+    uint8_t  alert_voice_conn;
+    uint8_t  alert_voice_disc;
+    uint8_t  wifi_max_tx_dbm;
+    uint8_t  octoprint_enabled;
+    char     octoprint_url[128];
+    char     octoprint_api_key[64];
+    uint16_t octoprint_update_interval_s;
+    uint8_t  octoprint_image_source;
+    uint8_t  octoprint_layout;
+    char     octoprint_snapshot_url[128];
+    bool     goes_enabled;
+    bool     moon_enabled;
+    bool     solar_enabled;
+    bool     custom_enabled;
+    uint16_t solar_update_interval_s;
+    uint16_t moon_update_interval_s;
+    bool     goes_crop;
+    bool     solar_crop;
+    bool     custom_crop;
+    bool     goes_show_overlay;
+    bool     moon_show_overlay;
+    bool     solar_show_overlay;
+    bool     custom_show_overlay;
+    bool     octoprint_overlay_visible;
+    bool     radar_enabled;
+    char     radar_token[16];
+    uint16_t radar_update_interval_s;
+    bool     radar_show_overlay;
+    uint8_t  radar_crop;
+    uint8_t  radar_frames;
+    uint8_t  auto_rotate_order2[ARP_ORDER_CAPACITY];
+    bool     radar_dark_mode;
+    uint8_t  radar_map_style;
+    bool     clouds_enabled;
+    bool     clouds_show_overlay;
+    uint16_t clouds_update_interval_s;
+    uint8_t  clouds_frames;
+    uint8_t  clouds_zoom;
+    char     custom_image_header[256];
+    uint8_t  clouds_channel;
+    bool     flights_enabled;
+    char     flights_url[128];
+    uint16_t flights_update_interval_s;
+    uint16_t flights_range_nm;
+    uint8_t  flights_min_el;
+    uint16_t flights_up_azimuth;
+    uint8_t  flights_mode;
+    bool     flights_route_lookup;
+} app_config_v69_t;
+
+/* flights_label_max (uint8_t, align 1) appends directly after
+ * flights_route_lookup (bool, align 1), so no alignment padding can sit
+ * between them. Nothing moved in v70 — the field is a pure append — so this
+ * is the plain end-of-last-field equality the v62..v68 asserts use. */
+_Static_assert(offsetof(app_config_t, flights_label_max) ==
+                   offsetof(app_config_v69_t, flights_route_lookup) +
+                       sizeof(((app_config_v69_t *)0)->flights_route_lookup),
+               "app_config_v69_t snapshot drifted from app_config_t layout");
+
+/* migrate_from_v69 memcpy's sizeof(app_config_v69_t) bytes into app_config_t;
+ * it must never exceed the destination. */
+_Static_assert(sizeof(app_config_v69_t) <= sizeof(app_config_t),
+               "v69 snapshot must not exceed the current config struct");
 
 
 

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1869,6 +1869,10 @@
     let _currentTab=null;
     async function switchTab(name){
       _currentTab=name;
+      /* Keep the URL in step with the visible tab so a reload (or a copied
+         link) lands back here, not on whatever hash the page arrived with.
+         replaceState: no history entry per tab, no hashchange feedback loop. */
+      try{ if(location.hash!=='#'+name) history.replaceState(null,'','#'+name); }catch(e){}
       $$('.tab-panel').forEach(p=>p.classList.remove('active'));
       $$('.tab-btn').forEach(b=>b.classList.remove('active'));
       var panel=$('tab-'+name);
@@ -2665,6 +2669,9 @@
        There is no whole-form fallback: with no baseline we post only the
        explicitly touched keys. */
     const _touched=new Set();
+    /* Form snapshot at the last user edit; markTouched() diffs against it to
+       map edits to real config keys. null = re-seed from loadedConfig. */
+    var _prevSnap=null;
     function touchedPayload(data){
       var base=null;
       try{ if(loadedConfig) base=JSON.parse(loadedConfig); }catch(e){}
@@ -3193,6 +3200,7 @@
       else cfgOverlay('hide');
 
       loadedConfig=JSON.stringify(getConfigData());
+      _prevSnap=null;  /* re-seed the markTouched diff from the fresh baseline */
       _populating=false;
       /* The device holding an unsaved live-applied change raises the Save bar
          (see checkDirty) but must NOT widen the POST body: dropping the
@@ -4263,6 +4271,23 @@
       if(c){
         c.getAttribute('data-cfg-key').split(/\s+/).forEach(function(k){ if(k) _touched.add(k); });
       }
+      /* Some control ids are not config keys (flights_label_mode feeds
+         flights_label_max) and carry no data-cfg-key. Diff this event's
+         collected form against the previous event's snapshot and record the
+         REAL keys that moved, so a value the user sets BACK to the baseline
+         still rides touchedPayload out -- otherwise the live-applied preview
+         stays on the device while the save bar retracts. Keys absent from the
+         previous snapshot (fragment loaded since) are skipped: their first
+         edit diffs against the baseline anyway. */
+      var data=getConfigData();
+      var prev=_prevSnap;
+      if(!prev&&loadedConfig){ try{ prev=JSON.parse(loadedConfig); }catch(e2){} }
+      if(prev){
+        Object.keys(data).forEach(function(k){
+          if(k in prev && JSON.stringify(data[k])!==JSON.stringify(prev[k])) _touched.add(k);
+        });
+      }
+      _prevSnap=data;
     }
     document.querySelector('.content').addEventListener('input',(e)=>{if(isNonSettingTarget(e))return;markTouched(e);checkDirty();liveApply();});
     document.querySelector('.content').addEventListener('change',(e)=>{if(isNonSettingTarget(e))return;markTouched(e);checkDirty();liveApply();});

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -2461,6 +2461,7 @@
       var up=parseInt($('flights_up_azimuth').value,10);
       data.flights_up_azimuth=isNaN(up)?0:up;
       data.flights_mode=parseInt($('flights_mode').value,10)||0;
+      data.flights_icon_style=parseInt($('flights_icon_style').value,10)||0;
       data.flights_route_lookup=!!$('flights_route_lookup').checked;
       /* Radar Scope label count: mode select + number box fold into one
          0-64 value (0 = none, 64 = all, else up to N). */
@@ -2941,6 +2942,7 @@
       if($('flights_min_el')) $('flights_min_el').value=data.flights_min_el!=null?data.flights_min_el:10;
       if($('flights_up_azimuth')) $('flights_up_azimuth').value=data.flights_up_azimuth!=null?data.flights_up_azimuth:0;
       if($('flights_mode')) $('flights_mode').value=String(data.flights_mode||0);
+      if($('flights_icon_style')) $('flights_icon_style').value=String(data.flights_icon_style||0);
       /* Default is on, so an absent key must read as checked, not unchecked. */
       if($('flights_route_lookup')) $('flights_route_lookup').checked=data.flights_route_lookup!=null?!!data.flights_route_lookup:true;
       /* Default is 64 (all), so an absent key must read as "All aircraft". */

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -1040,7 +1040,7 @@
         <button class="tab-btn" data-tab="image-goes">GOES</button>
         <button class="tab-btn" data-tab="image-moon">Moon</button>
         <button class="tab-btn" data-tab="image-solar">Solar</button>
-        <button class="tab-btn" data-tab="image-custom">Custom URL</button>
+        <button class="tab-btn" data-tab="image-custom">Custom Image</button>
         <button class="tab-btn" data-tab="image-radar">Radar</button>
         <button class="tab-btn" data-tab="image-clouds">Cloud Cover</button>
         <button class="tab-btn" data-tab="octoprint">OctoPrint</button>
@@ -2458,6 +2458,16 @@
       data.flights_up_azimuth=isNaN(up)?0:up;
       data.flights_mode=parseInt($('flights_mode').value,10)||0;
       data.flights_route_lookup=!!$('flights_route_lookup').checked;
+      /* Radar Scope label count: mode select + number box fold into one
+         0-64 value (0 = none, 64 = all, else up to N). */
+      var lm=$('flights_label_mode')?$('flights_label_mode').value:'all';
+      if(lm==='none') data.flights_label_max=0;
+      else if(lm==='max'){
+        var ln=parseInt($('flights_label_n')?$('flights_label_n').value:'',10);
+        if(isNaN(ln)||ln<1) ln=10;
+        if(ln>63) ln=63;
+        data.flights_label_max=ln;
+      } else data.flights_label_max=64;
     }
 
     function collectTab_display(data){
@@ -2926,6 +2936,14 @@
       if($('flights_mode')) $('flights_mode').value=String(data.flights_mode||0);
       /* Default is on, so an absent key must read as checked, not unchecked. */
       if($('flights_route_lookup')) $('flights_route_lookup').checked=data.flights_route_lookup!=null?!!data.flights_route_lookup:true;
+      /* Default is 64 (all), so an absent key must read as "All aircraft". */
+      if($('flights_label_mode')){
+        var lmax=data.flights_label_max!=null?parseInt(data.flights_label_max,10):64;
+        if(isNaN(lmax)) lmax=64;
+        $('flights_label_mode').value=(lmax<=0)?'none':(lmax>=64?'all':'max');
+        if($('flights_label_n')) $('flights_label_n').value=(lmax>0&&lmax<64)?lmax:10;
+        if(typeof window.adsbLabelModeSync==='function') window.adsbLabelModeSync();
+      }
       /* Turn the compass preview to the value just loaded. Published by the
          fragment's own script, which runs before this hook. */
       if(typeof window.adsbDrawCompass==='function') window.adsbDrawCompass();

--- a/main/fragment_adsb.html
+++ b/main/fragment_adsb.html
@@ -51,6 +51,18 @@
             <div class="field-hint">How the aircraft are drawn; a tap on the device cycles through the same three.</div>
           </div>
           <div class="field">
+            <label class="field-label" for="flights_label_mode">Radar Scope labels</label>
+            <div style="display:flex;align-items:center;gap:10px">
+              <select class="input" id="flights_label_mode" style="flex:1;min-width:0">
+                <option value="all">All aircraft</option>
+                <option value="max">Up to a number</option>
+                <option value="none">None</option>
+              </select>
+              <input type="number" class="input" id="flights_label_n" min="1" max="63" step="1" placeholder="10" style="flex:0 0 90px;display:none">
+            </div>
+            <div class="field-hint">Which aircraft on the Radar Scope get a text label (flight, altitude and speed) next to their arrow. "Up to a number" labels the aircraft nearest to your receiver first. Sky Dome and Board are not affected.</div>
+          </div>
+          <div class="field">
             <label class="field-label" for="flights_min_el">Minimum elevation</label>
             <input type="number" class="input" id="flights_min_el" min="0" max="89" step="1" placeholder="10">
             <div class="field-hint">Degrees above the horizon, 0 to 89. Aircraft lower than this are counted but not drawn.</div>
@@ -144,5 +156,18 @@
      loaded value. Draw once now too, for the fragment's own default. */
   window.adsbDrawCompass=adsbDrawCompass;
   adsbDrawCompass();
+
+  /* The number box only makes sense for "Up to a number"; hide it otherwise.
+     The shell maps mode + number to the single flights_label_max value. */
+  function adsbLabelModeSync(){
+    var m=document.getElementById('flights_label_mode');
+    var n=document.getElementById('flights_label_n');
+    if(!m||!n) return;
+    n.style.display=(m.value==='max')?'':'none';
+  }
+  var m=document.getElementById('flights_label_mode');
+  if(m) m.addEventListener('change',adsbLabelModeSync);
+  window.adsbLabelModeSync=adsbLabelModeSync;
+  adsbLabelModeSync();
 })();
 </script>

--- a/main/fragment_adsb.html
+++ b/main/fragment_adsb.html
@@ -51,6 +51,14 @@
             <div class="field-hint">How the aircraft are drawn; a tap on the device cycles through the same three.</div>
           </div>
           <div class="field">
+            <label class="field-label" for="flights_icon_style">Radar Scope icons</label>
+            <select class="input" id="flights_icon_style">
+              <option value="0">Arrows</option>
+              <option value="1">Aircraft shapes</option>
+            </select>
+            <div class="field-hint">Shape drawn for each aircraft on the Radar Scope. Aircraft shapes pick a jet, small plane, or helicopter outline from the aircraft's reported category. Sky Dome and Board are not affected.</div>
+          </div>
+          <div class="field">
             <label class="field-label" for="flights_label_mode">Radar Scope labels</label>
             <div style="display:flex;align-items:center;gap:10px">
               <select class="input" id="flights_label_mode" style="flex:1;min-width:0">

--- a/main/fragment_api.html
+++ b/main/fragment_api.html
@@ -91,6 +91,7 @@
                 <tr><td>flights_up_azimuth</td><td>int</td><td>0 to 359</td><td>Which azimuth is drawn at the top of the Sky Dome and Radar Scope. An out-of-range value falls back to 0 (north up).</td></tr>
                 <tr><td>flights_mode</td><td>int</td><td>0 to 2</td><td>View: 0 = Sky Dome, 1 = Radar Scope, 2 = Board. An invalid value falls back to 0.</td></tr>
                 <tr><td>flights_route_lookup</td><td>bool</td><td>true / false</td><td>Look up each flight's origin and destination online (adsb.im route service). Default true; false keeps the ADS-B page fully local.</td></tr>
+                <tr><td>flights_label_max</td><td>int</td><td>0 to 64</td><td>How many Radar Scope contacts get a text label: 0 = none, 1 to 63 = at most that many, nearest first, 64 = every drawn contact. Default 64; an out-of-range value falls back to 64.</td></tr>
               </tbody>
             </table>
           </div>
@@ -598,7 +599,7 @@
 
         <div class="api-ep">
           <div class="api-ep-head"><span class="api-method">GET</span><span class="api-path">/api/image-display-config</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Read the settings for the six image pages (GOES, Moon, Solar, Custom URL, Weather Radar, Cloud Cover). Returns the full current value of every persisted parameter listed in the POST table below (force_fetch is not part of the output).</p>
+          <p class="api-purpose">Read the settings for the six image pages (GOES, Moon, Solar, Custom Image, Weather Radar, Cloud Cover). Returns the full current value of every persisted parameter listed in the POST table below (force_fetch is not part of the output).</p>
           <div class="api-snip-label">Request</div>
           <div class="api-snip" data-curl="curl -b cookies.txt http://HOST/api/image-display-config">
             <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>
@@ -633,11 +634,11 @@
                 <tr><td>goes_enabled</td><td>bool</td><td>true / false</td><td>Enable that image page.</td></tr>
                 <tr><td>moon_enabled</td><td>bool</td><td>true / false</td><td>Enable that image page.</td></tr>
                 <tr><td>solar_enabled</td><td>bool</td><td>true / false</td><td>Enable that image page.</td></tr>
-                <tr><td>custom_enabled</td><td>bool</td><td>true / false</td><td>Enable that image page. The Custom URL page also needs custom_image_url set.</td></tr>
+                <tr><td>custom_enabled</td><td>bool</td><td>true / false</td><td>Enable that image page. The Custom Image page also needs custom_image_url set.</td></tr>
                 <tr><td>goes_show_overlay</td><td>bool</td><td>true / false</td><td>Show the info overlay on the GOES page.</td></tr>
                 <tr><td>moon_show_overlay</td><td>bool</td><td>true / false</td><td>Show the info overlay on the Moon page.</td></tr>
                 <tr><td>solar_show_overlay</td><td>bool</td><td>true / false</td><td>Show the info overlay on the Solar page.</td></tr>
-                <tr><td>custom_show_overlay</td><td>bool</td><td>true / false</td><td>Show the info overlay on the Custom URL page.</td></tr>
+                <tr><td>custom_show_overlay</td><td>bool</td><td>true / false</td><td>Show the info overlay on the Custom Image page.</td></tr>
                 <tr><td>goes_crop</td><td>bool</td><td>true / false</td><td>Crop vs full-frame; re-renders the cached frame locally (no re-download).</td></tr>
                 <tr><td>solar_crop</td><td>bool</td><td>true / false</td><td>Crop vs full-frame; re-renders the cached frame locally (no re-download).</td></tr>
                 <tr><td>custom_crop</td><td>bool</td><td>true / false</td><td>Crop vs full-frame; re-renders the cached frame locally (no re-download).</td></tr>
@@ -671,7 +672,7 @@
                 <tr><td>moon_north_up</td><td>int</td><td>0 or 1</td><td>Force north-up.</td></tr>
                 <tr><td>moon_spin_mode</td><td>int</td><td>0 or 1</td><td>Enable spin interaction.</td></tr>
                 <tr><td>moon_spin_return_s</td><td>int</td><td>3 to 60 (clamped)</td><td>Seconds before spin returns to rest.</td></tr>
-                <tr><td>force_fetch</td><td>bool</td><td>true / false</td><td>Action only, not persisted. Forces an immediate re-fetch (used by the Preview / Refresh button). Forces a download only for the Custom URL page; for GOES and Solar a fetch happens automatically when the band or region changed.</td></tr>
+                <tr><td>force_fetch</td><td>bool</td><td>true / false</td><td>Action only, not persisted. Forces an immediate re-fetch (used by the Preview / Refresh button). Forces a download only for the Custom Image page; for GOES and Solar a fetch happens automatically when the band or region changed.</td></tr>
               </tbody>
             </table>
           </div>
@@ -828,7 +829,7 @@
 
         <div class="api-ep">
           <div class="api-ep-head"><span class="api-method">POST</span><span class="api-path">/api/image-display/refresh</span><span class="api-badge auth">Auth</span></div>
-          <p class="api-purpose">Force an immediate re-fetch of one image page with the loading overlay. With no body it refreshes the image page currently on screen; pass {"source":0..5} (0=GOES, 1=Moon, 2=Solar, 3=Custom, 4=Weather Radar, 5=Cloud Cover) to refresh a specific page. This works for all six pages, unlike the force_fetch flag on /api/image-display-config which forces a download only for the Custom URL page.</p>
+          <p class="api-purpose">Force an immediate re-fetch of one image page with the loading overlay. With no body it refreshes the image page currently on screen; pass {"source":0..5} (0=GOES, 1=Moon, 2=Solar, 3=Custom, 4=Weather Radar, 5=Cloud Cover) to refresh a specific page. This works for all six pages, unlike the force_fetch flag on /api/image-display-config which forces a download only for the Custom Image page.</p>
           <div class="api-snip-label">Request (page on screen)</div>
           <div class="api-snip" data-curl="curl -H 'X-Auth-Password: YOUR_PASSWORD' -X POST http://HOST/api/image-display/refresh">
             <button type="button" class="api-copy" onclick="apiCopy(this)">Copy</button>

--- a/main/fragment_api.html
+++ b/main/fragment_api.html
@@ -92,6 +92,7 @@
                 <tr><td>flights_mode</td><td>int</td><td>0 to 2</td><td>View: 0 = Sky Dome, 1 = Radar Scope, 2 = Board. An invalid value falls back to 0.</td></tr>
                 <tr><td>flights_route_lookup</td><td>bool</td><td>true / false</td><td>Look up each flight's origin and destination online (adsb.im route service). Default true; false keeps the ADS-B page fully local.</td></tr>
                 <tr><td>flights_label_max</td><td>int</td><td>0 to 64</td><td>How many Radar Scope contacts get a text label: 0 = none, 1 to 63 = at most that many, nearest first, 64 = every drawn contact. Default 64; an out-of-range value falls back to 64.</td></tr>
+                <tr><td>flights_icon_style</td><td>int</td><td>0 to 1</td><td>Shape drawn for each Radar Scope contact: 0 = arrows, 1 = aircraft silhouettes picked from the aircraft's reported category. Default 0; an invalid value falls back to 0.</td></tr>
               </tbody>
             </table>
           </div>

--- a/main/fragment_behavior.html
+++ b/main/fragment_behavior.html
@@ -33,7 +33,7 @@
             <div class="field">
               <label class="field-label">Interval (seconds)</label>
               <input type="number" class="input" id="auto_rotate_interval" min="4" max="3600" value="30">
-              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600. For pages that download a picture (GOES, Solar, Custom URL, Weather Radar, Cloud Cover, OctoPrint), the countdown starts once the picture has finished loading.</div>
+              <div class="field-hint">Seconds each page is shown before Auto Cycle advances to the next one, from 4 to 3600. For pages that download a picture (GOES, Solar, Custom Image, Weather Radar, Cloud Cover, OctoPrint), the countdown starts once the picture has finished loading.</div>
             </div>
             <div class="field">
               <label class="field-label">Transition</label>
@@ -56,7 +56,7 @@
             <div class="pn-section-label">Pages in Rotation</div>
             <div class="pg-list" id="arp-container" data-cfg-key="auto_rotate_order2" role="group" aria-label="Pages in Rotation"></div>
             <div class="field-hint">Tick the pages to cycle through. The number is the order; drag a ticked page onto another to move it earlier or later. Pages marked disabled are switched off in their own settings tab.</div>
-            <div class="field-hint">Note: Image pages (GOES, Solar, Custom URL, Weather Radar, and Cloud Cover) download a fresh image from their source each time the rotation reaches them, even if their refresh interval has not elapsed yet. Shorter rotation intervals mean more frequent downloads from those image servers.</div>
+            <div class="field-hint">Note: Image pages (GOES, Solar, Custom Image, Weather Radar, and Cloud Cover) download a fresh image from their source each time the rotation reaches them, even if their refresh interval has not elapsed yet. Shorter rotation intervals mean more frequent downloads from those image servers.</div>
           </div>
         </div>
         </div>

--- a/main/fragment_image_custom.html
+++ b/main/fragment_image_custom.html
@@ -1,9 +1,9 @@
 
         <div class="card">
-          <div class="card-title"><span class="card-title-label">Custom URL <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
-          <div class="help-popover"><div class="help-popover-title">Custom URL page</div><p>Adds a full-screen page that shows a JPEG from a web address you provide (for example an all-sky camera or a weather map). The picture refreshes at the update interval you choose. The page appears in the page list only once a URL is set.</p><p>Fill (crop borders) trims the picture's edges to fill the 720x720 panel. Rotation and the two flips correct a picture that appears sideways or mirrored on your panel.</p></div>
+          <div class="card-title"><span class="card-title-label">Custom Image <button type="button" class="help-btn" aria-label="About this section" onclick="toggleHelp(event,this)"><svg viewBox="0 0 20 20" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clip-rule="evenodd"/></svg></button></span></div>
+          <div class="help-popover"><div class="help-popover-title">Custom Image page</div><p>Adds a full-screen page that shows a JPEG from a web address you provide (for example an all-sky camera or a weather map). The picture refreshes at the update interval you choose. The page appears in the page list only once a URL is set.</p><p>Fill (crop borders) trims the picture's edges to fill the 720x720 panel. Rotation and the two flips correct a picture that appears sideways or mirrored on your panel.</p></div>
           <div class="toggle-row" style="border-bottom:1px solid rgba(255,255,255,0.06)">
-            <span class="toggle-label">Enable Custom URL page</span>
+            <span class="toggle-label">Enable Custom Image page</span>
             <label class="toggle"><input type="checkbox" id="custom_enabled" onchange="updateImagePageEnabledUI('image-custom');applyImagePage('image-custom');checkDirty()"><span class="toggle-track"></span></label>
           </div>
           <div class="field-hint">Adds a page that shows a JPEG from a web address you provide.</div>

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -217,7 +217,7 @@ static esp_err_t fetch_image_into(const char *url, const char *label, image_fram
      * below rather than failing outright. The User-Agent is always sent: NWS
      * asks automated clients to identify themselves and Iowa Environmental
      * Mesonet blocks anonymous ones outright. extra_header stays free for the
-     * caller's optional credential line (the Custom URL page's user-supplied
+     * caller's optional credential line (the Custom Image page's user-supplied
      * "Name: value" header); NULL/empty means no extra header at all. */
     const http_fetch_binary_opts_t bopts = {
         .timeout_ms = GOES_HTTP_TIMEOUT_MS,

--- a/main/home_ui.html
+++ b/main/home_ui.html
@@ -263,7 +263,7 @@ body{font-family:system-ui,-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sa
    <a class="nav-tab" href="/config#image-goes">GOES</a>
    <a class="nav-tab" href="/config#image-moon">Moon</a>
    <a class="nav-tab" href="/config#image-solar">Solar</a>
-   <a class="nav-tab" href="/config#image-custom">Custom URL</a>
+   <a class="nav-tab" href="/config#image-custom">Custom Image</a>
    <a class="nav-tab" href="/config#image-radar">Radar</a>
    <a class="nav-tab" href="/config#image-clouds">Cloud Cover</a>
    <a class="nav-tab" href="/config#octoprint">OctoPrint</a>

--- a/main/http_fetch.h
+++ b/main/http_fetch.h
@@ -205,7 +205,7 @@ typedef struct {
                                  *  ':' and applied as one request header -- same
                                  *  semantics as http_fetch_opts_t.extra_header. Needed
                                  *  by image sources behind an API-key header (OctoPrint
-                                 *  gcode thumbnails, a user-supplied Custom URL header).
+                                 *  gcode thumbnails, a user-supplied Custom Image header).
                                  *  NULL = no extra header. */
     const char *user_agent;    /**< optional: sets the "User-Agent" header, same as
                                  *  http_fetch_opts_t.user_agent. Separate from

--- a/main/settings_table.h
+++ b/main/settings_table.h
@@ -162,7 +162,7 @@
     INT       (nav_grace_s,                  "nav_grace_s",                  10,    10,    300) \
     /* -- Custom Image URL source -- */ \
     STR       (custom_image_url,             "custom_image_url",             "https://picsum.photos/720") \
-    STR       (custom_image_header,          "custom_image_header",          "")               /* SECRET: optional raw "Name: value" header sent with the Custom URL image fetch. Marked is_sensitive+mask_preview in s_backup_fields, so strip_masked_secrets() preserves it on a sentinel POST and config_get_handler redacts it on GET */ \
+    STR       (custom_image_header,          "custom_image_header",          "")               /* SECRET: optional raw "Name: value" header sent with the Custom Image fetch. Marked is_sensitive+mask_preview in s_backup_fields, so strip_masked_secrets() preserves it on a sentinel POST and config_get_handler redacts it on GET */ \
     INT_RESET (custom_orientation,           "custom_orientation",           0,     0,     3) \
     INT_RESET (custom_update_interval_s,     "custom_update_interval_s",     60,    10,    7200) \
     /* -- First-boot setup hint -- */ \
@@ -224,7 +224,9 @@
     INT_RESET (flights_range_nm,             "flights_range_nm",             50,    10,    250)   /* Radar Scope outer ring, nautical miles. RESET for the same reason: 0 from an unset blob must not become a 10 nm scope */ \
     INT_RESET (flights_min_el,               "flights_min_el",               10,    0,     89)    /* elevation gate in degrees; contacts below it are counted, not drawn. RESET: 0 is a legal value here, so only an out-of-range byte (>89) falls back to the default */ \
     INT_RESET (flights_up_azimuth,           "flights_up_azimuth",           0,     0,     359)   /* which azimuth is drawn "up". RESET rather than wrap: both writers (the on-device drag and the web field) already store a wrapped 0-359 value, so anything outside it is a stale byte and north-up is the safe fallback */ \
-    INT_RESET (flights_mode,                 "flights_mode",                 0,     0,     2)     /* 0 = Sky Dome (default), 1 = Radar Scope, 2 = Board. RESET, not clamp: an unknown mode (stale byte, or a mode a future firmware knows) falls back to Sky Dome rather than to the nearest bound */     /* -- ADS-B route lookup (v69) -- */     BOOL      (flights_route_lookup,         "flights_route_lookup",         true)  /* look up each flight's origin-destination pair online (adsb.im). Default on; off keeps the ADS-B page fully local */
+    INT_RESET (flights_mode,                 "flights_mode",                 0,     0,     2)     /* 0 = Sky Dome (default), 1 = Radar Scope, 2 = Board. RESET, not clamp: an unknown mode (stale byte, or a mode a future firmware knows) falls back to Sky Dome rather than to the nearest bound */     /* -- ADS-B route lookup (v69) -- */     BOOL      (flights_route_lookup,         "flights_route_lookup",         true)  /* look up each flight's origin-destination pair online (adsb.im). Default on; off keeps the ADS-B page fully local */ \
+    /* -- ADS-B Radar Scope labels (v70) -- */ \
+    INT_RESET (flights_label_max,            "flights_label_max",            64,    0,     64)    /* how many Radar Scope contacts get a text label: 0 = none, 1..63 = at most N, nearest first, 64 (= ADSB_MAX_AC) = every drawn contact. RESET, not clamp: a stale byte above 64 falls back to "all", never to a partial count the user never chose */
 
 /* Apply every row's default value to *cfg. Called from set_defaults()
  * immediately after the memset(). Does not touch excluded/complex fields

--- a/main/settings_table.h
+++ b/main/settings_table.h
@@ -226,7 +226,9 @@
     INT_RESET (flights_up_azimuth,           "flights_up_azimuth",           0,     0,     359)   /* which azimuth is drawn "up". RESET rather than wrap: both writers (the on-device drag and the web field) already store a wrapped 0-359 value, so anything outside it is a stale byte and north-up is the safe fallback */ \
     INT_RESET (flights_mode,                 "flights_mode",                 0,     0,     2)     /* 0 = Sky Dome (default), 1 = Radar Scope, 2 = Board. RESET, not clamp: an unknown mode (stale byte, or a mode a future firmware knows) falls back to Sky Dome rather than to the nearest bound */     /* -- ADS-B route lookup (v69) -- */     BOOL      (flights_route_lookup,         "flights_route_lookup",         true)  /* look up each flight's origin-destination pair online (adsb.im). Default on; off keeps the ADS-B page fully local */ \
     /* -- ADS-B Radar Scope labels (v70) -- */ \
-    INT_RESET (flights_label_max,            "flights_label_max",            64,    0,     64)    /* how many Radar Scope contacts get a text label: 0 = none, 1..63 = at most N, nearest first, 64 (= ADSB_MAX_AC) = every drawn contact. RESET, not clamp: a stale byte above 64 falls back to "all", never to a partial count the user never chose */
+    INT_RESET (flights_label_max,            "flights_label_max",            64,    0,     64)    /* how many Radar Scope contacts get a text label: 0 = none, 1..63 = at most N, nearest first, 64 (= ADSB_MAX_AC) = every drawn contact. RESET, not clamp: a stale byte above 64 falls back to "all", never to a partial count the user never chose */ \
+    /* -- ADS-B Radar Scope icon style (v71) -- */ \
+    INT_RESET (flights_icon_style,           "flights_icon_style",           0,     0,     1)     /* Radar Scope contact glyph: 0 = arrows, 1 = aircraft silhouettes */
 
 /* Apply every row's default value to *cfg. Called from set_defaults()
  * immediately after the memset(). Does not touch excluded/complex fields

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -1773,7 +1773,7 @@ main_loop:
          *   PAGE_IDX_IMG_GOES      (3)                  = GOES Satellite image page
          *   PAGE_IDX_IMG_MOON      (4)                  = Moon image page
          *   PAGE_IDX_IMG_SOLAR     (5)                  = Solar image page
-         *   PAGE_IDX_IMG_CUSTOM    (6)                  = Custom URL image page
+         *   PAGE_IDX_IMG_CUSTOM    (6)                  = Custom Image page
          *   PAGE_IDX_IMG_RADAR     (7)                  = Weather Radar image page
          *   PAGE_IDX_IMG_CLOUDS    (8)                  = Clouds satellite image page
          *   PAGE_IDX_JSON          (9)                  = JSON Display page

--- a/main/ui/nina_adsb.c
+++ b/main/ui/nina_adsb.c
@@ -156,6 +156,12 @@ LV_FONT_DECLARE(lv_font_overpass_27);
 #define MK_SQUARE  0x02   /* military (dbFlags & 1)                */
 #define MK_EMERG   0x04   /* emergency squawk: red halo            */
 #define MK_TRI     0x08   /* Scope: heading-rotated triangle       */
+#define MK_PLANE   0x10   /* Scope: heading-rotated silhouette (flights_icon_style 1) */
+
+/* Silhouette classes for MK_PLANE, picked from readsb `category`. */
+#define PLANE_JET    0    /* airliner: swept wings and tailplane   */
+#define PLANE_SMALL  1    /* light aircraft: straight wing         */
+#define PLANE_HELI   2    /* helicopter: body, boom, rotor cross   */
 
 /* ── Fixed palette (the tar1090 domain convention; only the colour-brightness
  *    slider and the Red Night remap touch it, never the theme hues) ──────── */
@@ -274,6 +280,10 @@ typedef struct {
     uint32_t color;
     uint8_t  opa;
     uint8_t  flags;
+    uint8_t  shape;   /* PLANE_* class, valid iff MK_PLANE          */
+    float    st, ct;  /* sin/cos of the heading, precomputed here so
+                       * the draw callback multiplies but never calls
+                       * trig (file header rule)                    */
 } adsb_mark_t;
 
 static adsb_mark_t s_mark[ADSB_MAX_AC];
@@ -641,6 +651,82 @@ static void draw_square(lv_layer_t *layer, const adsb_mark_t *m)
     }
 }
 
+/* ── Aircraft silhouettes (flights_icon_style 1) ─────────────────────────
+ * Nose-up local coordinates (x right, y down, nose toward -y), one row per
+ * filled triangle: x0,y0,x1,y1,x2,y2. Sized to the 30 px triangle class the
+ * arrows use (~38 px long, ~34 px span for the jet). Rotation happens in
+ * draw_plane with the sin/cos precomputed by recompute(). */
+
+static const int8_t JET_TRIS[][6] = {
+    {   0, -19,   2, -13,  -2, -13 },   /* nose cone            */
+    {  -2, -13,   2, -13,   2,  19 },   /* fuselage quad        */
+    {  -2, -13,   2,  19,  -2,  19 },
+    {   2,  -4,  17,   9,  17,  12 },   /* right wing quad      */
+    {   2,  -4,  17,  12,   2,   5 },
+    {  -2,  -4, -17,   9, -17,  12 },   /* left wing quad       */
+    {  -2,  -4, -17,  12,  -2,   5 },
+    {   1,  13,   9,  18,   1,  17 },   /* right tailplane      */
+    {  -1,  13,  -9,  18,  -1,  17 },   /* left tailplane       */
+};
+
+static const int8_t SMALL_TRIS[][6] = {
+    {   0, -14,   2, -10,  -2, -10 },   /* nose cone            */
+    {  -2, -10,   2, -10,   2,  14 },   /* fuselage quad        */
+    {  -2, -10,   2,  14,  -2,  14 },
+    { -16,  -6,  16,  -6,  16,  -1 },   /* straight wing quad   */
+    { -16,  -6,  16,  -1, -16,  -1 },
+    {  -7,  10,   7,  10,   7,  14 },   /* straight tailplane   */
+    {  -7,  10,   7,  14,  -7,  14 },
+};
+
+static const int8_t HELI_TRIS[][6] = {
+    {   0,  -9,   5,  -2,  -5,  -2 },   /* diamond fuselage     */
+    {  -5,  -2,   5,  -2,   0,   4 },
+    {  -1,   4,   1,   4,   1,  15 },   /* tail boom quad       */
+    {  -1,   4,   1,  15,  -1,  15 },
+};
+
+/* Two crossed rotor blades over the fuselage centre (0,-2), ~26 px tip to
+ * tip, drawn as line segments: x1,y1,x2,y2. */
+static const int8_t HELI_BLADES[2][4] = {
+    {  -9, -11,   9,   7 },
+    {   9, -11,  -9,   7 },
+};
+
+/** Heading-rotated silhouette at (x,y). Same clockwise screen rotation as the
+ *  MK_TRI nose[] path: rx = px*ct - py*st, ry = px*st + py*ct. */
+static void draw_plane(lv_layer_t *layer, int x, int y, float st, float ct,
+                       uint8_t shape, uint32_t color, lv_opa_t opa)
+{
+    const int8_t (*tris)[6];
+    int n;
+    switch (shape) {
+    case PLANE_SMALL: tris = SMALL_TRIS; n = (int)(sizeof(SMALL_TRIS) / sizeof(SMALL_TRIS[0])); break;
+    case PLANE_HELI:  tris = HELI_TRIS;  n = (int)(sizeof(HELI_TRIS)  / sizeof(HELI_TRIS[0]));  break;
+    default:          tris = JET_TRIS;   n = (int)(sizeof(JET_TRIS)   / sizeof(JET_TRIS[0]));   break;
+    }
+    for (int i = 0; i < n; i++) {
+        int16_t xs[3], ys[3];
+        for (int k = 0; k < 3; k++) {
+            float px = (float)tris[i][2 * k];
+            float py = (float)tris[i][2 * k + 1];
+            xs[k] = (int16_t)(x + (int)(px * ct - py * st));
+            ys[k] = (int16_t)(y + (int)(px * st + py * ct));
+        }
+        draw_tri(layer, xs, ys, color, opa);
+    }
+    if (shape == PLANE_HELI) {
+        for (int i = 0; i < 2; i++) {
+            float x1 = (float)HELI_BLADES[i][0], y1 = (float)HELI_BLADES[i][1];
+            float x2 = (float)HELI_BLADES[i][2], y2 = (float)HELI_BLADES[i][3];
+            draw_seg(layer,
+                     x + (int)(x1 * ct - y1 * st), y + (int)(x1 * st + y1 * ct),
+                     x + (int)(x2 * ct - y2 * st), y + (int)(x2 * st + y2 * ct),
+                     color, 2, opa);
+        }
+    }
+}
+
 static void disc_draw_cb(lv_event_t *e)
 {
     lv_layer_t *layer = lv_event_get_layer(e);
@@ -719,7 +805,9 @@ static void disc_draw_cb(lv_event_t *e)
         if (m->flags & MK_EMERG) {
             draw_ring(layer, m->x, m->y, 26, s_col_emerg, 3, LV_OPA_60);
         }
-        if (m->flags & MK_TRI) {
+        if (m->flags & MK_PLANE) {
+            draw_plane(layer, m->x, m->y, m->st, m->ct, m->shape, m->color, m->opa);
+        } else if (m->flags & MK_TRI) {
             draw_tri(layer, m->tx, m->ty, m->color, m->opa);
         } else if (m->flags & MK_SQUARE) {
             draw_square(layer, m);
@@ -1506,6 +1594,18 @@ static void fill_scope_corners(int within, int tracked, float range, page_conn_t
     lv_label_set_text(s_sc_dist, buf);
 }
 
+/** Silhouette class from the readsb emitter category: A7 rotorcraft, A1/A2
+ *  light/small fixed wing, everything else (including "" and the B and C
+ *  non-aircraft code groups) the airliner outline. */
+static uint8_t shape_of_cat(const char *cat)
+{
+    if (cat[0] == 'A') {
+        if (cat[1] == '7') return PLANE_HELI;
+        if (cat[1] == '1' || cat[1] == '2') return PLANE_SMALL;
+    }
+    return PLANE_JET;
+}
+
 /**
  * Turn the held snapshot into screen coordinates and label text.
  *
@@ -1655,22 +1755,33 @@ static void recompute(void)
         build_trail(i, m->color, gate, range);
 
         if (s_mode == MODE_SCOPE) {
-            /* Heading-rotated triangle, nose along (track - up). */
+            /* Nose along (track - up), for both icon styles. */
             float hdg = (a->track_deg < 0.0f) ? 0.0f : a->track_deg;
             float t = (hdg - s_up_deg) * ADSB_DEG2RAD;
             float st_ = sinf(t), ct = cosf(t);
-            static const float nose[3][2] = { { 0.0f, -18.0f }, { 10.0f, 12.0f }, { -10.0f, 12.0f } };
-            for (int k = 0; k < 3; k++) {
-                /* Clockwise screen rotation (y down): heading 90 = nose to the right. */
-                float rx = nose[k][0] * ct - nose[k][1] * st_;
-                float ry = nose[k][0] * st_ + nose[k][1] * ct;
-                m->tx[k] = (int16_t)(x + (int)rx);
-                m->ty[k] = (int16_t)(y + (int)ry);
-            }
-            if (!(m->flags & MK_SQUARE)) {
-                m->flags |= MK_TRI;
+            if (cfg->flights_icon_style == 1 && !(m->flags & MK_SQUARE)) {
+                /* Aircraft silhouette: store the rotation, draw_plane spins
+                 * the shape table in the draw callback. Military squares and
+                 * the emergency halo keep the style-0 path below. */
+                m->st    = st_;
+                m->ct    = ct;
+                m->shape = shape_of_cat(a->cat);
+                m->flags |= MK_PLANE;
             } else {
-                m->flags |= MK_FILLED;
+                /* Heading-rotated triangle. */
+                static const float nose[3][2] = { { 0.0f, -18.0f }, { 10.0f, 12.0f }, { -10.0f, 12.0f } };
+                for (int k = 0; k < 3; k++) {
+                    /* Clockwise screen rotation (y down): heading 90 = nose to the right. */
+                    float rx = nose[k][0] * ct - nose[k][1] * st_;
+                    float ry = nose[k][0] * st_ + nose[k][1] * ct;
+                    m->tx[k] = (int16_t)(x + (int)rx);
+                    m->ty[k] = (int16_t)(y + (int)ry);
+                }
+                if (!(m->flags & MK_SQUARE)) {
+                    m->flags |= MK_TRI;
+                } else {
+                    m->flags |= MK_FILLED;
+                }
             }
         } else if (a->el_deg >= 20.0f) {
             m->flags |= MK_FILLED;

--- a/main/ui/nina_adsb.c
+++ b/main/ui/nina_adsb.c
@@ -81,8 +81,8 @@ LV_FONT_DECLARE(lv_font_overpass_27);
 #define ADSB_SNAP_DEG    5.0f
 
 /* Tag box: two lines (Montserrat 20 over 18) plus 2 px of breathing room. */
-#define TAG_W  150
-#define TAG_H  48
+#define TAG_W  184
+#define TAG_H  60
 
 /* Board grid. Column x are relative to the row panel, which is 680 wide.
  *
@@ -597,7 +597,7 @@ static void disc_draw_cb(lv_event_t *e)
     for (int i = 0; i < s_mark_n; i++) {
         const adsb_mark_t *m = &s_mark[i];
         if (m->flags & MK_EMERG) {
-            draw_ring(layer, m->x, m->y, 20, COL_EMERG, 3, LV_OPA_60);
+            draw_ring(layer, m->x, m->y, 26, COL_EMERG, 3, LV_OPA_60);
         }
         if (m->flags & MK_TRI) {
             draw_tri(layer, m->tx, m->ty, m->color, m->opa);
@@ -754,7 +754,7 @@ static int inner_ring_r(void)
 /** Cost of putting a tag box here: lower is better. A hidden glyph costs 1, a
  *  hidden tag box costs 4 (two lines of text lost, not one triangle) and a
  *  scrim overlap 2. @p skip is the tagged contact's own glyph, which the leader
- *  line is supposed to reach. Glyph half-extent is 14 px (12 px triangle nose
+ *  line is supposed to reach. Glyph half-extent is 20 px (18 px triangle nose
  *  plus a margin). */
 static int tag_score(const lv_area_t *box, int skip)
 {
@@ -762,8 +762,8 @@ static int tag_score(const lv_area_t *box, int skip)
     for (int i = 0; i < s_mark_n; i++) {
         if (i == skip) continue;
         int gx = s_mark[i].x, gy = s_mark[i].y;
-        if (gx + 14 < box->x1 || gx - 14 > box->x2) continue;
-        if (gy + 14 < box->y1 || gy - 14 > box->y2) continue;
+        if (gx + 20 < box->x1 || gx - 20 > box->x2) continue;
+        if (gy + 20 < box->y1 || gy - 20 > box->y2) continue;
         s++;
     }
     for (int i = 0; i < s_tag_area_n; i++) {
@@ -803,8 +803,8 @@ static void place_tag(int slot, int x, int y, int mark_idx,
     int dx0 = x - DISC_CX, dy0 = y - DISC_CY;
     int inner = inner_ring_r();
     bool crowded = (dx0 * dx0 + dy0 * dy0) < (inner * inner);
-    int gap_x = crowded ? 70 : 20;
-    int gap_y = crowded ? 24 : 8;
+    int gap_x = crowded ? 70 : 26;
+    int gap_y = crowded ? 24 : 12;
 
     int best_x = x, best_y = y, best_score = -1;
     lv_area_t best = { x, y, x + TAG_W, y + TAG_H };
@@ -865,10 +865,10 @@ static void place_compass(void)
         /* Keep the letter clear of the header and status scrims: a letter
          * that the rotation carries to the very top or bottom slides
          * inward instead of vanishing under the strip text. */
-        int ly = y - 14;
+        int ly = y - 16;
         if (ly < HDR_H + 2)                       ly = HDR_H + 2;
-        if (ly > SCREEN_SIZE - STRIP_H - 30)      ly = SCREEN_SIZE - STRIP_H - 30;
-        lv_obj_set_pos(s_lbl_card[i], x - 10, ly);
+        if (ly > SCREEN_SIZE - STRIP_H - 34)      ly = SCREEN_SIZE - STRIP_H - 34;
+        lv_obj_set_pos(s_lbl_card[i], x - 12, ly);
     }
     float tn = (-s_up_deg) * ADSB_DEG2RAD;
     s_ntick[0] = (int16_t)(DISC_CX + (int)(NTICK_OUT * sinf(tn)));
@@ -888,7 +888,7 @@ static void place_ring_label(int slot, int r, const char *text)
 {
     int d = (int)(0.707f * (float)(r - 22));
     lv_label_set_text(s_lbl_ring[slot], text);
-    lv_obj_set_pos(s_lbl_ring[slot], DISC_CX - d - 16, DISC_CY - d - 12);
+    lv_obj_set_pos(s_lbl_ring[slot], DISC_CX - d - 20, DISC_CY - d - 14);
     show_obj(s_lbl_ring[slot], true);
 }
 
@@ -1356,7 +1356,7 @@ static void recompute(void)
             float hdg = (a->track_deg < 0.0f) ? 0.0f : a->track_deg;
             float t = (hdg - s_up_deg) * ADSB_DEG2RAD;
             float st_ = sinf(t), ct = cosf(t);
-            static const float nose[3][2] = { { 0.0f, -12.0f }, { 7.0f, 8.0f }, { -7.0f, 8.0f } };
+            static const float nose[3][2] = { { 0.0f, -18.0f }, { 10.0f, 12.0f }, { -10.0f, 12.0f } };
             for (int k = 0; k < 3; k++) {
                 /* Clockwise screen rotation (y down): heading 90 = nose to the right. */
                 float rx = nose[k][0] * ct - nose[k][1] * st_;
@@ -1563,10 +1563,10 @@ static lv_obj_t *adsb_page_create(lv_obj_t *parent)
     lv_obj_add_event_cb(s_disc, disc_draw_cb, LV_EVENT_DRAW_MAIN_END, NULL);
 
     for (int i = 0; i < 4; i++) {
-        s_lbl_card[i] = mk_label(s_content, &lv_font_montserrat_22, 0xFFFFFF, "");
+        s_lbl_card[i] = mk_label(s_content, &lv_font_montserrat_28, 0xFFFFFF, "");
     }
     for (int i = 0; i < 3; i++) {
-        s_lbl_ring[i] = mk_label(s_content, &lv_font_montserrat_18, COL_RING_LBL, "");
+        s_lbl_ring[i] = mk_label(s_content, &lv_font_montserrat_22, COL_RING_LBL, "");
     }
 
     /* A tag is a bordered scrim box with its two lines inside, so the declutter
@@ -1580,10 +1580,10 @@ static lv_obj_t *adsb_page_create(lv_obj_t *parent)
         lv_obj_set_style_border_opa(s_tag_box[i], LV_OPA_60, 0);
         lv_obj_set_style_radius(s_tag_box[i], 3, 0);
         lv_obj_clear_flag(s_tag_box[i], LV_OBJ_FLAG_CLICKABLE | LV_OBJ_FLAG_SCROLLABLE);
-        s_tag_l1[i] = mk_label(s_tag_box[i], &lv_font_montserrat_20, 0xFFFFFF, "");
-        lv_obj_set_pos(s_tag_l1[i], 8, 1);
-        s_tag_l2[i] = mk_label(s_tag_box[i], &lv_font_montserrat_18, 0x808080, "");
-        lv_obj_set_pos(s_tag_l2[i], 8, 25);
+        s_tag_l1[i] = mk_label(s_tag_box[i], &lv_font_montserrat_24, 0xFFFFFF, "");
+        lv_obj_set_pos(s_tag_l1[i], 8, 2);
+        s_tag_l2[i] = mk_label(s_tag_box[i], &lv_font_montserrat_22, 0x808080, "");
+        lv_obj_set_pos(s_tag_l2[i], 8, 31);
         show_obj(s_tag_box[i], false);
     }
 
@@ -1690,13 +1690,13 @@ static lv_obj_t *adsb_page_create(lv_obj_t *parent)
 
     /* Scrims LAST so they sit over the disc and the board. */
     s_hdr = mk_scrim(s_root, 0, HDR_H);
-    s_lbl_title = mk_label(s_hdr, &lv_font_montserrat_22, 0xFFFFFF, "ADS-B");
+    s_lbl_title = mk_label(s_hdr, &lv_font_montserrat_26, 0xFFFFFF, "ADS-B");
     lv_obj_align(s_lbl_title, LV_ALIGN_LEFT_MID, 20, 0);
-    s_lbl_mount = mk_label(s_hdr, &lv_font_montserrat_18, 0x808080, "");
+    s_lbl_mount = mk_label(s_hdr, &lv_font_montserrat_22, 0x808080, "");
     lv_obj_align(s_lbl_mount, LV_ALIGN_RIGHT_MID, -20, 0);
 
     s_strip = mk_scrim(s_root, SCREEN_SIZE - STRIP_H, STRIP_H);
-    s_lbl_strip = mk_label(s_strip, &lv_font_montserrat_22, 0x808080, "");
+    s_lbl_strip = mk_label(s_strip, &lv_font_montserrat_26, 0x808080, "");
     lv_obj_align(s_lbl_strip, LV_ALIGN_LEFT_MID, 20, 0);
 
     /* Empty state needs its own opaque backdrop (nina_empty_state is 80%

--- a/main/ui/nina_adsb.c
+++ b/main/ui/nina_adsb.c
@@ -17,8 +17,22 @@
  *      ui_styles.c widget_draw_cb).
  *
  * Text is lv_labels, pre-created once and repositioned/retexted per update:
- * cardinals, ring labels, the three tag boxes, the header/status scrims, the
- * Board rows and the Board detail card. Nothing is created per poll.
+ * cardinals, ring labels, the three Sky tag boxes, the header/status scrims,
+ * the Scope corner blocks, the Board rows and the Board detail card. Nothing is
+ * created per poll. The ONE exception is the Radar Scope contact labels: up to
+ * ADSB_MAX_AC two-line texts drawn straight into the layer by disc_draw_cb()
+ * (lv_draw_label over static strings filled by recompute()), because 64 label
+ * objects repositioned per poll cost more than 64 draw tasks.
+ *
+ * RADAR SCOPE (redesign 2026-08-19): phosphor-green, no scrims. The header and
+ * status strips are hidden; four corner blocks (contacts / max range / closest
+ * aircraft / message rate) sit over the disc's outside corners with NO
+ * background. Rim, rings, crosshairs, cardinals and ring numbers are green.
+ * Every number that changes lives in its own fixed-width right-aligned label
+ * (Montserrat digits are proportional, "1" is narrow) so the text never jumps.
+ *
+ * RED NIGHT: page_col() maps every colour the page emits to a red shade
+ * (luminance into R) when theme_is_red_night(current_theme). All three modes.
  *
  * BOARD MODE is flight awareness, not an observing aid (retarget 2026-08-18):
  * it applies no elevation gate, and carries no elevation, azimuth or relative
@@ -75,14 +89,25 @@ LV_FONT_DECLARE(lv_font_overpass_27);
 #define STRIP_H        44
 #define HDR_H          44
 
-#define ADSB_TAG_COUNT   3
+#define ADSB_TAG_COUNT   3      /* Sky Dome boxed tags (rank 0-2)          */
 #define ADSB_BOARD_ROWS  5
 #define ADSB_TAP_SLOP_PX 12
 #define ADSB_SNAP_DEG    5.0f
 
-/* Tag box: two lines (Montserrat 20 over 18) plus 2 px of breathing room. */
+/* Tag block: two lines (Montserrat 24 over 22) plus 2 px of breathing room.
+ * The Sky boxes are exactly this big; the Scope text labels reuse the same
+ * footprint for the declutter pass so one scorer serves both. */
 #define TAG_W  184
 #define TAG_H  60
+
+/* Scope corner blocks (x1,y1,x2,y2). The tag scorer treats them like placed
+ * tags so contact labels do not land on the corner text. */
+#define CORNER_PAD   20
+#define CORNER_TOP_H 84
+#define CORNER_BL_Y  574
+#define CORNER_BR_Y  640
+#define CORNER_W_L   300
+#define CORNER_W_R   240
 
 /* Board grid. Column x are relative to the row panel, which is 680 wide.
  *
@@ -132,7 +157,8 @@ LV_FONT_DECLARE(lv_font_overpass_27);
 #define MK_EMERG   0x04   /* emergency squawk: red halo            */
 #define MK_TRI     0x08   /* Scope: heading-rotated triangle       */
 
-/* ── Fixed palette (never themed: it is the tar1090 domain convention) ── */
+/* ── Fixed palette (the tar1090 domain convention; only the colour-brightness
+ *    slider and the Red Night remap touch it, never the theme hues) ──────── */
 
 static const uint32_t ADSB_RAMP[6] = {
     0xFF5C5C,   /* ground .. 2,000 ft */
@@ -147,10 +173,18 @@ static const uint32_t ADSB_RAMP[6] = {
 /* Frame furniture, from the mockup deck (flights-options.html options 5-7).
  * These are DELIBERATELY not theme colours: current_theme->bento_border lands
  * near black on the dark themes and the range rings vanished on the panel. They
- * still go through themed() so the colour-brightness slider applies. */
-#define COL_RING_OUT    0x4A5665   /* outer rim, 2 px, fully opaque */
-#define COL_RING_IN     0x36404C   /* inner range/elevation rings   */
-#define COL_RING_LBL    0x7E8B99   /* the "10" / "30 deg" numbers   */
+ * still go through page_col() so the colour-brightness slider applies. */
+#define COL_RING_OUT    0x4A5665   /* Sky: outer rim, 2 px, fully opaque */
+#define COL_RING_IN     0x36404C   /* Sky: inner range/elevation rings   */
+#define COL_RING_LBL    0x7E8B99   /* Sky: the "10" / "30 deg" numbers   */
+
+/* Radar Scope phosphor greens. Rings/rim/cardinals/crosshairs take
+ * COL_SCOPE_GREEN, the inner rings a dimmer green that reads about as strong
+ * as COL_RING_IN did, ring numbers and corner captions sit in between. */
+#define COL_SCOPE_GREEN    0x22C55E   /* rim, cardinals, corner data lines */
+#define COL_SCOPE_RING_IN  0x1E7A45   /* inner rings, crosshair chords     */
+#define COL_SCOPE_RING_LBL 0x3FA66A   /* ring numbers                      */
+#define COL_SCOPE_CAP      0x2E9E5A   /* "CONTACTS" / "MAX RANGE" captions */
 #define COL_THREAT      0xE6B450   /* the one accent: lead contact  */
 #define COL_LEAD_BRD    0x4A3A12
 #define COL_LEAD_BG     0x120D04
@@ -179,9 +213,21 @@ static lv_obj_t *s_lbl_title;
 static lv_obj_t *s_lbl_mount;
 static lv_obj_t *s_strip;
 static lv_obj_t *s_lbl_strip;
-static lv_obj_t *s_tag_box[ADSB_TAG_COUNT];     /* scrim + border, the declutter unit */
+static lv_obj_t *s_tag_box[ADSB_TAG_COUNT];     /* Sky: scrim + border, the declutter unit */
 static lv_obj_t *s_tag_l1[ADSB_TAG_COUNT];
 static lv_obj_t *s_tag_l2[ADSB_TAG_COUNT];
+/* Scope corner blocks. Every changing number is its own fixed-width,
+ * right-aligned label; the units next to it are static text. */
+static lv_obj_t *s_sc_cap_contacts;             /* TL caption "CONTACTS"          */
+static lv_obj_t *s_sc_within;                   /* TL "%d / %d" (left aligned)    */
+static lv_obj_t *s_sc_cap_range;                /* TR caption "MAX RANGE" (right) */
+static lv_obj_t *s_sc_range;                    /* TR "%3d NM" (fixed, right)     */
+static lv_obj_t *s_sc_call;                     /* BL closest callsign / hex      */
+static lv_obj_t *s_sc_ident;                    /* BL "TYPE REG"                  */
+static lv_obj_t *s_sc_alt;                      /* BL "N ft  N kt  NNN°" (left)   */
+static lv_obj_t *s_sc_dist;                     /* BL "N.N NM" (left)             */
+static lv_obj_t *s_sc_rate;                     /* BR "%5d msg/s" (fixed, right)  */
+static lv_obj_t *s_sc_cue;                      /* BR "Reconnecting..." on STALE; on s_root so it never dims */
 static lv_obj_t *s_board;
 static lv_obj_t *s_lbl_gkk;                     /* amber eyebrow over the callsign */
 static lv_obj_t *s_lbl_glance;                  /* lead callsign, Montserrat 64   */
@@ -241,8 +287,29 @@ static adsb_fov_t s_fov[MAX_NINA_INSTANCES];
 static int        s_fov_n;
 
 typedef struct { int16_t x1, y1, x2, y2; } adsb_lead_t;
-static adsb_lead_t s_lead[ADSB_TAG_COUNT];
+static adsb_lead_t s_lead[ADSB_MAX_AC];
 static int         s_lead_n;
+
+/* Radar Scope contact labels, drawn by disc_draw_cb() with lv_draw_label.
+ * Filled for every drawn Scope contact in recompute(), then the first
+ * flights_label_max of them (rank order) are PLACED by the declutter pass and
+ * get `placed` set; the draw callback skips the rest. l1/l2 are static storage
+ * so the draw task may keep the pointer (text_local = 0): recompute() and the
+ * refresh both run under the display lock, never concurrently.
+ * PSRAM: 64 x 48 B is 3 KB the UI task's .bss does not need. */
+typedef struct {
+    int16_t  x, y;        /* top-left of the TAG_W x TAG_H block */
+    int16_t  mark;        /* index into s_mark (the glyph the leader reaches) */
+    int16_t  gx, gy;      /* glyph position */
+    int8_t   rank;        /* client rank: emergency first, then nearest */
+    uint8_t  opa;
+    bool     placed;
+    uint32_t color;       /* arrow colour, already page_col()'d */
+    char     l1[16];      /* callsign or hex (<= 10 chars)      */
+    char     l2[16];      /* "%3d %c %3d" = 9 chars             */
+} adsb_slbl_t;
+static adsb_slbl_t *s_slbl;       /* [ADSB_MAX_AC], PSRAM; NULL = no labels */
+static int          s_slbl_n;
 
 /* Position trails, projected in recompute() and drawn as polylines.
  *
@@ -275,16 +342,18 @@ static bool    s_show_rx;     /* Scope: receiver marker at the centre */
 
 /* Theme-derived draw colours, refreshed by apply_colors() so the draw callback
  * never touches current_theme or the config mutex. */
-static uint32_t s_col_line;      /* outer rim */
-static uint32_t s_col_ring_in;   /* inner rings */
+static uint32_t s_col_line;      /* outer rim (mode dependent: grey / green) */
+static uint32_t s_col_ring_in;   /* inner rings + crosshair chords */
 static uint32_t s_col_dim;
 static uint32_t s_col_ink;
+static uint32_t s_col_emerg;     /* emergency halo, page_col()'d */
 
 /* ── Forward declarations ─────────────────────────────────────────────── */
 
 static void recompute(void);
 static void apply_mode(void);
 static void apply_colors(void);
+static void apply_disc_colors(void);
 static void persist_nav_fields(void);
 
 /* ── Small helpers ────────────────────────────────────────────────────── */
@@ -299,19 +368,40 @@ static uint32_t themed(uint32_t raw)
     return app_config_apply_brightness(raw, cfg_brightness());
 }
 
+/**
+ * The ONE colour gate for this page. Under a Red Night theme every colour the
+ * page emits (ring greys, the altitude ramp, rig hues, the scope greens,
+ * scrims, board rows) collapses to a red shade: Rec.601 luminance into R,
+ * G = B = 0. A colour that is already a pure red shade (the Red Night theme's
+ * own text/label/border values, black, and anything already mapped) passes
+ * through untouched, so the function is idempotent. The colour-brightness
+ * slider is applied last in both branches.
+ */
+static uint32_t page_col(uint32_t raw)
+{
+    if (theme_is_red_night(current_theme) && (raw & 0x00FFFFu) != 0u) {
+        uint32_t r = (raw >> 16) & 0xFFu;
+        uint32_t g = (raw >> 8) & 0xFFu;
+        uint32_t b = raw & 0xFFu;
+        uint32_t luma = (299u * r + 587u * g + 114u * b) / 1000u;
+        raw = luma << 16;
+    }
+    return themed(raw);
+}
+
 static uint32_t col_bg(void)
 {
-    return themed(current_theme ? current_theme->bg_main : 0x050505);
+    return page_col(current_theme ? current_theme->bg_main : 0x050505);
 }
 
 static uint32_t col_text(void)
 {
-    return themed(current_theme ? current_theme->text_color : 0xE5E7EB);
+    return page_col(current_theme ? current_theme->text_color : 0xE5E7EB);
 }
 
 static uint32_t col_label(void)
 {
-    return themed(current_theme ? current_theme->label_color : 0x6B7280);
+    return page_col(current_theme ? current_theme->label_color : 0x6B7280);
 }
 
 /** Altitude ramp bucket. Unknown altitude (no position report yet) is grey. */
@@ -334,6 +424,15 @@ static char vrate_char(float fpm)
     return '-';
 }
 
+/** Scope-label vertical-rate cue (spec 2026-08-19): +-256 fpm dead band and a
+ *  blank, not a dash, for level flight. */
+static char scope_vc(float fpm)
+{
+    if (fpm >=  256.0f) return '^';
+    if (fpm <= -256.0f) return 'v';
+    return ' ';
+}
+
 /** Altitude in hundreds of feet, clamped to three printed digits. */
 static int alt_hundreds(const adsb_ac_t *a)
 {
@@ -346,7 +445,11 @@ static int alt_hundreds(const adsb_ac_t *a)
 /** Callsign, falling back to the ICAO hex when the contact broadcasts none. */
 static const char *call_of(const adsb_ac_t *a)
 {
-    return (a->flight[0] != '\0') ? a->flight : a->hex;
+    /* Some transponders broadcast an all-zero ident ("00000000"): treat it as
+     * none so the hex shows instead of a row of zeros. */
+    const char *f = a->flight;
+    while (*f == '0') f++;
+    return (a->flight[0] != '\0' && *f != '\0') ? a->flight : a->hex;
 }
 
 /** What is flying: the type description ("BOEING 737-800"), else the ICAO
@@ -404,6 +507,20 @@ static lv_obj_t *mk_label(lv_obj_t *parent, const lv_font_t *font, uint32_t colo
     lv_obj_set_style_text_font(l, font, 0);
     lv_obj_set_style_text_color(l, lv_color_hex(color), 0);
     lv_label_set_text(l, text ? text : "");
+    return l;
+}
+
+/** Fixed-width, right-aligned label at (x, y): the anchor for every Scope
+ *  corner number. Montserrat digits are proportional ("1" is half a "0"), so a
+ *  free-width label walks its neighbours around on every poll; pinning the
+ *  width and aligning right keeps the right edge, and the unit after it, still. */
+static lv_obj_t *mk_num(lv_obj_t *parent, const lv_font_t *font, uint32_t color,
+                        int x, int y, int w)
+{
+    lv_obj_t *l = mk_label(parent, font, color, "");
+    lv_obj_set_width(l, w);
+    lv_obj_set_style_text_align(l, LV_TEXT_ALIGN_RIGHT, 0);
+    lv_obj_set_pos(l, x, y);
     return l;
 }
 
@@ -540,11 +657,14 @@ static void disc_draw_cb(lv_event_t *e)
 
     /* Cross hairs through the centre, plus the true-north tick. Both chords are
      * rotated with the compass (endpoints from place_compass) so the N-S line
-     * runs through the N and S letters. */
+     * runs through the N and S letters. The Scope's chords are the dim green
+     * already, so they get more opacity than the Sky's grey hairlines. */
+    bool scope = (s_mode == MODE_SCOPE);
+    lv_opa_t chord_opa = scope ? LV_OPA_70 : LV_OPA_40;
     draw_seg(layer, s_axis_x[0], s_axis_y[0], s_axis_x[2], s_axis_y[2],
-             s_col_ring_in, 1, LV_OPA_40);
+             s_col_ring_in, 1, chord_opa);
     draw_seg(layer, s_axis_x[1], s_axis_y[1], s_axis_x[3], s_axis_y[3],
-             s_col_ring_in, 1, LV_OPA_40);
+             s_col_ring_in, 1, chord_opa);
     draw_seg(layer, s_ntick[0], s_ntick[1], s_ntick[2], s_ntick[3],
              s_col_ink, 3, LV_OPA_COVER);
 
@@ -597,7 +717,7 @@ static void disc_draw_cb(lv_event_t *e)
     for (int i = 0; i < s_mark_n; i++) {
         const adsb_mark_t *m = &s_mark[i];
         if (m->flags & MK_EMERG) {
-            draw_ring(layer, m->x, m->y, 26, COL_EMERG, 3, LV_OPA_60);
+            draw_ring(layer, m->x, m->y, 26, s_col_emerg, 3, LV_OPA_60);
         }
         if (m->flags & MK_TRI) {
             draw_tri(layer, m->tx, m->ty, m->color, m->opa);
@@ -605,6 +725,28 @@ static void disc_draw_cb(lv_event_t *e)
             draw_square(layer, m);
         } else {
             draw_diamond(layer, m);
+        }
+    }
+
+    /* Radar Scope contact labels: two lines of text in the arrow's colour, no
+     * box, no background. Same 8 px / 2 px / 31 px offsets as the Sky tag box
+     * so the declutter geometry (TAG_W x TAG_H) stays honest. */
+    if (scope && s_slbl) {
+        lv_draw_label_dsc_t ld;
+        lv_draw_label_dsc_init(&ld);
+        for (int i = 0; i < s_slbl_n; i++) {
+            const adsb_slbl_t *s = &s_slbl[i];
+            if (!s->placed) continue;
+            ld.color = lv_color_hex(s->color);
+            ld.opa   = s->opa;
+            ld.font  = &lv_font_montserrat_24;
+            ld.text  = s->l1;
+            lv_area_t a1 = { s->x + 8, s->y + 2, s->x + TAG_W, s->y + 2 + 27 };
+            lv_draw_label(layer, &ld, &a1);
+            ld.font  = &lv_font_montserrat_22;
+            ld.text  = s->l2;
+            lv_area_t a2 = { s->x + 8, s->y + 31, s->x + TAG_W, s->y + 31 + 24 };
+            lv_draw_label(layer, &ld, &a2);
         }
     }
 }
@@ -710,6 +852,7 @@ static void persist_nav_fields(void)
 static void apply_mode(void)
 {
     bool disc_mode = (s_mode != MODE_BOARD);
+    bool scope     = (s_mode == MODE_SCOPE);
 
     show_obj(s_disc, disc_mode);
     for (int i = 0; i < 4; i++) show_obj(s_lbl_card[i], disc_mode);
@@ -721,14 +864,39 @@ static void apply_mode(void)
     /* The mount pointing is an observing aid; the Board is flight awareness
      * and carries no elevation or azimuth at all. */
     show_obj(s_lbl_mount, disc_mode);
+
+    /* Radar Scope: no scrims at all, four corner blocks instead. */
+    show_obj(s_hdr,   !scope);
+    show_obj(s_strip, !scope);
+    lv_obj_t *corners[] = {
+        s_sc_cap_contacts, s_sc_within, s_sc_cap_range, s_sc_range,
+        s_sc_call, s_sc_ident, s_sc_alt, s_sc_dist, s_sc_rate, s_sc_cue,
+    };
+    for (size_t i = 0; i < sizeof(corners) / sizeof(corners[0]); i++) {
+        show_obj(corners[i], scope);
+    }
+    apply_disc_colors();
 }
 
 /* ── Coordinate pipeline ──────────────────────────────────────────────── */
 
 /* Tag boxes already committed this cycle — the declutter pass tests against
  * these and nothing else. Reset alongside s_lead_n in recompute(). */
-static lv_area_t s_tag_area[ADSB_TAG_COUNT];
+static lv_area_t s_tag_area[ADSB_MAX_AC];
 static int       s_tag_area_n;
+
+/* Ring-number label boxes ("10", "50 NM"), recorded by place_ring_label() so
+ * a contact label is not parked on top of one. */
+static lv_area_t s_ring_lbl_area[3];
+static bool      s_ring_lbl_used[3];     /* slot placed this cycle */
+
+/* Scope corner text blocks, scored like placed tags (Scope only). */
+static const lv_area_t s_corner_area[4] = {
+    { 0,                        0,           CORNER_W_L,  CORNER_TOP_H },
+    { SCREEN_SIZE - CORNER_W_R, 0,           SCREEN_SIZE, CORNER_TOP_H },
+    { 0,                        CORNER_BL_Y, CORNER_W_L,  SCREEN_SIZE  },
+    { SCREEN_SIZE - CORNER_W_R, CORNER_BR_Y, SCREEN_SIZE, SCREEN_SIZE  },
+};
 
 static bool boxes_hit(const lv_area_t *a, const lv_area_t *b)
 {
@@ -769,6 +937,14 @@ static int tag_score(const lv_area_t *box, int skip)
     for (int i = 0; i < s_tag_area_n; i++) {
         if (boxes_hit(box, &s_tag_area[i])) s += 4;
     }
+    if (s_mode == MODE_SCOPE) {
+        for (int i = 0; i < 4; i++) {
+            if (boxes_hit(box, &s_corner_area[i])) s += 4;
+        }
+    }
+    for (int i = 0; i < 3; i++) {
+        if (s_ring_lbl_used[i] && boxes_hit(box, &s_ring_lbl_area[i])) s += 3;
+    }
     if (box->y1 < HDR_H || box->y2 > SCREEN_SIZE - STRIP_H) s += 2;
     return s;
 }
@@ -789,10 +965,16 @@ static int tag_score(const lv_area_t *box, int skip)
  * nearest traffic clusters at the centre, which is exactly where the boxes did
  * the most damage.
  *
- * Cost is 3 tags x 8 candidates x <=64 marks, integer compares only.
+ * Cost is tags x 8 candidates x (<=64 marks + placed tags), integer compares
+ * only: 3 tags on the Sky, up to ADSB_MAX_AC on the Scope.
+ * ponytail: O(labels x marks) per recompute, ~65K compares worst case at 64
+ * labels; fine at touch rate on the P4. A grid bucket would cut it if the
+ * drag ever stutters.
+ *
+ * Returns the chosen block in @p out and records it in s_tag_area / s_lead
+ * (the leader is dropped when the block touches the glyph, as before).
  */
-static void place_tag(int slot, int x, int y, int mark_idx,
-                      const char *l1, const char *l2)
+static void place_tag_box(int x, int y, int mark_idx, lv_area_t *out)
 {
     static const int8_t qx[4] = {  1,  1, -1, -1 };
     static const int8_t qy[4] = {  1, -1, -1,  1 };
@@ -806,7 +988,7 @@ static void place_tag(int slot, int x, int y, int mark_idx,
     int gap_x = crowded ? 70 : 26;
     int gap_y = crowded ? 24 : 12;
 
-    int best_x = x, best_y = y, best_score = -1;
+    int best_score = -1;
     lv_area_t best = { x, y, x + TAG_W, y + TAG_H };
 
     for (int c = 0; c < 8; c++) {
@@ -821,22 +1003,17 @@ static void place_tag(int slot, int x, int y, int mark_idx,
         int sc = tag_score(&box, mark_idx);
         if (best_score < 0 || sc < best_score) {
             best_score = sc;
-            best_x = ax;
-            best_y = ay;
             best   = box;
             if (sc == 0) break;      /* clean air: nothing can beat it */
         }
     }
 
-    lv_label_set_text(s_tag_l1[slot], l1);
-    lv_label_set_text(s_tag_l2[slot], l2);
-    lv_obj_set_pos(s_tag_box[slot], best_x, best_y);
-    show_obj(s_tag_box[slot], true);
+    *out = best;
 
-    if (s_tag_area_n < ADSB_TAG_COUNT) {
+    if (s_tag_area_n < ADSB_MAX_AC) {
         s_tag_area[s_tag_area_n++] = best;
     }
-    if (s_lead_n < ADSB_TAG_COUNT) {
+    if (s_lead_n < ADSB_MAX_AC) {
         /* Nearest point of the box to the glyph — with a long radial leader the
          * closest edge is as often horizontal as vertical. */
         int ex = (x < best.x1) ? best.x1 : ((x > best.x2) ? best.x2 : x);
@@ -846,6 +1023,46 @@ static void place_tag(int slot, int x, int y, int mark_idx,
         s_lead[s_lead_n].x2 = (int16_t)ex;
         s_lead[s_lead_n].y2 = (int16_t)ey;
         s_lead_n++;
+    }
+}
+
+/** Sky Dome: place one of the three boxed tags. */
+static void place_tag(int slot, int x, int y, int mark_idx,
+                      const char *l1, const char *l2)
+{
+    lv_area_t box;
+    place_tag_box(x, y, mark_idx, &box);
+    lv_label_set_text(s_tag_l1[slot], l1);
+    lv_label_set_text(s_tag_l2[slot], l2);
+    lv_obj_set_pos(s_tag_box[slot], box.x1, box.y1);
+    show_obj(s_tag_box[slot], true);
+}
+
+/**
+ * Radar Scope: place the text labels for the first @p max drawn contacts in
+ * rank order (the client ranks nearest-first; ranks are contiguous from 0).
+ * s_slbl[] already holds every drawn contact; this marks the winners `placed`
+ * and gives each its block origin. Nearest first, so rank 0 gets the pick of
+ * the free air, exactly as the Sky tags do.
+ */
+static void place_scope_labels(int max)
+{
+    if (!s_slbl || max <= 0) return;
+    /* Rank order = emergency first, then nearest to the receiver (client's
+     * rank_contacts); no telescope input on the Scope. Selection pass, n <= 64. */
+    for (int placed = 0; placed < max; placed++) {
+        adsb_slbl_t *best = NULL;
+        for (int i = 0; i < s_slbl_n; i++) {
+            adsb_slbl_t *s = &s_slbl[i];
+            if (s->placed) continue;
+            if (!best || s->rank < best->rank) best = s;
+        }
+        if (!best) break;
+        lv_area_t box;
+        place_tag_box(best->gx, best->gy, best->mark, &box);
+        best->x = (int16_t)box.x1;
+        best->y = (int16_t)box.y1;
+        best->placed = true;
     }
 }
 
@@ -890,12 +1107,17 @@ static void place_ring_label(int slot, int r, const char *text)
     lv_label_set_text(s_lbl_ring[slot], text);
     lv_obj_set_pos(s_lbl_ring[slot], DISC_CX - d - 20, DISC_CY - d - 14);
     show_obj(s_lbl_ring[slot], true);
+    /* "50 NM" at 22 px is about 72 x 26; over-cover slightly for the margin. */
+    s_ring_lbl_area[slot] = (lv_area_t){ DISC_CX - d - 24, DISC_CY - d - 18,
+                                         DISC_CX - d + 60, DISC_CY - d + 14 };
+    s_ring_lbl_used[slot] = true;
 }
 
 /** Ring radii + their labels. Sky gets 60/30 plus the gate at the rim. */
 static void place_rings(float gate, float range)
 {
     s_ring_n = 0;
+    for (int i = 0; i < 3; i++) s_ring_lbl_used[i] = false;
     char buf[16];
 
     if (s_mode == MODE_SKY) {
@@ -957,7 +1179,7 @@ static void place_fov(const nina_pointing_t *pt, int n, float gate)
         s_fov[s_fov_n].x     = (int16_t)cxp;
         s_fov[s_fov_n].y     = (int16_t)cyp;
         s_fov[s_fov_n].r     = (int16_t)r;
-        s_fov[s_fov_n].color = RIG_COL[inst];
+        s_fov[s_fov_n].color = page_col(RIG_COL[inst]);
         s_fov_n++;
     }
 }
@@ -1130,7 +1352,7 @@ static void fill_card(const adsb_ac_t *a)
     }
     /* Squawk is field 3: the only value that ever goes red. */
     lv_obj_set_style_text_color(s_card_val[3],
-                                lv_color_hex(a->emergency ? themed(COL_EMERG) : s_col_ink), 0);
+                                lv_color_hex(a->emergency ? page_col(COL_EMERG) : s_col_ink), 0);
 
     lv_label_set_text(s_card_title, call_of(a));
     show_obj(s_card_mil, (a->db_flags & 0x01) != 0);
@@ -1170,7 +1392,7 @@ static void fill_board(float range)
 
     lv_label_set_text(s_lbl_gkk, lead->emergency ? "EMERGENCY" : "NEAREST");
     lv_obj_set_style_text_color(s_lbl_gkk,
-                                lv_color_hex(themed(lead->emergency ? COL_EMERG : COL_THREAT)), 0);
+                                lv_color_hex(page_col(lead->emergency ? COL_EMERG : COL_THREAT)), 0);
     lv_label_set_text(s_lbl_glance, call_of(lead));
     lv_obj_set_style_text_color(s_lbl_glance, lv_color_hex(s_col_ink), 0);
     fill_lead_lines(lead);
@@ -1190,7 +1412,7 @@ static void fill_board(float range)
 
         lv_label_set_text(s_row_call[i], call_of(a));
         lv_obj_set_style_text_color(s_row_call[i],
-                                    lv_color_hex(a->emergency ? themed(COL_EMERG) : s_col_ink), 0);
+                                    lv_color_hex(a->emergency ? page_col(COL_EMERG) : s_col_ink), 0);
 
         lv_label_set_text(s_row_route[i], row_route_of(a));
 
@@ -1198,7 +1420,7 @@ static void fill_board(float range)
          * altitude column jitters on every poll. */
         snprintf(buf, sizeof(buf), "%03d%c", alt_hundreds(a), vrate_char(a->vrate_fpm));
         lv_label_set_text(s_row_alt[i], buf);
-        lv_obj_set_style_text_color(s_row_alt[i], lv_color_hex(themed(alt_color(a))), 0);
+        lv_obj_set_style_text_color(s_row_alt[i], lv_color_hex(page_col(alt_color(a))), 0);
 
         snprintf(buf, sizeof(buf), "%03d",
                  (int)((a->track_deg < 0.0f) ? 0.0f : a->track_deg + 0.5f));
@@ -1211,6 +1433,77 @@ static void fill_board(float range)
                              (a->seen_pos_s > STALE_DIM_S) ? LV_OPA_40 : LV_OPA_COVER, 0);
         show_obj(s_row_panel[i], true);
     }
+}
+
+/**
+ * Radar Scope corner blocks. Every number goes into its own fixed-width
+ * right-aligned label (mk_num), so nothing on screen shifts when a digit
+ * count changes. The closest aircraft is by dist_nm over has_pos contacts,
+ * deliberately NOT by rank: rank is the observing-aid order (emergency,
+ * separation from the mount), the corner is a plain "nearest traffic" read.
+ */
+static void fill_scope_corners(int within, int tracked, float range, page_conn_t st)
+{
+    char buf[32];
+
+    if (within > 99) within = 99;
+    if (tracked < 0)   tracked = 0;
+    if (tracked > 999) tracked = 999;
+    snprintf(buf, sizeof(buf), "%d / %d", within, tracked);
+    lv_label_set_text(s_sc_within, buf);
+
+    int rng = (int)(range + 0.5f);
+    if (rng > 999) rng = 999;
+    snprintf(buf, sizeof(buf), "%3d NM", rng);
+    lv_label_set_text(s_sc_range, buf);
+
+    /* msg_rate is float msg/s from the client; 0 until two polls are in. */
+    int rate = (int)(s_snap->msg_rate + 0.5f);
+    if (rate < 0)     rate = 0;
+    if (rate > 99999) rate = 99999;
+    snprintf(buf, sizeof(buf), "%5d msg/s", rate);
+    lv_label_set_text(s_sc_rate, buf);
+    lv_label_set_text(s_sc_cue, (st == PAGE_CONN_STALE) ? "Reconnecting..." : "");
+
+    const adsb_ac_t *nearest = NULL;
+    for (int i = 0; i < s_snap->count; i++) {
+        const adsb_ac_t *a = &s_snap->ac[i];
+        if (!a->has_pos) continue;
+        if (!nearest || a->dist_nm < nearest->dist_nm) nearest = a;
+    }
+
+    lv_obj_t *bl[] = { s_sc_call, s_sc_ident, s_sc_alt, s_sc_dist };
+    for (size_t i = 0; i < sizeof(bl) / sizeof(bl[0]); i++) {
+        show_obj(bl[i], nearest != NULL);
+    }
+    if (!nearest) return;
+
+    lv_label_set_text(s_sc_call, call_of(nearest));
+
+    if (nearest->type[0] && nearest->reg[0]) {
+        snprintf(buf, sizeof(buf), "%s %s", nearest->type, nearest->reg);
+    } else {
+        snprintf(buf, sizeof(buf), "%s", nearest->type[0] ? nearest->type : nearest->reg);
+    }
+    lv_label_set_text(s_sc_ident, buf);
+
+    int alt = (int)(nearest->alt_ft + 0.5f);
+    if (alt < 0)     alt = 0;
+    if (alt > 99999) alt = 99999;
+    int gs = (int)(nearest->gs_kt + 0.5f);
+    if (gs < 0)   gs = 0;
+    if (gs > 999) gs = 999;
+    int trk = (nearest->track_deg < 0.0f) ? 0 : (int)(nearest->track_deg + 0.5f);
+    if (trk > 359) trk = 359;
+    char line[48];
+    snprintf(line, sizeof(line), "%d ft  %d kt  %03d\xc2\xb0", alt, gs, trk);
+    lv_label_set_text(s_sc_alt, line);
+
+    float d = nearest->dist_nm;
+    if (d < 0.0f)   d = 0.0f;
+    if (d > 999.9f) d = 999.9f;
+    snprintf(buf, sizeof(buf), "%.1f NM", (double)d);
+    lv_label_set_text(s_sc_dist, buf);
 }
 
 /**
@@ -1292,6 +1585,7 @@ static void recompute(void)
         s_mark_n = 0;
         s_lead_n = 0;
         s_trun_n = 0;
+        s_slbl_n = 0;
         fill_board(range);
         return;
     }
@@ -1299,20 +1593,29 @@ static void recompute(void)
     /* ── Disc modes ── */
     place_compass();
     place_rings(gate, range);
-    place_fov(pt, np, gate);
+    /* Mount pointing circles are the Sky Dome's business; the Scope is a plain
+     * distance picture with no telescope input. */
+    if (s_mode == MODE_SKY) place_fov(pt, np, gate);
+    else                    s_fov_n = 0;
     s_show_rx = (s_mode == MODE_SCOPE);
+    if (s_mode == MODE_SCOPE) {
+        fill_scope_corners(within, tracked, range, st);
+    }
 
     s_mark_n     = 0;
     s_lead_n     = 0;
     s_trun_n     = 0;
     s_tag_area_n = 0;
+    s_slbl_n     = 0;
     for (int i = 0; i < ADSB_TAG_COUNT; i++) {
         show_obj(s_tag_box[i], false);
     }
 
     /* Tags are queued here and placed AFTER the mark loop: the declutter score
      * counts glyphs, so it needs every positioned contact, not just the ones
-     * walked so far. l1 points into s_snap, which outlives this function. */
+     * walked so far. l1 points into s_snap, which outlives this function.
+     * Sky: three boxed tags via pend[]. Scope: every drawn contact goes into
+     * s_slbl[] and place_scope_labels() picks the first flights_label_max. */
     struct { int slot, x, y, mark; const char *l1; char l2[32]; } pend[ADSB_TAG_COUNT] = {{ 0 }};
     int pend_n = 0;
 
@@ -1343,7 +1646,7 @@ static void recompute(void)
         memset(m, 0, sizeof(*m));
         m->x     = (int16_t)x;
         m->y     = (int16_t)y;
-        m->color = alt_color(a);
+        m->color = page_col(alt_color(a));
         m->opa   = (a->seen_pos_s > STALE_DIM_S) ? LV_OPA_50 : LV_OPA_COVER;
         if (a->db_flags & 0x01) m->flags |= MK_SQUARE;
         if (a->emergency)       m->flags |= MK_EMERG;
@@ -1374,18 +1677,35 @@ static void recompute(void)
         }
         s_mark_n++;
 
-        if (a->rank >= 0 && a->rank < ADSB_TAG_COUNT && tags_done < ADSB_TAG_COUNT) {
-            /* Written straight into the slot: cppcheck flags an alias pointer
-             * taken before the array element is first assigned. */
-            if (s_mode == MODE_SKY) {
-                snprintf(pend[pend_n].l2, sizeof(pend[pend_n].l2), "%03d%c  %02d\xc2\xb0",
-                         alt_hundreds(a), vrate_char(a->vrate_fpm), (int)(a->el_deg + 0.5f));
-            } else {
-                /* Scope: altitude over range — heading is already in the
-                 * rotated triangle, so repeating it in the tag is noise. */
-                snprintf(pend[pend_n].l2, sizeof(pend[pend_n].l2), "%03d  %4.1f",
-                         alt_hundreds(a), (double)a->dist_nm);
+        if (s_mode == MODE_SCOPE) {
+            /* Every drawn contact is a label candidate; the count cap is
+             * applied nearest-first (rank) by place_scope_labels(). Line 2 is
+             * FL / climb cue / ground speed: "%3d %c %3d". Written straight
+             * into the slot (cppcheck: no alias before first assignment). */
+            if (s_slbl && s_slbl_n < ADSB_MAX_AC) {
+                int gs = (int)(a->gs_kt + 0.5f);
+                if (gs < 0)   gs = 0;
+                if (gs > 999) gs = 999;
+                snprintf(s_slbl[s_slbl_n].l1, sizeof(s_slbl[s_slbl_n].l1), "%s", call_of(a));
+                snprintf(s_slbl[s_slbl_n].l2, sizeof(s_slbl[s_slbl_n].l2), "%3d %c %3d",
+                         alt_hundreds(a), scope_vc(a->vrate_fpm), gs);
+                s_slbl[s_slbl_n].gx     = (int16_t)x;
+                s_slbl[s_slbl_n].gy     = (int16_t)y;
+                s_slbl[s_slbl_n].x      = (int16_t)x;
+                s_slbl[s_slbl_n].y      = (int16_t)y;
+                s_slbl[s_slbl_n].mark   = (int16_t)midx;
+                s_slbl[s_slbl_n].rank   = a->rank;
+                s_slbl[s_slbl_n].opa    = m->opa;
+                s_slbl[s_slbl_n].color  = m->color;
+                s_slbl[s_slbl_n].placed = false;
+                s_slbl_n++;
             }
+        } else if (a->rank >= 0 && a->rank < ADSB_TAG_COUNT && tags_done < ADSB_TAG_COUNT) {
+            /* Sky: three boxed tags. Written straight into the slot: cppcheck
+             * flags an alias pointer taken before the array element is first
+             * assigned. */
+            snprintf(pend[pend_n].l2, sizeof(pend[pend_n].l2), "%03d%c  %02d\xc2\xb0",
+                     alt_hundreds(a), vrate_char(a->vrate_fpm), (int)(a->el_deg + 0.5f));
             pend[pend_n].slot = a->rank;
             pend[pend_n].x    = x;
             pend[pend_n].y    = y;
@@ -1396,13 +1716,20 @@ static void recompute(void)
         }
     }
 
-    /* Nearest first, so rank 0 gets the pick of the free air. */
-    for (int r = 0; r < ADSB_TAG_COUNT; r++) {
-        for (int i = 0; i < pend_n; i++) {
-            if (pend[i].slot == r) {
-                place_tag(r, pend[i].x, pend[i].y, pend[i].mark,
-                          pend[i].l1, pend[i].l2);
-                break;
+    if (s_mode == MODE_SCOPE) {
+        /* 0 = none, 64 (ADSB_MAX_AC) = all drawn, else the first N by rank. */
+        int lmax = cfg->flights_label_max;
+        if (lmax > ADSB_MAX_AC) lmax = ADSB_MAX_AC;
+        place_scope_labels(lmax);
+    } else {
+        /* Nearest first, so rank 0 gets the pick of the free air. */
+        for (int r = 0; r < ADSB_TAG_COUNT; r++) {
+            for (int i = 0; i < pend_n; i++) {
+                if (pend[i].slot == r) {
+                    place_tag(r, pend[i].x, pend[i].y, pend[i].mark,
+                              pend[i].l1, pend[i].l2);
+                    break;
+                }
             }
         }
     }
@@ -1438,13 +1765,45 @@ uint8_t nina_adsb_get_mode(void)
 
 /* ── Theme ────────────────────────────────────────────────────────────── */
 
+/** Disc furniture colours are mode dependent: Sky keeps the fixed greys,
+ *  Scope is phosphor green. Called from apply_colors() and apply_mode(). */
+static void apply_disc_colors(void)
+{
+    bool scope = (s_mode == MODE_SCOPE);
+    s_col_line    = page_col(scope ? COL_SCOPE_GREEN   : COL_RING_OUT);
+    s_col_ring_in = page_col(scope ? COL_SCOPE_RING_IN : COL_RING_IN);
+    uint32_t card = scope ? page_col(COL_SCOPE_GREEN) : s_col_ink;
+    uint32_t rlbl = page_col(scope ? COL_SCOPE_RING_LBL : COL_RING_LBL);
+    for (int i = 0; i < 4; i++) {
+        lv_obj_set_style_text_color(s_lbl_card[i], lv_color_hex(card), 0);
+    }
+    for (int i = 0; i < 3; i++) {
+        lv_obj_set_style_text_color(s_lbl_ring[i], lv_color_hex(rlbl), 0);
+    }
+}
+
 static void apply_colors(void)
 {
     /* Rings use the fixed scope greys, not bento_border: see COL_RING_OUT. */
-    s_col_line    = themed(COL_RING_OUT);
-    s_col_ring_in = themed(COL_RING_IN);
     s_col_dim     = col_label();
     s_col_ink     = col_text();
+    s_col_emerg   = page_col(COL_EMERG);
+    apply_disc_colors();
+
+    /* Scope corner blocks. */
+    {
+        uint32_t cap = page_col(COL_SCOPE_CAP);
+        uint32_t grn = page_col(COL_SCOPE_GREEN);
+        lv_obj_set_style_text_color(s_sc_cap_contacts, lv_color_hex(cap), 0);
+        lv_obj_set_style_text_color(s_sc_cap_range,    lv_color_hex(cap), 0);
+        lv_obj_set_style_text_color(s_sc_within,  lv_color_hex(s_col_ink), 0);
+        lv_obj_set_style_text_color(s_sc_range,   lv_color_hex(s_col_ink), 0);
+        lv_obj_set_style_text_color(s_sc_call,    lv_color_hex(s_col_ink), 0);
+        lv_obj_t *greens[] = { s_sc_ident, s_sc_alt, s_sc_dist, s_sc_rate, s_sc_cue };
+        for (size_t i = 0; i < sizeof(greens) / sizeof(greens[0]); i++) {
+            lv_obj_set_style_text_color(greens[i], lv_color_hex(grn), 0);
+        }
+    }
 
     lv_obj_set_style_bg_color(s_root, lv_color_hex(col_bg()), 0);
     lv_obj_set_style_bg_color(s_backdrop, lv_color_hex(col_bg()), 0);
@@ -1455,38 +1814,32 @@ static void apply_colors(void)
     lv_obj_set_style_text_color(s_lbl_mount, lv_color_hex(s_col_dim), 0);
     lv_obj_set_style_text_color(s_lbl_strip, lv_color_hex(s_col_dim), 0);
     lv_obj_set_style_text_color(s_lbl_glance, lv_color_hex(s_col_ink), 0);
-    lv_obj_set_style_text_color(s_lbl_gsub,   lv_color_hex(themed(COL_SUB)), 0);
-    lv_obj_set_style_text_color(s_lbl_gsub2,  lv_color_hex(themed(COL_MUTED)), 0);
-    for (int i = 0; i < 4; i++) {
-        lv_obj_set_style_text_color(s_lbl_card[i], lv_color_hex(s_col_ink), 0);
-    }
+    lv_obj_set_style_text_color(s_lbl_gsub,   lv_color_hex(page_col(COL_SUB)), 0);
+    lv_obj_set_style_text_color(s_lbl_gsub2,  lv_color_hex(page_col(COL_MUTED)), 0);
     for (int i = 0; i < 5; i++) {
-        lv_obj_set_style_text_color(s_hdr_col[i], lv_color_hex(themed(COL_MUTED_DIM)), 0);
-    }
-    for (int i = 0; i < 3; i++) {
-        lv_obj_set_style_text_color(s_lbl_ring[i], lv_color_hex(themed(COL_RING_LBL)), 0);
+        lv_obj_set_style_text_color(s_hdr_col[i], lv_color_hex(page_col(COL_MUTED_DIM)), 0);
     }
     for (int i = 0; i < ADSB_TAG_COUNT; i++) {
         lv_obj_set_style_bg_color(s_tag_box[i], lv_color_hex(col_bg()), 0);
-        lv_obj_set_style_border_color(s_tag_box[i], lv_color_hex(s_col_ring_in), 0);
+        lv_obj_set_style_border_color(s_tag_box[i], lv_color_hex(page_col(COL_RING_IN)), 0);
         lv_obj_set_style_text_color(s_tag_l1[i], lv_color_hex(s_col_ink), 0);
-        lv_obj_set_style_text_color(s_tag_l2[i], lv_color_hex(themed(COL_MUTED)), 0);
+        lv_obj_set_style_text_color(s_tag_l2[i], lv_color_hex(page_col(COL_MUTED)), 0);
     }
     for (int i = 0; i < ADSB_BOARD_ROWS; i++) {
-        lv_obj_set_style_bg_color(s_row_panel[i], lv_color_hex(themed(COL_ROW_BG)), 0);
-        lv_obj_set_style_border_color(s_row_panel[i], lv_color_hex(themed(COL_ROW_BRD)), 0);
+        lv_obj_set_style_bg_color(s_row_panel[i], lv_color_hex(page_col(COL_ROW_BG)), 0);
+        lv_obj_set_style_border_color(s_row_panel[i], lv_color_hex(page_col(COL_ROW_BRD)), 0);
         lv_obj_set_style_text_color(s_row_call[i], lv_color_hex(s_col_ink), 0);
-        lv_obj_set_style_text_color(s_row_route[i], lv_color_hex(themed(COL_MUTED)), 0);
-        lv_obj_set_style_text_color(s_row_hdg[i], lv_color_hex(themed(COL_MUTED)), 0);
-        lv_obj_set_style_text_color(s_row_dist[i], lv_color_hex(themed(COL_MUTED)), 0);
+        lv_obj_set_style_text_color(s_row_route[i], lv_color_hex(page_col(COL_MUTED)), 0);
+        lv_obj_set_style_text_color(s_row_hdg[i], lv_color_hex(page_col(COL_MUTED)), 0);
+        lv_obj_set_style_text_color(s_row_dist[i], lv_color_hex(page_col(COL_MUTED)), 0);
     }
-    lv_obj_set_style_bg_color(s_card, lv_color_hex(themed(COL_ROW_BG)), 0);
-    lv_obj_set_style_border_color(s_card, lv_color_hex(themed(COL_ROW_BRD)), 0);
+    lv_obj_set_style_bg_color(s_card, lv_color_hex(page_col(COL_ROW_BG)), 0);
+    lv_obj_set_style_border_color(s_card, lv_color_hex(page_col(COL_ROW_BRD)), 0);
     lv_obj_set_style_text_color(s_card_title, lv_color_hex(s_col_ink), 0);
-    lv_obj_set_style_bg_color(s_card_mil, lv_color_hex(themed(COL_THREAT)), 0);
-    lv_obj_set_style_text_color(s_card_mil, lv_color_hex(themed(COL_LEAD_BG)), 0);
+    lv_obj_set_style_bg_color(s_card_mil, lv_color_hex(page_col(COL_THREAT)), 0);
+    lv_obj_set_style_text_color(s_card_mil, lv_color_hex(page_col(COL_LEAD_BG)), 0);
     for (int i = 0; i < CARD_FIELDS; i++) {
-        lv_obj_set_style_text_color(s_card_key[i], lv_color_hex(themed(COL_MUTED_DIM)), 0);
+        lv_obj_set_style_text_color(s_card_key[i], lv_color_hex(page_col(COL_MUTED_DIM)), 0);
         lv_obj_set_style_text_color(s_card_val[i], lv_color_hex(s_col_ink), 0);
     }
     nina_empty_state_apply_theme(s_empty, current_theme, cfg_brightness());
@@ -1530,6 +1883,11 @@ static lv_obj_t *adsb_page_create(lv_obj_t *parent)
     if (!s_tb) {
         s_tb = heap_caps_calloc(1, sizeof(adsb_trailbuf_t), MALLOC_CAP_SPIRAM);
         if (!s_tb) ESP_LOGW(TAG, "no PSRAM for trails; drawing contacts only");
+    }
+    /* Not fatal either: the Scope draws arrows without labels. */
+    if (!s_slbl) {
+        s_slbl = heap_caps_calloc(ADSB_MAX_AC, sizeof(adsb_slbl_t), MALLOC_CAP_SPIRAM);
+        if (!s_slbl) ESP_LOGW(TAG, "no PSRAM for scope labels; drawing arrows only");
     }
 
     s_root = lv_obj_create(parent);
@@ -1585,6 +1943,39 @@ static lv_obj_t *adsb_page_create(lv_obj_t *parent)
         s_tag_l2[i] = mk_label(s_tag_box[i], &lv_font_montserrat_22, 0x808080, "");
         lv_obj_set_pos(s_tag_l2[i], 8, 31);
         show_obj(s_tag_box[i], false);
+    }
+
+    /* Radar Scope corner blocks (shown by apply_mode in Scope only). No
+     * backgrounds. Line heights: Montserrat 36 = 40 px, 22 = 24 px, 18 = 21 px.
+     * Digit advance at 36 pt is <= 24 px, at 22 pt <= 15 px; the fixed widths
+     * below are sized from that. */
+    {
+        const int right_x = SCREEN_SIZE - CORNER_PAD;
+        /* Top-left: CONTACTS  "NN / NNN" */
+        s_sc_cap_contacts = mk_label(s_content, &lv_font_montserrat_18, COL_SCOPE_CAP, "CONTACTS");
+        lv_obj_set_pos(s_sc_cap_contacts, CORNER_PAD, 12);
+        s_sc_within = mk_label(s_content, &lv_font_montserrat_36, 0xFFFFFF, "");
+        lv_obj_set_pos(s_sc_within, CORNER_PAD, 32);
+        /* Top-right: MAX RANGE  "NNN NM", both right aligned on x = 700 */
+        s_sc_cap_range = mk_num(s_content, &lv_font_montserrat_18, COL_SCOPE_CAP, right_x - 200, 12, 200);
+        lv_label_set_text(s_sc_cap_range, "MAX RANGE");
+        s_sc_range = mk_num(s_content, &lv_font_montserrat_36, 0xFFFFFF, right_x - 200, 32, 200);
+        /* Bottom-left: closest aircraft, four lines ending 4 px above the edge */
+        s_sc_call  = mk_label(s_content, &lv_font_montserrat_36, 0xFFFFFF, "");
+        lv_obj_set_pos(s_sc_call, CORNER_PAD, 578);
+        clip_label(s_sc_call, CORNER_W_L - CORNER_PAD);
+        s_sc_ident = mk_label(s_content, &lv_font_montserrat_22, COL_SCOPE_GREEN, "");
+        lv_obj_set_pos(s_sc_ident, CORNER_PAD, 620);
+        clip_label(s_sc_ident, CORNER_W_L - CORNER_PAD);
+        s_sc_alt = mk_label(s_content, &lv_font_montserrat_22, COL_SCOPE_GREEN, "");
+        lv_obj_set_pos(s_sc_alt, CORNER_PAD, 646);
+        clip_label(s_sc_alt, CORNER_W_L - CORNER_PAD);
+        s_sc_dist = mk_label(s_content, &lv_font_montserrat_22, COL_SCOPE_GREEN, "");
+        lv_obj_set_pos(s_sc_dist, CORNER_PAD, 672);
+        /* Bottom-right: message rate on the same baseline as the BL bottom
+         * line; the reconnect cue above it. The cue lives on s_root (added
+         * after the scrims below) so the STALE dim never touches it. */
+        s_sc_rate = mk_num(s_content, &lv_font_montserrat_22, COL_SCOPE_GREEN, right_x - CORNER_W_R, 672, CORNER_W_R);
     }
 
     /* Board: lead block, five ranked rows, lead detail card. */
@@ -1698,6 +2089,11 @@ static lv_obj_t *adsb_page_create(lv_obj_t *parent)
     s_strip = mk_scrim(s_root, SCREEN_SIZE - STRIP_H, STRIP_H);
     s_lbl_strip = mk_label(s_strip, &lv_font_montserrat_26, 0x808080, "");
     lv_obj_align(s_lbl_strip, LV_ALIGN_LEFT_MID, 20, 0);
+
+    /* Scope reconnect cue: bottom-right, above the message rate, undimmed. */
+    s_sc_cue = mk_num(s_root, &lv_font_montserrat_22, COL_SCOPE_GREEN,
+                      SCREEN_SIZE - CORNER_PAD - CORNER_W_R, 646, CORNER_W_R);
+    lv_obj_clear_flag(s_sc_cue, LV_OBJ_FLAG_CLICKABLE);
 
     /* Empty state needs its own opaque backdrop (nina_empty_state is 80%
      * inline by contract; full-coverage consumers supply the ground). */

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -177,7 +177,7 @@ static const page_ops_t s_clock_page_ops = {
 static lv_obj_t *img_obj[IMG_SRC_COUNT];
 static lv_obj_t *img_created[IMG_SRC_COUNT];
 
-/* Custom URL is navigable only with a URL configured: the registry says so
+/* Custom Image is navigable only with a URL configured: the registry says so
  * (page_ref_is_available) and the dashboard/swipe/BOOT/arbiter must agree, or
  * a swipe lands on a page that toasts "Failed to load image" every interval. */
 static bool img_custom_available(void) {
@@ -343,7 +343,7 @@ lv_obj_t *create_value_label(lv_obj_t *parent) {
  *   PAGE_IDX_IMG_GOES      (3)                  = Image page: GOES
  *   PAGE_IDX_IMG_MOON      (4)                  = Image page: Moon
  *   PAGE_IDX_IMG_SOLAR     (5)                  = Image page: Solar
- *   PAGE_IDX_IMG_CUSTOM    (6)                  = Image page: Custom URL
+ *   PAGE_IDX_IMG_CUSTOM    (6)                  = Image page: Custom Image
  *   PAGE_IDX_IMG_RADAR     (7)                  = Image page: Weather Radar
  *   PAGE_IDX_IMG_CLOUDS    (8)                  = Image page: Clouds (GOES GeoColor)
  *   PAGE_IDX_JSON          (9)                  = JSON Display page
@@ -392,7 +392,7 @@ static bool ops_get_obj(int idx, lv_obj_t **obj_out) {
     const page_ops_t *ops = page_registry_get_ops(rid);
     if (!ops) return false;
     /* Optional availability veto (page_registry.h): a page may exist but be
-     * un-navigable right now (Custom URL with no URL configured). */
+     * un-navigable right now (Custom Image with no URL configured). */
     if (ops->is_available && !ops->is_available()) {
         *obj_out = NULL;
         return true;

--- a/main/ui/nina_dashboard_internal.h
+++ b/main/ui/nina_dashboard_internal.h
@@ -23,7 +23,7 @@
  *   PAGE_IDX_IMG_GOES       (3)  = GOES Satellite image page
  *   PAGE_IDX_IMG_MOON       (4)  = Moon image page
  *   PAGE_IDX_IMG_SOLAR      (5)  = Solar image page
- *   PAGE_IDX_IMG_CUSTOM     (6)  = Custom URL image page
+ *   PAGE_IDX_IMG_CUSTOM     (6)  = Custom Image page
  *   PAGE_IDX_IMG_RADAR      (7)  = Weather Radar image page
  *   PAGE_IDX_IMG_CLOUDS     (8)  = Clouds (GOES GeoColor satellite) image page
  *   PAGE_IDX_JSON           (9)  = JSON Display page

--- a/main/ui/nina_image_page.c
+++ b/main/ui/nina_image_page.c
@@ -456,7 +456,7 @@ void image_page_render_frame(image_page_t *p)
      * other frame read here), and when a reason is present render it as the
      * caption text and bail. A successful fetch clears error_msg, so the normal
      * swap path below runs and overwrites the caption — no stale error. Scoped to
-     * the sources whose failures are user-visible (Custom URL, Radar whose site
+     * the sources whose failures are user-visible (Custom Image, Radar whose site
      * token can be mistyped into a 404, Clouds behind a GIBS outage), so
      * GOES/Solar/Moon are visually unchanged. */
     if (image_page_shows_error(p->src) && p->frame.error_msg[0] != '\0') {

--- a/main/ui/nina_image_page.h
+++ b/main/ui/nina_image_page.h
@@ -3,7 +3,7 @@
 /**
  * @file nina_image_page.h
  * @brief Image page spine: ONE implementation, SIX instances (GOES, Moon,
- *        Solar, Custom URL, Weather Radar, Clouds). Each instance is a first-class page
+ *        Solar, Custom Image, Weather Radar, Clouds). Each instance is a first-class page
  *        with its own runtime index (PAGE_IDX_IMG_*), LVGL page, decoded frame,
  *        poller and gates. Rendering lives in ui/nina_image_page.c; the pollers
  *        live in image_page_poll.c and are built on the poll_task spine.
@@ -62,7 +62,7 @@ static inline bool image_src_is_animated(image_src_t s)
 }
 
 /* Sources whose fetch failure is rendered as the page caption (user-addressed
- * or outage-prone): Custom URL, Radar (site token) and Clouds (GIBS). */
+ * or outage-prone): Custom Image, Radar (site token) and Clouds (GIBS). */
 static inline bool image_page_shows_error(image_src_t s)
 {
     return s == IMG_SRC_CUSTOM || image_src_is_animated(s);

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -456,7 +456,7 @@ esp_err_t config_get_handler(httpd_req_t *req)
     /* weather_api_key: same shape as octoprint_api_key (SETTINGS_TABLE row,
      * is_sensitive in s_backup_fields, so the POST sentinel is stripped). */
     REDACT_STRING_FIELD(weather_api_key);
-    /* custom_image_header: an optional "Name: value" header for the Custom URL
+    /* custom_image_header: an optional "Name: value" header for the Custom Image
      * image fetch, so it may carry an API key or bearer token. Same shape as
      * the two above (SETTINGS_TABLE row, is_sensitive in s_backup_fields, so
      * the POST sentinel is stripped and the stored value survives). */
@@ -645,9 +645,9 @@ static const backup_field_t s_backup_fields[] = {
     {"solar_show_overlay",         "Solar Show Overlay",   "Solar", false, false},
     {"solar_crop",                 "Solar Crop/Fill",      "Solar", false, false},
     {"solar_update_interval_s",    "Solar Update Interval","Solar", false, false},
-    {"custom_enabled",             "Custom Page Enabled",  "Custom URL", false, false},
-    {"custom_show_overlay",        "Custom Show Overlay",  "Custom URL", false, false},
-    {"custom_crop",                "Custom Crop/Fill",     "Custom URL", false, false},
+    {"custom_enabled",             "Custom Page Enabled",  "Custom Image", false, false},
+    {"custom_show_overlay",        "Custom Show Overlay",  "Custom Image", false, false},
+    {"custom_crop",                "Custom Crop/Fill",     "Custom Image", false, false},
     /* Weather Radar page (v63, plus radar_dark_mode at v64 and radar_map_style at v65).
      * All eight are SETTINGS_TABLE rows, so
      * serialize_config_to_json() emits them and parse_config_from_json() reads
@@ -684,11 +684,12 @@ static const backup_field_t s_backup_fields[] = {
     {"flights_up_azimuth",         "ADS-B Up Azimuth",     "ADS-B", false, false},
     {"flights_mode",               "ADS-B View",           "ADS-B", false, false},
     {"flights_route_lookup",       "ADS-B Route Lookup",   "ADS-B", false, false},   /* v69 */
+    {"flights_label_max",          "ADS-B Scope Labels",   "ADS-B", false, false},   /* v70 */
     {"goes_region",                "GOES Region",          "GOES", false, false},
     {"goes_update_interval_s",     "GOES Update Interval", "GOES", false, false},
-    {"custom_image_url",           "Custom Image URL",     "Custom URL", false, false},
-    {"custom_orientation",         "Custom Orientation",   "Custom URL", false, false},
-    {"custom_update_interval_s",   "Custom Update Interval","Custom URL", false, false},
+    {"custom_image_url",           "Custom Image URL",     "Custom Image", false, false},
+    {"custom_orientation",         "Custom Orientation",   "Custom Image", false, false},
+    {"custom_update_interval_s",   "Custom Update Interval","Custom Image", false, false},
     {"moon_bg_style",              "Moon Background Style", "Moon", false, false},
     {"moon_lat",                   "Moon Latitude",        "Moon", false, false},
     {"moon_lon",                   "Moon Longitude",       "Moon", false, false},
@@ -698,8 +699,8 @@ static const backup_field_t s_backup_fields[] = {
     {"goes_hflip",                 "GOES Flip Horizontal", "GOES", false, false},
     {"solar_vflip",                "Solar Flip Vertical",  "Solar", false, false},
     {"solar_hflip",                "Solar Flip Horizontal","Solar", false, false},
-    {"custom_vflip",               "Custom Flip Vertical", "Custom URL", false, false},
-    {"custom_hflip",               "Custom Flip Horizontal","Custom URL", false, false},
+    {"custom_vflip",               "Custom Flip Vertical", "Custom Image", false, false},
+    {"custom_hflip",               "Custom Flip Horizontal","Custom Image", false, false},
     {"moon_flip_u",                "Moon Flip U",          "Moon", false, false},
     {"moon_flip_v",                "Moon Flip V",          "Moon", false, false},
     {"moon_roll_offset",           "Moon Roll Offset",     "Moon", false, false},
@@ -738,10 +739,10 @@ static const backup_field_t s_backup_fields[] = {
      * change renames the device mid-session and is the diff a user most needs
      * to see. */
     {"weather_api_key",    "Weather API Key",    "Weather", true, false, true},
-    /* v67: the Custom URL image header may carry a key or bearer token, so it is
+    /* v67: the Custom Image header may carry a key or bearer token, so it is
      * sensitive+mask_preview like the other credentials here even though its
-     * category is the Custom URL page. */
-    {"custom_image_header","Custom Image Header","Custom URL", true, false, true},
+     * category is the Custom Image page. */
+    {"custom_image_header","Custom Image Header","Custom Image", true, false, true},
     {"mqtt_username",      "MQTT Username",      "MQTT",    true, false, true},
     {"mqtt_password",      "MQTT Password",      "MQTT",    true, false, true},
     {"mqtt_broker_url",    "MQTT Broker URL",    "MQTT",    true, false, true},
@@ -1098,7 +1099,7 @@ static cJSON *build_restore_preview(const cJSON *backup_root, const cJSON *curre
     bool restore_blocked = false;
 
     /* Track which categories have changes */
-    const char *categories[] = {"Display", "Behavior", "Nodes & Data", "System", "AllSky", "Spotify", "MQTT", "OctoPrint", "GOES", "Moon", "Solar", "Custom URL", "Radar", "Cloud Cover", "ADS-B"};
+    const char *categories[] = {"Display", "Behavior", "Nodes & Data", "System", "AllSky", "Spotify", "MQTT", "OctoPrint", "GOES", "Moon", "Solar", "Custom Image", "Radar", "Cloud Cover", "ADS-B"};
     int cat_counts[15] = {0};
     int num_categories = 15;
 

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -685,6 +685,7 @@ static const backup_field_t s_backup_fields[] = {
     {"flights_mode",               "ADS-B View",           "ADS-B", false, false},
     {"flights_route_lookup",       "ADS-B Route Lookup",   "ADS-B", false, false},   /* v69 */
     {"flights_label_max",          "ADS-B Scope Labels",   "ADS-B", false, false},   /* v70 */
+    {"flights_icon_style",         "ADS-B Icon Style",     "ADS-B", false, false},   /* v71 */
     {"goes_region",                "GOES Region",          "GOES", false, false},
     {"goes_update_interval_s",     "GOES Update Interval", "GOES", false, false},
     {"custom_image_url",           "Custom Image URL",     "Custom Image", false, false},

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -184,7 +184,7 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
     }
     /* Image pages (GOES/Moon/Solar/Custom/Radar/Clouds): one live-apply for all six; an
      * enable toggle is a topology change (an optional page appeared/disappeared).
-     * A changed Custom URL request header means the next download is a
+     * A changed Custom Image request header means the next download is a
      * different request, so force the Custom refetch (force_fetch is consulted
      * for that page only). */
     image_page_config_apply_live(old_cfg, new_cfg,
@@ -217,7 +217,9 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
     bool adsb_view_changed = (new_cfg->flights_mode != old_cfg->flights_mode
                               || new_cfg->flights_up_azimuth != old_cfg->flights_up_azimuth
                               || new_cfg->flights_min_el != old_cfg->flights_min_el
-                              || new_cfg->flights_range_nm != old_cfg->flights_range_nm);
+                              || new_cfg->flights_range_nm != old_cfg->flights_range_nm
+                              /* label count is read by the scope painter */
+                              || new_cfg->flights_label_max != old_cfg->flights_label_max);
     if (adsb_enable_changed || adsb_view_changed) {
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             if (adsb_enable_changed) {

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -218,8 +218,9 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
                               || new_cfg->flights_up_azimuth != old_cfg->flights_up_azimuth
                               || new_cfg->flights_min_el != old_cfg->flights_min_el
                               || new_cfg->flights_range_nm != old_cfg->flights_range_nm
-                              /* label count is read by the scope painter */
-                              || new_cfg->flights_label_max != old_cfg->flights_label_max);
+                              /* label count and icon style are read by the scope painter */
+                              || new_cfg->flights_label_max != old_cfg->flights_label_max
+                              || new_cfg->flights_icon_style != old_cfg->flights_icon_style);
     if (adsb_enable_changed || adsb_view_changed) {
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             if (adsb_enable_changed) {

--- a/main/web_handlers_image_display.c
+++ b/main/web_handlers_image_display.c
@@ -29,7 +29,7 @@ static bool radar_token_is_valid(const char *tok)
 
 /**
  * @brief GET /api/image-display-config -- return the config fields of all six
- *        image pages (GOES, Moon, Solar, Custom URL, Radar, Clouds).
+ *        image pages (GOES, Moon, Solar, Custom Image, Radar, Clouds).
  */
 esp_err_t image_display_config_get_handler(httpd_req_t *req)
 {


### PR DESCRIPTION
### Summary
The ADSB Radar Scope is visually redesigned with a classic phosphor-green look, featuring new corner readouts for flight information and configurable per-contact labels. Readability on other ADSB views improves with larger UI elements, and a new Red Night theme is available. The update also fixes web UI tab synchronization and ensures configuration value reverts apply correctly.

### Changes
*   The ADSB Radar Scope is redesigned with a phosphor-green look, featuring corner readouts for flight information and receiver message rate.
*   Radar Scope contacts can now display as aircraft silhouettes, chosen by emitter category, instead of classic arrows.
*   Per-contact labels on the Radar Scope show callsign, flight level, climb, and speed, colored by altitude, with a configurable display limit.
*   UI elements, including scope arrows, fonts, and cardinal numbers, are larger on ADSB disc views for improved readability.
*   A new Red Night theme applies red shades across all page colors.
*   The ADSB client publishes message rates and dynamically scales the aircraft trail window based on the configured range.
*   The web UI's URL hash synchronizes with the active tab, preventing reloads from jumping to an incorrect tab.
*   Reverting configuration values in the web UI now correctly applies baseline values to the device, discarding live-applied previews.

---
<sub>Analyzed **7** commit(s) | Updated: 2026-08-20T03:53:17.152Z | Generated by GitHub Actions</sub>