### PR TITLE
fix(ota): stop release walk terminating on out-of-channel stable tags

### DIFF
--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -614,26 +614,19 @@ ota_check_result_t ota_github_check(int channel, const char *current_version, gi
              * page 1. */
             if (strcmp(tag->valuestring, SND_ALPHA_TAG) == 0) continue;
 
-            /* Check pre-release flag — each channel only sees its own releases */
+            /* Check pre-release flag — each channel only sees its own releases.
+             * Out-of-channel releases never terminate the walk: the GitHub list
+             * orders stable X above X-dev.N even though this project ships the
+             * dev builds after the stable release, so a same-base stable release
+             * would end the walk before the newer dev target is reached. Each
+             * channel compares against its own tags only; termination comes from
+             * an in-channel release at-or-below installed, the target's
+             * full-erase floor marker, or the end of the list. A dev target with
+             * no floor marker whose installed release was deleted falls through
+             * to the page-cap fail-safe (offered as requires_full_erase). */
             cJSON *prerelease = cJSON_GetObjectItem(release, "prerelease");
             bool is_pre = cJSON_IsTrue(prerelease);
             if ((is_pre && !include_prereleases) || (!is_pre && include_prereleases)) {
-                /* Out of channel: never a target, never a marker contributor — but
-                 * it may still TERMINATE the walk. Versions across channels are one
-                 * monotone line here, so an out-of-channel release at-or-below
-                 * installed proves the path is covered. Without this the dev channel
-                 * cannot terminate at all once its own historical releases have been
-                 * deleted, and every check walks to the page cap. Only a tag that
-                 * parses as a full version may terminate: any non-semver tag
-                 * sscanf-parses as 0.0.0 and would falsely terminate on page 1. */
-                if (!channel_switch &&
-                    floor_tag_parses_as_version(tag->valuestring) &&
-                    compare_versions(tag->valuestring, current_version) <= 0) {
-                    ESP_LOGI(TAG, "Walk terminated by out-of-channel release %s (<= installed %s)",
-                             tag->valuestring, current_version);
-                    reached_installed = true;
-                    break;
-                }
                 continue;
             }
 


### PR DESCRIPTION
### Summary
OTA update checks for dev-channel devices previously stopped prematurely when an older stable release with the same base version was encountered, preventing newer dev builds from being offered. The update process now correctly compares tags only within the device's designated channel, ensuring dev-channel devices receive appropriate updates.

### Changes
*   The OTA release walk no longer terminates if it encounters an out-of-channel stable tag that is older than or equal to the currently installed dev build.
*   The update check now only compares release tags that belong to the device's specific update channel.
*   The release walk now terminates when it finds an in-channel release that is at or below the installed version.
*   The walk also terminates if it encounters a target release's full-erase floor marker.
*   The existing page-cap fail-safe handles cases where a dev target lacks a floor marker and has deleted history.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-21T15:55:32.581Z | Generated by GitHub Actions</sub>