### PR TITLE
fix(websocket): detect half-open connections with pong timeout

### DIFF
--- a/main/nina_websocket.c
+++ b/main/nina_websocket.c
@@ -1175,6 +1175,12 @@ static void ws_start_locked(int index, const char *base_url, nina_client_t *data
         .reconnect_timeout_ms = 86400000, // Effectively disabled; reconnect managed externally with backoff
         .network_timeout_ms = 10000,
         .buffer_size = 2048,            // Reduced from 4096 to save heap; largest WS events ~1.2KB
+        /* Half-open TCP detection: without a pong deadline the client keeps a
+         * dead connection "connected" forever, which also gates off the HTTP
+         * image-history fallback in nina_client.c. Default ping interval is
+         * 10s; a missed pong for 20s trips WEBSOCKET_EVENT_DISCONNECTED and
+         * hands recovery to the external reconnect/backoff path. */
+        .pingpong_timeout_sec = 20,
     };
 
     ws_clients[index] = esp_websocket_client_init(&ws_cfg);


### PR DESCRIPTION
### Summary
The dashboard previously froze because half-open WebSocket connections remained active indefinitely, preventing new image events and HTTP history fallback. This change configures the WebSocket client to detect these unresponsive connections by timing out on missing PONG responses, allowing the system to properly disconnect and reconnect.

### Changes
* Configure the WebSocket client to time out if PONG responses are not received from the server.
* Set the PONG timeout to 20 seconds, which detects unresponsive connections after two missed pings.
* This ensures the client disconnects from half-open WebSocket connections that previously remained active forever.
* The system can now recover from these disconnections using its existing reconnect and backoff mechanisms.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-21T02:21:35.859Z | Generated by GitHub Actions</sub>