### PR TITLE
fix: ota walk no longer terminates on out-of-channel tags

### DIFF
--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -614,26 +614,19 @@ ota_check_result_t ota_github_check(int channel, const char *current_version, gi
              * page 1. */
             if (strcmp(tag->valuestring, SND_ALPHA_TAG) == 0) continue;
 
-            /* Check pre-release flag — each channel only sees its own releases */
+            /* Check pre-release flag — each channel only sees its own releases.
+             * Out-of-channel releases never terminate the walk: the GitHub list
+             * orders stable X above X-dev.N even though this project ships the
+             * dev builds after the stable release, so a same-base stable release
+             * would end the walk before the newer dev target is reached. Each
+             * channel compares against its own tags only; termination comes from
+             * an in-channel release at-or-below installed, the target's
+             * full-erase floor marker, or the end of the list. A dev target with
+             * no floor marker whose installed release was deleted falls through
+             * to the page-cap fail-safe (offered as requires_full_erase). */
             cJSON *prerelease = cJSON_GetObjectItem(release, "prerelease");
             bool is_pre = cJSON_IsTrue(prerelease);
             if ((is_pre && !include_prereleases) || (!is_pre && include_prereleases)) {
-                /* Out of channel: never a target, never a marker contributor — but
-                 * it may still TERMINATE the walk. Versions across channels are one
-                 * monotone line here, so an out-of-channel release at-or-below
-                 * installed proves the path is covered. Without this the dev channel
-                 * cannot terminate at all once its own historical releases have been
-                 * deleted, and every check walks to the page cap. Only a tag that
-                 * parses as a full version may terminate: any non-semver tag
-                 * sscanf-parses as 0.0.0 and would falsely terminate on page 1. */
-                if (!channel_switch &&
-                    floor_tag_parses_as_version(tag->valuestring) &&
-                    compare_versions(tag->valuestring, current_version) <= 0) {
-                    ESP_LOGI(TAG, "Walk terminated by out-of-channel release %s (<= installed %s)",
-                             tag->valuestring, current_version);
-                    reached_installed = true;
-                    break;
-                }
                 continue;
             }
 

--- a/main/ui/nina_clock.c
+++ b/main/ui/nina_clock.c
@@ -1187,7 +1187,9 @@ static void build_layout_broadside(void) {
 
     /* ── Hero: huge time, rotated PM on its right ── */
     lv_obj_t *hero = make_container(clock_root);
-    lv_obj_set_size(hero, LV_PCT(100), 212);
+    /* 24 px wider than the content column so the PM mark can sit in the
+     * root's right padding, clear of a four-digit time ("10:12"). */
+    lv_obj_set_size(hero, SCREEN_SIZE - 2 * 34 + 24, 212);
 
     lbl_time = make_label(hero, &lv_font_saira_black_300, BS_BONE, -4, "");
     lv_obj_align(lbl_time, LV_ALIGN_LEFT_MID, -6, 0);
@@ -1196,7 +1198,12 @@ static void build_layout_broadside(void) {
     lv_obj_set_style_transform_pivot_x(lbl_ampm, lv_pct(50), 0);
     lv_obj_set_style_transform_pivot_y(lbl_ampm, lv_pct(50), 0);
     lv_obj_set_style_transform_rotation(lbl_ampm, 900, 0);
-    lv_obj_align(lbl_ampm, LV_ALIGN_RIGHT_MID, 0, 0);
+    /* Rotation does not change the layout box, so the glyphs sit (w-h)/2
+     * left of the box's right edge; slide right by that to hug hero's edge. */
+    lv_label_set_text(lbl_ampm, "PM");
+    lv_obj_update_layout(lbl_ampm);
+    int32_t ampm_slide = (lv_obj_get_width(lbl_ampm) - lv_obj_get_height(lbl_ampm)) / 2;
+    lv_obj_align(lbl_ampm, LV_ALIGN_RIGHT_MID, ampm_slide, 0);
 
     /* ── Condition line (sanitized to the thin_84 glyph range) ── */
     lbl_cond = make_label(clock_root, &lv_font_saira_thin_84, BS_BONE, 2, "");
@@ -1785,16 +1792,16 @@ static void build_layout_network(void) {
     lbl_wind_val  = c_vals[4];
 
     /* Temperature line (vertical) with end ticks */
-    met_tick_a = make_bg_rect(forecast_row, 606, 33, 44, 14, MET_TEAL);
-    met_tick_b = make_bg_rect(forecast_row, 606, 697, 44, 14, MET_TEAL);
+    met_tick_a = make_bg_rect(forecast_row, 606, 21, 44, 14, MET_TEAL);
+    met_tick_b = make_bg_rect(forecast_row, 606, 685, 44, 14, MET_TEAL);
     for (int i = 0; i < FORECAST_BARS; i++) {
-        met_segs[i] = make_bg_rect(forecast_row, 621, 47 + 65 * i, 14, 65,
+        met_segs[i] = make_bg_rect(forecast_row, 621, 35 + 65 * i, 14, 65,
                                    MET_TEAL);
     }
 
     /* Temperature stations: dot on the line, hour + temp to its left */
     for (int i = 0; i < FORECAST_BARS; i++) {
-        int sy = 79 + 65 * i;
+        int sy = 67 + 65 * i;
         met_dots[i] = make_station_dot(forecast_row, 628, sy, 10, 4, MET_TEAL);
 
         forecast_lbls[i] = make_label(forecast_row, &lv_font_overpass_27,
@@ -1815,18 +1822,18 @@ static void build_layout_network(void) {
     /* Peak interchange: double ring + PEAK tag, moved to the hottest hour */
     met_peak_ring = make_container(forecast_row);
     lv_obj_set_size(met_peak_ring, 36, 36);
-    lv_obj_set_pos(met_peak_ring, 610, 61);
+    lv_obj_set_pos(met_peak_ring, 610, 49);
     lv_obj_set_style_radius(met_peak_ring, LV_RADIUS_CIRCLE, 0);
     lv_obj_set_style_border_width(met_peak_ring, 5, 0);
     lv_obj_set_style_border_color(met_peak_ring, lv_color_hex(0xFFFFFF), 0);
     lv_obj_set_style_border_opa(met_peak_ring, LV_OPA_COVER, 0);
 
-    met_peak_core = make_bg_rect(forecast_row, 622, 73, 12, 12, 0xFFFFFF);
+    met_peak_core = make_bg_rect(forecast_row, 622, 61, 12, 12, 0xFFFFFF);
     lv_obj_set_style_radius(met_peak_core, LV_RADIUS_CIRCLE, 0);
 
     met_peak_lbl = make_label(forecast_row, &lv_font_overpass_16, MET_RED, 1,
                               "PEAK");
-    lv_obj_set_pos(met_peak_lbl, 654, 69);
+    lv_obj_set_pos(met_peak_lbl, 654, 57);
 
     /* ── Legend panel ── */
     met_legend = make_container(forecast_row);
@@ -2079,7 +2086,7 @@ static void restyle_forecast(const weather_data_t *wd, bool red_night) {
     }
 
     if (s_layout == 6) {
-        int yp = 79 + 65 * i_pk;
+        int yp = 67 + 65 * i_pk;
         if (met_peak_ring) lv_obj_set_pos(met_peak_ring, 610, yp - 18);
         if (met_peak_core) lv_obj_set_pos(met_peak_core, 622, yp - 6);
         if (met_peak_lbl)  lv_obj_set_pos(met_peak_lbl, 654, yp - 10);


### PR DESCRIPTION
### Summary
Devices on a development channel might not receive updates if a stable release with the same base version was published. The update process now correctly considers only tags relevant to the device's specific update channel, ensuring development devices receive their intended updates.

### Changes
*   The OTA update process no longer stops searching for new releases when it encounters a stable tag from a different update channel.
*   The system now compares only tags belonging to the device's specific update channel to find the next available release.
*   The release walk terminates when an in-channel release is found at or below the installed version, when a full-erase floor marker is reached, or at the end of the release list.
*   This ensures development channel devices correctly receive updates even when a stable release with the same base version exists.
*   Adjusted the Broadside clock layout to prevent PM glyphs from overlapping with four-digit times.
*   Centered the Night Network clock's vertical temperature line by shifting its elements for balanced margins.

---
<sub>Analyzed **4** commit(s) | Updated: 2026-08-21T23:28:33.083Z | Generated by GitHub Actions</sub>