### PR TITLE
fix: Fix PSRAM usage when displaying cloud and weather radar pages

### DIFF
--- a/main/clouds_wms.h
+++ b/main/clouds_wms.h
@@ -69,22 +69,22 @@
 /* Channel table (config field clouds_channel, 0..2). All six layer names and
  * their PT10M DescribeDomains lists verified live 2026-08-18; a wrong name
  * returns a 460 B XML ServiceException, so a typo cannot silently serve the
- * wrong picture. blank_pct is the per-channel pure-black sample fraction above
- * which clouds_frame_incomplete() calls the frame a hole (see the measurements
+ * wrong picture. blank_pct is the near-black sample fraction above which
+ * clouds_frame_incomplete() calls the frame a blank slot (see the measurements
  * at that function). */
 typedef struct {
     const char *east;       /* GIBS layer name, GOES-East */
     const char *west;       /* GIBS layer name, GOES-West */
     const char *label;      /* overlay strip caption */
-    uint8_t     blank_pct;  /* > this % of samples pure black = incomplete frame */
+    uint8_t     blank_pct;  /* > this % of samples near black = blank (not ingested) frame */
 } clouds_channel_t;
 
 #define CLOUDS_CHANNEL_COUNT 3
 
 static const clouds_channel_t s_clouds_channels[CLOUDS_CHANNEL_COUNT] = {
-    { "GOES-East_ABI_GeoColor",              "GOES-West_ABI_GeoColor",              "GeoColor", 3  },
-    { "GOES-East_ABI_Band13_Clean_Infrared", "GOES-West_ABI_Band13_Clean_Infrared", "Clean IR", 10 },
-    { "GOES-East_ABI_Air_Mass",              "GOES-West_ABI_Air_Mass",              "Air Mass", 80 },
+    { "GOES-East_ABI_GeoColor",              "GOES-West_ABI_GeoColor",              "GeoColor", 90 },
+    { "GOES-East_ABI_Band13_Clean_Infrared", "GOES-West_ABI_Band13_Clean_Infrared", "Clean IR", 90 },
+    { "GOES-East_ABI_Air_Mass",              "GOES-West_ABI_Air_Mass",              "Air Mass", 90 },
 };
 
 /* Row for @p ch; an out-of-range value falls back to GeoColor rather than
@@ -409,35 +409,67 @@ static inline int clouds_parse_domains(const char *xml, size_t len, uint32_t *ou
 /* ---- blank / partial frame detection ---- */
 
 /* GIBS answers HTTP 200 for a slot whose tiles are missing: a BLANK frame is the
- * selected vector basemap overlay drawn over black (~99% pure black, and pure
- * black everywhere when the basemap is "none"), and a
- * PARTIAL frame (tiles not yet ingested) has rectangular pure-black blocks.
- * Sample every CLOUDS_BLANK_STEP-th pixel of every CLOUDS_BLANK_STEP-th row
- * (8100 samples of a 720x720 frame) and call the frame incomplete when more
- * than the channel's blank_pct percent of them are 0x0000. Raw decoded pixels,
- * before any bake or Red Night remap.
+ * selected vector basemap overlay drawn over black (~98 % near black on the
+ * sample grid, and black everywhere when the basemap is "none"). Sample every
+ * CLOUDS_BLANK_STEP-th pixel of every CLOUDS_BLANK_STEP-th row (8100 samples of
+ * a 720x720 frame) and call the frame incomplete when more than blank_pct of
+ * them are near black (all channels below 24). Raw decoded pixels, before any
+ * bake or Red Night remap.
  *
- * The threshold is PER CHANNEL because the channels differ enormously in how
- * much legitimate black they contain. Measured 2026-08-18 on real 720x720
- * zoom-7 GetMaps over Kansas / Florida / the Gulf (black = RGB565 0x0000 on the
- * same 8-px sample grid this function uses):
+ * The test catches BLANK slots only. It does not try to catch partially
+ * ingested frames (one black quadrant): blackness cannot separate those from
+ * a real night frame (2026-08-24: a GeoColor night frame over Missouri is 8 %
+ * near black on stb and the HW decoder crushes the dark night side to exact
+ * zero, so an exact-0x0000 gate at 3 % rejected every real frame and the page
+ * went black). Partials self-heal instead: the poller re-fetches the newest
+ * two slots every poll and a same-stamp slot is replaced when its hash changes.
  *
- *   GeoColor   0.00 - 0.09 %   (dark navy night, never pure black)  -> 3
- *   Clean IR   0.00 %          (warm clear ground is mid-grey, not
- *                               black; no day/night swing, it is a
- *                               temperature product)                -> 10
- *   Air Mass  17.3 - 54.2 %    (the product itself renders large pure
- *                               black areas)                        -> 80
- *   blank/partial (any channel) 95.4 - 100 %  (overlay over black)
- *
- * Clean IR gets 10 rather than 3 purely as headroom over a hotter scene than
- * the ones sampled; blanks sit at 95 %+, so the extra slack costs no detection
- * power. Air Mass at 80 still separates a real frame (54 % worst case) from a
- * blank (95 %), but a partially ingested Air Mass frame does slip through.
- * ponytail: single global number would reject every Air Mass frame; per-channel
- * table entry is the cheapest fix. Upgrade path if partial Air Mass frames
- * annoy: compare the black mask against the previous frame for the same stamp. */
+ * Measured on real 720x720 GetMaps (near-black share of the sample grid):
+ *   GeoColor  day 1.5 %, night 8 %      Clean IR  0 %      Air Mass  20 %
+ *   (author's earlier pure-black survey saw Air Mass up to 54 %)
+ *   blank, any channel: 96 - 98 %
+ * 90 clears the worst real frame by 36 points and sits 6 under a blank. The
+ * per-channel table column stays (it is the layer table anyway) so a channel
+ * can still be tuned individually. */
 #define CLOUDS_BLANK_STEP 8      /* sample stride, pixels and rows */
+
+/* Missing-tile (partial ingest) detection. A tile GIBS has not ingested yet is
+ * rendered EXACTLY black (0x0000 from either decoder), while the same area in
+ * the neighbouring frame of the loop (10 min apart) is lit. Night sky is dark
+ * in both, so it never trips this. Count, on the CLOUDS_BLANK_STEP grid, the
+ * samples that are lit in @p ref (any channel >= 24) and exactly zero in @p f;
+ * call @p f partial when they exceed CLOUDS_HOLE_PCT of the lit samples.
+ *
+ * Threshold math (zoom 6, 720 px): the day/night terminator moves ~90 px in
+ * the 10 min between frames, so at dusk up to ~12 % of samples go lit -> dark
+ * (and the HW decoder crushes dark to exact zero). ONE missing 256 px tile is
+ * also ~12 %. Those two cannot be told apart, so the bar sits at 30: catches
+ * the multi-tile holes seen after a channel change (45-55 % of the frame),
+ * never a terminator; a single-tile hole is left to the re-fetch to heal.
+ * Needs at least 1/20 of the grid lit in @p ref to say anything (a blank
+ * reference is no reference). Both buffers w x h, same stride. */
+#define CLOUDS_HOLE_PCT 30
+static inline bool clouds_frame_holes(const uint16_t *f, const uint16_t *ref,
+                                      int w, int h, int stride_px)
+{
+    if (f == NULL || ref == NULL || w <= 0 || h <= 0) return false;
+    if (stride_px < w) stride_px = w;
+    uint32_t n = 0, lit = 0, hole = 0;
+    for (int y = 0; y < h; y += CLOUDS_BLANK_STEP) {
+        const uint16_t *fr = f   + (size_t)y * (size_t)stride_px;
+        const uint16_t *rr = ref + (size_t)y * (size_t)stride_px;
+        for (int x = 0; x < w; x += CLOUDS_BLANK_STEP) {
+            n++;
+            uint16_t v = rr[x];
+            bool is_lit = (v >> 11) >= 3 || ((v >> 5) & 0x3F) >= 6 || (v & 0x1F) >= 3;
+            if (!is_lit) continue;
+            lit++;
+            if (fr[x] == 0x0000u) hole++;
+        }
+    }
+    if (lit * 20u < n) return false;
+    return hole * 100u > lit * (uint32_t)CLOUDS_HOLE_PCT;
+}
 
 static inline bool clouds_frame_incomplete(const uint16_t *rgb565, int w, int h,
                                            int stride_px, uint8_t ch)
@@ -449,7 +481,14 @@ static inline bool clouds_frame_incomplete(const uint16_t *rgb565, int w, int h,
         const uint16_t *row = rgb565 + (size_t)y * (size_t)stride_px;
         for (int x = 0; x < w; x += CLOUDS_BLANK_STEP) {
             n++;
-            if (row[x] == 0x0000u) black++;
+            /* NEAR black (every channel < 24, i.e. R5 < 3, G6 < 6, B5 < 3),
+             * not exactly 0x0000: the P4 hardware JPEG path crushes dark
+             * values to 0 where stb keeps 1-3, so an exact-zero test read a
+             * real night frame as 7-8 % black on HW vs <1 % on stb and the
+             * thresholds flipped with the decoder. Both decoders agree on
+             * "below 24". */
+            uint16_t v = row[x];
+            if ((v >> 11) < 3 && ((v >> 5) & 0x3F) < 6 && (v & 0x1F) < 3) black++;
         }
     }
     return black * 100u > n * (uint32_t)clouds_channel(ch)->blank_pct;

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -218,7 +218,10 @@ static esp_err_t fetch_image_into(const char *url, const char *label, image_fram
      * asks automated clients to identify themselves and Iowa Environmental
      * Mesonet blocks anonymous ones outright. extra_header stays free for the
      * caller's optional credential line (the Custom Image page's user-supplied
-     * "Name: value" header); NULL/empty means no extra header at all. */
+     * "Name: value" header); NULL/empty means no extra header at all.
+     * shrink_to_fit: a chunked response (GIBS) has no Content-Length, so the
+     * buffer is sized at the full max_size cap; without the shrink the frame
+     * ring would retain a 1 MiB allocation per slot for a ~120 KB image. */
     const http_fetch_binary_opts_t bopts = {
         .timeout_ms = GOES_HTTP_TIMEOUT_MS,
         .use_tls_bundle = true,
@@ -227,6 +230,7 @@ static esp_err_t fetch_image_into(const char *url, const char *label, image_fram
         .tx_buffer_size = 1024,
         .max_size = GOES_JPEG_MAX_SIZE,
         .oversize = HTTP_BIN_OVERSIZE_CLAMP,
+        .shrink_to_fit = true,
         .user_agent = "NINA-Display/1.0 (ESP32-P4 dashboard)",
         .extra_header = (auth_header && auth_header[0] != '\0') ? auth_header : NULL,
         .label = "image",
@@ -274,7 +278,7 @@ static esp_err_t fetch_image_into(const char *url, const char *label, image_fram
     uint8_t *rgb565 = NULL;
     uint32_t out_w = 0, out_h = 0;
     size_t out_size = 0;
-    bool decoded = jpeg_sw_decode_rgb565(jpeg_buf, total_read, &rgb565, &out_w, &out_h, &out_size);
+    bool decoded = jpeg_decode_rgb565(jpeg_buf, total_read, &rgb565, &out_w, &out_h, &out_size);
     if (out_src && decoded && rgb565) {
         *out_src     = jpeg_buf;              /* ownership moves to the caller */
         *out_src_len = (size_t)total_read;

--- a/main/image_page_poll.c
+++ b/main/image_page_poll.c
@@ -547,15 +547,33 @@ static bool anim_frame_url(image_page_t *p, const app_config_t *cfg, const char 
  * is not held, so the existing paths re-fetch it on the next poll (times[0]/[1]
  * every poll; older slots via retry_backfill). Not a failure: no caption, no
  * toast, no spine backoff. Radar (and a NULL frame) always returns false. */
+static uint32_t anim_stamp(image_page_t *p, int i);
+/* image_page_ring_with_neighbour adapter: @p arg is the fresh image_frame_t. */
+static bool clouds_holes_cb(const uint16_t *ref, int w, int h, void *arg)
+{
+    const image_frame_t *f = arg;
+    if (w != f->w || h != f->h) return false;
+    return clouds_frame_holes((const uint16_t *)f->buf, ref, w, h, w);
+}
+
 static bool clouds_drop_incomplete(image_page_t *p, const app_config_t *cfg,
                                    image_frame_t *f, uint8_t **src, int i)
 {
     if (p->src != IMG_SRC_CLOUDS || f->buf == NULL) return false;
-    if (!clouds_frame_incomplete((const uint16_t *)f->buf, f->w, f->h, f->w,
-                                 cfg->clouds_channel)) return false;
     anim_state_t *a = &s_anim[p->src];
-    ESP_LOGI(TAG, "clouds: slot %s incomplete, will retry",
-             (i >= 0 && i < a->ntimes) ? a->times[i] : "?");
+    const char *why = NULL;
+    if (clouds_frame_incomplete((const uint16_t *)f->buf, f->w, f->h, f->w,
+                                cfg->clouds_channel)) {
+        why = "blank";
+    } else if (image_page_ring_with_neighbour(p, anim_stamp(p, i), clouds_holes_cb, f)) {
+        /* Missing tiles: exactly black here, lit in the neighbouring frame.
+         * Seen after a channel change, when the whole ring is fetched fresh and
+         * the newest slots are still being ingested. */
+        why = "has missing tiles";
+    }
+    if (why == NULL) return false;
+    ESP_LOGI(TAG, "clouds: slot %s %s, will retry",
+             (i >= 0 && i < a->ntimes) ? a->times[i] : "?", why);
     heap_caps_free(f->buf);
     f->buf = NULL;
     if (*src) {
@@ -607,6 +625,47 @@ static bool anim_fetch_index(image_page_t *p, const app_config_t *cfg, const cha
  * attempt per stamp per poll). */
 #define RADAR_BACKFILL_GAP_MS 1000
 
+/* Transient PSRAM one frame decode needs on top of the frame itself: the stb
+ * software path holds an RGB888 buffer (~1.55 MB) plus the RGB565 output
+ * (~1.04 MB) at the same time. The hardware JPEG path needs only the latter;
+ * the conservative figure is the one that has to hold. */
+#define ANIM_DECODE_TRANSIENT_BYTES ((size_t)2600 * 1024)
+
+/* PSRAM headroom for one more animated frame, and the ONE place the ring is
+ * allowed to shrink. Without it the ring grows until the largest free block no
+ * longer fits a decode; the decode then fails every poll, the spine backs off,
+ * and the newest frame never updates again while the old ones keep animating.
+ *
+ * @p newest true = the frame the page exists to show: evict one frame from the
+ * oldest end when the decode would not fit, and attempt it regardless (if it
+ * still fails the existing backoff applies). false = an optional history frame:
+ * check only, never evict — freeing history to fetch history just re-fills the
+ * slot, and every extra download is radio time this panel pays for.
+ * ponytail: `need` is the stb worst case (3.64 MB); the HW JPEG path needs
+ * ~2.2 MB, so this can evict one frame more than strictly necessary. Tighten
+ * per source if a shorter loop is ever noticed on a healthy heap. */
+static bool anim_decode_headroom(image_page_t *p, bool newest)
+{
+    /* A panel-sized frame (clouds 720x720); radar frames are smaller, so this
+     * only ever errs toward more headroom. */
+    const size_t need = (size_t)SCREEN_SIZE * SCREEN_SIZE * 2 + ANIM_DECODE_TRANSIENT_BYTES;
+    if (!newest) {
+        if (heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM) >= need) return true;
+        ESP_LOGW(TAG, "%s backfill stopped: PSRAM headroom", p->name);
+        return false;
+    }
+    /* At most ONE drop per poll: freed holes rarely coalesce into one block, so
+     * a loop could collapse a 10-frame ring in a single poll. If one drop is not
+     * enough the decode fails, the spine backs off, and the next poll drops the
+     * next frame; the ring converges over a few intervals instead of at once. */
+    if (heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM) < need &&
+        image_page_ring_drop_oldest(p)) {
+        ESP_LOGI(TAG, "%s ring: dropped oldest frame for decode headroom, %d left",
+                 p->name, image_page_ring_count(p));
+    }
+    return true;
+}
+
 static void anim_backfill(image_page_t *p, const app_config_t *cfg, int first)
 {
     int cap = image_page_ring_capacity(p);
@@ -657,6 +716,10 @@ static void anim_backfill(image_page_t *p, const app_config_t *cfg, int first)
          * under the settings that just won. Safe to call from here: it runs on
          * this task, and no insert is in flight at this point in the loop. */
         image_page_ring_retransform_if_requested(p);
+
+        /* Optional history frame: only fetch it if its decode can actually land
+         * (one WARN per backfill attempt, and polls are interval-spaced). */
+        if (!anim_decode_headroom(p, false)) break;
 
         if (!anim_fetch_index(p, cfg, token, i, gen)) {
             ESP_LOGW(TAG, "%s backfill stopped at frame %d", p->name, i);
@@ -737,6 +800,10 @@ static bool net_poll_once(void *arg)
      * must not persist config). Radar only; "" for the others. */
     char token[16] = "";
     if (p->src == IMG_SRC_RADAR) image_page_radar_token(cfg, token, sizeof(token));
+    /* Make room for THIS decode before taking the fetch gate (the drop takes the
+     * display lock, which must never be held under the gate). The newest frame
+     * is attempted either way; the ring gives up its oldest slots to let it. */
+    if (animated) anim_decode_headroom(p, true);
     /* Serialize the fetch+decode across the six pollers (see s_fetch_gate).
      * A page that was left/un-warmed while we waited needs no extra test here:
      * image_page_commit_frame() retains the frame either way, and the resident

--- a/main/jpeg_utils.c
+++ b/main/jpeg_utils.c
@@ -4,6 +4,7 @@
  */
 
 #include "jpeg_utils.h"
+#include "driver/jpeg_decode.h"
 #include "driver/ppa.h"
 #include "esp_heap_caps.h"
 #include "esp_log.h"
@@ -128,6 +129,199 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
     *out_h = oh;
     *out_size = buf_sz;
     return true;
+}
+
+// =============================================================================
+// Hardware JPEG Decode (esp_driver_jpeg) with software fallback
+// =============================================================================
+
+/* One HW decode attempt. Returns ESP_OK (caller owns *out_buf) or the esp_err
+ * that says why HW cannot do this picture, so the caller falls back to stb.
+ *
+ * Peak PSRAM is the whole point: the HW path needs only the padded RGB565
+ * output (~1.04 MB at 720x720), where stb needs an RGB888 intermediate
+ * (~1.55 MB) live at the same time as that RGB565 buffer.
+ *
+ * Driver contract (esp-idf 5.5.2 components/esp_driver_jpeg/jpeg_decode.c):
+ *  - input buffer: no alignment requirement (comment at jpeg_decode.c:326-328),
+ *    a plain PSRAM heap buffer is fine;
+ *  - output buffer: address AND size must be cache-aligned, checked at
+ *    jpeg_decode.c:211 -- hence jpeg_alloc_decoder_mem(), which aligns to the
+ *    L2 line (128 B here) and reports the rounded-up size;
+ *  - jpeg_decoder_process() serializes on a shared codec mutex
+ *    (jpeg_decode.c:219, portMAX_DELAY), so a concurrent decode elsewhere
+ *    (the thumbnail fetch worker) waits rather than failing;
+ *  - progressive/CMYK/odd sampling are refused by the header parse or by
+ *    jpeg_decoder_process() with ESP_ERR_NOT_SUPPORTED. */
+/* Minimal baseline-JPEG header scan: walks the marker chain up to SOF0 and
+ * reads the frame size, component count and the Y sampling factors. Every read
+ * is bounds-checked. Returns false for anything that is not a plain SOF0
+ * baseline picture (progressive SOF2, arithmetic, 12-bit, truncated header).
+ *
+ * WHY not jpeg_decoder_get_info(): IDF 5.5.2's copy leaks its ~3.3 KB
+ * header_info allocation (internal RAM) on the "sampling factor cannot be
+ * recognized" path, and it hardcodes nothing about the MCU size we need for
+ * the repack below. This scan gives us both without the driver allocating. */
+static bool jpeg_scan_sof0(const uint8_t *d, size_t n, uint32_t *w, uint32_t *h,
+                           uint8_t *nf, uint8_t *hi0, uint8_t *vi0)
+{
+    if (n < 4 || d[0] != 0xFF || d[1] != 0xD8) return false;
+    size_t i = 2;
+    while (i + 4 <= n) {
+        if (d[i] != 0xFF) return false;
+        uint8_t m = d[i + 1];
+        if (m == 0xFF) { i++; continue; }              /* fill byte */
+        if (m == 0xD8 || (m >= 0xD0 && m <= 0xD7) || m == 0x01) { i += 2; continue; }
+        size_t seg = ((size_t)d[i + 2] << 8) | d[i + 3];
+        if (seg < 2 || i + 2 + seg > n) return false;
+        if (m == 0xC0) {                                /* SOF0: baseline */
+            const uint8_t *f = d + i + 4;               /* after length */
+            if (seg < 8 || f[0] != 8) return false;     /* 8-bit precision only */
+            *h  = ((uint32_t)f[1] << 8) | f[2];
+            *w  = ((uint32_t)f[3] << 8) | f[4];
+            *nf = f[5];
+            if (*nf < 1 || *nf > 3 || seg < 8u + 3u * *nf) return false;
+            *hi0 = f[7] >> 4;
+            *vi0 = f[7] & 0x0F;
+            return *w > 0 && *h > 0;
+        }
+        if (m == 0xDA || (m >= 0xC1 && m <= 0xCF && m != 0xC4 && m != 0xC8 && m != 0xCC)) {
+            return false;                               /* SOS before SOF0, or a non-baseline SOFn */
+        }
+        i += 2 + seg;
+    }
+    return false;
+}
+
+static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
+                                       uint8_t **out_buf, uint32_t *out_w,
+                                       uint32_t *out_h, size_t *out_size)
+{
+    uint32_t w = 0, h = 0;
+    uint8_t nf = 0, hi0 = 0, vi0 = 0;
+    if (!jpeg_scan_sof0(jpg, len, &w, &h, &nf, &hi0, &vi0)) return ESP_ERR_NOT_SUPPORTED;
+    /* Single-component JPEG: the HW only decodes it to GRAY8, and converting
+     * that to RGB565 is work stb already does for us in one pass. The HW
+     * accepts exactly 4:4:4 (1x1), 4:2:2 (2x1) and 4:2:0 (2x2) for 3 components
+     * (jpeg_decode.c get_info switch); anything else goes to stb. */
+    if (nf != 3) return ESP_ERR_NOT_SUPPORTED;
+    if (!((hi0 == 1 && vi0 == 1) || (hi0 == 2 && vi0 == 1) || (hi0 == 2 && vi0 == 2))) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+    if ((w * h) % 8 != 0) return ESP_ERR_NOT_SUPPORTED;   /* driver's own SOF check */
+
+    /* The decode engine's DMA descriptors come from the internal DMA heap. */
+    if (heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL) < 20 * 1024) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    /* HW writes whole MCUs: the row stride is the width padded to the Y MCU
+     * width (hi0*8: 8 for 4:4:4, 16 for 4:2:2/4:2:0) and the height to the Y
+     * MCU height (vi0*8) -- jpeg_parse_marker.c jpeg_parse_sof_marker(). A
+     * fixed 16 would shear every 4:4:4 picture whose width is 8 mod 16. */
+    uint32_t mcu_w = (uint32_t)hi0 * 8, mcu_h = (uint32_t)vi0 * 8;
+    uint32_t pad_w = ((w + mcu_w - 1) / mcu_w) * mcu_w;
+    uint32_t pad_h = ((h + mcu_h - 1) / mcu_h) * mcu_h;
+
+    jpeg_decode_memory_alloc_cfg_t mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
+    };
+    size_t alloc_size = 0;
+    uint8_t *buf = jpeg_alloc_decoder_mem((size_t)pad_w * pad_h * 2, &mem_cfg, &alloc_size);
+    if (!buf) return ESP_ERR_NO_MEM;
+
+    jpeg_decoder_handle_t decoder = NULL;
+    jpeg_decode_engine_cfg_t engine_cfg = { .intr_priority = 0, .timeout_ms = 5000 };
+    esp_err_t err = jpeg_new_decoder_engine(&engine_cfg, &decoder);
+    if (err != ESP_OK || !decoder) {
+        heap_caps_free(buf);
+        return (err != ESP_OK) ? err : ESP_FAIL;
+    }
+
+    /* DMA discipline: jpeg_alloc_decoder_mem() callocs the buffer through the
+     * CPU, which leaves up to L1+L2 (~320 KB) of DIRTY zero lines behind. The
+     * driver only invalidates (M2C) before and after the transfer; a dirty zero
+     * line that survives and is evicted after the DMA overwrites decoded pixels
+     * in PSRAM with black. Seen live on dash4: every HW-decoded Cloud Cover
+     * frame read back as >3% pure black and was rejected. Write the zeros back
+     * NOW so no dirty line outlives the transfer. */
+    esp_cache_msync(buf, alloc_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+
+    /* BGR element order gives the same in-memory RGB565 layout the SW path
+     * produces (R high, B low) -- see the packing comment above. */
+    jpeg_decode_cfg_t decode_cfg = {
+        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
+        .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
+    };
+    uint32_t decoded_size = 0;
+    err = jpeg_decoder_process(decoder, &decode_cfg, jpg, (uint32_t)len,
+                               buf, (uint32_t)alloc_size, &decoded_size);
+    jpeg_del_decoder_engine(decoder);
+    if (err != ESP_OK || decoded_size == 0) {
+        heap_caps_free(buf);
+        return (err != ESP_OK) ? err : ESP_FAIL;
+    }
+
+    /* Diagnostic: fraction of sampled pixels exactly 0x0000 in the raw DMA
+     * output. Confirmed 2026-08-24 on dash4: the HW colour conversion crushes
+     * dark values to 0 (7-8 % of a night GeoColor frame vs <1 % from stb),
+     * which is why clouds_frame_incomplete() tests NEAR black. Debug only. */
+    {
+        const uint16_t *px = (const uint16_t *)buf;
+        uint32_t n = 0, z = 0;
+        for (uint32_t y = 0; y < h; y += 8) {
+            for (uint32_t x = 0; x < w; x += 8) {
+                n++;
+                if (px[(size_t)y * pad_w + x] == 0) z++;
+            }
+        }
+        ESP_LOGD(TAG, "HW JPEG raw: %lu/%lu samples zero, px[0]=%04x mid=%04x",
+                 (unsigned long)z, (unsigned long)n, px[0],
+                 px[(size_t)(h / 2) * pad_w + w / 2]);
+    }
+
+    /* Callers expect tightly packed w*h*2 rows, so drop the MCU pad in place.
+     * Destination row y starts at or before source row y, and we walk top-down,
+     * so no row is overwritten before it is copied. */
+    if (pad_w != w) {
+        for (uint32_t y = 1; y < h; y++) {
+            memmove(buf + (size_t)y * w * 2,
+                    buf + (size_t)y * pad_w * 2,
+                    (size_t)w * 2);
+        }
+    }
+
+    /* The driver invalidated after the transfer, so the CPU (blank-frame check,
+     * the repack above, LVGL's software renderer) reads PSRAM, not stale lines.
+     * If we repacked, write those CPU rows back so the PPA scaler's DMA sees
+     * them; a no-op when nothing was repacked. */
+    if (pad_w != w) esp_cache_msync(buf, alloc_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+
+    *out_buf = buf;
+    *out_w = w;
+    *out_h = h;
+    *out_size = alloc_size;
+    return ESP_OK;
+}
+
+bool jpeg_decode_rgb565(const uint8_t *jpg, size_t len, uint8_t **out_buf,
+                        uint32_t *out_w, uint32_t *out_h, size_t *out_size)
+{
+    if (!jpg || !out_buf || !out_w || !out_h || !out_size || len == 0) return false;
+
+    /* Only JPEG goes near the HW engine: PNG/GIF payloads (radar tiles) are
+     * stb's job and must not log a HW failure every frame. */
+    if (len >= 3 && jpg[0] == 0xFF && jpg[1] == 0xD8 && jpg[2] == 0xFF) {
+        esp_err_t err = jpeg_hw_decode_rgb565(jpg, len, out_buf, out_w, out_h, out_size);
+        if (err == ESP_OK) {
+            ESP_LOGI(TAG, "HW JPEG decoded %lux%lu",
+                     (unsigned long)*out_w, (unsigned long)*out_h);
+            return true;
+        }
+        ESP_LOGI(TAG, "HW JPEG decode skipped (%s), using software decode",
+                 esp_err_to_name(err));
+    }
+    return jpeg_sw_decode_rgb565(jpg, len, out_buf, out_w, out_h, out_size);
 }
 
 // =============================================================================

--- a/main/jpeg_utils.h
+++ b/main/jpeg_utils.h
@@ -26,6 +26,24 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
                            size_t *out_size);
 
 /**
+ * @brief Decode an image to RGB565, ESP32-P4 hardware JPEG engine first.
+ *
+ * Tries the HW decoder for baseline JPEG and falls back to
+ * jpeg_sw_decode_rgb565() for anything it refuses (progressive, CMYK, grayscale,
+ * odd sampling, engine busy/out of memory) and for the non-JPEG formats stb
+ * handles (PNG, GIF). The HW path avoids stb's RGB888 intermediate (~1.55 MB at
+ * 720x720), which is what makes the image pages fit in a fragmented PSRAM heap.
+ *
+ * Output contract is identical to jpeg_sw_decode_rgb565(): tightly packed
+ * RGB565 rows top-down, out_w/out_h are the image's real pixel dimensions (the
+ * HW MCU padding is removed), 128-byte aligned PSRAM, caller frees with free().
+ *
+ * @return true on success (from either path)
+ */
+bool jpeg_decode_rgb565(const uint8_t *jpg, size_t len, uint8_t **out_buf,
+                        uint32_t *out_w, uint32_t *out_h, size_t *out_size);
+
+/**
  * @brief Probe a JPEG's pixel dimensions from its header WITHOUT decoding it.
  * Wraps stbi_info_from_memory(); reads only the header, allocates nothing for
  * pixel data. Use to reject oversized images before the full decode allocation.

--- a/main/radar_play.h
+++ b/main/radar_play.h
@@ -78,6 +78,7 @@ static inline bool radar_frame_is_stale(uint32_t frame_gen, uint32_t ring_gen)
 
 #define RADAR_PLAY_FRAME_MS  400   /* dwell on a history frame */
 #define RADAR_PLAY_NEWEST_MS 1200  /* longer hold on the newest frame */
+#define RADAR_PLAY_FADE_MS   250   /* dissolve between frames; must stay under RADAR_PLAY_FRAME_MS */
 
 /** FNV-1a over a byte range. Dedupe key for one radar frame. */
 static inline uint32_t radar_fnv1a(const void *data, size_t len)

--- a/main/ui/nina_image_page.c
+++ b/main/ui/nina_image_page.c
@@ -12,12 +12,13 @@
 
 #include "nina_image_page.h"
 #include "nina_wait_overlay.h"
+#include "nina_empty_state.h"
 #include "nina_nav_arbiter.h"          /* nav_arbiter_notify_content_ready */
 #include "nina_dashboard.h"            /* nina_dashboard_set_image_page_enabled (config apply, B5) */
 #include "nina_dashboard_internal.h"   /* SCREEN_SIZE, OUTER_PADDING, current_theme, PAGE_IDX_IMG_* */
 #include "image_red_remap.h"
 #include "image_night_invert.h"        /* radar: invert the greyscale basemap only */
-#include "jpeg_utils.h"                /* jpeg_sw_decode_rgb565 (radar local re-transform) */
+#include "jpeg_utils.h"                /* jpeg_decode_rgb565 (ring local re-transform) */
 #include "moon_interaction.h"
 #include "radar_sites.h"               /* radar_site_nearest (token resolution) */
 #include "radar_play.h"                /* ring size, dedupe hash, playback cursor */
@@ -44,7 +45,8 @@ static image_page_t s_pages[IMG_SRC_COUNT];
 /* Animation ring (Radar, Clouds) — implementation further down, forward-declared
  * here because the render/lifecycle functions above it dispatch into the ring
  * for the animated sources. All require the display lock held by the caller. */
-static void ring_show_idx(image_page_t *p, int idx);
+static void ring_show_idx(image_page_t *p, int idx, bool fade);
+static void ring_loading_sync(image_page_t *p);
 static void ring_timer_sync(image_page_t *p);
 static void ring_request_backfill(image_page_t *p);
 static bool ring_red_mismatch(image_page_t *p);
@@ -506,6 +508,19 @@ lv_obj_t *image_page_create(image_page_t *p, lv_obj_t *parent)
         lv_obj_add_flag(p->lbl_moon_set, LV_OBJ_FLAG_HIDDEN);
     }
 
+    /* Animated pages: a pulsing placeholder shown from page entry until the
+     * loop holds ring_show_gate() frames. Without it the first seconds after
+     * boot or entry are a black page (the ring is empty until the first
+     * download lands, and one or two frames loop badly). Hidden until
+     * ring_loading_sync() decides otherwise. */
+    if (image_src_is_animated(p->src)) {
+        p->loading = nina_empty_state_create(page_container, ICON_CLOUD_OFF,
+                                             p->src == IMG_SRC_CLOUDS ? "Loading Cloud Cover"
+                                                                      : "Loading Weather Radar",
+                                             NULL, 0);
+        if (p->loading) nina_empty_state_hide(p->loading);
+    }
+
     /* Cloud Cover location marker: created LAST so it stacks above both
      * crossfade images and the overlay bar. Clouds instance only; the other
      * five sources never build it and so can never show it. Independent of the
@@ -566,7 +581,7 @@ void image_page_render_frame(image_page_t *p)
      * and make sure the playback timer matches the current ring state. */
     if (image_src_is_animated(p->src)) {
         frame_unlock(p);
-        ring_show_idx(p, -1);           /* -1 = whatever the cursor is on */
+        ring_show_idx(p, -1, false);           /* -1 = whatever the cursor is on */
         ring_timer_sync(p);
         nina_wait_overlay_hide();
         return;
@@ -1000,7 +1015,7 @@ void image_page_show_scaled(image_page_t *p, const uint16_t *buf, int w, int h)
  * and the radar ring (owner = the ring slot). Each adds its own caption after
  * the swap. Caller holds the display lock and has already checked p->active,
  * p->root and the dimensions. */
-static void swap_borrowed_buf(image_page_t *p, const uint16_t *buf, int w, int h)
+static void swap_borrowed_buf(image_page_t *p, const uint16_t *buf, int w, int h, bool fade)
 {
     /* A settle->resting crossfade may still be in flight when a new drag frame
      * arrives (rapid re-swipe right at the grace boundary). Rather than DROP this
@@ -1045,10 +1060,38 @@ static void swap_borrowed_buf(image_page_t *p, const uint16_t *buf, int w, int h
     lv_obj_set_style_opa(p->img_back, LV_OPA_COVER, 0);
     lv_obj_clear_flag(p->img_back, LV_OBJ_FLAG_HIDDEN);
 
+    lv_image_dsc_t *old_dsc = p->front_is_a ? &p->dsc_a : &p->dsc_b;
+
+    /* Ring playback: dissolve into the next frame instead of cutting. Only ONE
+     * image animates, whichever is on top (child 1 draws over child 0): the
+     * incoming back fades in over a fully opaque front, or the outgoing front
+     * fades out over a fully opaque back. Animating both at once (the
+     * single-frame path) dips to ~75 % brightness at the midpoint, two half
+     * copies over black, which on near-identical satellite frames reads as a
+     * flicker. crossfade_done_cb retires the front when the fade lands; a tick
+     * arriving mid-fade goes through cancel_moon_crossfade above first. */
+    if (fade && old_dsc->data) {
+        lv_obj_t *top = p->front_is_a ? p->img_back : p->img_front;
+        int32_t from = p->front_is_a ? 0 : 255, to = p->front_is_a ? 255 : 0;
+        lv_obj_set_style_opa(top, (lv_opa_t)from, 0);
+        p->crossfade_active = true;
+        lv_anim_t a;
+        lv_anim_init(&a);
+        lv_anim_set_var(&a, top);
+        lv_anim_set_values(&a, from, to);
+        lv_anim_set_duration(&a, RADAR_PLAY_FADE_MS);
+        lv_anim_set_path_cb(&a, lv_anim_path_linear);
+        lv_anim_set_exec_cb(&a, anim_opa_cb);
+        lv_anim_set_user_data(&a, p);
+        lv_anim_set_completed_cb(&a, crossfade_done_cb);
+        lv_anim_start(&a);
+        p->displayed_stamp_ms = esp_timer_get_time() / 1000;
+        return;
+    }
+
     /* Instant swap: retire the old front and flip designations, mirroring the
      * instant branch of image_page_render_frame(). release_dsc() frees the old
      * front only if this page owned it (skips a prior borrowed buffer). */
-    lv_image_dsc_t *old_dsc = p->front_is_a ? &p->dsc_a : &p->dsc_b;
     lv_obj_add_flag(p->img_front, LV_OBJ_FLAG_HIDDEN);
     lv_image_set_src(p->img_front, NULL);
     release_dsc(p, old_dsc, p->front_is_a);
@@ -1068,7 +1111,7 @@ void image_page_show_borrowed(image_page_t *p, const uint16_t *buf, int w, int h
     if (!atomic_load(&p->active)) return;
     if (!buf || !p->root || w <= 0 || h <= 0) return;
 
-    swap_borrowed_buf(p, buf, w, h);
+    swap_borrowed_buf(p, buf, w, h, false);
 
     /* Keep the moon caption live during the drag. */
     char name[24], pct[16];
@@ -1172,6 +1215,7 @@ void image_page_apply_theme(image_page_t *p)
     /* Cloud Cover location marker follows the theme accent / Red Night rule.
      * No-op on the other five instances (s_clouds_marker is NULL there). */
     if (p->src == IMG_SRC_CLOUDS) marker_apply_theme();
+    if (p->loading) nina_empty_state_apply_theme(p->loading, current_theme, app_config_get()->color_brightness);
 
     /* Ring pixels (Radar, Clouds) are recoloured once, at insert, so restyling
      * labels is not enough here: crossing the Red Night boundary changes both
@@ -1297,6 +1341,7 @@ void image_page_set_active(image_page_t *p, bool active)
         ring_request_backfill(p);
         image_page_ensure_task_running(p);
         image_page_render_frame(p);   /* a retained or warm frame shows instantly; no-op when empty */
+        ring_loading_sync(p);         /* animated pages: placeholder until the loop has frames */
         image_page_wake(p);
         return;
     }
@@ -1312,6 +1357,7 @@ void image_page_set_active(image_page_t *p, bool active)
      * here rather than let a parked page sit on it; the next activation
      * backfills. No-op for the single-frame sources. */
     image_page_ring_reset(p);
+    ring_loading_sync(p);             /* page hidden: placeholder down */
     nina_wait_overlay_hide();
     image_page_wake(p);
 }
@@ -1722,6 +1768,39 @@ bool image_page_ring_has_stamp(image_page_t *p, uint32_t stamp)
     return false;
 }
 
+bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
+                                    bool (*fn)(const uint16_t *ref, int w, int h, void *arg),
+                                    void *arg)
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || !fn || stamp == 0) return false;
+    if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) return false;
+    int n = atomic_load(&r->count);
+    if (n > RADAR_RING_MAX) n = RADAR_RING_MAX;
+    uint32_t cur = atomic_load(&r->bake_gen);
+    int best = -1;
+    uint32_t best_d = 0;
+    bool best_same = true;
+    for (int i = 0; i < n; i++) {
+        ring_slot_t *s = &r->slots[i];
+        if (!s->buf || s->stamp == 0 || s->bake_gen != cur) continue;
+        uint32_t d = (s->stamp > stamp) ? s->stamp - stamp : stamp - s->stamp;
+        bool same = (d == 0);
+        /* A different stamp always beats the same stamp (a re-fetch must not be
+         * judged against its own earlier, possibly partial, version). */
+        if (best < 0 || (best_same && !same) || (same == best_same && d < best_d)) {
+            best = i; best_d = d; best_same = same;
+        }
+    }
+    bool ret = false;
+    if (best >= 0) {
+        ring_slot_t *s = &r->slots[best];
+        ret = fn((const uint16_t *)s->buf, (int)s->w, (int)s->h, arg);
+    }
+    bsp_display_unlock();
+    return ret;
+}
+
 /* Free one slot — BOTH its allocations, the decoded pixels and the retained
  * compressed source. Display lock held. Detaches the LVGL descriptors first if
  * they borrow this slot's buffer, so the free can never leave LVGL on freed
@@ -1731,9 +1810,19 @@ bool image_page_ring_has_stamp(image_page_t *p, uint32_t stamp)
 static void ring_free_slot(image_page_t *p, image_ring_t *r, int i)
 {
     ring_slot_t *s = &r->slots[i];
-    if (s->buf && (const uint8_t *)s->buf == r->shown) {
-        image_page_release_lvgl(p);      /* drops both descriptors + borrowed flags */
-        r->shown = NULL;
+    if (s->buf) {
+        const uint8_t *b = (const uint8_t *)s->buf;
+        /* During the playback dissolve the OUTGOING frame is still drawn for
+         * RADAR_PLAY_FADE_MS after r->shown moved on. Finalize the fade first:
+         * that retires and detaches the outgoing descriptor, so freeing its
+         * slot below is safe and the incoming frame stays on screen. */
+        if (p->crossfade_active && (b == p->dsc_a.data || b == p->dsc_b.data)) {
+            cancel_moon_crossfade(p);
+        }
+        if (b == r->shown || b == p->dsc_a.data || b == p->dsc_b.data) {
+            image_page_release_lvgl(p);  /* drops both descriptors + borrowed flags */
+            r->shown = NULL;
+        }
     }
     if (s->buf) heap_caps_free(s->buf);
     if (s->src) heap_caps_free(s->src);
@@ -1742,7 +1831,7 @@ static void ring_free_slot(image_page_t *p, image_ring_t *r, int i)
 
 /* Put ring slot @p idx on screen (idx < 0 = the current cursor). Display lock
  * held. No-op when the page has no LVGL objects or the slot is empty. */
-static void ring_show_idx(image_page_t *p, int idx)
+static void ring_show_idx(image_page_t *p, int idx, bool fade)
 {
     image_ring_t *r = ring_of(p);
     if (!r) return;
@@ -1753,7 +1842,7 @@ static void ring_show_idx(image_page_t *p, int idx)
     ring_slot_t *s = &r->slots[idx];
     if (!s->buf || !p->root || s->w == 0 || s->h == 0) return;
 
-    swap_borrowed_buf(p, (const uint16_t *)s->buf, (int)s->w, (int)s->h);
+    swap_borrowed_buf(p, (const uint16_t *)s->buf, (int)s->w, (int)s->h, fade);
     r->shown    = s->buf;
     r->play_idx = idx;
 
@@ -1816,26 +1905,112 @@ static void ring_tick_cb(lv_timer_t *t)
 
     int next = radar_play_next_baked(r->play_idx, count, gens, cur_gen);
     if (next == r->play_idx) return;
-    ring_show_idx(p, next);
+    ring_show_idx(p, next, true);
     lv_timer_set_period(t, radar_play_period_ms(next));
 }
 
 /* Create or delete the playback timer to match the current state. Display lock
  * held. A single still (frames == 1, or a ring that has not filled past one
  * frame) never animates, matching the other image pages. */
+/* Frames the loop must hold before anything is put on screen: 3, or the whole
+ * capacity when it is smaller. One frame is a still, two flicker. */
+static int ring_show_gate(image_page_t *p)
+{
+    int c = image_page_ring_capacity(p);
+    return c < 3 ? c : 3;
+}
+
+/* Show or hide the loading placeholder to match the ring state. Display lock
+ * held. "Loading" = the page is visible, nothing has been shown yet and the
+ * ring is still under the gate; once a frame is up the placeholder never
+ * returns for that visit (a ring shrunk by memory pressure keeps playing). The
+ * Cloud Cover marker hides with it so the page is not a lone dot on black. */
+static void ring_loading_sync(image_page_t *p)
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || !p->loading) return;
+    int count = atomic_load(&r->count);
+    int gate  = ring_show_gate(p);
+    bool loading = atomic_load(&p->active) && r->shown == NULL && count < gate;
+    if (loading) {
+        /* Progress in the title so the wait reads as work, not a hang: each
+         * frame is a ~3 s download + decode, so "1 of 3" is the honest ETA. */
+        char title[48];
+        snprintf(title, sizeof(title), "Loading %s  %d of %d",
+                 p->src == IMG_SRC_CLOUDS ? "Cloud Cover" : "Weather Radar", count, gate);
+        nina_empty_state_set_title(p->loading, title);
+        nina_empty_state_show(p->loading);
+        nina_empty_state_set_busy(p->loading, true);
+        if (p->src == IMG_SRC_CLOUDS) marker_set_visible(false);
+    } else {
+        nina_empty_state_set_busy(p->loading, false);
+        nina_empty_state_hide(p->loading);
+        if (p->src == IMG_SRC_CLOUDS) marker_set_visible(app_config_get()->clouds_show_location);
+    }
+}
+
 static void ring_timer_sync(image_page_t *p)
 {
     image_ring_t *r = ring_of(p);
     if (!r) return;
     bool want = atomic_load(&p->active) &&
                 image_page_ring_capacity(p) > 1 &&
-                atomic_load(&r->count) > 1;
+                atomic_load(&r->count) > 1 &&
+                r->shown != NULL;              /* nothing plays before the gate */
     if (want && !r->timer) {
         r->timer = lv_timer_create(ring_tick_cb, RADAR_PLAY_FRAME_MS, p);
     } else if (!want && r->timer) {
         lv_timer_delete(r->timer);
         r->timer = NULL;
     }
+}
+
+/* Free the OLDEST resident frame so the next decode has somewhere to go.
+ *
+ * WHY: a full ring is 6-10 MB and nothing ever shrank it. Once PSRAM is
+ * fragmented past the point where a decode can get its blocks, the fetch fails,
+ * the poll spine backs off, and the poller retries the same doomed decode
+ * forever — the NEWEST frame stops updating while the old ones keep animating.
+ * This is the release valve; the caller (anim_decode_headroom in
+ * image_page_poll.c) decides when to pull it.
+ *
+ * LOCKING / CURSOR: identical to the oldest-end eviction inside
+ * image_page_ring_add() — display lock taken here (this runs on the page's poll
+ * task, outside the lock, exactly like _add), ring_free_slot() for the pairing
+ * of pixels + retained source and for detaching the LVGL descriptor if that
+ * buffer is the one on screen. The only case _add does not have to handle is the
+ * cursor sitting ON the freed tail (it always inserts afterwards and re-shows),
+ * so clamp play_idx and put the newest frame up instead; ring_timer_sync() then
+ * stops the timer if a single frame is left.
+ *
+ * Never drops the last frame: the newest must survive or the page goes blank. */
+bool image_page_ring_drop_oldest(image_page_t *p)
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || atomic_load(&r->count) <= 1) return false;
+    if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) return false;
+
+    int count = atomic_load(&r->count);
+    if (count <= 1) {                      /* re-tested under the lock */
+        bsp_display_unlock();
+        return false;
+    }
+    ring_free_slot(p, r, count - 1);
+    count--;
+    atomic_store(&r->count, count);
+    if (r->play_idx >= count) {            /* the cursor was on the slot just freed */
+        r->play_idx = 0;
+        if (atomic_load(&p->active)) ring_show_idx(p, 0, false);   /* same gate as _add */
+    }
+    ring_timer_sync(p);
+    bsp_display_unlock();
+
+    /* Deliberately NO backfill re-arm. The backfill assumes an empty ring (its
+     * URL index i lands in slot i); on a partial ring it would fetch the wrong
+     * history slot (Radar) or re-download the stamp just evicted (Clouds), once
+     * per poll, forever. A ring shrunk under memory pressure stays shorter until
+     * the next page activation rebuilds it. */
+    return true;
 }
 
 void image_page_ring_reset(image_page_t *p)
@@ -1867,6 +2042,7 @@ void image_page_ring_reset(image_page_t *p)
      * the display lock held, the same lock image_page_ring_add() tests it
      * under, so there is no window between the bump and the free. */
     atomic_fetch_add(&r->gen, 1);
+    ring_loading_sync(p);
 }
 
 void image_page_ring_invalidate(image_page_t *p)
@@ -2108,8 +2284,13 @@ void image_page_ring_add(image_page_t *p, image_frame_t *fresh, bool at_head, ui
             if (atomic_load(&p->active)) {
                 /* Re-show only if the healed slot was on screen (its buffer is
                  * gone) or nothing is up yet; otherwise playback carries on. */
-                if (was_shown || !r->shown) ring_show_idx(p, was_shown ? same : -1);
-                ring_timer_sync(p);
+                if (!r->shown && atomic_load(&r->count) < ring_show_gate(p)) {
+                    ring_loading_sync(p);
+                } else {
+                    if (was_shown || !r->shown) ring_show_idx(p, was_shown ? same : 0, false);
+                    ring_loading_sync(p);
+                    ring_timer_sync(p);
+                }
                 notify = true;
             }
             bsp_display_unlock();
@@ -2175,8 +2356,16 @@ void image_page_ring_add(image_page_t *p, image_frame_t *fresh, bool at_head, ui
          * frame just inserted was baked live, so it is the one slot guaranteed
          * current: jumping to it is what ends that hold at the first opportunity
          * instead of waiting for the pass. */
-        ring_show_idx(p, (r->shown && ring_slot_current(r, r->play_idx)) ? -1 : pos);
-        ring_timer_sync(p);
+        if (!r->shown && count < ring_show_gate(p)) {
+            ring_loading_sync(p);             /* keep the placeholder up */
+        } else {
+            /* First show of the visit goes to the NEWEST frame (index 0), not
+             * to the slot just inserted, which past the gate is history. */
+            ring_show_idx(p, !r->shown ? 0
+                             : (ring_slot_current(r, r->play_idx) ? -1 : pos), false);
+            ring_loading_sync(p);
+            ring_timer_sync(p);
+        }
         notify = true;
     }
     bsp_display_unlock();
@@ -2303,7 +2492,7 @@ static bool ring_retransform_pass(image_page_t *p, image_ring_t *r)
         uint8_t *px = NULL;
         uint32_t w = 0, h = 0;
         size_t   sz = 0;
-        if (jpeg_sw_decode_rgb565(src, len, &px, &w, &h, &sz) && px) {
+        if (jpeg_decode_rgb565(src, len, &px, &w, &h, &sz) && px) {
             f.buf = px;
             f.w   = (uint16_t)w;
             f.h   = (uint16_t)h;
@@ -2346,7 +2535,7 @@ static bool ring_retransform_pass(image_page_t *p, image_ring_t *r)
          * playback by the time it is on screen. */
         r->slots[i].bake_gen = bake_gen;
         /* .hash is over the compressed bytes, so it survives the re-bake. */
-        if (was_shown) ring_show_idx(p, i);
+        if (was_shown) ring_show_idx(p, i, false);
         bsp_display_unlock();
         if (old) heap_caps_free(old);
         done++;

--- a/main/ui/nina_image_page.h
+++ b/main/ui/nina_image_page.h
@@ -89,6 +89,7 @@ typedef struct image_page {
 
     /* LVGL state (display lock held by the caller for every access) */
     lv_obj_t *root, *img_front, *img_back, *overlay_bar, *lbl_region, *lbl_timestamp;
+    lv_obj_t *loading;                 /* animated pages: pulsing placeholder until the loop has a few frames; else NULL */
     lv_obj_t *lbl_moon_age, *lbl_moon_next, *lbl_moon_rise, *lbl_moon_set;   /* Moon instance only, else NULL */
     lv_image_dsc_t dsc_a, dsc_b;
     bool      dsc_a_borrowed, dsc_b_borrowed, front_is_a, crossfade_active, force_redraw;
@@ -202,6 +203,20 @@ int  image_page_ring_count(image_page_t *p);        /* resident frames (lock-fre
 int  image_page_ring_capacity(image_page_t *p);     /* radar_frames / clouds_frames, clamped 1..RADAR_RING_MAX */
 bool image_page_ring_backfill_take(image_page_t *p);   /* consume the pending-backfill request */
 bool image_page_ring_has_stamp(image_page_t *p, uint32_t stamp);   /* lock-free; a held stamp needs no re-download */
+/* Run @p fn on the pixels of the resident frame nearest in time to @p stamp
+ * (a different stamp preferred over the same one; current bake only) with the
+ * display lock held for the duration, so the slot cannot be freed under it.
+ * Returns fn's result, or false when the ring has no usable neighbour. */
+bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
+                                    bool (*fn)(const uint16_t *ref, int w, int h, void *arg),
+                                    void *arg);
+/* Free the OLDEST resident frame (pixels + retained source) to give the next
+ * decode room. Takes the display lock itself; the page's poll task only, same as
+ * image_page_ring_add(). Returns false — freeing nothing — when the ring holds
+ * one frame or none: the newest must survive so the page never goes blank.
+ * Does NOT re-arm the backfill (it assumes an empty ring); a shrunk ring stays
+ * shorter until the next page activation rebuilds it. */
+bool image_page_ring_drop_oldest(image_page_t *p);
 /* Enforce IMAGE_PAGE_MAX_RESIDENT: while more than the cap are resident, free the
  * frame of the least-recently-shown instance that is neither active nor warm.
  * Called by image_page_commit_frame after every commit; no display lock. */

--- a/test/host/test_clouds_wms.c
+++ b/test/host/test_clouds_wms.c
@@ -305,20 +305,43 @@ int main(void) {
         memset(px, 0, sizeof(px));
         check_bool("incomplete: all black", clouds_frame_incomplete(px, W, H, W, 0), true);
         check_bool("incomplete: all black (Air Mass too)", clouds_frame_incomplete(px, W, H, W, 2), true);
-        for (int i = 0; i < W * H; i++) px[i] = 0x0841;          /* night navy */
+        for (int i = 0; i < W * H; i++) px[i] = 0x0004;          /* night navy, RGB(0,0,32): above the near-black gate */
         check_bool("incomplete: all dark navy", clouds_frame_incomplete(px, W, H, W, 0), false);
-        /* 25% black block: top-left quadrant */
+        for (int i = 0; i < W * H; i++) px[i] = 0x0841;          /* RGB(8,8,8): HW crushes this to 0, stb keeps it; both count as near black */
+        check_bool("incomplete: all crushed-dark counts as black", clouds_frame_incomplete(px, W, H, W, 0), true);
+        for (int i = 0; i < W * H; i++) px[i] = 0x0004;
+        /* 25% black block (one missing quadrant) is NOT rejected any more: the
+         * gate only catches blank slots; partials self-heal on the next poll. */
         for (int y = 0; y < H / 2; y++)
             for (int x = 0; x < W / 2; x++) px[y * W + x] = 0;
-        check_bool("incomplete: 25% black block (GeoColor, 3%)", clouds_frame_incomplete(px, W, H, W, 0), true);
-        check_bool("incomplete: 25% black block (Clean IR, 10%)", clouds_frame_incomplete(px, W, H, W, 1), true);
-        /* Air Mass renders large legitimately black areas: 25% black is a GOOD frame */
-        check_bool("incomplete: 25% black block (Air Mass, 80%)", clouds_frame_incomplete(px, W, H, W, 2), false);
+        check_bool("incomplete: 25% black block passes (GeoColor)", clouds_frame_incomplete(px, W, H, W, 0), false);
+        check_bool("incomplete: 25% black block passes (Air Mass)", clouds_frame_incomplete(px, W, H, W, 2), false);
+        /* 95% black = blank slot with a few basemap lines */
+        for (int i = 0; i < W * H; i++) px[i] = 0;
+        for (int x = 0; x < W; x += 8) px[x] = 0x0004;               /* 12 of 96 samples lit = 87.5% black */
+        check_bool("incomplete: 87% black passes", clouds_frame_incomplete(px, W, H, W, 0), false);
+        for (int x = 8; x < W; x += 8) px[x] = 0;                     /* 1 of 96 lit = 99% black */
+        check_bool("incomplete: 99% black is blank", clouds_frame_incomplete(px, W, H, W, 1), true);
         /* ~1% black: 1 of the 96 sampled pixels */
-        for (int i = 0; i < W * H; i++) px[i] = 0x0841;
+        for (int i = 0; i < W * H; i++) px[i] = 0x0004;
         px[0] = 0;
         check_bool("incomplete: 1% black", clouds_frame_incomplete(px, W, H, W, 0), false);
         check_bool("incomplete: NULL is not incomplete", clouds_frame_incomplete(NULL, W, H, W, 0), false);
+        /* missing tiles vs the neighbouring frame */
+        static uint16_t ref[W * H];
+        for (int i = 0; i < W * H; i++) { ref[i] = 0x5aac; px[i] = 0x5aac; }   /* both lit */
+        check_bool("holes: identical lit frames", clouds_frame_holes(px, ref, W, H, W), false);
+        for (int y = 0; y < H / 2; y++)
+            for (int x = 0; x < W / 2; x++) px[y * W + x] = 0;            /* one tile: 25% < 30% bar */
+        check_bool("holes: single quadrant is under the bar", clouds_frame_holes(px, ref, W, H, W), false);
+        for (int y = 0; y < H / 2; y++)
+            for (int x = 0; x < W; x++) px[y * W + x] = 0;                /* top half: 50% */
+        check_bool("holes: black half where ref is lit", clouds_frame_holes(px, ref, W, H, W), true);
+        for (int y = 0; y < H / 2; y++)
+            for (int x = 0; x < W; x++) ref[y * W + x] = 0x0841;          /* same area dark in ref too (night) */
+        check_bool("holes: dark in both is not a hole", clouds_frame_holes(px, ref, W, H, W), false);
+        for (int i = 0; i < W * H; i++) ref[i] = 0;
+        check_bool("holes: blank reference says nothing", clouds_frame_holes(px, ref, W, H, W), false);
     }
 
     printf("\n%s (%d failures)\n", fails == 0 ? "ALL PASSED" : "FAILED", fails);


### PR DESCRIPTION
### Summary
This PR resolves issues where the cloud display would freeze due to memory exhaustion when decoding new images. It improves image decoding efficiency and memory management, while also enhancing the user experience with smoother frame transitions and loading indicators.

### Changes
*   Shrinks image fetch buffers to reduce memory usage and prevent PSRAM wedging.
*   Implements hardware-accelerated JPEG decoding for RGB565 images, with a software fallback, to improve performance.
*   Manages image ring buffer memory by dropping the oldest frame when a new decode requires more space.
*   Adjusts the blank frame detection threshold for cloud images to correctly display dark night frames.
*   Rejects incomplete multi-tile cloud frames, ensuring only full images are displayed.
*   Adds a smooth 250ms dissolve effect when transitioning between cloud images.
*   Displays a "Loading N of 3" message to indicate progress while cloud frames are buffering.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-08-25T05:50:27.107Z | Generated by GitHub Actions</sub>