### PR TITLE
feat(adsb): add aircraft silhouette icons to Radar Scope

### DIFF
--- a/main/adsb_client.c
+++ b/main/adsb_client.c
@@ -293,6 +293,7 @@ static void parse_one(const cJSON *item, adsb_ac_t *a, float min_el,
     str_of(item, "hex", a->hex, sizeof(a->hex));
     str_of(item, "flight", a->flight, sizeof(a->flight));
     str_of(item, "t", a->type, sizeof(a->type));
+    str_of(item, "category", a->cat, sizeof(a->cat));
     /* Aircraft-database extras (readsb serves these when it has a db loaded;
      * all three are simply absent on a bare dump1090 feed). */
     str_of(item, "r", a->reg, sizeof(a->reg));

--- a/main/adsb_client.h
+++ b/main/adsb_client.h
@@ -57,6 +57,7 @@ typedef struct {
     char     hex[8];
     char     flight[10];        /**< trimmed callsign, "" if none */
     char     type[6];           /**< readsb `t` */
+    char     cat[4];            /**< readsb `category` (A0-A7, B*, C*), "" if absent */
     float    lat, lon;          /**< valid iff has_pos */
     float    alt_ft;            /**< alt_geom else alt_baro; ground = 0 */
     bool     alt_is_geom;

--- a/main/app_config.c
+++ b/main/app_config.c
@@ -914,6 +914,9 @@ static void set_defaults(app_config_t *cfg) {
     // v70 addition (ADS-B Radar Scope label count). Also a SETTINGS_TABLE row.
     cfg->flights_label_max = 64;        // 64 = label every drawn contact
 
+    // v71 addition (ADS-B Radar Scope icon style). Also a SETTINGS_TABLE row.
+    cfg->flights_icon_style = 0;        // 0 = classic arrows
+
     // Spotify client ID: secret-like sentinel, not table-driven
     cfg->spotify_client_id[0] = '\0';
 
@@ -2875,9 +2878,11 @@ static void migrate_from_v68(const void *raw, size_t raw_size, app_config_t *cfg
      * 4) still lands on it, so re-assert the default. Existing devices opt in
      * by default, matching a fresh install. */
     cfg->flights_route_lookup = true;
-    /* flights_label_max (v70) sits right after flights_route_lookup, inside
-     * that same tail padding, so re-assert it too. */
+    /* flights_label_max (v70) and flights_icon_style (v71) sit right after
+     * flights_route_lookup, inside that same tail padding, so re-assert
+     * them too. */
     cfg->flights_label_max = 64;
+    cfg->flights_icon_style = 0;
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v68 to v%d", APP_CONFIG_VERSION);
@@ -2897,9 +2902,32 @@ static void migrate_from_v69(const void *raw, size_t raw_size, app_config_t *cfg
      * still lands on it, so re-assert the default: label every drawn contact,
      * matching a fresh install. */
     cfg->flights_label_max = 64;
+    /* flights_icon_style (v71) sits right after flights_label_max, inside
+     * that same tail padding, so re-assert it too. */
+    cfg->flights_icon_style = 0;
 
     cfg->config_version = APP_CONFIG_VERSION;
     ESP_LOGI(TAG, "Migrated config from v69 to v%d", APP_CONFIG_VERSION);
+}
+
+/* --- v70 -> v71 migration: appends flights_icon_style, the Radar Scope's
+ *     contact-glyph choice (arrows or aircraft silhouettes). Additive and at
+ *     the very end, so this stays a plain prefix memcpy like every migration
+ *     around it. --- */
+static void migrate_from_v70(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t copy = raw_size < sizeof(app_config_v70_t) ? raw_size : sizeof(app_config_v70_t);
+    memcpy(cfg, raw, copy);
+
+    /* The field sits past the v70 snapshot, so memcpy(copy) never touches it on
+     * purpose; the snapshot's tail padding (it ends on a uint8_t but aligns to
+     * 4) still lands on it, so re-assert the default: classic arrows, matching
+     * a fresh install. */
+    cfg->flights_icon_style = 0;
+
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v70 to v%d", APP_CONFIG_VERSION);
 }
 
 
@@ -3700,6 +3728,13 @@ static bool validate_config(app_config_t *cfg) {
         cfg->flights_label_max = 64;
         fixed = true;
     }
+    /* flights_icon_style (v71) is a SETTINGS_TABLE INT_RESET row (0-1), so
+     * settings_clamp_apply() already reset a stale byte above 1 to the
+     * default. Belt and braces: an unknown style falls back to arrows. */
+    if (cfg->flights_icon_style > 1) {
+        cfg->flights_icon_style = 0;
+        fixed = true;
+    }
     if (cfg->flights_url[0] != '\0' &&
         strncmp(cfg->flights_url, "http://", 7) != 0 &&
         strncmp(cfg->flights_url, "https://", 8) != 0) {
@@ -3799,6 +3834,17 @@ void app_config_init(void) {
             nvs_commit(handle);
         }
         /* tiles_loaded stays false -> tail loads "json_tiles"/"ha_tiles" keys */
+    } else if (version_check == 70) {
+        /* v70 -> v71: appended flights_icon_style (ADS-B Radar Scope glyph).
+         * tiles_loaded stays false: a v70 device already keeps its tiles in
+         * the "json_tiles"/"ha_tiles" NVS keys, so the tail loads them.
+         * Safe to write back immediately, same reasoning as the v69 branch:
+         * both dispatcher-tail fixups below are excluded by their literal
+         * version bounds. */
+        migrate_from_v70(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 69) {
         /* v69 -> v70: appended flights_label_max (ADS-B Radar Scope labels).
          * tiles_loaded stays false: a v69 device already keeps its tiles in

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -83,7 +83,7 @@ extern "C" {
 #define ARP_ORDER_CAPACITY_RETIRED 16
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 70
+#define APP_CONFIG_VERSION 71
 
 /* Tiles-config blobs no longer live inside app_config_t (v52 split them out to
  * dedicated NVS string keys "json_tiles"/"ha_tiles"). These bound the value
@@ -519,6 +519,11 @@ typedef struct {
     uint8_t  flights_label_max;        // how many Radar Scope contacts get a text label:
                                        // 0 = none, 1..63 = at most N, nearest first,
                                        // 64 (= ADSB_MAX_AC) = all drawn contacts. Default 64.
+
+    // Added after v70 (ADS-B Radar Scope icon style) — must stay at end to preserve NVS binary compatibility
+    uint8_t  flights_icon_style;       // Radar Scope contact glyph: 0 = classic arrows
+                                       // (default), 1 = aircraft silhouettes. Values
+                                       // above 1 fall back to 0.
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -4666,6 +4671,206 @@ _Static_assert(offsetof(app_config_t, flights_label_max) ==
  * it must never exceed the destination. */
 _Static_assert(sizeof(app_config_v69_t) <= sizeof(app_config_t),
                "v69 snapshot must not exceed the current config struct");
+
+/* ── Version 70 config struct — used only for NVS migration to v71 ────── */
+/* Byte-identical to app_config_t minus the trailing flights_icon_style    */
+/* field v71 appended. Same body as the v69 snapshot plus the              */
+/* flights_label_max uint8_t v70 added at the end.                         */
+typedef struct {
+    uint32_t config_version;
+    char api_url[3][128];
+    char ntp_server[64];
+    char tz_string[64];
+    char filter_colors[3][512];
+    char rms_thresholds[3][256];
+    char hfr_thresholds[3][256];
+    int theme_index;
+    int brightness;
+    int color_brightness;
+    bool mqtt_enabled;
+    char mqtt_broker_url[128];
+    char mqtt_username[64];
+    char mqtt_password[64];
+    char mqtt_topic_prefix[64];
+    uint16_t mqtt_port;
+    int8_t   active_page_override;
+    bool     auto_rotate_enabled;
+    uint16_t auto_rotate_interval_s;
+    uint8_t  auto_rotate_effect;
+    bool     auto_rotate_skip_disconnected;
+    uint8_t  auto_rotate_pages;
+    uint8_t  update_rate_s;
+    uint8_t  graph_update_interval_s;
+    uint8_t  connection_timeout_s;
+    uint8_t  toast_duration_s;
+    bool     debug_mode;
+    bool     instance_enabled[3];
+    bool     screen_sleep_enabled;
+    uint16_t screen_sleep_timeout_s;
+    bool     alert_flash_enabled;
+    uint8_t  idle_poll_interval_s;
+    bool     wifi_power_save;
+    uint8_t  widget_style;
+    uint8_t  auto_update_check;
+    uint8_t  update_channel;
+    bool     deep_sleep_enabled;
+    uint32_t deep_sleep_wake_timer_s;
+    bool     deep_sleep_on_idle;
+    uint8_t  screen_rotation;
+    char     hostname[32];
+    char     allsky_hostname[128];
+    uint16_t allsky_update_interval_s;
+    float    allsky_dew_offset;
+    char     allsky_field_config[1536];
+    char     allsky_thresholds[1024];
+    bool     allsky_enabled;
+    bool     demo_mode;
+    bool     spotify_enabled;
+    char     spotify_client_id[64];
+    uint16_t spotify_poll_interval_ms;
+    bool     spotify_show_progress_bar;
+    uint8_t  spotify_overlay_timeout_s;
+    bool     spotify_minimal_mode;
+    bool     spotify_scroll_text;
+    wifi_network_t wifi_networks[3];
+    bool     spotify_overlay_visible;
+    uint8_t  auto_rotate_order[8];
+    uint8_t  toast_aggregation_window_s;
+    uint32_t toast_notify_mask;
+    bool     toast_instance_muted[3];
+    uint8_t  weather_provider;
+    char     weather_api_key[64];
+    float    weather_lat;
+    float    weather_lon;
+    char     weather_location_name[64];
+    uint16_t weather_poll_interval_s;
+    uint8_t  weather_units;
+    uint8_t  weather_time_format;
+    bool     idle_page_override_enabled;
+    int8_t   idle_page_override_target;
+    bool     idle_page_persistent;
+    bool     idle_indicator_enabled;
+    char     admin_password[33];
+    bool     auth_enabled;
+    bool     image_display_enabled;
+    bool     image_display_show_overlay;
+    char     goes_region[16];
+    uint16_t goes_update_interval_s;
+    uint8_t  image_display_source;
+    uint8_t  moon_bg_style;
+    float    moon_lat;
+    float    moon_lon;
+    uint8_t  solar_band;
+    bool     image_display_crop;
+    uint8_t  moon_drag_light_mode;
+    uint8_t  moon_flip_u;
+    uint8_t  moon_flip_v;
+    float    moon_roll_offset;
+    float    moon_yaw_offset;
+    float    moon_pitch_offset;
+    uint8_t  moon_north_up;
+    uint8_t  moon_spin_mode;
+    uint8_t  moon_spin_return_s;
+    uint8_t  crash_log_retention_days;
+    uint8_t  auto_rotate_pages_hi;
+    uint8_t  auto_rotate_order_ext;
+    uint8_t  goes_orientation;
+    uint8_t  solar_orientation;
+    uint16_t nav_grace_s;
+    char     custom_image_url[256];
+    uint8_t  custom_orientation;
+    uint16_t custom_update_interval_s;
+    uint8_t  auto_rotate_order2_retired[16];   /* the RETIRED mid-struct array,
+                                        * named exactly as the live struct
+                                        * names it — see the note there */
+    uint8_t  goes_vflip;
+    uint8_t  goes_hflip;
+    uint8_t  solar_vflip;
+    uint8_t  solar_hflip;
+    uint8_t  custom_vflip;
+    uint8_t  custom_hflip;
+    bool     home_page_lock;
+    bool     json_enabled;
+    char     json_url[256];
+    char     json_auth_header[256];
+    uint16_t json_update_interval_s;
+    bool     ha_enabled;
+    char     ha_base_url[256];
+    char     ha_token[256];
+    uint16_t ha_update_interval_s;
+    bool     setup_hint_dismissed;
+    uint8_t  alert_voice_enabled;
+    uint8_t  alert_voice_volume;
+    uint8_t  alert_voice_types;
+    uint8_t  alert_voice_repeat_min;
+    bool     alert_voice_muted[3];
+    uint32_t voice_notify_mask;
+    uint8_t  boot_jingle_enabled;
+    uint8_t  alert_voice_brief;
+    uint8_t  alert_voice_conn;
+    uint8_t  alert_voice_disc;
+    uint8_t  wifi_max_tx_dbm;
+    uint8_t  octoprint_enabled;
+    char     octoprint_url[128];
+    char     octoprint_api_key[64];
+    uint16_t octoprint_update_interval_s;
+    uint8_t  octoprint_image_source;
+    uint8_t  octoprint_layout;
+    char     octoprint_snapshot_url[128];
+    bool     goes_enabled;
+    bool     moon_enabled;
+    bool     solar_enabled;
+    bool     custom_enabled;
+    uint16_t solar_update_interval_s;
+    uint16_t moon_update_interval_s;
+    bool     goes_crop;
+    bool     solar_crop;
+    bool     custom_crop;
+    bool     goes_show_overlay;
+    bool     moon_show_overlay;
+    bool     solar_show_overlay;
+    bool     custom_show_overlay;
+    bool     octoprint_overlay_visible;
+    bool     radar_enabled;
+    char     radar_token[16];
+    uint16_t radar_update_interval_s;
+    bool     radar_show_overlay;
+    uint8_t  radar_crop;
+    uint8_t  radar_frames;
+    uint8_t  auto_rotate_order2[ARP_ORDER_CAPACITY];
+    bool     radar_dark_mode;
+    uint8_t  radar_map_style;
+    bool     clouds_enabled;
+    bool     clouds_show_overlay;
+    uint16_t clouds_update_interval_s;
+    uint8_t  clouds_frames;
+    uint8_t  clouds_zoom;
+    char     custom_image_header[256];
+    uint8_t  clouds_channel;
+    bool     flights_enabled;
+    char     flights_url[128];
+    uint16_t flights_update_interval_s;
+    uint16_t flights_range_nm;
+    uint8_t  flights_min_el;
+    uint16_t flights_up_azimuth;
+    uint8_t  flights_mode;
+    bool     flights_route_lookup;
+    uint8_t  flights_label_max;
+} app_config_v70_t;
+
+/* flights_icon_style (uint8_t, align 1) appends directly after
+ * flights_label_max (uint8_t, align 1), so no alignment padding can sit
+ * between them. Nothing moved in v71 — the field is a pure append — so this
+ * is the plain end-of-last-field equality the v62..v69 asserts use. */
+_Static_assert(offsetof(app_config_t, flights_icon_style) ==
+                   offsetof(app_config_v70_t, flights_label_max) +
+                       sizeof(((app_config_v70_t *)0)->flights_label_max),
+               "app_config_v70_t snapshot drifted from app_config_t layout");
+
+/* migrate_from_v70 memcpy's sizeof(app_config_v70_t) bytes into app_config_t;
+ * it must never exceed the destination. */
+_Static_assert(sizeof(app_config_v70_t) <= sizeof(app_config_t),
+               "v70 snapshot must not exceed the current config struct");
 
 
 

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -2461,6 +2461,7 @@
       var up=parseInt($('flights_up_azimuth').value,10);
       data.flights_up_azimuth=isNaN(up)?0:up;
       data.flights_mode=parseInt($('flights_mode').value,10)||0;
+      data.flights_icon_style=parseInt($('flights_icon_style').value,10)||0;
       data.flights_route_lookup=!!$('flights_route_lookup').checked;
       /* Radar Scope label count: mode select + number box fold into one
          0-64 value (0 = none, 64 = all, else up to N). */
@@ -2941,6 +2942,7 @@
       if($('flights_min_el')) $('flights_min_el').value=data.flights_min_el!=null?data.flights_min_el:10;
       if($('flights_up_azimuth')) $('flights_up_azimuth').value=data.flights_up_azimuth!=null?data.flights_up_azimuth:0;
       if($('flights_mode')) $('flights_mode').value=String(data.flights_mode||0);
+      if($('flights_icon_style')) $('flights_icon_style').value=String(data.flights_icon_style||0);
       /* Default is on, so an absent key must read as checked, not unchecked. */
       if($('flights_route_lookup')) $('flights_route_lookup').checked=data.flights_route_lookup!=null?!!data.flights_route_lookup:true;
       /* Default is 64 (all), so an absent key must read as "All aircraft". */

--- a/main/fragment_adsb.html
+++ b/main/fragment_adsb.html
@@ -51,6 +51,14 @@
             <div class="field-hint">How the aircraft are drawn; a tap on the device cycles through the same three.</div>
           </div>
           <div class="field">
+            <label class="field-label" for="flights_icon_style">Radar Scope icons</label>
+            <select class="input" id="flights_icon_style">
+              <option value="0">Arrows</option>
+              <option value="1">Aircraft shapes</option>
+            </select>
+            <div class="field-hint">Shape drawn for each aircraft on the Radar Scope. Aircraft shapes pick a jet, small plane, or helicopter outline from the aircraft's reported category. Sky Dome and Board are not affected.</div>
+          </div>
+          <div class="field">
             <label class="field-label" for="flights_label_mode">Radar Scope labels</label>
             <div style="display:flex;align-items:center;gap:10px">
               <select class="input" id="flights_label_mode" style="flex:1;min-width:0">

--- a/main/fragment_api.html
+++ b/main/fragment_api.html
@@ -92,6 +92,7 @@
                 <tr><td>flights_mode</td><td>int</td><td>0 to 2</td><td>View: 0 = Sky Dome, 1 = Radar Scope, 2 = Board. An invalid value falls back to 0.</td></tr>
                 <tr><td>flights_route_lookup</td><td>bool</td><td>true / false</td><td>Look up each flight's origin and destination online (adsb.im route service). Default true; false keeps the ADS-B page fully local.</td></tr>
                 <tr><td>flights_label_max</td><td>int</td><td>0 to 64</td><td>How many Radar Scope contacts get a text label: 0 = none, 1 to 63 = at most that many, nearest first, 64 = every drawn contact. Default 64; an out-of-range value falls back to 64.</td></tr>
+                <tr><td>flights_icon_style</td><td>int</td><td>0 to 1</td><td>Shape drawn for each Radar Scope contact: 0 = arrows, 1 = aircraft silhouettes picked from the aircraft's reported category. Default 0; an invalid value falls back to 0.</td></tr>
               </tbody>
             </table>
           </div>

--- a/main/settings_table.h
+++ b/main/settings_table.h
@@ -226,7 +226,9 @@
     INT_RESET (flights_up_azimuth,           "flights_up_azimuth",           0,     0,     359)   /* which azimuth is drawn "up". RESET rather than wrap: both writers (the on-device drag and the web field) already store a wrapped 0-359 value, so anything outside it is a stale byte and north-up is the safe fallback */ \
     INT_RESET (flights_mode,                 "flights_mode",                 0,     0,     2)     /* 0 = Sky Dome (default), 1 = Radar Scope, 2 = Board. RESET, not clamp: an unknown mode (stale byte, or a mode a future firmware knows) falls back to Sky Dome rather than to the nearest bound */     /* -- ADS-B route lookup (v69) -- */     BOOL      (flights_route_lookup,         "flights_route_lookup",         true)  /* look up each flight's origin-destination pair online (adsb.im). Default on; off keeps the ADS-B page fully local */ \
     /* -- ADS-B Radar Scope labels (v70) -- */ \
-    INT_RESET (flights_label_max,            "flights_label_max",            64,    0,     64)    /* how many Radar Scope contacts get a text label: 0 = none, 1..63 = at most N, nearest first, 64 (= ADSB_MAX_AC) = every drawn contact. RESET, not clamp: a stale byte above 64 falls back to "all", never to a partial count the user never chose */
+    INT_RESET (flights_label_max,            "flights_label_max",            64,    0,     64)    /* how many Radar Scope contacts get a text label: 0 = none, 1..63 = at most N, nearest first, 64 (= ADSB_MAX_AC) = every drawn contact. RESET, not clamp: a stale byte above 64 falls back to "all", never to a partial count the user never chose */ \
+    /* -- ADS-B Radar Scope icon style (v71) -- */ \
+    INT_RESET (flights_icon_style,           "flights_icon_style",           0,     0,     1)     /* Radar Scope contact glyph: 0 = arrows, 1 = aircraft silhouettes */
 
 /* Apply every row's default value to *cfg. Called from set_defaults()
  * immediately after the memset(). Does not touch excluded/complex fields

--- a/main/ui/nina_adsb.c
+++ b/main/ui/nina_adsb.c
@@ -156,6 +156,12 @@ LV_FONT_DECLARE(lv_font_overpass_27);
 #define MK_SQUARE  0x02   /* military (dbFlags & 1)                */
 #define MK_EMERG   0x04   /* emergency squawk: red halo            */
 #define MK_TRI     0x08   /* Scope: heading-rotated triangle       */
+#define MK_PLANE   0x10   /* Scope: heading-rotated silhouette (flights_icon_style 1) */
+
+/* Silhouette classes for MK_PLANE, picked from readsb `category`. */
+#define PLANE_JET    0    /* airliner: swept wings and tailplane   */
+#define PLANE_SMALL  1    /* light aircraft: straight wing         */
+#define PLANE_HELI   2    /* helicopter: body, boom, rotor cross   */
 
 /* ── Fixed palette (the tar1090 domain convention; only the colour-brightness
  *    slider and the Red Night remap touch it, never the theme hues) ──────── */
@@ -274,6 +280,10 @@ typedef struct {
     uint32_t color;
     uint8_t  opa;
     uint8_t  flags;
+    uint8_t  shape;   /* PLANE_* class, valid iff MK_PLANE          */
+    float    st, ct;  /* sin/cos of the heading, precomputed here so
+                       * the draw callback multiplies but never calls
+                       * trig (file header rule)                    */
 } adsb_mark_t;
 
 static adsb_mark_t s_mark[ADSB_MAX_AC];
@@ -641,6 +651,82 @@ static void draw_square(lv_layer_t *layer, const adsb_mark_t *m)
     }
 }
 
+/* ── Aircraft silhouettes (flights_icon_style 1) ─────────────────────────
+ * Nose-up local coordinates (x right, y down, nose toward -y), one row per
+ * filled triangle: x0,y0,x1,y1,x2,y2. Sized to the 30 px triangle class the
+ * arrows use (~38 px long, ~34 px span for the jet). Rotation happens in
+ * draw_plane with the sin/cos precomputed by recompute(). */
+
+static const int8_t JET_TRIS[][6] = {
+    {   0, -19,   2, -13,  -2, -13 },   /* nose cone            */
+    {  -2, -13,   2, -13,   2,  19 },   /* fuselage quad        */
+    {  -2, -13,   2,  19,  -2,  19 },
+    {   2,  -4,  17,   9,  17,  12 },   /* right wing quad      */
+    {   2,  -4,  17,  12,   2,   5 },
+    {  -2,  -4, -17,   9, -17,  12 },   /* left wing quad       */
+    {  -2,  -4, -17,  12,  -2,   5 },
+    {   1,  13,   9,  18,   1,  17 },   /* right tailplane      */
+    {  -1,  13,  -9,  18,  -1,  17 },   /* left tailplane       */
+};
+
+static const int8_t SMALL_TRIS[][6] = {
+    {   0, -14,   2, -10,  -2, -10 },   /* nose cone            */
+    {  -2, -10,   2, -10,   2,  14 },   /* fuselage quad        */
+    {  -2, -10,   2,  14,  -2,  14 },
+    { -16,  -6,  16,  -6,  16,  -1 },   /* straight wing quad   */
+    { -16,  -6,  16,  -1, -16,  -1 },
+    {  -7,  10,   7,  10,   7,  14 },   /* straight tailplane   */
+    {  -7,  10,   7,  14,  -7,  14 },
+};
+
+static const int8_t HELI_TRIS[][6] = {
+    {   0,  -9,   5,  -2,  -5,  -2 },   /* diamond fuselage     */
+    {  -5,  -2,   5,  -2,   0,   4 },
+    {  -1,   4,   1,   4,   1,  15 },   /* tail boom quad       */
+    {  -1,   4,   1,  15,  -1,  15 },
+};
+
+/* Two crossed rotor blades over the fuselage centre (0,-2), ~26 px tip to
+ * tip, drawn as line segments: x1,y1,x2,y2. */
+static const int8_t HELI_BLADES[2][4] = {
+    {  -9, -11,   9,   7 },
+    {   9, -11,  -9,   7 },
+};
+
+/** Heading-rotated silhouette at (x,y). Same clockwise screen rotation as the
+ *  MK_TRI nose[] path: rx = px*ct - py*st, ry = px*st + py*ct. */
+static void draw_plane(lv_layer_t *layer, int x, int y, float st, float ct,
+                       uint8_t shape, uint32_t color, lv_opa_t opa)
+{
+    const int8_t (*tris)[6];
+    int n;
+    switch (shape) {
+    case PLANE_SMALL: tris = SMALL_TRIS; n = (int)(sizeof(SMALL_TRIS) / sizeof(SMALL_TRIS[0])); break;
+    case PLANE_HELI:  tris = HELI_TRIS;  n = (int)(sizeof(HELI_TRIS)  / sizeof(HELI_TRIS[0]));  break;
+    default:          tris = JET_TRIS;   n = (int)(sizeof(JET_TRIS)   / sizeof(JET_TRIS[0]));   break;
+    }
+    for (int i = 0; i < n; i++) {
+        int16_t xs[3], ys[3];
+        for (int k = 0; k < 3; k++) {
+            float px = (float)tris[i][2 * k];
+            float py = (float)tris[i][2 * k + 1];
+            xs[k] = (int16_t)(x + (int)(px * ct - py * st));
+            ys[k] = (int16_t)(y + (int)(px * st + py * ct));
+        }
+        draw_tri(layer, xs, ys, color, opa);
+    }
+    if (shape == PLANE_HELI) {
+        for (int i = 0; i < 2; i++) {
+            float x1 = (float)HELI_BLADES[i][0], y1 = (float)HELI_BLADES[i][1];
+            float x2 = (float)HELI_BLADES[i][2], y2 = (float)HELI_BLADES[i][3];
+            draw_seg(layer,
+                     x + (int)(x1 * ct - y1 * st), y + (int)(x1 * st + y1 * ct),
+                     x + (int)(x2 * ct - y2 * st), y + (int)(x2 * st + y2 * ct),
+                     color, 2, opa);
+        }
+    }
+}
+
 static void disc_draw_cb(lv_event_t *e)
 {
     lv_layer_t *layer = lv_event_get_layer(e);
@@ -719,7 +805,9 @@ static void disc_draw_cb(lv_event_t *e)
         if (m->flags & MK_EMERG) {
             draw_ring(layer, m->x, m->y, 26, s_col_emerg, 3, LV_OPA_60);
         }
-        if (m->flags & MK_TRI) {
+        if (m->flags & MK_PLANE) {
+            draw_plane(layer, m->x, m->y, m->st, m->ct, m->shape, m->color, m->opa);
+        } else if (m->flags & MK_TRI) {
             draw_tri(layer, m->tx, m->ty, m->color, m->opa);
         } else if (m->flags & MK_SQUARE) {
             draw_square(layer, m);
@@ -1506,6 +1594,18 @@ static void fill_scope_corners(int within, int tracked, float range, page_conn_t
     lv_label_set_text(s_sc_dist, buf);
 }
 
+/** Silhouette class from the readsb emitter category: A7 rotorcraft, A1/A2
+ *  light/small fixed wing, everything else (including "" and the B and C
+ *  non-aircraft code groups) the airliner outline. */
+static uint8_t shape_of_cat(const char *cat)
+{
+    if (cat[0] == 'A') {
+        if (cat[1] == '7') return PLANE_HELI;
+        if (cat[1] == '1' || cat[1] == '2') return PLANE_SMALL;
+    }
+    return PLANE_JET;
+}
+
 /**
  * Turn the held snapshot into screen coordinates and label text.
  *
@@ -1655,22 +1755,33 @@ static void recompute(void)
         build_trail(i, m->color, gate, range);
 
         if (s_mode == MODE_SCOPE) {
-            /* Heading-rotated triangle, nose along (track - up). */
+            /* Nose along (track - up), for both icon styles. */
             float hdg = (a->track_deg < 0.0f) ? 0.0f : a->track_deg;
             float t = (hdg - s_up_deg) * ADSB_DEG2RAD;
             float st_ = sinf(t), ct = cosf(t);
-            static const float nose[3][2] = { { 0.0f, -18.0f }, { 10.0f, 12.0f }, { -10.0f, 12.0f } };
-            for (int k = 0; k < 3; k++) {
-                /* Clockwise screen rotation (y down): heading 90 = nose to the right. */
-                float rx = nose[k][0] * ct - nose[k][1] * st_;
-                float ry = nose[k][0] * st_ + nose[k][1] * ct;
-                m->tx[k] = (int16_t)(x + (int)rx);
-                m->ty[k] = (int16_t)(y + (int)ry);
-            }
-            if (!(m->flags & MK_SQUARE)) {
-                m->flags |= MK_TRI;
+            if (cfg->flights_icon_style == 1 && !(m->flags & MK_SQUARE)) {
+                /* Aircraft silhouette: store the rotation, draw_plane spins
+                 * the shape table in the draw callback. Military squares and
+                 * the emergency halo keep the style-0 path below. */
+                m->st    = st_;
+                m->ct    = ct;
+                m->shape = shape_of_cat(a->cat);
+                m->flags |= MK_PLANE;
             } else {
-                m->flags |= MK_FILLED;
+                /* Heading-rotated triangle. */
+                static const float nose[3][2] = { { 0.0f, -18.0f }, { 10.0f, 12.0f }, { -10.0f, 12.0f } };
+                for (int k = 0; k < 3; k++) {
+                    /* Clockwise screen rotation (y down): heading 90 = nose to the right. */
+                    float rx = nose[k][0] * ct - nose[k][1] * st_;
+                    float ry = nose[k][0] * st_ + nose[k][1] * ct;
+                    m->tx[k] = (int16_t)(x + (int)rx);
+                    m->ty[k] = (int16_t)(y + (int)ry);
+                }
+                if (!(m->flags & MK_SQUARE)) {
+                    m->flags |= MK_TRI;
+                } else {
+                    m->flags |= MK_FILLED;
+                }
             }
         } else if (a->el_deg >= 20.0f) {
             m->flags |= MK_FILLED;

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -685,6 +685,7 @@ static const backup_field_t s_backup_fields[] = {
     {"flights_mode",               "ADS-B View",           "ADS-B", false, false},
     {"flights_route_lookup",       "ADS-B Route Lookup",   "ADS-B", false, false},   /* v69 */
     {"flights_label_max",          "ADS-B Scope Labels",   "ADS-B", false, false},   /* v70 */
+    {"flights_icon_style",         "ADS-B Icon Style",     "ADS-B", false, false},   /* v71 */
     {"goes_region",                "GOES Region",          "GOES", false, false},
     {"goes_update_interval_s",     "GOES Update Interval", "GOES", false, false},
     {"custom_image_url",           "Custom Image URL",     "Custom Image", false, false},

--- a/main/web_handlers_display.c
+++ b/main/web_handlers_display.c
@@ -218,8 +218,9 @@ void config_trigger_side_effects(const app_config_t *old_cfg, const app_config_t
                               || new_cfg->flights_up_azimuth != old_cfg->flights_up_azimuth
                               || new_cfg->flights_min_el != old_cfg->flights_min_el
                               || new_cfg->flights_range_nm != old_cfg->flights_range_nm
-                              /* label count is read by the scope painter */
-                              || new_cfg->flights_label_max != old_cfg->flights_label_max);
+                              /* label count and icon style are read by the scope painter */
+                              || new_cfg->flights_label_max != old_cfg->flights_label_max
+                              || new_cfg->flights_icon_style != old_cfg->flights_icon_style);
     if (adsb_enable_changed || adsb_view_changed) {
         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
             if (adsb_enable_changed) {


### PR DESCRIPTION
### Summary
Users can now choose to display aircraft on the Radar Scope as distinct silhouettes, such as helicopters, light aircraft, or jets, instead of generic arrows. These silhouettes rotate to match the aircraft's track, offering a more intuitive visual representation.

### Changes
* Added a new option to display aircraft on the Radar Scope as silhouettes (helicopter, light aircraft, or jet) instead of heading-rotated arrows.
* The ADS-B client now parses the aircraft category to determine the correct silhouette shape.
* Updated the application configuration to version 71, including the new `flights_icon_style` field.
* Implemented configuration migration logic from previous versions to support the new setting.
* Added a dropdown menu to the web UI's ADS-B tab for selecting the flight icon style.
* Updated the API documentation and internal settings table to reflect the new configuration option.
* Modified the Radar Scope rendering logic to draw and rotate the selected aircraft silhouettes.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-20T03:52:54.318Z | Generated by GitHub Actions</sub>