### PR TITLE
perf: move image fit, dissolve, decode to PPA

### DIFF
--- a/main/clouds_wms.h
+++ b/main/clouds_wms.h
@@ -33,10 +33,12 @@
  *    origin has not filled, and a partial frame whose missing tiles are black
  *    blocks, are caught by clouds_frame_incomplete() (black-sample fraction)
  *    before the frame reaches the ring; the poller re-fetches the stamp on the
- *    next poll. ponytail: a partial frame that leaves less than the channel's
- *    blank_pct of the samples black still slips through and is only healed by the
- *    same-stamp replace on the next poll. Upgrade path: also compare the
- *    tile grid against the previous frame for the same stamp.
+ *    next poll. A PARTIALLY ingested frame (black tile rectangles under the
+ *    vector basemap) is too light to trip that gate and is caught instead by
+ *    clouds_frame_holes(), per cell against the neighbouring frame of the loop.
+ *    ponytail: that needs a neighbour, so the very first frame into an empty
+ *    ring is still accepted unjudged. Upgrade path: re-judge the head once the
+ *    backfill has given it one (image_page_poll.c).
  *
  * All maths is float-only (the P4 FPU is single precision); the calendar
  * helpers are integer days-from-civil / civil-from-days, no localtime.
@@ -416,13 +418,12 @@ static inline int clouds_parse_domains(const char *xml, size_t len, uint32_t *ou
  * them are near black (all channels below 24). Raw decoded pixels, before any
  * bake or Red Night remap.
  *
- * The test catches BLANK slots only. It does not try to catch partially
- * ingested frames (one black quadrant): blackness cannot separate those from
- * a real night frame (2026-08-24: a GeoColor night frame over Missouri is 8 %
- * near black on stb and the HW decoder crushes the dark night side to exact
- * zero, so an exact-0x0000 gate at 3 % rejected every real frame and the page
- * went black). Partials self-heal instead: the poller re-fetches the newest
- * two slots every poll and a same-stamp slot is replaced when its hash changes.
+ * The test catches BLANK slots only: blackness ALONE cannot separate a partially
+ * ingested frame from a real night frame (2026-08-24: a GeoColor night frame over
+ * Missouri is 8 % near black on stb and the HW decoder crushes the dark night
+ * side to exact zero, so an exact-0x0000 gate at 3 % rejected every real frame
+ * and the page went black). Partial frames are caught by clouds_frame_holes()
+ * instead, which needs a neighbouring frame to compare against.
  *
  * Measured on real 720x720 GetMaps (near-black share of the sample grid):
  *   GeoColor  day 1.5 %, night 8 %      Clean IR  0 %      Air Mass  20 %
@@ -433,42 +434,80 @@ static inline int clouds_parse_domains(const char *xml, size_t len, uint32_t *ou
  * can still be tuned individually. */
 #define CLOUDS_BLANK_STEP 8      /* sample stride, pixels and rows */
 
-/* Missing-tile (partial ingest) detection. A tile GIBS has not ingested yet is
- * rendered EXACTLY black (0x0000 from either decoder), while the same area in
- * the neighbouring frame of the loop (10 min apart) is lit. Night sky is dark
- * in both, so it never trips this. Count, on the CLOUDS_BLANK_STEP grid, the
- * samples that are lit in @p ref (any channel >= 24) and exactly zero in @p f;
- * call @p f partial when they exceed CLOUDS_HOLE_PCT of the lit samples.
+/* Shared near-black predicate: every channel below 24 (R5 < 3, G6 < 6, B5 < 3).
+ * NOT an exact-0x0000 test: the P4 hardware JPEG decoder crushes dark values to
+ * 0 where stb keeps 1-3, so an exact-zero gate flips its verdict with the
+ * decoder. Both gates below are built on this one predicate, so "lit" and
+ * "black" mean the same thing on both sides of a comparison. */
+static inline bool clouds_px_near_black(uint16_t v)
+{
+    return (v >> 11) < 3 && ((v >> 5) & 0x3Fu) < 6 && (v & 0x1Fu) < 3;
+}
+
+/* Missing-tile (partial ingest) detection, per CELL against the neighbouring
+ * frame of the loop (10 min apart). A tile GIBS has not ingested is rendered
+ * black, but the vector basemap is composited over the WHOLE canvas regardless,
+ * so a hole keeps its border/road/graticule lines drawn over black -- which is
+ * exactly what the reported partial frames look like.
  *
- * Threshold math (zoom 6, 720 px): the day/night terminator moves ~90 px in
- * the 10 min between frames, so at dusk up to ~12 % of samples go lit -> dark
- * (and the HW decoder crushes dark to exact zero). ONE missing 256 px tile is
- * also ~12 %. Those two cannot be told apart, so the bar sits at 30: catches
- * the multi-tile holes seen after a channel change (45-55 % of the frame),
- * never a terminator; a single-tile hole is left to the re-fetch to heal.
- * Needs at least 1/20 of the grid lit in @p ref to say anything (a blank
- * reference is no reference). Both buffers w x h, same stride. */
-#define CLOUDS_HOLE_PCT 30
+ * Split the frame into a CLOUDS_HOLE_CELLS x CLOUDS_HOLE_CELLS grid (6x6 = 120 px
+ * cells on a 720 px frame; a GIBS hole is a large rectangle covering at least one
+ * whole cell -- the pitch of the origin's internal tiles cannot be derived from
+ * the GetMap bbox, since the server reprojects them into one flat render). Sample
+ * on the CLOUDS_BLANK_STEP grid, and for each cell count the samples LIT in @p ref
+ * that went NEAR BLACK in @p f. Flag the frame when ONE cell crosses the bar.
+ *
+ * Calibration (device pixels, ninadash4 2026-08-25, a complete GeoColor night
+ * frame at zoom 6 over Missouri, basemap 2, on this same sample grid):
+ *   - 57.6 % of samples near black, 42.4 % lit. The old global gate used an
+ *     exact-zero numerator and measured only 15.0 % -- a ~4x undercount -- and
+ *     then divided a localised hole by the WHOLE frame's lit count, so a
+ *     35-45 % hole scored in the single digits. It never fired once on device.
+ *   - Terminator, the one thing that can look like a hole: a cell that flips
+ *     day -> night in 10 min keeps that same 42 % lit, so at most ~58 % of its
+ *     ref-lit samples go dark.
+ *   - A real hole keeps only the 1-2 px vector line cores lit (a few percent of
+ *     the cell), so ~80-90 % of its ref-lit samples go dark.
+ * CLOUDS_HOLE_CELL_PCT 75 sits between the two, with ~17 points of margin over
+ * the terminator worst case. (The task brief suggested starting at 85; 85 sits
+ * ON the hole floor and would keep missing the exact frames this fixes, so the
+ * bar is set on the terminator side instead. A false positive costs one
+ * re-fetch; a false negative is the bug.)
+ *
+ * A cell is judged only when at least 1/CLOUDS_HOLE_MIN_LIT_Q of its samples are
+ * lit in @p ref: an ocean-at-night or blank-reference cell says nothing, and a
+ * reference that is itself holed in the same place (consecutive partial slots)
+ * falls under the floor rather than voting "clean". Both buffers w x h, same
+ * stride. Pure: no allocation, sampling grid only, never reads every pixel. */
+#define CLOUDS_HOLE_CELLS      6    /* grid side: 6x6 cells = 120 px on a 720 px frame */
+#define CLOUDS_HOLE_CELL_PCT   75   /* >= this % of a cell's ref-lit samples gone black = hole */
+#define CLOUDS_HOLE_MIN_LIT_Q  4    /* ref cell needs >= samples/4 lit to be judged at all */
+#define CLOUDS_HOLE_MIN_CELL_N 8    /* and at least this many samples (tiny frames say nothing) */
 static inline bool clouds_frame_holes(const uint16_t *f, const uint16_t *ref,
                                       int w, int h, int stride_px)
 {
     if (f == NULL || ref == NULL || w <= 0 || h <= 0) return false;
     if (stride_px < w) stride_px = w;
-    uint32_t n = 0, lit = 0, hole = 0;
+    enum { NCELL = CLOUDS_HOLE_CELLS * CLOUDS_HOLE_CELLS };
+    uint32_t n[NCELL] = {0}, lit[NCELL] = {0}, hole[NCELL] = {0};
     for (int y = 0; y < h; y += CLOUDS_BLANK_STEP) {
         const uint16_t *fr = f   + (size_t)y * (size_t)stride_px;
         const uint16_t *rr = ref + (size_t)y * (size_t)stride_px;
+        int row = (y * CLOUDS_HOLE_CELLS / h) * CLOUDS_HOLE_CELLS;
         for (int x = 0; x < w; x += CLOUDS_BLANK_STEP) {
-            n++;
-            uint16_t v = rr[x];
-            bool is_lit = (v >> 11) >= 3 || ((v >> 5) & 0x3F) >= 6 || (v & 0x1F) >= 3;
-            if (!is_lit) continue;
-            lit++;
-            if (fr[x] == 0x0000u) hole++;
+            int c = row + x * CLOUDS_HOLE_CELLS / w;
+            n[c]++;
+            if (clouds_px_near_black(rr[x])) continue;
+            lit[c]++;
+            if (clouds_px_near_black(fr[x])) hole[c]++;
         }
     }
-    if (lit * 20u < n) return false;
-    return hole * 100u > lit * (uint32_t)CLOUDS_HOLE_PCT;
+    for (int c = 0; c < NCELL; c++) {
+        if (n[c] < CLOUDS_HOLE_MIN_CELL_N) continue;
+        if (lit[c] * (uint32_t)CLOUDS_HOLE_MIN_LIT_Q < n[c]) continue;
+        if (hole[c] * 100u >= lit[c] * (uint32_t)CLOUDS_HOLE_CELL_PCT) return true;
+    }
+    return false;
 }
 
 static inline bool clouds_frame_incomplete(const uint16_t *rgb565, int w, int h,
@@ -481,14 +520,7 @@ static inline bool clouds_frame_incomplete(const uint16_t *rgb565, int w, int h,
         const uint16_t *row = rgb565 + (size_t)y * (size_t)stride_px;
         for (int x = 0; x < w; x += CLOUDS_BLANK_STEP) {
             n++;
-            /* NEAR black (every channel < 24, i.e. R5 < 3, G6 < 6, B5 < 3),
-             * not exactly 0x0000: the P4 hardware JPEG path crushes dark
-             * values to 0 where stb keeps 1-3, so an exact-zero test read a
-             * real night frame as 7-8 % black on HW vs <1 % on stb and the
-             * thresholds flipped with the decoder. Both decoders agree on
-             * "below 24". */
-            uint16_t v = row[x];
-            if ((v >> 11) < 3 && ((v >> 5) & 0x3F) < 6 && (v & 0x1F) < 3) black++;
+            if (clouds_px_near_black(row[x])) black++;   /* see clouds_px_near_black */
         }
     }
     return black * 100u > n * (uint32_t)clouds_channel(ch)->blank_pct;

--- a/main/image_fit.h
+++ b/main/image_fit.h
@@ -1,0 +1,174 @@
+/**
+ * @file image_fit.h
+ * @brief Pure geometry for fitting a decoded image onto the 720 px panel with
+ *        ONE PPA SRM pass, so LVGL is handed a picture that is exactly panel
+ *        width at scale 256 and only has to blit it.
+ *
+ * Why this exists: the PPA SRM scale factor is n/16 with n an integer, and the
+ * written block width is TRUNCATED (`out = floor(block * n / 16)`). There is no
+ * n that turns an arbitrary source width into exactly 720. Two ways out:
+ *   - round the scale UP (n = ceil(720*16/lw)), which overshoots 720, and trim
+ *     the source block symmetrically until the output lands on <= 720. Costs a
+ *     small centre crop.
+ *   - round the scale DOWN, which undershoots 720, and centre the result with
+ *     black bands left and right. Costs nothing but shows bands.
+ * The rule below takes the crop while it is small (<= 4 % of the width) and the
+ * bands otherwise.
+ *
+ * Header-only, integer-only, no ESP includes: host-tested by
+ * test/host/test_image_fit.c.
+ *
+ * All widths/heights are pixels. "LOGICAL" space means POST-rotation: the
+ * caller has already applied its config crop to the source and knows what the
+ * rotated result would measure. image_fit_logical_to_source() maps the trim
+ * window back to the source rectangle the PPA job must read.
+ */
+#ifndef IMAGE_FIT_H
+#define IMAGE_FIT_H
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/* Crop budget for the round-up branch, in thousandths of the source width. */
+#define IMAGE_FIT_MAX_CROP_PERMILLE 40u    /* 4 %: 500, 600 and 1080 wide sources fill; 3 % put 1080 on side bands */
+
+typedef struct {
+    uint8_t  n16;        /* PPA scale numerator: scale = n16/16, 1..255        */
+    uint32_t block_x;    /* trim window inside the LOGICAL picture             */
+    uint32_t block_y;
+    uint32_t block_w;
+    uint32_t block_h;
+    uint32_t out_w;      /* = block_w * n16 / 16, always <= target             */
+    uint32_t out_h;      /* = block_h * n16 / 16, always <= target             */
+    uint32_t dst_x;      /* = (target - out_w) / 2: centres the bands          */
+} image_fit_t;
+
+/**
+ * @brief Pick the SRM scale and the source trim for a @p lw x @p lh logical
+ *        picture landing on a @p target wide destination.
+ *
+ * Formulas, in order:
+ *   n_up    = ceil(target * 16 / lw)                 scale that overshoots
+ *   w_up    = floor(target * 16 / n_up)              source width that fits at n_up
+ *   crop    = (lw - w_up) / lw                       what that costs
+ *   n16     = (crop <= 4 %) ? n_up : floor(target * 16 / lw)
+ *   n16     = clamp(n16, 1, 255)                     PPA register range
+ *   block_w = lw, shrunk to floor(target*16/n16) if it would overshoot
+ *   block_h = lh, same shrink (this is the vertical centre crop the old
+ *             center_image_y + LVGL clip produced for over-tall sources)
+ *   out_w   = floor(block_w * n16 / 16), out_h = floor(block_h * n16 / 16)
+ *   block_x = (lw - block_w) / 2, block_y = (lh - block_h) / 2   (centred)
+ *   dst_x   = (target - out_w) / 2
+ *
+ * dst_y is deliberately NOT produced: the destination picture is
+ * target x out_h and the CALLER positions that object vertically (the existing
+ * center_image_y() at scale 256), exactly as it did before.
+ *
+ * @return false if any input is 0 or the result would be degenerate (out_w or
+ *         out_h == 0); @p out is then untouched.
+ */
+static inline bool image_fit_pick(uint32_t lw, uint32_t lh, uint32_t target,
+                                  image_fit_t *out)
+{
+    if (!out || lw == 0 || lh == 0 || target == 0) return false;
+
+    const uint32_t t16 = target * 16u;
+    uint32_t n_up = (t16 + lw - 1u) / lw;              /* ceil */
+    if (n_up == 0) n_up = 1u;
+    const uint32_t w_up = t16 / n_up;                  /* source width that fits */
+    uint32_t n16;
+    if (w_up < lw && (lw - w_up) * 1000u > IMAGE_FIT_MAX_CROP_PERMILLE * lw) {
+        n16 = t16 / lw;                                /* crop too dear: bands */
+    } else {
+        n16 = n_up;                                    /* cheap crop: fill */
+    }
+    if (n16 < 1u)   n16 = 1u;
+    if (n16 > 255u) n16 = 255u;
+
+    const uint32_t fit = t16 / n16;   /* largest source extent that stays <= target */
+    uint32_t bw = lw, bh = lh;
+    if (bw > fit) bw = fit;
+    if (bh > fit) bh = fit;
+
+    const uint32_t ow = bw * n16 / 16u;
+    const uint32_t oh = bh * n16 / 16u;
+    if (ow == 0 || oh == 0) return false;
+
+    out->n16     = (uint8_t)n16;
+    out->block_w = bw;
+    out->block_h = bh;
+    out->block_x = (lw - bw) / 2u;
+    out->block_y = (lh - bh) / 2u;
+    out->out_w   = ow;
+    out->out_h   = oh;
+    out->dst_x   = (target > ow) ? (target - ow) / 2u : 0u;
+    return true;
+}
+
+/**
+ * @brief Map the LOGICAL (post-rotation) trim window of @p fit back to a
+ *        rectangle in the SOURCE block, which measures @p crop_w x @p crop_h.
+ *
+ * @p rotate_cw is 0..3 = 0/90/180/270 degrees CLOCKWISE, the page convention.
+ * The inverse of each rotation, with logical column X and row Y:
+ *   0:   src = (X, Y)                     logical is source
+ *   1:   src = (Y, crop_h - 1 - X)        90 CW,  logical is crop_h x crop_w
+ *   2:   src = (crop_w - 1 - X, crop_h - 1 - Y)
+ *   3:   src = (crop_w - 1 - Y, X)        270 CW, logical is crop_h x crop_w
+ * so a logical rectangle becomes a source rectangle with the axes swapped for
+ * 90/270 and the origin reflected for 180/270 (x) and 90/180 (y).
+ *
+ * MIRRORING IS NOT APPLIED HERE. The PPA does hflip/vflip itself, and because
+ * both trims are CENTRED the mirrored window is the same window, up to the one
+ * pixel an odd (extent - block) split puts on the other side, which is below
+ * anything visible on a 720 px panel.
+ *
+ * Outputs are clamped into the source block, so a caller that passed mismatched
+ * dimensions gets a valid (if wrong) rectangle rather than an out-of-range PPA
+ * job. Returns false only on a NULL argument or a zero-sized source.
+ */
+static inline bool image_fit_logical_to_source(const image_fit_t *fit,
+                                               uint32_t crop_w, uint32_t crop_h,
+                                               uint8_t rotate_cw,
+                                               uint32_t *src_x, uint32_t *src_y,
+                                               uint32_t *src_w, uint32_t *src_h)
+{
+    if (!fit || !src_x || !src_y || !src_w || !src_h) return false;
+    if (crop_w == 0 || crop_h == 0) return false;
+
+    const uint32_t X = fit->block_x, Y = fit->block_y;
+    const uint32_t bw = fit->block_w, bh = fit->block_h;
+    uint32_t x, y, w, h;
+
+    switch (rotate_cw & 3u) {
+    case 1:                                   /* 90 CW  */
+        x = Y;              w = bh;
+        y = (crop_h > X + bw) ? crop_h - X - bw : 0u;
+        h = bw;
+        break;
+    case 2:                                   /* 180    */
+        x = (crop_w > X + bw) ? crop_w - X - bw : 0u;
+        w = bw;
+        y = (crop_h > Y + bh) ? crop_h - Y - bh : 0u;
+        h = bh;
+        break;
+    case 3:                                   /* 270 CW */
+        x = (crop_w > Y + bh) ? crop_w - Y - bh : 0u;
+        w = bh;
+        y = X;              h = bw;
+        break;
+    default:                                  /* 0      */
+        x = X;  y = Y;  w = bw;  h = bh;
+        break;
+    }
+
+    if (x >= crop_w) x = crop_w - 1u;
+    if (y >= crop_h) y = crop_h - 1u;
+    if (w > crop_w - x) w = crop_w - x;
+    if (h > crop_h - y) h = crop_h - y;
+
+    *src_x = x; *src_y = y; *src_w = w; *src_h = h;
+    return true;
+}
+
+#endif /* IMAGE_FIT_H */

--- a/main/image_page_poll.c
+++ b/main/image_page_poll.c
@@ -380,6 +380,24 @@ static void radar_frame_url(char *url, size_t sz, const char token[16], int fram
     snprintf(url, sz, "https://radar.weather.gov/ridge/standard/%s_%d.gif", token, frame);
 }
 
+/* Per-stamp HOLES-rejection tally. One entry per frame time the gate has
+ * rejected without that time having since been accepted; ANIM_HOLES_TRACK is 4
+ * because the poller has at most three stamps in flight (indices 0..2 are
+ * re-fetched every poll) plus one aging out, and the table is overwritten
+ * oldest-stamp-first when it fills.
+ *
+ * IT HAS TO BE PER STAMP. A single "last rejected stamp + count" cannot break a
+ * dusk latch at the default 900 s Clouds poll: three DIFFERENT stamps are
+ * rejected each poll (0, 1, 2), the sequence is S, S+1, S, S+2, S+1, S, ... so
+ * two consecutive rejections are never the same stamp, the count restarts every
+ * time and never reaches the bar. With its own entry each stamp reaches the bar
+ * on its own second rejection, which for index 1 or 2 is the very next poll. */
+typedef struct {
+    uint32_t stamp;
+    uint8_t  n;
+} anim_holes_t;
+#define ANIM_HOLES_TRACK 4
+
 /* Per-instance poller state for the ANIMATED sources (image_src_is_animated),
  * indexed by src; the single-frame sources' entries are never touched.
  *   last_push_ms  time of the last successful newest-frame push, so the
@@ -389,8 +407,12 @@ static void radar_frame_url(char *url, size_t sz, const char token[16], int fram
  *   stamps[]      the same list as UTC seconds for a source whose stamps are
  *                 parsed (Clouds; 0 for radar = unknown, hash-only dedupe);
  *   retry_backfill Clouds: a history slot was fetched but rejected as
- *                 incomplete (clouds_drop_incomplete), so run the backfill
+ *                 incomplete (anim_drop_incomplete), so run the backfill
  *                 again on the next poll even without an activation request.
+ *   holes[]       small per-stamp rejection table (see ANIM_HOLES_TRACK), so a
+ *                 rejection cannot latch;
+ *   judged_stamp  the head stamp anim_rejudge_head() has already acted on, so
+ *                 the re-judge drops a given frame at most once.
  * Touched only by that page's poll task (net_poll_once and anim_backfill run on
  * it sequentially). File-scope on purpose: the string table is 320 B per source
  * and does not belong on the 12288 B poller stack. */
@@ -400,6 +422,8 @@ typedef struct {
     char     times[RADAR_WMS_TIMES_MAX][RADAR_WMS_TIME_MAX];
     uint32_t stamps[RADAR_WMS_TIMES_MAX];
     bool     retry_backfill;
+    anim_holes_t holes[ANIM_HOLES_TRACK];
+    uint32_t judged_stamp;
 } anim_state_t;
 static anim_state_t s_anim[IMG_SRC_COUNT];
 /* The ring indexes stamps[]/times[] up to its capacity, so the two times lists
@@ -439,6 +463,30 @@ static bool anim_fetch_small(const char *url, size_t cap, char **body, size_t *l
     return http_fetch_text(url, &opts, body, len) == ESP_OK;
 }
 
+/* One advertised WMS TIME -> UTC seconds, 0 when it is not a time we trust.
+ * NCEP writes milliseconds ("2026-08-17T20:50:22.000Z"), which the strict
+ * clouds_time_parse() rejects on the trailing junk after the seconds; drop the
+ * fraction and re-terminate rather than grow a second ISO parser. Everything
+ * else — the calendar, the range checks, the bare-date rejection — stays in the
+ * one host-tested helper (clouds_wms.h). */
+static uint32_t radar_wms_time_stamp(const char *t)
+{
+    char buf[RADAR_WMS_TIME_MAX];
+    size_t n = strlen(t);
+    const char *dot = memchr(t, '.', n);
+    if (dot != NULL) {
+        size_t keep = (size_t)(dot - t);
+        if (keep + 2 > sizeof(buf)) return 0;
+        memcpy(buf, t, keep);
+        buf[keep]     = 'Z';
+        buf[keep + 1] = '\0';
+        t = buf;
+        n = keep + 1;
+    }
+    uint32_t s = 0;
+    return clouds_time_parse(t, n, &s) ? s : 0;
+}
+
 /* Refresh the radar times list from the namespace-scoped GetCapabilities
  * document (styles 1/2). Blind time stepping does not work (the newest frame
  * lags wall clock by a variable amount and out-of-range TIME returns a valid
@@ -463,7 +511,23 @@ static void radar_wms_refresh_times(anim_state_t *a, const char *token)
     }
     a->ntimes = radar_wms_parse_times(body, len, layer, a->times, RADAR_WMS_TIMES_MAX);
     heap_caps_free(body);
-    memset(a->stamps, 0, sizeof(a->stamps));   /* radar stamps stay unknown */
+    /* Real stamps for styles 1/2: they are what puts a radar frame on the ring's
+     * stamped path (insert by time, same-stamp replace when a partly rendered
+     * mosaic heals), what makes the partial-frame gates able to find a
+     * neighbour, and what puts the frame's OWN time in the caption instead of
+     * the wall clock. ALL OR NOTHING: one unparsable entry zeroes the list, so a
+     * ring is never half stamped (an unstamped slot sorts to the oldest end and
+     * would reorder the loop). A site whose caps advertise no list (KHDC) keeps
+     * ntimes 0 and shows its single newest frame unstamped, exactly as before. */
+    memset(a->stamps, 0, sizeof(a->stamps));
+    for (int i = 0; i < a->ntimes; i++) {
+        a->stamps[i] = radar_wms_time_stamp(a->times[i]);
+        if (a->stamps[i] == 0) {
+            ESP_LOGW(TAG, "unparsable radar time \"%s\"; stamps off for %s", a->times[i], token);
+            memset(a->stamps, 0, sizeof(a->stamps));
+            break;
+        }
+    }
     if (a->ntimes == 0) ESP_LOGW(TAG, "no advertised radar times for %s; newest only", token);
 }
 
@@ -539,40 +603,124 @@ static bool anim_frame_url(image_page_t *p, const app_config_t *cfg, const char 
     return radar_wms_url_for(url, sz, cfg, token, a->ntimes > 0 ? a->times[i] : NULL);
 }
 
-/* Clouds only: GIBS answers 200 for a slot it has not finished ingesting (the
- * borders overlay over black, or black tile blocks), and such a frame must never
- * reach the ring. Tests the raw decoded pixels (clouds_frame_incomplete); on a
- * hit frees the frame and its retained source exactly as a failed decode is
- * freed, logs once, and returns true so the caller skips the insert. The stamp
- * is not held, so the existing paths re-fetch it on the next poll (times[0]/[1]
- * every poll; older slots via retry_backfill). Not a failure: no caption, no
- * toast, no spine backoff. Radar (and a NULL frame) always returns false. */
+/* A WMS origin answers 200 for a TIME it advertises but has not finished
+ * rendering (the vector overlay over black, or black tile rectangles), and such
+ * a frame must never reach the ring. Tests the raw decoded pixels; on a hit
+ * frees the frame and its retained source exactly as a failed decode is freed,
+ * logs once, and returns true so the caller skips the insert. The stamp is not
+ * held, so the existing paths re-fetch it on the next poll (times[0]/[1] every
+ * poll; older slots via retry_backfill). Not a failure: no caption, no toast,
+ * no spine backoff.
+ *
+ * Applies to Clouds (GIBS) and to radar styles 1/2 (NCEP GeoServer), which can
+ * serve a partly rendered mosaic for the same structural reason. Two gates:
+ *   - BLANK (clouds_frame_incomplete, > blank_pct near black): Clouds only. A
+ *     styles-1/2 radar frame is state lines on black BY DESIGN and sits at
+ *     94-98 % near black with no precipitation on it, so this gate would reject
+ *     every good radar frame. Radar is gated on holes only.
+ *   - HOLES (clouds_frame_holes, per cell vs the neighbouring frame): both. Its
+ *     per-cell lit floor means it can only speak about cells the neighbour
+ *     actually lit, so on a line-only radar map it stays quiet unless real
+ *     reflectivity vanished -- quiet is the correct answer there.
+ * Radar style 0 (one RIDGE _i.gif still, not a tile mosaic) and a NULL frame
+ * always return false. */
 static uint32_t anim_stamp(image_page_t *p, int i);
-/* image_page_ring_with_neighbour adapter: @p arg is the fresh image_frame_t. */
-static bool clouds_holes_cb(const uint16_t *ref, int w, int h, void *arg)
+/* image_page_ring_with_neighbour / _judge_head adapter: @p arg is the frame
+ * UNDER TEST (the fresh one at insert, a view of the head slot at re-judge). */
+static bool anim_holes_cb(const uint16_t *ref, int w, int h, void *arg)
 {
     const image_frame_t *f = arg;
     if (w != f->w || h != f->h) return false;
     return clouds_frame_holes((const uint16_t *)f->buf, ref, w, h, w);
 }
 
-static bool clouds_drop_incomplete(image_page_t *p, const app_config_t *cfg,
-                                   image_frame_t *f, uint8_t **src, int i)
+/* The sources whose frames the partial-frame gates judge. */
+static inline bool anim_partial_gated(const image_page_t *p, const app_config_t *cfg)
 {
-    if (p->src != IMG_SRC_CLOUDS || f->buf == NULL) return false;
+    return p->src == IMG_SRC_CLOUDS ||
+           (p->src == IMG_SRC_RADAR && cfg->radar_map_style != 0);
+}
+
+/* Consecutive HOLES rejections of one stamp after which it is accepted anyway.
+ *
+ * WITHOUT THIS BOUND A DUSK FALSE POSITIVE LATCHES THE PAGE. The holes rule
+ * fires when a cell's ref-lit samples go near black, and a rural or ocean cell
+ * crossing the terminator does exactly that legitimately (at zoom 7 the
+ * crossing band is ~1.5 cells per 10-minute step). A rejected frame never
+ * enters the ring, so the reference stays the pre-dusk frame and every later
+ * stamp is judged against it and rejected too — the loop would freeze one frame
+ * behind until the page is left or dawn re-lights the cell.
+ *
+ * 2 is the right bar because the two failure modes have different lifetimes: a
+ * genuinely partial origin slot completes within 10-20 minutes, so a SECOND
+ * fetch of the same stamp still showing holes is far more likely a real scene
+ * change than a still-missing tile. If it was partial after all, the head
+ * re-judge (anim_rejudge_head) and the newest-three re-fetch still repair it.
+ * The blank gate has no such bound: a blank slot is unambiguous. */
+#define ANIM_HOLES_MAX_REJECTS 2
+
+/* Count one HOLES rejection of @p stamp and return its running total. A stamp
+ * with no entry takes a free slot, or evicts the entry with the OLDEST stamp:
+ * that is the one the poller can no longer re-fetch (only indices 0..2 are
+ * retried), so its tally can never grow again. */
+static uint8_t anim_holes_bump(anim_state_t *a, uint32_t stamp)
+{
+    int free_i = -1, oldest = 0;
+    for (int k = 0; k < ANIM_HOLES_TRACK; k++) {
+        if (a->holes[k].stamp == stamp) {
+            if (a->holes[k].n < 255) a->holes[k].n++;
+            return a->holes[k].n;
+        }
+        if (a->holes[k].stamp == 0 && free_i < 0) free_i = k;
+        if (a->holes[k].stamp < a->holes[oldest].stamp) oldest = k;
+    }
+    int k = (free_i >= 0) ? free_i : oldest;
+    a->holes[k].stamp = stamp;
+    a->holes[k].n = 1;
+    return 1;
+}
+
+/* Forget @p stamp's rejection streak: it just passed the gate, so the streak is
+ * over and a later rejection starts from one again. */
+static void anim_holes_clear(anim_state_t *a, uint32_t stamp)
+{
+    if (stamp == 0) return;
+    for (int k = 0; k < ANIM_HOLES_TRACK; k++) {
+        if (a->holes[k].stamp == stamp) {
+            a->holes[k].stamp = 0;
+            a->holes[k].n = 0;
+            return;
+        }
+    }
+}
+
+static bool anim_drop_incomplete(image_page_t *p, const app_config_t *cfg,
+                                 image_frame_t *f, uint8_t **src, int i)
+{
+    if (!anim_partial_gated(p, cfg) || f->buf == NULL) return false;
+    bool clouds = (p->src == IMG_SRC_CLOUDS);
     anim_state_t *a = &s_anim[p->src];
     const char *why = NULL;
-    if (clouds_frame_incomplete((const uint16_t *)f->buf, f->w, f->h, f->w,
-                                cfg->clouds_channel)) {
+    if (clouds && clouds_frame_incomplete((const uint16_t *)f->buf, f->w, f->h, f->w,
+                                          cfg->clouds_channel)) {
         why = "blank";
-    } else if (image_page_ring_with_neighbour(p, anim_stamp(p, i), clouds_holes_cb, f)) {
-        /* Missing tiles: exactly black here, lit in the neighbouring frame.
-         * Seen after a channel change, when the whole ring is fetched fresh and
-         * the newest slots are still being ingested. */
+    } else if (image_page_ring_with_neighbour(p, anim_stamp(p, i), anim_holes_cb, f)) {
+        /* Missing tiles: a cell that is near black here and lit in the
+         * neighbouring frame. Seen after a channel change, and on the newest
+         * slot or two while the origin is still ingesting them. */
+        uint8_t n = anim_holes_bump(a, anim_stamp(p, i));
+        if (n >= ANIM_HOLES_MAX_REJECTS) {
+            ESP_LOGI(TAG, "%s: %s accepted after %u holes rejections (terminator?)",
+                     p->name, (i >= 0 && i < a->ntimes) ? a->times[i] : "?", (unsigned)n);
+            return false;                       /* entry kept: a later re-fetch of it stays accepted */
+        }
         why = "has missing tiles";
     }
-    if (why == NULL) return false;
-    ESP_LOGI(TAG, "clouds: slot %s %s, will retry",
+    if (why == NULL) {
+        anim_holes_clear(a, anim_stamp(p, i));  /* it passed: the streak is over */
+        return false;
+    }
+    ESP_LOGI(TAG, "%s: slot %s %s, will retry", p->name,
              (i >= 0 && i < a->ntimes) ? a->times[i] : "?", why);
     heap_caps_free(f->buf);
     f->buf = NULL;
@@ -605,12 +753,48 @@ static bool anim_fetch_index(image_page_t *p, const app_config_t *cfg, const cha
         /* src is NULL on every error return (see image_fetch_custom_retain). */
         return false;
     }
-    if (clouds_drop_incomplete(p, cfg, &old, &src, i)) {
+    if (anim_drop_incomplete(p, cfg, &old, &src, i)) {
         s_anim[p->src].retry_backfill = true;
         return true;
     }
     image_page_ring_add(p, &old, false, gen, src, src_len, anim_stamp(p, i));
     return true;
+}
+
+/* Re-judge the ring's head (newest) slot once the ring has a settled neighbour
+ * to judge it against, and drop it if it is partial.
+ *
+ * WHY THE HEAD NEEDS ITS OWN PASS: every page entry frees the ring, so the
+ * newest frame — the one slot the origin is most likely to be still ingesting —
+ * goes into an EMPTY ring, where anim_drop_incomplete() can find no neighbour
+ * and waves it through. Nothing else ever looks at a frame again after it is
+ * inserted, so that unverified frame stays for its whole ~1 h life in the loop.
+ * Dropping it is enough to repair it: the stamp is no longer held, so the next
+ * poll's unconditional newest fetch re-downloads it and the ring's
+ * same-stamp/different-hash path installs the completed frame.
+ *
+ * AT MOST ONE DROP PER STAMP (judged_stamp). A check that keeps disagreeing
+ * with a genuine frame then costs one re-fetch rather than a drop-and-refetch
+ * loop for as long as that frame is newest; the counter is cleared on the next
+ * activation, where the ring is rebuilt from empty and the head is unjudged
+ * again. Runs on the page's poll task, where no insert is in flight, exactly
+ * like image_page_ring_retransform_if_requested(). Costs no network. */
+static void anim_rejudge_head(image_page_t *p, const app_config_t *cfg, uint32_t gen)
+{
+    anim_state_t *a = &s_anim[p->src];
+    if (!anim_partial_gated(p, cfg)) return;
+    if (image_page_ring_count(p) < 2) return;                    /* nothing to judge against */
+    if (radar_frame_is_stale(gen, image_page_ring_gen(p))) return;
+    uint32_t bad = image_page_ring_judge_head(p, anim_holes_cb);
+    if (bad == 0 || bad == a->judged_stamp) return;
+    a->judged_stamp = bad;                                       /* one attempt per stamp, hit or miss */
+    if (!image_page_ring_drop_stamp(p, bad)) return;
+    char ts[32];
+    if (!clouds_time_format(ts, sizeof(ts), bad)) strlcpy(ts, "?", sizeof(ts));
+    ESP_LOGI(TAG, "%s: head %s re-judged partial, dropped; refetch next poll", p->name, ts);
+    /* The freshness early-return in net_poll_once() keys off this: zeroing it
+     * removes any dependence on the ring also having become not-full. */
+    a->last_push_ms = 0;
 }
 
 /* Rebuild the history behind the newest frame after a page activation: fetch
@@ -630,6 +814,13 @@ static bool anim_fetch_index(image_page_t *p, const app_config_t *cfg, const cha
  * (~1.04 MB) at the same time. The hardware JPEG path needs only the latter;
  * the conservative figure is the one that has to hold. */
 #define ANIM_DECODE_TRANSIENT_BYTES ((size_t)2600 * 1024)
+/* Cloud Cover frames are baseline JPEG and decode on the hardware engine: the
+ * decoder writes straight into the frame-sized buffer, so the only extra is the
+ * compressed download (~150-300 KB). 2.6 MB here was the stb figure, and with
+ * the three 1 MB playback scratch buffers resident it left the largest free
+ * block (~3.3 MB on dash4) permanently under the bar: every optional fetch was
+ * refused, the newest slot was a GIBS blank, and the page froze on one frame. */
+#define ANIM_DECODE_TRANSIENT_HW_BYTES ((size_t)512 * 1024)
 
 /* PSRAM headroom for one more animated frame, and the ONE place the ring is
  * allowed to shrink. Without it the ring grows until the largest free block no
@@ -646,9 +837,15 @@ static bool anim_fetch_index(image_page_t *p, const app_config_t *cfg, const cha
  * per source if a shorter loop is ever noticed on a healthy heap. */
 static bool anim_decode_headroom(image_page_t *p, bool newest)
 {
-    /* A panel-sized frame (clouds 720x720); radar frames are smaller, so this
-     * only ever errs toward more headroom. */
-    const size_t need = (size_t)SCREEN_SIZE * SCREEN_SIZE * 2 + ANIM_DECODE_TRANSIENT_BYTES;
+    /* A panel-sized frame is the SAFE UPPER BOUND, not the typical slot: a
+     * clouds frame is exactly 720x720x2, a radar slot is stored at its native
+     * size (~660 KB for a cropped RIDGE tile) and the panel-width scale happens
+     * per playback step in the page, not per fetched frame. Erring high here is
+     * deliberate — it makes the headroom check reject slightly early rather than
+     * let a decode fail. */
+    const size_t transient = (p->src == IMG_SRC_CLOUDS) ? ANIM_DECODE_TRANSIENT_HW_BYTES
+                                                        : ANIM_DECODE_TRANSIENT_BYTES;
+    const size_t need = (size_t)SCREEN_SIZE * SCREEN_SIZE * 2 + transient;
     if (!newest) {
         if (heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM) >= need) return true;
         ESP_LOGW(TAG, "%s backfill stopped: PSRAM headroom", p->name);
@@ -680,11 +877,22 @@ static void anim_backfill(image_page_t *p, const app_config_t *cfg, int first)
 
     for (int i = first; i < cap; i++) {
         if (!atomic_load(&p->poll_gate)) break;             /* page left / un-warmed */
-        if (image_page_ring_count(p) >= cap) break;         /* ring full */
-        /* A stamped frame the ring already holds (Clouds re-entry after a
-         * partial teardown, or the times[1] repair fetch below) costs no
-         * download. */
-        if (image_page_ring_has_stamp(p, anim_stamp(p, i))) continue;
+        /* A stamped frame the ring already holds costs no download -- EXCEPT
+         * for the newest three, which the origin may still have been ingesting
+         * when they were accepted. Re-fetching lets the ring's
+         * same-stamp/different-hash path replace such a slot in place; an
+         * unchanged slot hashes equal and is dropped as a duplicate. The
+         * ring-full break is what ENDS this loop, so it is asked second: a
+         * replacement does not grow the ring and must not be blocked by it.
+         *
+         * This exemption only ever runs when a backfill runs (activation, or a
+         * rejected slot), so it is NOT what covers a steady-state poll —
+         * net_poll_once() re-fetches indices 1..2 itself for the same reason,
+         * and anim_rejudge_head() covers the head. Here it just keeps a
+         * rebuild from re-using a slot the last visit left unverified. */
+        bool held = image_page_ring_has_stamp(p, anim_stamp(p, i));
+        if (held && i > 2) continue;
+        if (!held && image_page_ring_count(p) >= cap) break;   /* ring full */
         /* Times list exhausted (short clouds list, KHDC on styles 1/2): the
          * history simply ends here. Checked BEFORE the delay, no warning.
          * Radar style 0 (RIDGE _i.gif) has no list and is never exhausted. */
@@ -870,7 +1078,7 @@ static bool net_poll_once(void *arg)
              * and the poll still counts as a success (no backoff); last_push_ms
              * is left alone so the next poll re-fetches it. */
             anim_state_t *a = &s_anim[p->src];
-            if (clouds_drop_incomplete(p, cfg, &fresh, &ring_src, 0)) {
+            if (anim_drop_incomplete(p, cfg, &fresh, &ring_src, 0)) {
                 if (show_wait && bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                     nina_wait_overlay_hide();
                     bsp_display_unlock();
@@ -890,17 +1098,56 @@ static bool net_poll_once(void *arg)
              * slot rejected below is retried on the NEXT poll, never twice now. */
             bool retry = a->retry_backfill;
             a->retry_backfill = false;
-            /* Clouds: GIBS serves the newest one or two slots partially at
-             * first (black quadrants until every tile is ingested), so the
-             * second-newest is re-fetched on every poll too; the ring replaces
-             * a held stamp whose bytes changed and drops it when identical. */
-            if (p->src == IMG_SRC_CLOUDS && atomic_load(&p->poll_gate)) {
-                vTaskDelay(pdMS_TO_TICKS(RADAR_BACKFILL_GAP_MS));   /* same radio stagger as the backfill */
-                anim_fetch_index(p, cfg, token, 1, ring_gen);
+            /* THE NEWEST THREE, ON EVERY POLL — CLOUDS ONLY. GIBS serves the
+             * newest one or two slots partially at first (black rectangles
+             * until every tile is ingested), and index 0 above is the only one
+             * re-fetched unconditionally; the backfill's matching exemption
+             * runs only after an activation or a rejection, so on a
+             * steady-state poll with a full ring nothing used to re-examine
+             * indices 1 and 2 and a partial that aged past index 0 stayed for
+             * its whole life in the loop. The ring replaces a held stamp whose
+             * bytes changed and drops it when identical.
+             *
+             * NOT extended to radar styles 1/2, deliberately. A re-fetch is NOT
+             * cheap — image_fetch_custom_retain() downloads AND decodes, and
+             * image_page_ring_add() bakes, before the hash comparison that
+             * drops the duplicate — so each one costs a full 2.6 MB decode
+             * transient. At the Clouds interval floor (300 s) three of those
+             * per poll is affordable; at the radar floor (120 s) it is not, and
+             * NCEP partials are cosmetic on a map that is black by design.
+             * Radar keeps index 0 plus the backfill exemption and the head
+             * re-judge. See the report's ESCALATION on making this hash-first.
+             *
+             * Headroom-gated exactly like the backfill: an optional re-fetch
+             * must never be the decode that fails on a fragmented heap.
+             * Staggered the same way too — sustained radio transmission is what
+             * glitches this panel. */
+            if (p->src == IMG_SRC_CLOUDS) {
+                for (int i = 1; i <= 2 && atomic_load(&p->poll_gate); i++) {
+                    if (i >= a->ntimes) break;             /* short times list */
+                    /* Index 1 is the frame that actually shows while GIBS still
+                     * serves index 0 blank, so it may evict like the newest
+                     * fetch; index 2 stays optional (check only). */
+                    if (!anim_decode_headroom(p, i == 1)) break;
+                    vTaskDelay(pdMS_TO_TICKS(RADAR_BACKFILL_GAP_MS));
+                    anim_fetch_index(p, cfg, token, i, ring_gen);
+                }
             }
-            if (image_page_ring_backfill_take(p) || retry) {
-                anim_backfill(p, cfg, p->src == IMG_SRC_CLOUDS ? 2 : 1);
+            bool take = image_page_ring_backfill_take(p);
+            /* An activation means the ring was rebuilt from empty: the last
+             * visit's head verdict and every rejection streak are spent. */
+            if (take) {
+                a->judged_stamp = 0;
+                memset(a->holes, 0, sizeof(a->holes));
             }
+            if (take || retry) {
+                /* Clouds fetched 1 and 2 just above (one attempt per stamp per
+                 * poll), so its history starts at 3; radar still starts at 1. */
+                anim_backfill(p, cfg, p->src == IMG_SRC_CLOUDS ? 3 : 1);
+            }
+            /* Last, with the ring at its most complete this pass: give the head
+             * the neighbour it never had at insert. */
+            anim_rejudge_head(p, cfg, ring_gen);
         } else {
             image_page_commit_frame(p, &fresh, false);
         }

--- a/main/jpeg_utils.c
+++ b/main/jpeg_utils.c
@@ -10,12 +10,151 @@
 #include "esp_log.h"
 #include "stb_image.h"
 #include "esp_cache.h"
+#include "freertos/FreeRTOS.h"
 #include <string.h>
 
 static const char *TAG = "jpeg_utils";
 
-/* PPA SRM client for hardware image scaling (lazy-initialized) */
+/* One PPA SRM client shared by every scaler here. max_pending_trans_num = 4:
+ * four tasks on two cores can be inside a blocking scaler at once (thumbnail
+ * zoom on the LVGL task, Spotify art, the image-page pollers, the moon drag
+ * loop) and ppa_do_scale_rotate_mirror() returns ESP_FAIL to any caller that
+ * cannot take a free transaction element (ppa_srm.c:307-310). */
+/* Largest SRM output block per axis the engine accepts without wedging (13-bit
+ * output field); ppa_core.c waits portMAX_DELAY and never sees the error. */
+#define PPA_SRM_OUT_MAX_PX 8191u
+
 static ppa_client_handle_t s_ppa_srm_client = NULL;
+static portMUX_TYPE s_ppa_srm_mux = portMUX_INITIALIZER_UNLOCKED;
+
+/* The single registration site. Registration happens OUTSIDE the spinlock (it
+ * allocates and creates a queue); the loser of a first-call race unregisters
+ * its own handle instead of leaking it. */
+static ppa_client_handle_t ppa_srm_client_ensure(void)
+{
+    portENTER_CRITICAL(&s_ppa_srm_mux);
+    ppa_client_handle_t h = s_ppa_srm_client;
+    portEXIT_CRITICAL(&s_ppa_srm_mux);
+    if (h) return h;
+
+    ppa_client_config_t cfg = {
+        .oper_type = PPA_OPERATION_SRM,
+        .max_pending_trans_num = 4,
+    };
+    ppa_client_handle_t mine = NULL;
+    if (ppa_register_client(&cfg, &mine) != ESP_OK || !mine) {
+        ESP_LOGE(TAG, "PPA SRM client registration failed");
+        return NULL;
+    }
+
+    portENTER_CRITICAL(&s_ppa_srm_mux);
+    if (!s_ppa_srm_client) {
+        s_ppa_srm_client = mine;
+        mine = NULL;
+    }
+    h = s_ppa_srm_client;
+    portEXIT_CRITICAL(&s_ppa_srm_mux);
+
+    if (mine) ppa_unregister_client(mine);   /* lost the race */
+    return h;
+}
+
+/* One PPA Blend client, registered the same lazy way as the SRM one above.
+ * max_pending_trans_num = 2: the image pages' playback dissolve runs on the
+ * LVGL task and is the only caller today; the spare slot keeps a second caller
+ * from being refused outright (ppa_blend.c returns ESP_FAIL when the client has
+ * no free transaction element). */
+static ppa_client_handle_t s_ppa_blend_client = NULL;
+static portMUX_TYPE s_ppa_blend_mux = portMUX_INITIALIZER_UNLOCKED;
+
+static ppa_client_handle_t ppa_blend_client_ensure(void)
+{
+    portENTER_CRITICAL(&s_ppa_blend_mux);
+    ppa_client_handle_t h = s_ppa_blend_client;
+    portEXIT_CRITICAL(&s_ppa_blend_mux);
+    if (h) return h;
+
+    ppa_client_config_t cfg = {
+        .oper_type = PPA_OPERATION_BLEND,
+        .max_pending_trans_num = 2,
+    };
+    ppa_client_handle_t mine = NULL;
+    if (ppa_register_client(&cfg, &mine) != ESP_OK || !mine) {
+        ESP_LOGE(TAG, "PPA blend client registration failed");
+        return NULL;
+    }
+
+    portENTER_CRITICAL(&s_ppa_blend_mux);
+    if (!s_ppa_blend_client) {
+        s_ppa_blend_client = mine;
+        mine = NULL;
+    }
+    h = s_ppa_blend_client;
+    portEXIT_CRITICAL(&s_ppa_blend_mux);
+
+    if (mine) ppa_unregister_client(mine);   /* lost the race */
+    return h;
+}
+
+void jpeg_utils_ppa_init(void)
+{
+    if (ppa_srm_client_ensure()) {
+        ESP_LOGI(TAG, "PPA SRM client registered (4 pending transactions)");
+    }
+    if (ppa_blend_client_ensure()) {
+        ESP_LOGI(TAG, "PPA blend client registered (2 pending transactions)");
+    }
+}
+
+esp_err_t ppa_blend_rgb565(const uint8_t *bg, const uint8_t *fg, uint8_t *out,
+                           uint32_t w, uint32_t h, uint8_t fg_alpha)
+{
+    if (!bg || !fg || !out) return ESP_ERR_INVALID_ARG;
+    /* A block of 0 or over 8191 px per axis raises an engine error the driver
+     * never services (no error IRQ; ppa_core.c waits portMAX_DELAY), so a
+     * blocking caller would hang forever. Refuse instead. */
+    if (w == 0 || h == 0 || w > PPA_SRM_OUT_MAX_PX || h > PPA_SRM_OUT_MAX_PX) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    /* The driver checks the output ADDRESS and the declared buffer size against
+     * the cache line (128 B on this build); it cannot check the allocation, so
+     * the contract in the header says the caller owns that. */
+    if (((uintptr_t)out & 127u) != 0) return ESP_ERR_INVALID_ARG;
+    size_t need = (((size_t)w * h * 2) + 127) & ~(size_t)127;
+
+    ppa_client_handle_t client = ppa_blend_client_ensure();
+    if (!client) return ESP_ERR_INVALID_STATE;
+
+    /* RGB565 inputs have no alpha channel, so the hardware fills A = 255 for
+     * both. Leaving the FG at that would make the blend a plain copy of the FG
+     * (ppa.rst); PPA_ALPHA_FIX_VALUE is what turns it into
+     * out = bg*(1 - a) + fg*a with a = fg_alpha/255. */
+    ppa_blend_oper_config_t cfg = {
+        .in_bg = {
+            .buffer = bg,
+            .pic_w = w, .pic_h = h,
+            .block_w = w, .block_h = h,
+            .blend_cm = PPA_BLEND_COLOR_MODE_RGB565,
+        },
+        .in_fg = {
+            .buffer = fg,
+            .pic_w = w, .pic_h = h,
+            .block_w = w, .block_h = h,
+            .blend_cm = PPA_BLEND_COLOR_MODE_RGB565,
+        },
+        .out = {
+            .buffer = out,
+            .buffer_size = need,
+            .pic_w = w, .pic_h = h,
+            .blend_cm = PPA_BLEND_COLOR_MODE_RGB565,
+        },
+        .bg_alpha_update_mode = PPA_ALPHA_NO_CHANGE,
+        .fg_alpha_update_mode = PPA_ALPHA_FIX_VALUE,
+        .fg_alpha_fix_val = fg_alpha,
+        .mode = PPA_TRANS_MODE_BLOCKING,
+    };
+    return ppa_do_blend(client, &cfg);
+}
 
 // =============================================================================
 // Software JPEG Decode Fallback (stb_image)
@@ -100,29 +239,31 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
         return false;
     }
 
-    /* Convert RGB888 to standard RGB565 (R high, B low) — same in-memory layout
-     * the HW decoder produces, which the panel/LVGL pipeline renders correctly. */
-    uint16_t *dst = (uint16_t *)rgb565;
+    /* Convert RGB888 to standard RGB565 (R high, B low) -- same in-memory layout
+     * the HW decoder produces, which the panel/LVGL pipeline renders correctly.
+     * The PPA does the whole picture in one DMA pass; the loop below is the
+     * fallback for when the hardware refuses it. */
+    if (!ppa_rgb888_to_rgb565(rgb, ow, oh, rgb565, buf_sz)) {
+        uint16_t *dst = (uint16_t *)rgb565;
 
-    for (int y = 0; y < h; y++) {
-        const uint8_t *src_row = rgb + y * w * 3;
-        uint16_t *dst_row = dst + y * ow;
-        for (int x = 0; x < w; x++) {
-            uint8_t r = src_row[x * 3 + 0];
-            uint8_t g = src_row[x * 3 + 1];
-            uint8_t b = src_row[x * 3 + 2];
-            /* Standard RGB565 (R high, B low). This matches the in-memory layout
-             * the panel/LVGL pipeline expects — the same result the HW decoder
-             * produces with JPEG_DEC_RGB_ELEMENT_ORDER_BGR. Packing B into the
-             * high bits here swaps red and blue (sodium lights render blue). */
-            dst_row[x] = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+        for (int y = 0; y < h; y++) {
+            const uint8_t *src_row = rgb + y * w * 3;
+            uint16_t *dst_row = dst + y * ow;
+            for (int x = 0; x < w; x++) {
+                uint8_t r = src_row[x * 3 + 0];
+                uint8_t g = src_row[x * 3 + 1];
+                uint8_t b = src_row[x * 3 + 2];
+                /* Standard RGB565 (R high, B low). This matches the in-memory
+                 * layout the panel/LVGL pipeline expects -- the same result the
+                 * HW decoder produces with JPEG_DEC_RGB_ELEMENT_ORDER_BGR.
+                 * Packing B into the high bits here swaps red and blue (sodium
+                 * lights render blue). */
+                dst_row[x] = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
+            }
         }
     }
 
     stbi_image_free(rgb);
-
-    /* Flush CPU cache to PSRAM so PPA DMA reads correct data */
-    esp_cache_msync(rgb565, buf_sz, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
 
     *out_buf = rgb565;
     *out_w = ow;
@@ -200,12 +341,17 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
     uint32_t w = 0, h = 0;
     uint8_t nf = 0, hi0 = 0, vi0 = 0;
     if (!jpeg_scan_sof0(jpg, len, &w, &h, &nf, &hi0, &vi0)) return ESP_ERR_NOT_SUPPORTED;
-    /* Single-component JPEG: the HW only decodes it to GRAY8, and converting
-     * that to RGB565 is work stb already does for us in one pass. The HW
-     * accepts exactly 4:4:4 (1x1), 4:2:2 (2x1) and 4:2:0 (2x2) for 3 components
-     * (jpeg_decode.c get_info switch); anything else goes to stb. */
-    if (nf != 3) return ESP_ERR_NOT_SUPPORTED;
-    if (!((hi0 == 1 && vi0 == 1) || (hi0 == 2 && vi0 == 1) || (hi0 == 2 && vi0 == 2))) {
+    /* Single-component JPEG decodes to GRAY8 and is expanded to RGB565 below --
+     * far cheaper than handing a 3-6 MP mono camera frame to stb. For 3
+     * components the HW accepts exactly 4:4:4 (1x1), 4:2:2 (2x1) and 4:2:0
+     * (2x2) (jpeg_decode.c get_info switch); anything else goes to stb. */
+    const bool is_gray = (nf == 1);
+    if (nf == 2) return ESP_ERR_NOT_SUPPORTED;
+    if (is_gray) {
+        /* Any sane sampling factor: the pad below only needs hi0/vi0 non-zero. */
+        if (hi0 < 1 || hi0 > 4 || vi0 < 1 || vi0 > 4) return ESP_ERR_NOT_SUPPORTED;
+    } else if (!((hi0 == 1 && vi0 == 1) || (hi0 == 2 && vi0 == 1) ||
+                 (hi0 == 2 && vi0 == 2))) {
         return ESP_ERR_NOT_SUPPORTED;
     }
     if ((w * h) % 8 != 0) return ESP_ERR_NOT_SUPPORTED;   /* driver's own SOF check */
@@ -227,7 +373,8 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
         .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
     };
     size_t alloc_size = 0;
-    uint8_t *buf = jpeg_alloc_decoder_mem((size_t)pad_w * pad_h * 2, &mem_cfg, &alloc_size);
+    uint8_t *buf = jpeg_alloc_decoder_mem((size_t)pad_w * pad_h * (is_gray ? 1 : 2),
+                                          &mem_cfg, &alloc_size);
     if (!buf) return ESP_ERR_NO_MEM;
 
     jpeg_decoder_handle_t decoder = NULL;
@@ -250,7 +397,8 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
     /* BGR element order gives the same in-memory RGB565 layout the SW path
      * produces (R high, B low) -- see the packing comment above. */
     jpeg_decode_cfg_t decode_cfg = {
-        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
+        .output_format = is_gray ? JPEG_DECODE_OUT_FORMAT_GRAY
+                                 : JPEG_DECODE_OUT_FORMAT_RGB565,
         .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
     };
     uint32_t decoded_size = 0;
@@ -266,7 +414,7 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
      * output. Confirmed 2026-08-24 on dash4: the HW colour conversion crushes
      * dark values to 0 (7-8 % of a night GeoColor frame vs <1 % from stb),
      * which is why clouds_frame_incomplete() tests NEAR black. Debug only. */
-    {
+    if (!is_gray) {
         const uint16_t *px = (const uint16_t *)buf;
         uint32_t n = 0, z = 0;
         for (uint32_t y = 0; y < h; y += 8) {
@@ -280,6 +428,32 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
                  px[(size_t)(h / 2) * pad_w + w / 2]);
     }
 
+    /* GRAY8 -> RGB565 into a tight w*h*2 buffer (the padded GRAY8 one is freed),
+     * using the same grey expansion the thumbnail path uses. */
+    if (is_gray) {
+        size_t rgb_sz = (((size_t)w * h * 2) + 127) & ~(size_t)127;
+        uint8_t *rgb = heap_caps_aligned_calloc(128, 1, rgb_sz, MALLOC_CAP_SPIRAM);
+        if (!rgb) {
+            heap_caps_free(buf);
+            return ESP_ERR_NO_MEM;
+        }
+        uint16_t *d = (uint16_t *)rgb;
+        for (uint32_t y = 0; y < h; y++) {
+            const uint8_t *srow = buf + (size_t)y * pad_w;
+            uint16_t *drow = d + (size_t)y * w;
+            for (uint32_t x = 0; x < w; x++) {
+                uint8_t g = srow[x];
+                drow[x] = (uint16_t)(((g >> 3) << 11) | ((g >> 2) << 5) | (g >> 3));
+            }
+        }
+        heap_caps_free(buf);
+        *out_buf = rgb;
+        *out_w = w;
+        *out_h = h;
+        *out_size = rgb_sz;
+        return ESP_OK;
+    }
+
     /* Callers expect tightly packed w*h*2 rows, so drop the MCU pad in place.
      * Destination row y starts at or before source row y, and we walk top-down,
      * so no row is overwritten before it is copied. */
@@ -291,11 +465,9 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
         }
     }
 
-    /* The driver invalidated after the transfer, so the CPU (blank-frame check,
-     * the repack above, LVGL's software renderer) reads PSRAM, not stale lines.
-     * If we repacked, write those CPU rows back so the PPA scaler's DMA sees
-     * them; a no-op when nothing was repacked. */
-    if (pad_w != w) esp_cache_msync(buf, alloc_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+    /* No write-back here: the CPU readers (blank-frame check, LVGL's software
+     * renderer) go through the cache, and the PPA scalers' driver C2Ms its own
+     * input window before every transfer (ppa_srm.c:250). */
 
     *out_buf = buf;
     *out_w = w;
@@ -335,18 +507,8 @@ uint8_t *ppa_scale_rgb565(const uint8_t *src, uint32_t src_w, uint32_t src_h,
     if (!src || src_w == 0 || src_h == 0 || dst_w == 0 || dst_h == 0) return NULL;
     if (src_stride == 0) src_stride = src_w;
 
-    /* Lazy-init PPA SRM client */
-    if (!s_ppa_srm_client) {
-        ppa_client_config_t cfg = {
-            .oper_type = PPA_OPERATION_SRM,
-            .max_pending_trans_num = 1,
-        };
-        if (ppa_register_client(&cfg, &s_ppa_srm_client) != ESP_OK) {
-            ESP_LOGE(TAG, "PPA SRM client registration failed");
-            return NULL;
-        }
-        ESP_LOGI(TAG, "PPA SRM client registered for image scaling");
-    }
+    ppa_client_handle_t client = ppa_srm_client_ensure();
+    if (!client) return NULL;
 
     /* Output buffer: 128-byte aligned address and size (L2 cache line requirement) */
     size_t buf_size = dst_w * dst_h * 2;  /* RGB565 = 2 bytes/pixel */
@@ -357,6 +519,10 @@ uint8_t *ppa_scale_rgb565(const uint8_t *src, uint32_t src_w, uint32_t src_h,
         ESP_LOGE(TAG, "Failed to allocate %zu bytes for PPA output", buf_size);
         return NULL;
     }
+    /* Write the CPU's zero lines back before the driver's M2C invalidate of the
+     * output window (ppa_srm.c:256) discards them and they later evict onto the
+     * DMA'd pixels -- the hazard the HW JPEG path proved live on dash4. */
+    esp_cache_msync(dst, buf_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
 
     float scale_x = (float)dst_w / (float)src_w;
     float scale_y = (float)dst_h / (float)src_h;
@@ -389,7 +555,22 @@ uint8_t *ppa_scale_rgb565(const uint8_t *src, uint32_t src_w, uint32_t src_h,
         .mode = PPA_TRANS_MODE_BLOCKING,
     };
 
-    esp_err_t err = ppa_do_scale_rotate_mirror(s_ppa_srm_client, &srm);
+    {
+        /* Same engine-hang guard as ppa_srm_rgb565(): the driver truncates the
+         * scale to 1/16 steps, so predict the written block the way it does. */
+        float sx16 = (float)((uint32_t)(scale_x * 16.0f)) / 16.0f;
+        float sy16 = (float)((uint32_t)(scale_y * 16.0f)) / 16.0f;
+        uint32_t ow = (uint32_t)(sx16 * (float)src_w), oh = (uint32_t)(sy16 * (float)src_h);
+        if (ow == 0 || oh == 0 || ow > PPA_SRM_OUT_MAX_PX || oh > PPA_SRM_OUT_MAX_PX) {
+            ESP_LOGE(TAG, "PPA scale %lux%lu -> %lux%lu refused: output block %lux%lu",
+                     (unsigned long)src_w, (unsigned long)src_h,
+                     (unsigned long)dst_w, (unsigned long)dst_h,
+                     (unsigned long)ow, (unsigned long)oh);
+            free(dst);
+            return NULL;
+        }
+    }
+    esp_err_t err = ppa_do_scale_rotate_mirror(client, &srm);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "PPA scale %lux%lu -> %lux%lu failed: %s",
                  (unsigned long)src_w, (unsigned long)src_h,
@@ -410,6 +591,164 @@ uint8_t *ppa_scale_rgb565(const uint8_t *src, uint32_t src_w, uint32_t src_h,
                  (unsigned long)dst_w, (unsigned long)dst_h, scale_x);
     }
     return dst;
+}
+
+bool ppa_rgb888_to_rgb565(const uint8_t *rgb888, uint32_t w, uint32_t h,
+                          uint8_t *dst565, size_t dst_size)
+{
+    if (!rgb888 || !dst565 || w == 0 || h == 0) return false;
+    /* 2D-DMA descriptor fields are 14-bit; a wider picture would silently
+     * truncate, so hand those to the software loop instead. */
+    if (w > PPA_SRM_OUT_MAX_PX || h > PPA_SRM_OUT_MAX_PX) return false;  /* see ppa_srm_rgb565 */
+    /* The driver rejects an unaligned output address or size outright
+     * (ppa_srm.c:178-181); check here so the fallback runs without an ERROR. */
+    if (((uintptr_t)dst565 & 127u) != 0 || (dst_size & 127u) != 0) return false;
+    if ((size_t)w * h * 2 > dst_size) return false;
+
+    ppa_client_handle_t client = ppa_srm_client_ensure();
+    if (!client) return false;
+
+    /* Same dirty-zero-line write-back as the scalers above: the caller's buffer
+     * came from a calloc and the driver only invalidates the output window. */
+    esp_cache_msync(dst565, dst_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+
+    ppa_srm_oper_config_t srm = {
+        .in = {
+            .buffer = rgb888,
+            .pic_w = w,
+            .pic_h = h,
+            .block_w = w,
+            .block_h = h,
+            .srm_cm = PPA_SRM_COLOR_MODE_RGB888,
+        },
+        .out = {
+            .buffer = dst565,
+            .buffer_size = dst_size,
+            .pic_w = w,
+            .pic_h = h,
+            .srm_cm = PPA_SRM_COLOR_MODE_RGB565,
+        },
+        .rotation_angle = PPA_SRM_ROTATION_ANGLE_0,
+        .scale_x = 1.0f,
+        .scale_y = 1.0f,
+        /* Byte order. hal/color_types.h:187-194 lays out the PPA's RGB888 pixel
+         * as b,g,r -- byte 0 is BLUE -- while stb writes r,g,b, so the input
+         * triplet needs the swap (ppa.h:174 "RGB becomes BGR"). The RGB565
+         * output word is (r<<11)|(g<<5)|b (color_types.h:199-206), which is
+         * exactly what the software pack and the HW JPEG BGR path produce, so
+         * no byte_swap and no change for LVGL. */
+        .rgb_swap = true,
+        .byte_swap = false,
+        .mode = PPA_TRANS_MODE_BLOCKING,
+    };
+
+    return ppa_do_scale_rotate_mirror(client, &srm) == ESP_OK;
+}
+
+esp_err_t ppa_srm_rgb565(ppa_srm_job_t *job)
+{
+    if (!job || !job->src || !job->dst) return ESP_ERR_INVALID_ARG;
+    if (job->scale_n16 == 0 || job->src_stride_px == 0 || job->src_h == 0 ||
+        job->block_w == 0 || job->block_h == 0 ||
+        job->dst_w == 0 || job->dst_h == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (job->src_stride_px > 16383u || job->src_h > 16383u ||
+        job->dst_w > 16383u || job->dst_h > 16383u) {
+        return ESP_ERR_INVALID_ARG;   /* 2D-DMA descriptor fields are 14-bit */
+    }
+    /* Source block inside the source picture. */
+    if (job->block_x + job->block_w > job->src_stride_px ||
+        job->block_y + job->block_h > job->src_h) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    size_t need = (((size_t)job->dst_w * job->dst_h * 2) + 127) & ~(size_t)127;
+    if (job->dst_buf_size < need) return ESP_ERR_INVALID_SIZE;
+
+    /* The driver enum counts COUNTER-clockwise (hal/ppa_types.h:29-32), the page
+     * convention is clockwise: 90 CW == 270 CCW, 270 CW == 90 CCW. */
+    static const ppa_srm_rotation_angle_t k_cw_to_ccw[4] = {
+        PPA_SRM_ROTATION_ANGLE_0,
+        PPA_SRM_ROTATION_ANGLE_270,
+        PPA_SRM_ROTATION_ANGLE_180,
+        PPA_SRM_ROTATION_ANGLE_90,
+    };
+    ppa_srm_rotation_angle_t angle = k_cw_to_ccw[job->rotate_cw & 3];
+
+    /* Exact 1/16 step, so scale_x_frag reproduces scale_n16 & 15 verbatim
+     * (ppa_srm.c:276-279) and out_w/out_h below are what the hardware writes. */
+    float scale = (float)job->scale_n16 / 16.0f;
+
+    uint32_t ow, oh;
+    if (angle == PPA_SRM_ROTATION_ANGLE_0 || angle == PPA_SRM_ROTATION_ANGLE_180) {
+        ow = (uint32_t)(scale * (float)job->block_w);
+        oh = (uint32_t)(scale * (float)job->block_h);
+    } else {
+        /* 90/270 swap the block axes (ppa_srm.c:215-222). */
+        ow = (uint32_t)(scale * (float)job->block_h);
+        oh = (uint32_t)(scale * (float)job->block_w);
+    }
+    if (job->dst_x + ow > job->dst_w || job->dst_y + oh > job->dst_h) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+    /* An output block of 0 or above 8191 px per axis makes the SRM engine raise
+     * an error the IDF driver never services (no error IRQ, portMAX_DELAY in
+     * ppa_core.c), so a blocking caller would hang forever. Refuse it here. */
+    if (ow == 0 || oh == 0 || ow > PPA_SRM_OUT_MAX_PX || oh > PPA_SRM_OUT_MAX_PX) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    ppa_client_handle_t client = ppa_srm_client_ensure();
+    if (!client) return ESP_ERR_INVALID_STATE;
+
+    if (job->clear_dst) {
+        memset(job->dst, 0, need);
+        /* Write those zero lines back before the driver's M2C invalidate of the
+         * output window discards them (see ppa_scale_rgb565). */
+        esp_cache_msync(job->dst, need, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
+    }
+
+    /* mirror_x/mirror_y are the hardware's own bits (ppa_ll.h:176-190); the
+     * pages flip the upright image and THEN rotate. If the engine turns out to
+     * mirror AFTER rotating, swap hflip/vflip for rotate_cw 1 and 3 here -- a
+     * mirror before a 90-degree rotation is the opposite-axis mirror after it. */
+    ppa_srm_oper_config_t srm = {
+        .in = {
+            .buffer = job->src,
+            .pic_w = job->src_stride_px,
+            .pic_h = job->src_h,
+            .block_w = job->block_w,
+            .block_h = job->block_h,
+            .block_offset_x = job->block_x,
+            .block_offset_y = job->block_y,
+            .srm_cm = PPA_SRM_COLOR_MODE_RGB565,
+        },
+        .out = {
+            .buffer = job->dst,
+            .buffer_size = job->dst_buf_size,
+            .pic_w = job->dst_w,
+            .pic_h = job->dst_h,
+            .block_offset_x = job->dst_x,
+            .block_offset_y = job->dst_y,
+            .srm_cm = PPA_SRM_COLOR_MODE_RGB565,
+        },
+        .rotation_angle = angle,
+        .scale_x = scale,
+        .scale_y = scale,
+        .mirror_x = job->hflip,
+        .mirror_y = job->vflip,
+        .rgb_swap = false,
+        .byte_swap = false,
+        .mode = PPA_TRANS_MODE_BLOCKING,
+    };
+
+    esp_err_t err = ppa_do_scale_rotate_mirror(client, &srm);
+    if (err == ESP_OK) {
+        job->out_w = ow;
+        job->out_h = oh;
+    }
+    return err;
 }
 
 // =============================================================================
@@ -487,63 +826,41 @@ static uint8_t *ppa_scale_rgb565_into_core(const uint8_t *src, uint32_t src_w, u
     if (!src || !dst_buf || src_w == 0 || src_h == 0 || dst_w == 0 || dst_h == 0) return NULL;
     if (src_stride == 0) src_stride = src_w;
 
-    size_t needed = dst_w * dst_h * 2;
-    needed = (needed + 127) & ~(size_t)127;
+    size_t needed = ((size_t)dst_w * dst_h * 2 + 127) & ~(size_t)127;
     if (needed > dst_buf_size) {
         ESP_LOGE(TAG, "Pre-allocated buffer too small: need %zu, have %zu", needed, dst_buf_size);
         return NULL;
     }
 
-    /* Lazy-init PPA SRM client */
-    if (!s_ppa_srm_client) {
-        ppa_client_config_t cfg = {
-            .oper_type = PPA_OPERATION_SRM,
-            .max_pending_trans_num = 1,
-        };
-        if (ppa_register_client(&cfg, &s_ppa_srm_client) != ESP_OK) {
-            ESP_LOGE(TAG, "PPA SRM client registration failed");
-            return NULL;
-        }
-        ESP_LOGI(TAG, "PPA SRM client registered for image scaling");
+    /* One 1/16-step factor drives both axes. Every caller here scales
+     * isotropically (thumbnail zoom 2.0x = 32, moon drag 3.0x = 48); an
+     * anisotropic request is refused rather than silently squashed on one axis,
+     * and the callers already treat NULL as "no hardware scale". */
+    uint32_t n16_x = (uint32_t)(((float)dst_w / (float)src_w) * 16.0f);
+    uint32_t n16_y = (uint32_t)(((float)dst_h / (float)src_h) * 16.0f);
+    if (n16_x != n16_y || n16_x == 0 || n16_x > 255) {
+        ESP_LOGE(TAG, "PPA scale %lux%lu -> %lux%lu not a single n/16 factor (x=%lu y=%lu)",
+                 (unsigned long)src_w, (unsigned long)src_h,
+                 (unsigned long)dst_w, (unsigned long)dst_h,
+                 (unsigned long)n16_x, (unsigned long)n16_y);
+        return NULL;
     }
 
-    /* Zero the destination to clear any stale data. Skippable when the caller
-     * guarantees the transfer overwrites every output pixel (exact integer
-     * ratio), avoiding a ~1MB/frame memset in the moon drag path. */
-    if (clear_dst) memset(dst_buf, 0, needed);
-
-    float scale_x = (float)dst_w / (float)src_w;
-    float scale_y = (float)dst_h / (float)src_h;
-
-    ppa_srm_oper_config_t srm = {
-        .in = {
-            .buffer = src,
-            .pic_w = src_stride,
-            .pic_h = src_h,
-            .block_w = src_w,
-            .block_h = src_h,
-            .block_offset_x = 0,
-            .block_offset_y = 0,
-            .srm_cm = PPA_SRM_COLOR_MODE_RGB565,
-        },
-        .out = {
-            .buffer = dst_buf,
-            .buffer_size = needed,
-            .pic_w = dst_w,
-            .pic_h = dst_h,
-            .block_offset_x = 0,
-            .block_offset_y = 0,
-            .srm_cm = PPA_SRM_COLOR_MODE_RGB565,
-        },
-        .rotation_angle = PPA_SRM_ROTATION_ANGLE_0,
-        .scale_x = scale_x,
-        .scale_y = scale_y,
-        .rgb_swap = false,
-        .byte_swap = false,
-        .mode = PPA_TRANS_MODE_BLOCKING,
+    ppa_srm_job_t job = {
+        .src = src,
+        .src_stride_px = src_stride,
+        .src_h = src_h,
+        .block_w = src_w,
+        .block_h = src_h,
+        .dst = dst_buf,
+        .dst_buf_size = dst_buf_size,
+        .dst_w = dst_w,
+        .dst_h = dst_h,
+        .scale_n16 = (uint8_t)n16_x,
+        .clear_dst = clear_dst,
     };
 
-    esp_err_t err = ppa_do_scale_rotate_mirror(s_ppa_srm_client, &srm);
+    esp_err_t err = ppa_srm_rgb565(&job);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "PPA scale %lux%lu -> %lux%lu failed: %s",
                  (unsigned long)src_w, (unsigned long)src_h,

--- a/main/jpeg_utils.h
+++ b/main/jpeg_utils.h
@@ -3,10 +3,19 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include "esp_err.h"
 
 /* img_fmt_t + the pure magic/PNG/GIF header logic image_probe_format_dims()
  * delegates to (host-testable; see test/host/test_image_probe.c). */
 #include "image_probe.h"
+
+/**
+ * @brief Register the shared PPA SRM client used by every scaler in this file.
+ * Call once from app_main after the display is up. The scalers register it
+ * lazily if this was never called, so it is an optimisation, not a hard
+ * prerequisite.
+ */
+void jpeg_utils_ppa_init(void);
 
 /**
  * @brief Software JPEG decode fallback (stb_image).
@@ -16,8 +25,8 @@
  * @param jpg_data  JPEG compressed data
  * @param jpg_size  Size in bytes
  * @param out_buf   Receives allocated RGB565 buffer
- * @param out_w     Receives image width (rounded up to 16)
- * @param out_h     Receives image height (rounded up to 16)
+ * @param out_w     Receives image width in pixels (exact)
+ * @param out_h     Receives image height in pixels (exact)
  * @param out_size  Receives buffer size in bytes
  * @return true on success
  */
@@ -37,6 +46,9 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
  * Output contract is identical to jpeg_sw_decode_rgb565(): tightly packed
  * RGB565 rows top-down, out_w/out_h are the image's real pixel dimensions (the
  * HW MCU padding is removed), 128-byte aligned PSRAM, caller frees with free().
+ * *out_size is the ALLOCATION size, which on the HW path is the MCU-padded
+ * decoder buffer (larger than w*h*2); never derive a stride or a pixel count
+ * from it, use out_w/out_h. Needs about 10 KB of caller stack.
  *
  * @return true on success (from either path)
  */
@@ -154,3 +166,68 @@ uint8_t *ppa_scale_rgb565_into_noclear(const uint8_t *src, uint32_t src_w, uint3
  */
 void sw_scale_rgb565_bilinear(const uint16_t *src, int sw, int sh,
                               uint16_t *dst, int dw, int dh);
+
+/**
+ * @brief One PPA SRM pass: crop + mirror + rotate + scale, RGB565 in/out.
+ *
+ * Everything the six software passes on the image pages do today, in one DMA
+ * transaction. Scale is a 1/16-step factor on BOTH axes (the hardware truncates
+ * to 1/16 regardless), so pick an exact ratio or over-provision the source block
+ * and show a window of the result.
+ */
+typedef struct {
+    const uint8_t *src;        /* RGB565 */
+    uint32_t src_stride_px;    /* pixels per source row (pic_w) */
+    uint32_t src_h;            /* pic_h */
+    uint32_t block_x, block_y, block_w, block_h;   /* source crop window */
+    uint8_t  rotate_cw;        /* 0..3 = 0/90/180/270 degrees CLOCKWISE (page convention) */
+    bool     hflip, vflip;     /* applied to the source before rotation, same as the page's SW passes */
+    uint8_t  *dst;             /* 128 B aligned PSRAM */
+    size_t   dst_buf_size;     /* 128 B multiple */
+    uint32_t dst_w, dst_h;     /* destination picture size */
+    uint32_t dst_x, dst_y;     /* where the scaled block lands in dst */
+    uint8_t  scale_n16;        /* scale = n/16, 1..255 (both axes) */
+    bool     clear_dst;        /* memset+C2M the whole dst first */
+    uint32_t out_w, out_h;     /* filled: size of the written block as the driver computes it */
+} ppa_srm_job_t;
+
+/**
+ * @brief Run one ppa_srm_job_t (BLOCKING). Fills job->out_w / job->out_h.
+ * @return ESP_OK, or the driver's error / ESP_ERR_INVALID_ARG on a bad job.
+ */
+esp_err_t ppa_srm_rgb565(ppa_srm_job_t *job);
+
+/**
+ * @brief One PPA Blend pass: out = bg*(1 - a) + fg*a, RGB565 throughout.
+ *
+ * All three pictures are @p w x @p h with no offsets (the Blend engine cannot
+ * scale, rotate or mirror). @p fg_alpha is the mix, 0 = @p bg, 255 = @p fg,
+ * applied as the hardware's PPA_ALPHA_FIX_VALUE — an RGB565 foreground carries
+ * no alpha of its own, so without it the blend would be a plain copy.
+ *
+ * @p out must be 128-byte aligned PSRAM (or internal RAM) of at least
+ * align128(w*h*2) bytes; the driver checks the pointer and the size it is
+ * given, not the allocation. @p bg and @p fg need no alignment and may live
+ * anywhere, including flash. The driver does its own cache maintenance (writes
+ * the inputs back, invalidates the output), so no esp_cache_msync() is needed
+ * around this — but the CPU must not be holding unflushed writes to @p out, and
+ * must not write @p out while the call is running (it BLOCKS until the DMA
+ * finishes). @p out may alias @p bg or @p fg; the ring playback does not.
+ *
+ * @return ESP_OK, ESP_ERR_INVALID_SIZE for a zero or over-8191 px axis,
+ *         ESP_ERR_INVALID_ARG / ESP_ERR_INVALID_STATE, or the driver's error.
+ */
+esp_err_t ppa_blend_rgb565(const uint8_t *bg, const uint8_t *fg, uint8_t *out,
+                           uint32_t w, uint32_t h, uint8_t fg_alpha);
+
+/**
+ * @brief Pack an RGB888 buffer (stb byte order: R,G,B) into RGB565 on the PPA.
+ *
+ * 1:1, no rotation. @p dst565 must be 128-byte aligned PSRAM and @p dst_size a
+ * 128-byte multiple of at least w*h*2 (the driver rejects anything else).
+ *
+ * @return true if the hardware did it; false means the caller must run its own
+ *         software pack.
+ */
+bool ppa_rgb888_to_rgb565(const uint8_t *rgb888, uint32_t w, uint32_t h,
+                          uint8_t *dst565, size_t dst_size);

--- a/main/main.c
+++ b/main/main.c
@@ -31,8 +31,8 @@
 #include "tasks.h"
 #include "esp_ota_ops.h"
 #include "ota_github.h"
-#include "driver/jpeg_decode.h"
 #include "driver/ppa.h"
+#include "jpeg_utils.h"      /* jpeg_utils_ppa_init(), jpeg_decode_rgb565() */
 #include "esp_lcd_mipi_dsi.h"   /* esp_lcd_dpi_panel_get_frame_buffer() */
 #include "display/lv_display_private.h"
 #include "display_defs.h"
@@ -887,9 +887,10 @@ void app_main(void)
 
     /* ── PPA hardware rotation setup ──
      * Grab all three DPI framebuffers and a dedicated SRM client.  A dedicated
-     * client (not the shared one in jpeg_utils.c) is required: that one has
-     * max_pending_trans_num = 1 and is driven from Core 0, so a decode
-     * overlapping a flush would fail the transaction. */
+     * client (not the shared one in jpeg_utils.c) keeps the flush path off the
+     * shared client's pending queue (4 slots, used by the pollers, the LVGL
+     * task and the fetch worker), so a burst of image fits can never fail the
+     * rotation transaction. */
     {
         lv_display_t *disp = lv_display_get_default();
         if (disp) {
@@ -929,6 +930,8 @@ void app_main(void)
         }
     }
 
+    jpeg_utils_ppa_init();  /* shared PPA SRM client for the image scalers */
+
     /* Initialize session stats (PSRAM allocation, no LVGL) */
     nina_session_stats_init();
 
@@ -938,59 +941,31 @@ void app_main(void)
         const uint8_t *jpg_data = logo_jpg_start;
         size_t jpg_size = (size_t)(logo_jpg_end - logo_jpg_start);
 
-        jpeg_decode_picture_info_t pic_info = {0};
-        esp_err_t err = jpeg_decoder_get_info(jpg_data, jpg_size, &pic_info);
-
-        if (err == ESP_OK && pic_info.width > 0) {
-            uint32_t out_w = ((pic_info.width + 15) / 16) * 16;
-            uint32_t out_h = ((pic_info.height + 15) / 16) * 16;
-
-            jpeg_decode_memory_alloc_cfg_t mem_cfg = {
-                .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
-            };
-            size_t allocated = 0;
-            uint8_t *rgb_buf = (uint8_t *)jpeg_alloc_decoder_mem(out_w * out_h * 2, &mem_cfg, &allocated);
-
-            if (rgb_buf) {
-                memset(rgb_buf, 0, allocated); /* Zero buffer so PPA edge interpolation reads black, not heap garbage */
-                jpeg_decoder_handle_t decoder = NULL;
-                jpeg_decode_engine_cfg_t engine_cfg = { .intr_priority = 0, .timeout_ms = 5000 };
-                err = jpeg_new_decoder_engine(&engine_cfg, &decoder);
-                if (err == ESP_OK && decoder) {
-                    jpeg_decode_cfg_t dec_cfg = {
-                        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
-                        .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
-                    };
-                    uint32_t out_size = 0;
-                    err = jpeg_decoder_process(decoder, &dec_cfg,
-                              jpg_data, jpg_size, rgb_buf, allocated, &out_size);
-                    jpeg_del_decoder_engine(decoder);
-
-                    if (err == ESP_OK && out_size > 0) {
-                        /* Red Night gate: live theme pointer is not set yet at splash,
-                         * so resolve the SAVED theme directly from config (loaded before
-                         * the display in app_main) and remap the logo to red/black if so. */
-                        const theme_t *saved_theme = themes_get(app_config_get()->theme_index);
-                        if (theme_is_red_night(saved_theme)) {
-                            image_red_remap_rgb565_force((uint16_t *)rgb_buf,
-                                                         (size_t)out_w * (size_t)out_h);
-                        }
-                        splash_dsc.header.magic  = LV_IMAGE_HEADER_MAGIC;
-                        splash_dsc.header.w      = (int32_t)out_w;
-                        splash_dsc.header.h      = (int32_t)out_h;
-                        splash_dsc.header.cf     = LV_COLOR_FORMAT_RGB565;
-                        splash_dsc.header.stride = out_w * 2;
-                        splash_dsc.data          = rgb_buf;
-                        splash_dsc.data_size     = out_size;
-                        splash_ready = true;
-                        ESP_LOGI(TAG, "Splash decoded: %lux%lu", (unsigned long)out_w, (unsigned long)out_h);
-                    } else {
-                        free(rgb_buf);
-                    }
-                } else {
-                    free(rgb_buf);
-                }
+        /* HW-first decode via the shared spine: tight w x h RGB565 in 128 B
+         * aligned PSRAM (no MCU padding), stb fallback for anything the engine
+         * refuses. */
+        uint8_t *rgb_buf = NULL;
+        uint32_t out_w = 0, out_h = 0;
+        size_t out_size = 0;
+        if (jpeg_decode_rgb565(jpg_data, jpg_size, &rgb_buf, &out_w, &out_h, &out_size)
+            && rgb_buf) {
+            /* Red Night gate: live theme pointer is not set yet at splash,
+             * so resolve the SAVED theme directly from config (loaded before
+             * the display in app_main) and remap the logo to red/black if so. */
+            const theme_t *saved_theme = themes_get(app_config_get()->theme_index);
+            if (theme_is_red_night(saved_theme)) {
+                image_red_remap_rgb565_force((uint16_t *)rgb_buf,
+                                             (size_t)out_w * (size_t)out_h);
             }
+            splash_dsc.header.magic  = LV_IMAGE_HEADER_MAGIC;
+            splash_dsc.header.w      = (int32_t)out_w;
+            splash_dsc.header.h      = (int32_t)out_h;
+            splash_dsc.header.cf     = LV_COLOR_FORMAT_RGB565;
+            splash_dsc.header.stride = out_w * 2;
+            splash_dsc.data          = rgb_buf;
+            splash_dsc.data_size     = (uint32_t)out_size;
+            splash_ready = true;
+            ESP_LOGI(TAG, "Splash decoded: %lux%lu", (unsigned long)out_w, (unsigned long)out_h);
         }
     }
 

--- a/main/octoprint_client.c
+++ b/main/octoprint_client.c
@@ -438,10 +438,13 @@ static bool fetch_image_bytes(const char *url, const char *hdr,
 /**
  * Validate and decode an encoded image into an RGB565 PSRAM buffer.
  *
- * jpeg_sw_decode_rgb565() is named for its first caller but is a plain
- * stb_image decode: PNG (gcode thumbnail) and JPEG (webcam snapshot) both go
- * through it, and it already delivers a 128-byte-aligned, cache-flushed PSRAM
- * buffer at the image's exact dimensions.
+ * jpeg_decode_rgb565() tries the ESP32-P4 hardware JPEG engine first and falls
+ * back to the same stb_image decode for whatever it refuses (progressive,
+ * CMYK, grayscale) and for PNG, which never goes near the engine. So the gcode
+ * thumbnail (PNG) decodes exactly as before, while the webcam snapshot (JPEG)
+ * skips stb's RGB888 intermediate (~1.5 MB at 960x720). Both paths deliver the
+ * same contract: 128-byte-aligned, cache-flushed PSRAM holding tightly packed
+ * RGB565 rows top-down at the image's exact dimensions, owned by the caller.
  */
 static bool decode_image(const uint8_t *buf, size_t len, const char *what,
                          uint8_t **out_rgb, uint16_t *out_w, uint16_t *out_h) {
@@ -469,7 +472,7 @@ static bool decode_image(const uint8_t *buf, size_t len, const char *what,
     uint8_t *rgb = NULL;
     uint32_t w = 0, h = 0;
     size_t out_size = 0;
-    if (!jpeg_sw_decode_rgb565(buf, len, &rgb, &w, &h, &out_size) || !rgb) {
+    if (!jpeg_decode_rgb565(buf, len, &rgb, &w, &h, &out_size) || !rgb) {
         ESP_LOGW(TAG, "%s: decode failed", what);
         if (rgb) {
             heap_caps_free(rgb);

--- a/main/tasks.c
+++ b/main/tasks.c
@@ -58,7 +58,6 @@
 #include "crash_log.h"
 #include "demo_data.h"
 #include "weather_client.h"
-#include "driver/jpeg_decode.h"
 #include "freertos/queue.h"
 #include "ui/nina_thumbnail.h"
 #include "poll_task.h"
@@ -975,133 +974,48 @@ void spotify_poll_task(void *arg)
                         /* Strip COM markers that the HW JPEG decoder can't handle */
                         jpg_size = strip_jpeg_com_markers(jpg_buf, jpg_size);
 
-                        /* Hardware JPEG decode to RGB565.
-                         * Buffer always rounded to 16px — the ESP32-P4 HW decoder
-                         * outputs with 16-pixel MCU alignment regardless of subsampling.
-                         * PPA uses actual pic_info dimensions to crop MCU padding. */
+                        /* HW-first decode through the shared spine (its own stb
+                         * fallback covers progressive/CMYK), then one PPA pass to
+                         * 720x720 so LVGL blits 1:1 instead of scaling per redraw.
+                         * nina_spotify_set_album_art() TAKES OWNERSHIP, frees the
+                         * previous buffer and red-remaps this one in place, so each
+                         * handoff has to be its own allocation -- no shared static. */
+                        uint8_t *art = NULL;
+                        uint32_t art_w = 0, art_h = 0;
+                        size_t art_size = 0;
                         perf_timer_start(&g_perf.spotify_art_decode);
-                        jpeg_decode_picture_info_t pic_info = {0};
-                        esp_err_t info_err = jpeg_decoder_get_info(jpg_buf, jpg_size, &pic_info);
-                        if (info_err == ESP_OK && pic_info.width > 0) {
-                            uint32_t out_w = ((pic_info.width + 15) / 16) * 16;
-                            uint32_t out_h = ((pic_info.height + 15) / 16) * 16;
+                        bool art_dec = jpeg_decode_rgb565(jpg_buf, jpg_size,
+                                                          &art, &art_w, &art_h, &art_size);
+                        if (art_dec && art && (art_w != 720 || art_h != 720)) {
+                            size_t scaled_size = 0;
+                            uint8_t *scaled = ppa_scale_rgb565(art, art_w, art_h, 0,
+                                                               720, 720, &scaled_size);
+                            if (scaled) {
+                                free(art);
+                                art = scaled;
+                                art_w = 720;
+                                art_h = 720;
+                                art_size = scaled_size;
+                            }
+                            /* PPA refused: hand over the unscaled frame and let LVGL
+                             * software-scale it, exactly as before. */
+                        }
+                        perf_timer_stop(&g_perf.spotify_art_decode);
 
-                            jpeg_decode_memory_alloc_cfg_t mem_cfg = {
-                                .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
-                            };
-                            size_t allocated = 0;
-                            uint8_t *rgb_buf = (uint8_t *)jpeg_alloc_decoder_mem(
-                                out_w * out_h * 2, &mem_cfg, &allocated);
-
-                            if (rgb_buf) {
-                                memset(rgb_buf, 0, allocated); /* Zero buffer so PPA edge interpolation reads black, not heap garbage */
-                                jpeg_decoder_handle_t decoder = NULL;
-                                jpeg_decode_engine_cfg_t engine_cfg = {
-                                    .intr_priority = 0, .timeout_ms = 5000
-                                };
-                                esp_err_t dec_err = jpeg_new_decoder_engine(&engine_cfg, &decoder);
-                                if (dec_err == ESP_OK && decoder) {
-                                    jpeg_decode_cfg_t dec_cfg = {
-                                        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
-                                        .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
-                                    };
-                                    uint32_t out_size = 0;
-                                    dec_err = jpeg_decoder_process(decoder, &dec_cfg,
-                                        jpg_buf, jpg_size, rgb_buf, allocated, &out_size);
-                                    jpeg_del_decoder_engine(decoder);
-
-                                    if (dec_err == ESP_OK && out_size > 0) {
-                                        /* Pre-scale to 720x720 using PPA hardware to
-                                         * eliminate per-frame LVGL software scaling */
-                                        uint8_t *final_buf = rgb_buf;
-                                        uint32_t final_w = out_w, final_h = out_h;
-                                        size_t final_size = out_size;
-
-                                        if (pic_info.width != 720 || pic_info.height != 720) {
-                                            size_t scaled_size = 0;
-                                            uint8_t *scaled = ppa_scale_rgb565(
-                                                rgb_buf, pic_info.width, pic_info.height,
-                                                out_w, 720, 720, &scaled_size);
-                                            if (scaled) {
-                                                free(rgb_buf);
-                                                final_buf = scaled;
-                                                final_w = 720;
-                                                final_h = 720;
-                                                final_size = scaled_size;
-                                            }
-                                            /* If PPA fails, fall through with original —
-                                             * LVGL will SW-scale as before */
-                                        }
-
-                                        perf_timer_stop(&g_perf.spotify_art_decode);
-
-                                        if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                                            nina_spotify_set_album_art(final_buf, final_w, final_h, final_size);
-                                            bsp_display_unlock();
-                                            art_ok = true;
-                                            /* Ownership transferred to UI — don't free final_buf */
-                                        } else {
-                                            /* Lock timed out — free the buffer and leave
-                                             * art_ok false so the art is retried next poll. */
-                                            free(final_buf);
-                                        }
-                                    } else {
-                                        perf_timer_stop(&g_perf.spotify_art_decode);
-                                        ESP_LOGW(TAG, "HW JPEG decode failed, trying SW fallback");
-                                        free(rgb_buf);
-                                        rgb_buf = NULL;
-                                        /* SW fallback (stb_image) — handles CMYK and other unsupported formats */
-                                        goto sw_fallback;
-                                    }
-                                } else {
-                                    perf_timer_stop(&g_perf.spotify_art_decode);
-                                    ESP_LOGW(TAG, "HW decoder engine creation failed, trying SW");
-                                    free(rgb_buf);
-                                    goto sw_fallback;
-                                }
+                        if (art_dec && art) {
+                            if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
+                                nina_spotify_set_album_art(art, art_w, art_h,
+                                                           (uint32_t)art_size);
+                                bsp_display_unlock();
+                                art_ok = true;
+                                /* Ownership transferred to UI -- don't free art */
                             } else {
-                                perf_timer_stop(&g_perf.spotify_art_decode);
-                                ESP_LOGW(TAG, "HW decoder mem alloc failed, trying SW");
-                                goto sw_fallback;
+                                /* Lock timed out -- free the buffer and leave
+                                 * art_ok false so the art is retried next poll. */
+                                free(art);
                             }
                         } else {
-                            perf_timer_stop(&g_perf.spotify_art_decode);
-                        sw_fallback: ;
-                            uint8_t *sw_buf = NULL;
-                            uint32_t sw_w = 0, sw_h = 0;
-                            size_t sw_size = 0;
-                            perf_timer_start(&g_perf.spotify_art_decode);
-                            bool sw_ok = jpeg_sw_decode_rgb565(jpg_buf, jpg_size,
-                                &sw_buf, &sw_w, &sw_h, &sw_size);
-                            perf_timer_stop(&g_perf.spotify_art_decode);
-                            if (sw_ok && sw_buf) {
-                                uint8_t *final_buf = sw_buf;
-                                uint32_t final_w = sw_w, final_h = sw_h;
-                                size_t final_size = sw_size;
-                                if (sw_w != 720 || sw_h != 720) {
-                                    size_t scaled_size = 0;
-                                    uint8_t *scaled = ppa_scale_rgb565(
-                                        sw_buf, sw_w, sw_h, 0, 720, 720, &scaled_size);
-                                    if (scaled) {
-                                        free(sw_buf);
-                                        final_buf = scaled;
-                                        final_w = 720;
-                                        final_h = 720;
-                                        final_size = scaled_size;
-                                    }
-                                }
-                                if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
-                                    nina_spotify_set_album_art(final_buf, final_w, final_h, final_size);
-                                    bsp_display_unlock();
-                                    art_ok = true;
-                                } else {
-                                    /* Lock timed out — free the buffer and leave
-                                     * art_ok false so the art is retried next poll. */
-                                    free(final_buf);
-                                }
-                            } else {
-                                ESP_LOGW(TAG, "SW JPEG decode also failed for album art");
-                            }
+                            ESP_LOGW(TAG, "Album art JPEG decode failed");
                         }
                         free(jpg_buf);
                     } else {
@@ -1209,78 +1123,25 @@ void fetch_worker_task(void *arg) {
             perf_timer_stop(&g_perf.jpeg_fetch);
             if (!jpeg_buf || jpeg_size == 0) break;
 
-            jpeg_decode_picture_info_t pic_info = {0};
-            esp_err_t err = jpeg_decoder_get_info(jpeg_buf, jpeg_size, &pic_info);
-            if (err != ESP_OK || pic_info.width == 0 || pic_info.height == 0) {
-                free(jpeg_buf);
-                break;
-            }
-
-            bool is_gray = (pic_info.sample_method == JPEG_DOWN_SAMPLING_GRAY);
-            uint32_t out_w = ((pic_info.width + 15) / 16) * 16;
-            uint32_t out_h = ((pic_info.height + 15) / 16) * 16;
-            uint32_t decode_buf_size = out_w * out_h * (is_gray ? 1 : 2);
-
-            jpeg_decode_memory_alloc_cfg_t mem_cfg = {
-                .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
-            };
-            size_t allocated_size = 0;
-            uint8_t *decode_buf = (uint8_t *)jpeg_alloc_decoder_mem(decode_buf_size, &mem_cfg, &allocated_size);
-            if (!decode_buf) { free(jpeg_buf); break; }
-            memset(decode_buf, 0, allocated_size); /* Zero buffer so PPA edge interpolation reads black, not heap garbage */
-
-            size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
-            if (free_dma < 20 * 1024) {
-                ESP_LOGW(TAG, "Fetch worker: low DMA heap (%d bytes), skipping HW decode", (int)free_dma);
-                free(decode_buf);
-                free(jpeg_buf);
-                break;
-            }
-
-            jpeg_decoder_handle_t decoder = NULL;
-            jpeg_decode_engine_cfg_t engine_cfg = { .intr_priority = 0, .timeout_ms = 5000 };
-            err = jpeg_new_decoder_engine(&engine_cfg, &decoder);
-            if (err != ESP_OK || !decoder) { free(decode_buf); free(jpeg_buf); break; }
-
-            jpeg_decode_cfg_t decode_cfg = {
-                .output_format = is_gray ? JPEG_DECODE_OUT_FORMAT_GRAY : JPEG_DECODE_OUT_FORMAT_RGB565,
-                .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
-            };
-            uint32_t out_size = 0;
+            /* HW-first decode: tight w x h RGB565 in 128 B aligned PSRAM, MCU
+             * padding removed, single-component JPEG expanded from GRAY8, stb
+             * fallback for progressive/CMYK. Carries its own low-DMA-heap
+             * guard, so the one that used to sit here is gone. */
+            uint8_t *rgb_buf = NULL;
+            uint32_t rgb_w = 0, rgb_h = 0;
+            size_t rgb_size = 0;
             perf_timer_start(&g_perf.jpeg_decode);
-            err = jpeg_decoder_process(decoder, &decode_cfg, jpeg_buf, jpeg_size,
-                                       decode_buf, allocated_size, &out_size);
+            bool decoded = jpeg_decode_rgb565(jpeg_buf, jpeg_size,
+                                              &rgb_buf, &rgb_w, &rgb_h, &rgb_size);
             perf_timer_stop(&g_perf.jpeg_decode);
-            jpeg_del_decoder_engine(decoder);
-
-            if (err != ESP_OK || out_size == 0) {
-                free(decode_buf);
-                free(jpeg_buf);
-                break;
-            }
-
-            uint8_t *rgb_buf = decode_buf;
-            uint32_t rgb_size = out_size;
-
-            if (is_gray) {
-                uint32_t pixel_count = out_w * out_h;
-                rgb_size = pixel_count * 2;
-                rgb_buf = heap_caps_malloc(rgb_size, MALLOC_CAP_SPIRAM);
-                if (!rgb_buf) { free(decode_buf); free(jpeg_buf); break; }
-                uint16_t *dst = (uint16_t *)rgb_buf;
-                for (uint32_t i = 0; i < pixel_count; i++) {
-                    uint8_t g = decode_buf[i];
-                    dst[i] = ((g >> 3) << 11) | ((g >> 2) << 5) | (g >> 3);
-                }
-                free(decode_buf);
-            }
+            free(jpeg_buf);
+            if (!decoded || !rgb_buf) break;
 
             result.success = true;
             result.thumbnail.rgb565_data = rgb_buf;
-            result.thumbnail.w = out_w;
-            result.thumbnail.h = out_h;
-            result.thumbnail.data_size = rgb_size;
-            free(jpeg_buf);
+            result.thumbnail.w = rgb_w;
+            result.thumbnail.h = rgb_h;
+            result.thumbnail.data_size = (uint32_t)rgb_size;
             break;
         }
 
@@ -1458,7 +1319,7 @@ static void ensure_network_stack(void) {
 
     /* Spawn async fetch worker (pinned to Core 0, networking) */
     if (s_fetch_queue && s_fetch_result_queue) {
-        psram_task_spawn(fetch_worker_task, "fetch_wk", 8192, NULL, 4, 0);
+        psram_task_spawn(fetch_worker_task, "fetch_wk", 12288, NULL, 4, 0);  /* jpeg_decode_rgb565 wants ~10 KB headroom */
     }
 }
 
@@ -1698,24 +1559,29 @@ main_loop:
                     if (fres.success && fres.thumbnail.rgb565_data) {
                         if (bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) {
                             /* Image-forward (layout 1) shows the last capture as its
-                             * page background. nina_dashboard_set_thumbnail() below
-                             * takes ownership of the original (and frees it when the
-                             * overlay is hidden), so the retained copy gets its own
-                             * PSRAM buffer — exactly one owner each. */
-                            /* The page must still be the visible one: hide_page_at()
-                             * has already released the capture, so attaching a copy
-                             * to a hidden page would leak it until that page is
-                             * entered and left again. */
-                            if (fres.instance_idx >= 0 && fres.instance_idx < MAX_NINA_INSTANCES
+                             * page background. The page must still be the visible
+                             * one: hide_page_at() has already released the capture,
+                             * so attaching a frame to a hidden page would leak it
+                             * until that page is entered and left again. */
+                            bool want_cap = (fres.instance_idx >= 0
+                                && fres.instance_idx < MAX_NINA_INSTANCES
                                 && nina_slot_available[fres.instance_idx]
                                 && pages[fres.instance_idx].layout == 1
                                 && nina_dashboard_get_active_page()
-                                       == NINA_PAGE_OFFSET + fres.instance_idx) {
+                                       == NINA_PAGE_OFFSET + fres.instance_idx);
+                            /* Both consumers TAKE OWNERSHIP, so the frame is copied
+                             * only when both want it. The overlay is normally hidden
+                             * (the capture is asked for by the layout, not by a tap)
+                             * and that case now hands the original straight to the
+                             * layout: no 1 MB alloc + memcpy + free per sub. */
+                            bool want_thumb = nina_dashboard_thumbnail_wants_data();
+                            uint8_t *buf = fres.thumbnail.rgb565_data;
+
+                            if (want_cap && want_thumb) {
                                 uint8_t *cap = heap_caps_malloc(fres.thumbnail.data_size,
                                                                 MALLOC_CAP_SPIRAM);
                                 if (cap) {
-                                    memcpy(cap, fres.thumbnail.rgb565_data,
-                                           fres.thumbnail.data_size);
+                                    memcpy(cap, buf, fres.thumbnail.data_size);
                                     nina_layout_image_set_capture(fres.instance_idx, cap,
                                         fres.thumbnail.w, fres.thumbnail.h,
                                         fres.thumbnail.data_size);
@@ -1725,11 +1591,19 @@ main_loop:
                                     nina_layout_image_note_capture_request(fres.instance_idx,
                                                                           false);
                                 }
+                                nina_dashboard_set_thumbnail(buf, fres.thumbnail.w,
+                                    fres.thumbnail.h, fres.thumbnail.data_size);
+                            } else if (want_cap) {
+                                nina_layout_image_set_capture(fres.instance_idx, buf,
+                                    fres.thumbnail.w, fres.thumbnail.h,
+                                    fres.thumbnail.data_size);
+                            } else if (want_thumb) {
+                                nina_dashboard_set_thumbnail(buf, fres.thumbnail.w,
+                                    fres.thumbnail.h, fres.thumbnail.data_size);
+                            } else {
+                                free(buf);
                             }
-                            nina_dashboard_set_thumbnail(fres.thumbnail.rgb565_data,
-                                fres.thumbnail.w, fres.thumbnail.h, fres.thumbnail.data_size);
                             bsp_display_unlock();
-                            /* Ownership transferred to UI */
                         } else {
                             free(fres.thumbnail.rgb565_data);
                         }

--- a/main/ui/nina_image_page.c
+++ b/main/ui/nina_image_page.c
@@ -17,6 +17,7 @@
 #include "nina_dashboard.h"            /* nina_dashboard_set_image_page_enabled (config apply, B5) */
 #include "nina_dashboard_internal.h"   /* SCREEN_SIZE, OUTER_PADDING, current_theme, PAGE_IDX_IMG_* */
 #include "image_red_remap.h"
+#include "image_fit.h"                 /* PPA fit: n/16 scale + symmetric trim */
 #include "image_night_invert.h"        /* radar: invert the greyscale basemap only */
 #include "jpeg_utils.h"                /* jpeg_decode_rgb565 (ring local re-transform) */
 #include "moon_interaction.h"
@@ -592,9 +593,9 @@ void image_page_render_frame(image_page_t *p)
         return;
     }
 
-    /* Copy the RGB565 source into a freshly allocated PSRAM buffer so we can
-     * release frame_mux before running the (asynchronous) crossfade and so the
-     * LVGL side owns its display buffers independently of the poller. */
+    /* Transform the RGB565 source into a freshly allocated PSRAM buffer (ONE PPA
+     * pass, below) so frame_mux is released before the (asynchronous) crossfade
+     * and the LVGL side owns its display buffers independently of the poller. */
     uint16_t sw = p->frame.w, sh = p->frame.h;
     if (sw == 0 || sh == 0) {
         frame_unlock(p);
@@ -623,91 +624,59 @@ void image_page_render_frame(image_page_t *p)
         oy = (uint16_t)((sh - h) / 2);
     }
 
-    size_t   buf_size = (size_t)w * h * 2;
-    uint8_t *copy = heap_caps_malloc(buf_size, MALLOC_CAP_SPIRAM);
-    if (!copy) {
-        ESP_LOGE(TAG, "PSRAM alloc failed for crossfade buffer (%u bytes)",
-                 (unsigned)buf_size);
-        frame_unlock(p);
-        /* New-image gate passed but the display copy failed — release any
-         * manual-fetch wait overlay so it can't get stuck. */
-        nina_wait_overlay_hide();
-        return;
-    }
-    /* Copy the (optionally cropped) source row-by-row. Decode is top-down end to
-     * end (the historical "SW decode is flipped" belief was stb's flip-on-load
-     * flag reading uninitialized TLS garbage; see STBI_NO_THREAD_LOCALS in
-     * stb_image.c), so src_y is simply oy + y. ox/oy apply the center-crop. */
-    size_t src_stride = (size_t)sw * 2;
-    size_t dst_stride = (size_t)w * 2;
+    /* Everything the LVGL side needs out of the frame, captured under the same
+     * lock as the pixels: the label so the on-screen text cannot desync from the
+     * picture if a config change lands between fetches (issue #166). */
+    int64_t stamp_ms = p->frame.stamp_ms;
+    char label_copy[48];
+    strlcpy(label_copy, p->frame.label, sizeof(label_copy));
 
     /* Optional caption mask (Solar bands only). The mask rect is in upright-full
      * image fractional coords; convert to a pixel rect [mx0..mx1, my0..my1]. For
-     * masked pixels we composite a color-sampled blend: per row, sample one
-     * source pixel just to the RIGHT of the mask (col mx1+PAD) at the same
-     * upright row and stretch it across the masked span. This extends the
-     * neighbouring background (black margin for HMI -> seamless; corona for
-     * LASCO -> blends) horizontally over the burned-in timestamp. */
-    bool  mask_on = false;
-    int   mx0 = 0, mx1 = 0, my0 = 0, my1 = 0, sample_col = 0;
-    /* Gate the caption mask on the same crop/clean toggle as the crop, so turning
-     * the toggle off shows the raw frame (incl. burned-in timestamp). */
-    if (image_page_config_crop(cfg, p->src) && p->src == IMG_SRC_SOLAR) {
-        float fx0, fy0, fx1, fy1;
-        if (solar_band_text_mask(cfg->solar_band, &fx0, &fy0, &fx1, &fy1)) {
-            mask_on = true;
-            mx0 = (int)(fx0 * sw);
-            mx1 = (int)(fx1 * sw);
-            my0 = (int)(fy0 * sh);
-            my1 = (int)(fy1 * sh);
-            const int PAD = 8;
-            sample_col = mx1 + PAD;
-            if (sample_col > sw - 1) sample_col = sw - 1;  /* clamp into bounds */
+     * masked pixels we composite a colour-sampled blend: per row, sample one
+     * source pixel just to the RIGHT of the mask (col mx1+PAD) and stretch it
+     * across the masked span. This extends the neighbouring background (black
+     * margin for HMI -> seamless; corona for LASCO -> blends) horizontally over
+     * the burned-in timestamp.
+     *
+     * The ONE case that still costs a full-frame CPU copy: the PPA cannot paint
+     * it, and mapping the mask rect into output space would be a second geometry
+     * to keep in step with image_fit. Every other source hands the PPA
+     * p->frame.buf directly. Gated on the same crop/clean toggle as the crop, so
+     * turning that off shows the raw frame, burned-in timestamp and all. */
+    const uint8_t *src_pix = p->frame.buf;
+    uint8_t *masked = NULL;
+    float fx0, fy0, fx1, fy1;
+    if (image_page_config_crop(cfg, p->src) && p->src == IMG_SRC_SOLAR &&
+        solar_band_text_mask(cfg->solar_band, &fx0, &fy0, &fx1, &fy1)) {
+        masked = heap_caps_malloc((size_t)sw * sh * 2, MALLOC_CAP_SPIRAM);
+        if (masked) {
+            memcpy(masked, p->frame.buf, (size_t)sw * sh * 2);
+            int mx0 = (int)(fx0 * sw), mx1 = (int)(fx1 * sw);
+            int my0 = (int)(fy0 * sh), my1 = (int)(fy1 * sh);
+            int sample_col = mx1 + 8;                  /* PAD past the mask edge */
+            if (sample_col > (int)sw - 1) sample_col = (int)sw - 1;
+            if (sample_col < 0) sample_col = 0;
+            if (mx0 < 0) mx0 = 0;
+            if (mx1 > (int)sw) mx1 = (int)sw;
+            if (my0 < 0) my0 = 0;
+            if (my1 > (int)sh) my1 = (int)sh;
+            for (int my = my0; my < my1; my++) {
+                uint16_t *row  = (uint16_t *)(masked + (size_t)my * sw * 2);
+                uint16_t  fill = row[sample_col];
+                for (int mx = mx0; mx < mx1; mx++) row[mx] = fill;
+            }
+            src_pix = masked;
+        } else {
+            ESP_LOGW(TAG, "%s: no PSRAM for the caption mask, showing it raw", p->name);
         }
     }
 
-    for (uint32_t y = 0; y < h; y++) {
-        uint32_t src_y = (uint32_t)oy + y;
-        memcpy((uint8_t *)copy + (size_t)y * dst_stride,
-               p->frame.buf + (size_t)src_y * src_stride + (size_t)ox * 2,
-               dst_stride);
-
-        if (!mask_on) continue;
-
-        /* Upright-full row for this dst row. Mask rect is in upright coords. */
-        int uY = (int)oy + (int)y;
-        if (uY < my0 || uY >= my1) continue;  /* row outside the mask band */
-
-        /* Sample the per-row replacement color ONCE (right of the mask, same
-         * upright row). */
-        const uint8_t *src_px = p->frame.buf
-                                + (size_t)src_y * src_stride
-                                + (size_t)sample_col * 2;
-        uint8_t lo = src_px[0], hi = src_px[1];
-
-        /* Overwrite the masked columns in this dst row. dst col x maps to
-         * upright col (ox + x); paint where ox+x is within [mx0, mx1). */
-        for (uint32_t x = 0; x < w; x++) {
-            int uX = (int)ox + (int)x;
-            if (uX < mx0 || uX >= mx1) continue;
-            uint8_t *dst_px = (uint8_t *)copy + (size_t)y * dst_stride + (size_t)x * 2;
-            dst_px[0] = lo;
-            dst_px[1] = hi;
-        }
-    }
-    int64_t stamp_ms = p->frame.stamp_ms;
-    /* Capture the label this buffer was fetched for UNDER the same lock so the
-     * on-screen text is coupled to frame.buf and cannot desync if a config
-     * change lands between fetches (issue #166). */
-    char label_copy[48];
-    strlcpy(label_copy, p->frame.label, sizeof(label_copy));
-    frame_unlock(p);
-
-    /* Per-source logical mirror pass. Runs on the upright `copy` (after the
-     * caption mask) and BEFORE the rotation block, so flips compose naturally
-     * with rotation. vflip reverses row order (top<->bottom); hflip reverses the
-     * pixel order within each row (left<->right). Moon is excluded — it has its
-     * own moon_flip_u/v handling elsewhere. Dimensions are unchanged. */
+    /* Per-source mirror and rotation flags. The PPA applies the mirrors to the
+     * source and then the rotation, the same order the old software passes ran
+     * in, so the on-screen result is unchanged. orient 0/1/2/3 = 0/90/180/270
+     * degrees CLOCKWISE. The Moon has neither (its own moon_flip_u/v handling
+     * lives elsewhere) and no crop, so its job below is an identity 1.0x copy. */
     uint8_t do_vflip = (p->src == IMG_SRC_GOES)   ? cfg->goes_vflip
                        : (p->src == IMG_SRC_SOLAR) ? cfg->solar_vflip
                        : (p->src == IMG_SRC_CUSTOM) ? cfg->custom_vflip
@@ -716,129 +685,150 @@ void image_page_render_frame(image_page_t *p)
                        : (p->src == IMG_SRC_SOLAR) ? cfg->solar_hflip
                        : (p->src == IMG_SRC_CUSTOM) ? cfg->custom_hflip
                                                     : 0;
-    if (do_vflip) {
-        /* Swap row y with row (h-1-y) using one PSRAM temp row of dst_stride. */
-        uint8_t *tmp_row = heap_caps_malloc(dst_stride, MALLOC_CAP_SPIRAM);
-        if (!tmp_row) {
-            ESP_LOGE(TAG, "PSRAM alloc failed for vflip temp row (%u bytes)",
-                     (unsigned)dst_stride);
-            heap_caps_free(copy);
-            /* frame_mux already released above; just retire the wait overlay. */
-            nina_wait_overlay_hide();
-            return;
+    uint8_t orient   = (p->src == IMG_SRC_GOES)   ? cfg->goes_orientation
+                       : (p->src == IMG_SRC_SOLAR) ? cfg->solar_orientation
+                       : (p->src == IMG_SRC_CUSTOM) ? cfg->custom_orientation
+                                                    : 0;
+
+    /* ONE hardware pass does crop + mirror + rotate + scale straight into a
+     * panel-width destination. What this replaces: a crop memcpy, a row-swap
+     * vflip, an in-row hflip and a gather-rotate into a second buffer, all on
+     * the display lock and on up to 1024x1024 pixels, plus — every bit as
+     * expensive — an lv_image_set_scale() != 256 that made LVGL software-
+     * resample the whole 720x720 screen on EVERY redraw in full-refresh mode.
+     * The destination is exactly SCREEN_SIZE wide, so the image is a blit now.
+     *
+     * image_fit_pick() works in LOGICAL (post-rotation) space and hands back the
+     * n/16 scale plus the symmetric trim that keeps the output inside the panel;
+     * image_fit_logical_to_source() turns that trim back into the source
+     * rectangle, which is then offset by the config crop origin (ox, oy). */
+    uint32_t lw = (orient & 1) ? h : w;
+    uint32_t lh = (orient & 1) ? w : h;
+    image_fit_t fit;
+    uint32_t bx = 0, by = 0, bw = 0, bh = 0;
+    uint8_t  *dst = NULL;
+    size_t    dst_size = 0;
+    esp_err_t err = ESP_ERR_INVALID_SIZE;
+    if (image_fit_pick(lw, lh, SCREEN_SIZE, &fit) &&
+        image_fit_logical_to_source(&fit, w, h, orient, &bx, &by, &bw, &bh)) {
+        /* 128 B aligned address AND size: the PPA rejects anything else. */
+        dst_size = ((size_t)SCREEN_SIZE * fit.out_h * 2 + 127) & ~(size_t)127;
+        dst = heap_caps_aligned_alloc(128, dst_size, MALLOC_CAP_SPIRAM);
+        if (dst) {
+            ppa_srm_job_t job = {
+                .src           = src_pix,
+                .src_stride_px = sw,
+                .src_h         = sh,
+                .block_x       = (uint32_t)ox + bx,
+                .block_y       = (uint32_t)oy + by,
+                .block_w       = bw,
+                .block_h       = bh,
+                .rotate_cw     = orient,
+                .hflip         = do_hflip != 0,
+                .vflip         = do_vflip != 0,
+                .dst           = dst,
+                .dst_buf_size  = dst_size,
+                .dst_w         = SCREEN_SIZE,
+                .dst_h         = fit.out_h,
+                .dst_x         = fit.dst_x,
+                .dst_y         = 0,
+                .scale_n16     = fit.n16,
+                /* Only a source too wide to fill the panel leaves bands to clear. */
+                .clear_dst     = (fit.out_w < SCREEN_SIZE),
+            };
+            err = ppa_srm_rgb565(&job);
+        } else {
+            ESP_LOGE(TAG, "PSRAM alloc failed for the display frame (%u bytes)",
+                     (unsigned)dst_size);
+            err = ESP_ERR_NO_MEM;
         }
-        for (uint32_t y = 0; y < h / 2; y++) {
-            uint8_t *row_a = (uint8_t *)copy + (size_t)y * dst_stride;
-            uint8_t *row_b = (uint8_t *)copy + (size_t)(h - 1 - y) * dst_stride;
-            memcpy(tmp_row, row_a, dst_stride);
-            memcpy(row_a, row_b, dst_stride);
-            memcpy(row_b, tmp_row, dst_stride);
-        }
-        heap_caps_free(tmp_row);
     }
-    if (do_hflip) {
-        /* Reverse the w pixels in each row: swap col x with (w-1-x). */
-        for (uint32_t y = 0; y < h; y++) {
-            uint16_t *row = (uint16_t *)((uint8_t *)copy + (size_t)y * dst_stride);
-            for (uint32_t x = 0; x < (uint32_t)w / 2; x++) {
-                uint16_t t          = row[x];
-                row[x]              = row[w - 1 - x];
-                row[w - 1 - x]      = t;
+    /* Degraded fallback for a PPA that would not run at all (pool starvation, an
+     * alignment corner the driver rejects): copy the config-crop window straight
+     * out of the source, rows as they are — no flip, no rotate — so the page can
+     * still put a picture up instead of staying blank forever after boot. It must
+     * happen HERE, while frame_mux is still held and src_pix (p->frame.buf, or
+     * `masked`) is still valid. LVGL scales it in software from the tail below,
+     * which is exactly what this page did before the PPA pass existed. Skipped
+     * when the PPA leg already failed on a PSRAM alloc: a second one would too. */
+    uint8_t *fb = NULL;
+    if (err != ESP_OK && err != ESP_ERR_NO_MEM) {
+        fb = heap_caps_malloc((size_t)w * h * 2, MALLOC_CAP_SPIRAM);
+        if (fb) {
+            for (uint16_t r = 0; r < h; r++) {
+                memcpy(fb + (size_t)r * w * 2,
+                       src_pix + ((size_t)(oy + r) * sw + ox) * 2,
+                       (size_t)w * 2);
             }
         }
     }
 
-    /* Per-source logical rotation pass. Rotates the decoded RGB565 pixel buffer
-     * (NOT via an LVGL transform) so it is independent of display rotation and
-     * runs on the upright `copy` produced above (after the caption mask).
-     * orient: 0/1/2/3 = 0/90/180/270 degrees CLOCKWISE. Moon never rotates.
-     * 90/270 swap width<->height. */
-    uint8_t orient = (p->src == IMG_SRC_GOES)   ? cfg->goes_orientation
-                     : (p->src == IMG_SRC_SOLAR) ? cfg->solar_orientation
-                     : (p->src == IMG_SRC_CUSTOM) ? cfg->custom_orientation
-                                                  : 0;
-    if (orient != 0) {
-        uint16_t rw, rh;
-        if (orient == 2) {            /* 180deg: same dims */
-            rw = w;  rh = h;
-        } else {                       /* 90/270: dims swap */
-            rw = h;  rh = w;
+    /* The PPA read the source (blocking call), so the frame is free again. */
+    frame_unlock(p);
+    if (masked) heap_caps_free(masked);
+
+    /* What the descriptor/crossfade tail below shows, set by whichever path won:
+     * the PPA output (panel width, 1.0x blit) or the fallback crop (software
+     * scale to panel width). */
+    uint8_t  *show_buf   = NULL;
+    uint16_t  show_w     = 0;
+    uint16_t  show_h     = 0;
+    uint16_t  show_scale = 256;
+
+    if (err != ESP_OK) {
+        if (dst) heap_caps_free(dst);
+        /* Warn ONCE so a systematic failure is visible in /api/logs without a
+         * line per frame. Screen rotation (main.c) drops the frame outright on a
+         * PPA failure; here we degrade instead, because an image page with no
+         * previous frame would otherwise stay blank until a later poll. */
+        static bool ppa_warned;
+        if (!ppa_warned) {
+            ppa_warned = true;
+            ESP_LOGE(TAG, "%s: PPA fit failed (%s); image pages fall back to "
+                          "software scaling (no flip/rotate)",
+                     p->name, esp_err_to_name(err));
         }
-        size_t   rot_size = (size_t)rw * rh * 2;
-        uint8_t *rot = heap_caps_malloc(rot_size, MALLOC_CAP_SPIRAM);
-        if (!rot) {
-            ESP_LOGE(TAG, "PSRAM alloc failed for rotation buffer (%u bytes)",
-                     (unsigned)rot_size);
-            heap_caps_free(copy);
-            /* frame_mux already released above; just retire the wait overlay. */
+        if (!fb) {
             nina_wait_overlay_hide();
             return;
         }
-        const uint16_t *src = (const uint16_t *)copy;
-        uint16_t       *dst = (uint16_t *)rot;
-        if (orient == 2) {
-            /* rot[x,y] = copy[w-1-x, h-1-y] */
-            for (uint32_t Y = 0; Y < rh; Y++) {
-                for (uint32_t X = 0; X < rw; X++) {
-                    uint32_t sx = (uint32_t)w - 1 - X;
-                    uint32_t sy = (uint32_t)h - 1 - Y;
-                    dst[(size_t)Y * rw + X] = src[(size_t)sy * w + sx];
-                }
-            }
-        } else if (orient == 1) {
-            /* 90deg CW: rot[X,Y] = copy[Y, h-1-X], dims rw=h, rh=w */
-            for (uint32_t Y = 0; Y < rh; Y++) {           /* Y in [0,w) */
-                for (uint32_t X = 0; X < rw; X++) {       /* X in [0,h) */
-                    uint32_t sx = Y;
-                    uint32_t sy = (uint32_t)h - 1 - X;
-                    dst[(size_t)Y * rw + X] = src[(size_t)sy * w + sx];
-                }
-            }
-        } else {  /* orient == 3 */
-            /* 270deg CW: rot[X,Y] = copy[w-1-Y, X], dims rw=h, rh=w */
-            for (uint32_t Y = 0; Y < rh; Y++) {           /* Y in [0,w) */
-                for (uint32_t X = 0; X < rw; X++) {       /* X in [0,h) */
-                    uint32_t sx = (uint32_t)w - 1 - Y;
-                    uint32_t sy = X;
-                    dst[(size_t)Y * rw + X] = src[(size_t)sy * w + sx];
-                }
-            }
-        }
-        heap_caps_free(copy);
-        copy     = rot;
-        w        = rw;
-        h        = rh;
-        buf_size = rot_size;
+        show_buf   = fb;
+        show_w     = w;
+        show_h     = h;
+        show_scale = (uint16_t)(((uint32_t)SCREEN_SIZE * 256 + w / 2) / w);
+    } else {
+        show_buf = dst;
+        show_w   = SCREEN_SIZE;
+        show_h   = (uint16_t)fit.out_h;
     }
 
     /* Red Night: recolour the decoded image to red shades (luma->red, in place).
-     * Self-gates inside the helper (no-op for every non-red theme), so call it
-     * unconditionally on the final upright/cropped/rotated `copy` before it is
-     * handed to LVGL. w*h is the committed pixel count. */
-    image_red_remap_rgb565((uint16_t *)copy, (size_t)w * h);
+     * Self-gates inside the helper (no-op for every non-red theme). Runs on
+     * whichever buffer won, with that buffer's own pixel count. */
+    image_red_remap_rgb565((uint16_t *)show_buf, (size_t)show_w * show_h);
 
-    /* Point the BACK slot's descriptor at the new copy. release_dsc() frees the
+    /* Point the BACK slot's descriptor at the new buffer. release_dsc() frees the
      * previous buffer unless it was borrowed (moon-drag), and clears that flag —
-     * this owned copy is not borrowed. */
+     * this owned buffer is not borrowed. */
     bool back_is_a = !p->front_is_a;
     lv_image_dsc_t *back_dsc = p->front_is_a ? &p->dsc_b : &p->dsc_a;
     release_dsc(p, back_dsc, back_is_a);
-    back_dsc->data          = copy;
-    back_dsc->data_size     = buf_size;
+    back_dsc->data          = show_buf;
+    back_dsc->data_size     = (size_t)show_w * show_h * 2;
     back_dsc->header.magic  = LV_IMAGE_HEADER_MAGIC;
     back_dsc->header.cf     = LV_COLOR_FORMAT_RGB565;
-    back_dsc->header.w      = w;
-    back_dsc->header.h      = h;
-    back_dsc->header.stride = w * 2;
+    back_dsc->header.w      = show_w;
+    back_dsc->header.h      = show_h;
+    back_dsc->header.stride = (uint32_t)show_w * 2;
 
-    /* Scale the source to fill the panel width. 256 = 1.0x. The image keeps its
-     * create-time x = 0; only y moves, and only when the scaled height changes
-     * (center_image_y), so the per-update lv_obj_set_pos() that once flipped the
-     * image under 90/270 display rotation is still not happening here. */
-    uint16_t scale = (w > 0) ? (uint16_t)(((uint32_t)SCREEN_SIZE * 256 + w / 2) / w) : 256;
+    /* On the PPA path the buffer is already panel width and LVGL only blits it
+     * (show_scale 256). The image keeps its create-time x = 0; only y moves, and
+     * only when the height changes (center_image_y), so the per-update
+     * lv_obj_set_pos() that once flipped the image under 90/270 display rotation
+     * is still not happening here. */
     lv_image_set_src(p->img_back, back_dsc);
-    lv_image_set_scale(p->img_back, scale);
-    center_image_y(p->img_back, (int)h, scale);
+    lv_image_set_scale(p->img_back, show_scale);
+    center_image_y(p->img_back, (int)show_h, show_scale);
     lv_obj_set_style_opa(p->img_back, LV_OPA_TRANSP, 0);
     lv_obj_clear_flag(p->img_back, LV_OBJ_FLAG_HIDDEN);
 
@@ -1010,12 +1000,20 @@ void image_page_show_scaled(image_page_t *p, const uint16_t *buf, int w, int h)
 }
 
 /* Instant swap of the LVGL descriptor onto a buffer the PAGE DOES NOT OWN, with
- * no copy: the slot is flagged "borrowed" so release_dsc() never frees it. Two
- * callers share this: the moon drag loop (owner = the PPA ping-pong scratch)
- * and the radar ring (owner = the ring slot). Each adds its own caption after
- * the swap. Caller holds the display lock and has already checked p->active,
- * p->root and the dimensions. */
-static void swap_borrowed_buf(image_page_t *p, const uint16_t *buf, int w, int h, bool fade)
+ * no copy: the slot is flagged "borrowed" so release_dsc() never frees it.
+ * Three callers share this: the moon drag loop (owner = the PPA ping-pong
+ * scratch), the ring playback (owner = the page's dissolve scratch, or a ring
+ * slot on the no-scratch fallback) and image_page_show_borrowed(). Each adds
+ * its own caption after the swap. Caller holds the display lock and has already
+ * checked p->active, p->root and the dimensions.
+ *
+ * ALWAYS INSTANT. The ring used to pass a fade flag here and cross-dissolve
+ * with an lv_anim on the top image's opa; in FULL_REFRESH mode that is a
+ * 720x720 SOFTWARE alpha blend on every animation tick (44 % SoC load on the
+ * Cloud Cover page, both LVGL swdraw tasks near 40 %). The dissolve now runs on
+ * the PPA Blend engine — see the ring playback scratch below — and the shown
+ * image stays at LV_OPA_COVER. */
+static void swap_borrowed_buf(image_page_t *p, const uint16_t *buf, int w, int h)
 {
     /* A settle->resting crossfade may still be in flight when a new drag frame
      * arrives (rapid re-swipe right at the grace boundary). Rather than DROP this
@@ -1049,9 +1047,11 @@ static void swap_borrowed_buf(image_page_t *p, const uint16_t *buf, int w, int h
     back_dsc->header.stride = w * 2;
     if (back_is_a) p->dsc_a_borrowed = true; else p->dsc_b_borrowed = true;
 
-    /* Scale to fill the panel width (256 = 1.0x). A full-panel 720 buffer (moon
-     * drag) lands on exactly 1.0x and costs no software scale; a smaller radar
-     * tile is scaled up by LVGL like every other image page. */
+    /* 256 = 1.0x, which is what the two normal callers hand us: the moon drag
+     * ping-pong is a full 720 PPA output, and the ring playback hands us its
+     * 720-wide dissolve scratch. The general expression stays for the ring's
+     * no-scratch fallback, which borrows a slot at its NATIVE size (a 600 px
+     * radar tile) and needs LVGL to scale it as it always did. */
     uint16_t scale = (w > 0) ? (uint16_t)(((uint32_t)SCREEN_SIZE * 256 + w / 2) / w) : 256;
     lv_image_set_src(p->img_back, back_dsc);
     lv_image_set_scale(p->img_back, scale);
@@ -1062,34 +1062,7 @@ static void swap_borrowed_buf(image_page_t *p, const uint16_t *buf, int w, int h
 
     lv_image_dsc_t *old_dsc = p->front_is_a ? &p->dsc_a : &p->dsc_b;
 
-    /* Ring playback: dissolve into the next frame instead of cutting. Only ONE
-     * image animates, whichever is on top (child 1 draws over child 0): the
-     * incoming back fades in over a fully opaque front, or the outgoing front
-     * fades out over a fully opaque back. Animating both at once (the
-     * single-frame path) dips to ~75 % brightness at the midpoint, two half
-     * copies over black, which on near-identical satellite frames reads as a
-     * flicker. crossfade_done_cb retires the front when the fade lands; a tick
-     * arriving mid-fade goes through cancel_moon_crossfade above first. */
-    if (fade && old_dsc->data) {
-        lv_obj_t *top = p->front_is_a ? p->img_back : p->img_front;
-        int32_t from = p->front_is_a ? 0 : 255, to = p->front_is_a ? 255 : 0;
-        lv_obj_set_style_opa(top, (lv_opa_t)from, 0);
-        p->crossfade_active = true;
-        lv_anim_t a;
-        lv_anim_init(&a);
-        lv_anim_set_var(&a, top);
-        lv_anim_set_values(&a, from, to);
-        lv_anim_set_duration(&a, RADAR_PLAY_FADE_MS);
-        lv_anim_set_path_cb(&a, lv_anim_path_linear);
-        lv_anim_set_exec_cb(&a, anim_opa_cb);
-        lv_anim_set_user_data(&a, p);
-        lv_anim_set_completed_cb(&a, crossfade_done_cb);
-        lv_anim_start(&a);
-        p->displayed_stamp_ms = esp_timer_get_time() / 1000;
-        return;
-    }
-
-    /* Instant swap: retire the old front and flip designations, mirroring the
+    /* Retire the old front and flip designations, mirroring the
      * instant branch of image_page_render_frame(). release_dsc() frees the old
      * front only if this page owned it (skips a prior borrowed buffer). */
     lv_obj_add_flag(p->img_front, LV_OBJ_FLAG_HIDDEN);
@@ -1111,7 +1084,7 @@ void image_page_show_borrowed(image_page_t *p, const uint16_t *buf, int w, int h
     if (!atomic_load(&p->active)) return;
     if (!buf || !p->root || w <= 0 || h <= 0) return;
 
-    swap_borrowed_buf(p, buf, w, h, false);
+    swap_borrowed_buf(p, buf, w, h);
 
     /* Keep the moon caption live during the drag. */
     char name[24], pct[16];
@@ -1622,7 +1595,9 @@ bool image_page_get_error(image_page_t *p, char *out, size_t sz)
  * is freed — ring_free_slot() does exactly that.
  *
  * MEMORY: a full ten-frame ring is ~6.6 MB (radar, 600x550) or ~10 MB (clouds,
- * 720x720), several times what a normal image page holds, so
+ * 720x720) — slots are kept at their NATIVE decoded size, the panel-width scale
+ * happens per playback step — plus 3 MB of playback scratch (see below), several
+ * times what a normal image page holds, so
  * IMAGE_PAGE_MAX_RESIDENT (which counts p->frame and therefore never counts a
  * ring) is not the right control. Instead the whole ring is freed when the
  * page is deactivated or disabled and rebuilt by the backfill on the next
@@ -1637,9 +1612,12 @@ bool image_page_get_error(image_page_t *p, char *out, size_t sz)
  * single place both are released.
  *
  * STAMPS: a slot may carry the frame's own time (uint32 UTC seconds, 0 =
- * unknown). Radar frames carry none (RIDGE stills have no per-frame time we
- * parse) and are ordered by insertion (head push / tail append). Clouds frames
- * carry the GIBS TIME they were fetched for: a stamped insert is placed by
+ * unknown). Radar style 0 (RIDGE _i.gif stills) has no per-frame time to parse,
+ * so those frames carry none and are ordered by insertion (head push / tail
+ * append); so does a styles-1/2 site whose capabilities advertise no time list
+ * (KHDC), which is one frame and no loop. Clouds frames carry the GIBS TIME and
+ * radar styles 1/2 the advertised WMS TIME they were fetched for: a stamped
+ * insert is placed by
  * time (newest first, whatever the caller's at_head hint), and a stamp already
  * held REPLACES that slot when the bytes differ (GIBS serves the newest one or
  * two frames partially at first) or is dropped as a duplicate when they match.
@@ -1702,6 +1680,21 @@ typedef struct {
      * that changes ring pixels from one that does not. Written and read only under
      * the display lock. */
     bool            ring_red;
+    /* Playback scratch — see "ring playback scratch" below. Three page-owned
+     * 720x720 RGB565 PSRAM buffers, allocated on the first show of a visit and
+     * freed with the ring. NULL = not allocated (or the alloc failed, which
+     * latches scratch_failed for the rest of the visit). */
+    uint8_t        *cur;            /* the picture ON SCREEN; the LVGL descriptor borrows it */
+    uint8_t        *nxt;            /* SRM staging for a slot that is not 720 wide */
+    uint8_t        *mix;            /* dissolve output, becomes the next `cur` */
+    uint16_t        cur_h;          /* rows valid in cur; 0 = nothing shown yet */
+    bool            scratch_failed; /* alloc failed this visit: cut, do not dissolve */
+    /* Running dissolve. fade_fg is `nxt` or a ring slot's buffer; both stay
+     * alive for the dissolve because ring_free_slot() lands it first. */
+    const uint8_t  *fade_fg;
+    uint16_t        fade_h;
+    int64_t         fade_t0;        /* esp_timer us at the start of the dissolve */
+    lv_timer_t     *fade_timer;     /* NULL = no dissolve running */
 } image_ring_t;
 
 static image_ring_t s_rings[IMG_SRC_COUNT];   /* only the animated sources' entries are ever touched */
@@ -1768,13 +1761,13 @@ bool image_page_ring_has_stamp(image_page_t *p, uint32_t stamp)
     return false;
 }
 
-bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
-                                    bool (*fn)(const uint16_t *ref, int w, int h, void *arg),
-                                    void *arg)
+/* Resident slot nearest in time to @p stamp and fit to judge a frame against:
+ * usable pixels, a stamp of its own, and the CURRENT bake. @p skip is a slot
+ * index to exclude (-1 = none), which is how the head re-judge keeps the head
+ * from being compared with itself. -1 when the ring has no such slot.
+ * Display lock held. */
+static int ring_neighbour_idx(image_ring_t *r, uint32_t stamp, int skip)
 {
-    image_ring_t *r = ring_of(p);
-    if (!r || !fn || stamp == 0) return false;
-    if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) return false;
     int n = atomic_load(&r->count);
     if (n > RADAR_RING_MAX) n = RADAR_RING_MAX;
     uint32_t cur = atomic_load(&r->bake_gen);
@@ -1783,7 +1776,7 @@ bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
     bool best_same = true;
     for (int i = 0; i < n; i++) {
         ring_slot_t *s = &r->slots[i];
-        if (!s->buf || s->stamp == 0 || s->bake_gen != cur) continue;
+        if (i == skip || !s->buf || s->stamp == 0 || s->bake_gen != cur) continue;
         uint32_t d = (s->stamp > stamp) ? s->stamp - stamp : stamp - s->stamp;
         bool same = (d == 0);
         /* A different stamp always beats the same stamp (a re-fetch must not be
@@ -1792,6 +1785,17 @@ bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
             best = i; best_d = d; best_same = same;
         }
     }
+    return best;
+}
+
+bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
+                                    bool (*fn)(const uint16_t *ref, int w, int h, void *arg),
+                                    void *arg)
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || !fn || stamp == 0) return false;
+    if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) return false;
+    int best = ring_neighbour_idx(r, stamp, -1);
     bool ret = false;
     if (best >= 0) {
         ring_slot_t *s = &r->slots[best];
@@ -1799,6 +1803,308 @@ bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
     }
     bsp_display_unlock();
     return ret;
+}
+
+/* Re-judge the HEAD slot (index 0, the newest) with the same predicate the
+ * insert gate runs — the one frame that gate cannot see, because every page
+ * entry frees the ring and the head therefore lands in it with no neighbour to
+ * be compared against.
+ *
+ * @p fn is handed the NEIGHBOUR's pixels and, as its `arg`, an image_frame_t
+ * view of the head slot, so the caller reuses its insert-time adapter verbatim
+ * rather than growing a second callback shape. The view is stack-local and the
+ * display lock is held across the call, so neither buffer can be freed under
+ * fn; fn must not take the lock itself and must not retain either pointer.
+ *
+ * Returns the head's stamp when fn says the head is bad — feed it straight to
+ * image_page_ring_drop_stamp(). 0 when the head is fine, when the ring holds
+ * fewer than two frames, when the head is unstamped or stale-baked, when no
+ * neighbour qualifies, or when the lock times out. */
+uint32_t image_page_ring_judge_head(image_page_t *p,
+                                    bool (*fn)(const uint16_t *ref, int w, int h, void *arg))
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || !fn) return 0;
+    if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) return 0;
+    uint32_t bad = 0;
+    ring_slot_t *hd = &r->slots[0];
+    if (atomic_load(&r->count) >= 2 && hd->buf && hd->stamp != 0 &&
+        hd->bake_gen == atomic_load(&r->bake_gen)) {
+        int ref = ring_neighbour_idx(r, hd->stamp, 0);
+        if (ref >= 0) {
+            image_frame_t view = { .buf = hd->buf, .w = hd->w, .h = hd->h };
+            ring_slot_t *s = &r->slots[ref];
+            if (fn((const uint16_t *)s->buf, (int)s->w, (int)s->h, &view)) bad = hd->stamp;
+        }
+    }
+    bsp_display_unlock();
+    return bad;
+}
+
+/* ───────────────────────── ring playback scratch ─────────────────────────────
+ *
+ * THE DISSOLVE RUNS ON THE PPA BLEND ENGINE, NOT ON THE CPU.
+ *
+ * Playback used to hand the ring slot straight to LVGL and cross-dissolve with
+ * an lv_anim on the top image's opa. In FULL_REFRESH mode every animation tick
+ * of that is a 720x720 SOFTWARE alpha blend: measured on the fleet, the Cloud
+ * Cover page sat at 44 % SoC load with the two LVGL swdraw tasks at 40 % and
+ * 38 %, against 1.8 % idle on the Clock page. Frames are already 720 wide for
+ * Clouds, so the scaling was not the cost — the blend was.
+ *
+ * Three page-owned 720x720 RGB565 PSRAM buffers per animated page carry the new
+ * scheme:
+ *
+ *   cur  the picture currently ON SCREEN. The LVGL descriptor BORROWS it, so
+ *        release_dsc() never frees it — the same contract moon_copy_buf uses.
+ *   nxt  staging for a slot that is not already 720 wide (one PPA SRM pass).
+ *   mix  the dissolve output, and the buffer that becomes the next `cur`.
+ *
+ * INVARIANT, whenever the scratch is available:
+ *   no dissolve  -> the descriptor points at `cur`, cur_h rows valid
+ *   dissolving   -> the descriptor points at `mix`; `cur` holds the OUTGOING
+ *                   picture and fade_fg the INCOMING one, both 720 x fade_h
+ *
+ * A commit is one blend at full alpha (the output is then the foreground
+ * exactly — 565 -> 888 -> 565 round trips losslessly) followed by rotating
+ * cur <-> mix, so committing and the last dissolve step are the same operation
+ * and neither costs a CPU memcpy of a megabyte on the LVGL task.
+ *
+ * Per step the CPU does: one blocking PPA blend per ~33 ms tick (a few ms of
+ * DMA each) and LVGL's 1:1 blit of `mix`. The shown image stays at
+ * LV_OPA_COVER and nothing animates.
+ *
+ * If PSRAM cannot give the three buffers, the page falls back to the pre-PPA
+ * behaviour for the rest of the visit: the descriptor borrows the ring slot and
+ * every show is an instant cut (swap_borrowed_buf still scales a native-size
+ * slot the way it always did).
+ */
+
+/* 1,036,800 B — a 128 B multiple, which is what the PPA demands of an output
+ * buffer's SIZE as well as its address. */
+#define RING_SCRATCH_BYTES ((size_t)SCREEN_SIZE * SCREEN_SIZE * 2)
+#define RING_FADE_STEP_MS  33          /* ~30 blends/s while a dissolve runs */
+
+/* Stop a running dissolve without committing it. Display lock held. */
+static void ring_fade_stop(image_ring_t *r)
+{
+    if (r->fade_timer) {
+        lv_timer_delete(r->fade_timer);
+        r->fade_timer = NULL;
+    }
+    r->fade_fg = NULL;
+    r->fade_h  = 0;
+}
+
+/* Free the three scratch buffers. Display lock held. The descriptor borrows the
+ * shown one and release_dsc() skips borrowed buffers, so this is the ONLY place
+ * they are released — and it drops the descriptor first so LVGL is never left
+ * on freed memory. Clears scratch_failed too: the next visit gets a fresh try
+ * on a heap that may have recovered. */
+static void ring_scratch_free(image_page_t *p, image_ring_t *r)
+{
+    ring_fade_stop(r);
+    uint8_t *bufs[3] = { r->cur, r->nxt, r->mix };
+    for (int i = 0; i < 3; i++) {
+        if (bufs[i] && (p->dsc_a.data == bufs[i] || p->dsc_b.data == bufs[i])) {
+            image_page_release_lvgl(p);
+            break;
+        }
+    }
+    for (int i = 0; i < 3; i++) {
+        if (bufs[i]) heap_caps_free(bufs[i]);
+    }
+    r->cur = r->nxt = r->mix = NULL;
+    r->cur_h = 0;
+    r->scratch_failed = false;
+}
+
+/* Allocate the scratch on the first show of a visit. Logs ONCE per visit on
+ * failure and latches, so a fragmented heap cannot turn every playback step
+ * into a warning. Display lock held. */
+static bool ring_scratch_ensure(image_page_t *p, image_ring_t *r)
+{
+    if (r->cur && r->nxt && r->mix) return true;
+    if (r->scratch_failed) return false;
+
+    uint8_t **slot[3] = { &r->cur, &r->nxt, &r->mix };
+    for (int i = 0; i < 3; i++) {
+        if (*slot[i]) continue;
+        *slot[i] = heap_caps_aligned_alloc(128, RING_SCRATCH_BYTES, MALLOC_CAP_SPIRAM);
+        if (!*slot[i]) {
+            ring_scratch_free(p, r);       /* give the partial allocation back */
+            r->scratch_failed = true;      /* set AFTER the free, which clears it */
+            ESP_LOGW(TAG, "%s: no PSRAM for the playback scratch (3 x %u KB); frames will cut",
+                     p->name, (unsigned)(RING_SCRATCH_BYTES / 1024));
+            return false;
+        }
+    }
+    r->cur_h = 0;                          /* nothing valid in a fresh `cur` */
+    return true;
+}
+
+/* Scale a NATIVE-size ring slot up to the panel width into `nxt` with one PPA
+ * SRM pass. Returns the rows written, 0 if the hardware refused.
+ *
+ * Ring slots are stored at their native size (WMS/RIDGE radar tiles are 600 px
+ * or less) because a 720-wide ring costs ~10 MB for a ten-frame radar loop
+ * against ~6.6 MB native. Paying one hardware scale per PLAYBACK STEP instead
+ * of one per FETCHED frame is the trade: the step already runs several blends,
+ * and the SRM engine is a different engine from the Blend one. Clouds frames
+ * are already 720 wide and never come here at all. */
+static int ring_fit_into(image_ring_t *r, const ring_slot_t *s)
+{
+    image_fit_t fit;
+    uint32_t bx = 0, by = 0, bw = 0, bh = 0;
+    if (!image_fit_pick(s->w, s->h, SCREEN_SIZE, &fit) ||
+        !image_fit_logical_to_source(&fit, s->w, s->h, 0, &bx, &by, &bw, &bh)) {
+        return 0;
+    }
+    ppa_srm_job_t job = {
+        .src           = s->buf,
+        .src_stride_px = s->w,
+        .src_h         = s->h,
+        .block_x       = bx,
+        .block_y       = by,
+        .block_w       = bw,
+        .block_h       = bh,
+        .rotate_cw     = 0,
+        .hflip         = false,
+        .vflip         = false,
+        .dst           = r->nxt,
+        .dst_buf_size  = RING_SCRATCH_BYTES,
+        .dst_w         = SCREEN_SIZE,
+        .dst_h         = fit.out_h,
+        .dst_x         = fit.dst_x,
+        .dst_y         = 0,
+        .scale_n16     = fit.n16,
+        .clear_dst     = (fit.out_w < SCREEN_SIZE),
+    };
+    return (ppa_srm_rgb565(&job) == ESP_OK) ? (int)fit.out_h : 0;
+}
+
+/* Land @p fg (720 x @p h) in `cur` and on screen. The full-alpha blend IS the
+ * copy — DMA, not a megabyte of memcpy on the LVGL task — and it writes `mix`,
+ * so the roles rotate afterwards and the displayed buffer is always `cur`.
+ * On a hardware refusal cur_h is cleared so the next show cuts instead of
+ * dissolving from a picture that is not the one on screen. Display lock held. */
+static bool ring_commit(image_page_t *p, image_ring_t *r, const uint8_t *fg, int h)
+{
+    if (ppa_blend_rgb565(r->cur, fg, r->mix, SCREEN_SIZE, (uint32_t)h, 255) != ESP_OK) {
+        r->cur_h = 0;
+        return false;
+    }
+    uint8_t *t = r->cur;
+    r->cur = r->mix;
+    r->mix = t;
+    r->cur_h = (uint16_t)h;
+    swap_borrowed_buf(p, (const uint16_t *)r->cur, SCREEN_SIZE, h);
+    return true;
+}
+
+/* One dissolve step: blend `cur` and the incoming frame into `mix` at the alpha
+ * @p el ms into the fade. Display lock held. */
+static bool ring_fade_blend(image_ring_t *r, int el)
+{
+    uint32_t a = (el <= 0) ? 0u : ((uint32_t)el * 255u) / RADAR_PLAY_FADE_MS;
+    if (a > 255u) a = 255u;
+    return ppa_blend_rgb565(r->cur, r->fade_fg, r->mix,
+                            SCREEN_SIZE, r->fade_h, (uint8_t)a) == ESP_OK;
+}
+
+/* End a running dissolve NOW, at full alpha: the incoming frame lands in `cur`
+ * and on screen exactly as the last timer step would have left it. This is the
+ * ring's cancel_moon_crossfade — every path that must not leave a half-mixed
+ * picture behind (a new frame, a slot being freed, page teardown) calls it.
+ * Display lock held. */
+static void ring_fade_finish(image_page_t *p, image_ring_t *r)
+{
+    const uint8_t *fg = r->fade_fg;
+    int h = r->fade_h;
+    ring_fade_stop(r);
+    /* No LVGL objects (page never built, or torn down): the timer is gone, which
+     * is the part that mattered; nothing is on screen to land. */
+    if (fg && h > 0 && p->root) ring_commit(p, r, fg, h);
+}
+
+/* Runs on the LVGL task, which holds the display lock. */
+static void ring_fade_cb(lv_timer_t *t)
+{
+    image_page_t *p = lv_timer_get_user_data(t);
+    image_ring_t *r = ring_of(p);
+    if (!r) return;
+    if (!r->fade_fg || !r->cur || !r->mix) {
+        ring_fade_stop(r);
+        return;
+    }
+    int el = (int)((esp_timer_get_time() - r->fade_t0) / 1000);
+    /* Past the duration, or the page went away mid-dissolve: land it. A failed
+     * blend lands it too — one cut beats a frozen half-mix. */
+    if (el >= RADAR_PLAY_FADE_MS || !atomic_load(&p->active) || !ring_fade_blend(r, el)) {
+        ring_fade_finish(p, r);
+        return;
+    }
+    /* The descriptor already points at `mix`; only its pixels changed, so a
+     * plain invalidate is the whole update. */
+    lv_obj_invalidate(p->img_front);
+}
+
+/* Start a dissolve from `cur` to @p fg. Returns false if the first blend failed,
+ * leaving the caller to commit instantly instead. Display lock held; no
+ * dissolve may be running. */
+static bool ring_fade_start(image_page_t *p, image_ring_t *r, const uint8_t *fg, int h)
+{
+    r->fade_fg = fg;
+    r->fade_h  = (uint16_t)h;
+    /* Backdated one step so the FIRST painted frame has already moved: starting
+     * at alpha 0 would paint a copy of what is already on screen and spend a
+     * blend doing it. */
+    r->fade_t0 = esp_timer_get_time() - (int64_t)RING_FADE_STEP_MS * 1000;
+    if (!ring_fade_blend(r, RING_FADE_STEP_MS)) {
+        ring_fade_stop(r);
+        return false;
+    }
+    swap_borrowed_buf(p, (const uint16_t *)r->mix, SCREEN_SIZE, h);
+    r->fade_timer = lv_timer_create(ring_fade_cb, RING_FADE_STEP_MS, p);
+    if (!r->fade_timer) {
+        ring_fade_finish(p, r);            /* no timer: land the frame now */
+    }
+    return true;
+}
+
+/* Put a ring slot on screen, dissolving from the frame already there when asked
+ * and the two are the same shape. Display lock held; the slot is non-empty. */
+static void ring_play(image_page_t *p, image_ring_t *r, const ring_slot_t *s, bool fade)
+{
+    /* A dissolve still running belongs to the PREVIOUS frame: land it before
+     * this one takes over, so `cur` describes what is actually on screen. */
+    if (r->fade_timer) ring_fade_finish(p, r);
+
+    if (!ring_scratch_ensure(p, r)) {
+        swap_borrowed_buf(p, (const uint16_t *)s->buf, (int)s->w, (int)s->h);
+        return;
+    }
+
+    /* A 720-wide slot IS the foreground — no copy, no scale. Anything else gets
+     * one SRM pass into `nxt`. */
+    const uint8_t *fg = s->buf;
+    int fg_h = (int)s->h;
+    if (s->w != SCREEN_SIZE || s->h > SCREEN_SIZE) {
+        fg_h = ring_fit_into(r, s);
+        if (fg_h <= 0) {
+            swap_borrowed_buf(p, (const uint16_t *)s->buf, (int)s->w, (int)s->h);
+            r->cur_h = 0;
+            return;
+        }
+        fg = r->nxt;
+    }
+
+    if (fade && r->cur_h == fg_h && ring_fade_start(p, r, fg, fg_h)) return;
+    /* Instant, and the fallback for a hardware refusal: borrow the slot the way
+     * playback did before the scratch existed. */
+    if (!ring_commit(p, r, fg, fg_h)) {
+        swap_borrowed_buf(p, (const uint16_t *)s->buf, (int)s->w, (int)s->h);
+    }
 }
 
 /* Free one slot — BOTH its allocations, the decoded pixels and the retained
@@ -1810,15 +2116,13 @@ bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
 static void ring_free_slot(image_page_t *p, image_ring_t *r, int i)
 {
     ring_slot_t *s = &r->slots[i];
+    /* A dissolve in flight may be reading THIS slot as its foreground, and in
+     * any case leaves the screen showing `mix` rather than `cur`. Land it first:
+     * afterwards the displayed picture lives entirely in the page-owned scratch,
+     * so freeing the slot below cannot pull it out from under LVGL. */
+    if (r->fade_timer) ring_fade_finish(p, r);
     if (s->buf) {
         const uint8_t *b = (const uint8_t *)s->buf;
-        /* During the playback dissolve the OUTGOING frame is still drawn for
-         * RADAR_PLAY_FADE_MS after r->shown moved on. Finalize the fade first:
-         * that retires and detaches the outgoing descriptor, so freeing its
-         * slot below is safe and the incoming frame stays on screen. */
-        if (p->crossfade_active && (b == p->dsc_a.data || b == p->dsc_b.data)) {
-            cancel_moon_crossfade(p);
-        }
         if (b == r->shown || b == p->dsc_a.data || b == p->dsc_b.data) {
             image_page_release_lvgl(p);  /* drops both descriptors + borrowed flags */
             r->shown = NULL;
@@ -1842,7 +2146,7 @@ static void ring_show_idx(image_page_t *p, int idx, bool fade)
     ring_slot_t *s = &r->slots[idx];
     if (!s->buf || !p->root || s->w == 0 || s->h == 0) return;
 
-    swap_borrowed_buf(p, (const uint16_t *)s->buf, (int)s->w, (int)s->h, fade);
+    ring_play(p, r, s, fade);
     r->shown    = s->buf;
     r->play_idx = idx;
 
@@ -1851,9 +2155,10 @@ static void ring_show_idx(image_page_t *p, int idx, bool fade)
     set_label_if_changed(p->lbl_region, label);
 
     /* A stamped frame shows its own time (local clock); the newest carries the
-     * "Latest" prefix. Unstamped rings (radar): the newest frame is stamped with
-     * the wall clock and the history frames show their position in the loop
-     * instead of a time we would be inventing. */
+     * "Latest" prefix. Unstamped rings (radar style 0, and a styles-1/2 site
+     * with no advertised time list): the newest frame is stamped with the wall
+     * clock and the history frames show their position in the loop instead of a
+     * time we would be inventing. */
     char ts[32];
     struct tm ti;
     if (s->stamp != 0) {
@@ -1934,10 +2239,12 @@ static void ring_loading_sync(image_page_t *p)
     bool loading = atomic_load(&p->active) && r->shown == NULL && count < gate;
     if (loading) {
         /* Progress in the title so the wait reads as work, not a hang: each
-         * frame is a ~3 s download + decode, so "1 of 3" is the honest ETA. */
+         * frame is a ~3 s download + decode. Shown as a countdown of frames
+         * still to come (3, 2, 1) on its own line, so it reads as a counter
+         * rather than a stray number next to the words. */
         char title[48];
-        snprintf(title, sizeof(title), "Loading %s  %d of %d",
-                 p->src == IMG_SRC_CLOUDS ? "Cloud Cover" : "Weather Radar", count, gate);
+        snprintf(title, sizeof(title), "Loading %s\n%d",
+                 p->src == IMG_SRC_CLOUDS ? "Cloud Cover" : "Weather Radar", gate - count);
         nina_empty_state_set_title(p->loading, title);
         nina_empty_state_show(p->loading);
         nina_empty_state_set_busy(p->loading, true);
@@ -2013,6 +2320,56 @@ bool image_page_ring_drop_oldest(image_page_t *p)
     return true;
 }
 
+/* Free the slot carrying @p stamp (the head, in practice: the re-judge in
+ * image_page_poll.c is the only caller) so the poller's next newest fetch
+ * re-downloads it and the same-stamp path in _add installs the completed frame.
+ *
+ * LOCKING / CURSOR / DISSOLVE: identical to image_page_ring_drop_oldest() —
+ * display lock taken here (the page's poll task, outside the lock, exactly like
+ * _add), and the free routed through ring_free_slot(), which LANDS ANY RUNNING
+ * DISSOLVE first. That is what makes dropping a slot that may be the live
+ * foreground of a dissolve safe: after ring_fade_finish() the displayed picture
+ * lives entirely in the page-owned scratch (`cur`), never in a ring slot, and
+ * ring_free_slot() then detaches the LVGL descriptors as well if the scratch
+ * was unavailable and they borrow this slot directly. Unlike the oldest-end
+ * eviction this one can free a slot in the MIDDLE of the list, so the slots
+ * above it are compacted down by one and the playback cursor follows them.
+ *
+ * false — freeing nothing — when @p stamp is 0, no slot carries it, the ring
+ * holds one frame or none (the newest must survive or the page goes blank), or
+ * the lock times out. Like _drop_oldest it does NOT re-arm the backfill. */
+bool image_page_ring_drop_stamp(image_page_t *p, uint32_t stamp)
+{
+    image_ring_t *r = ring_of(p);
+    if (!r || stamp == 0 || atomic_load(&r->count) <= 1) return false;
+    if (!bsp_display_lock(LVGL_LOCK_TIMEOUT_MS)) return false;
+
+    int count = atomic_load(&r->count);
+    if (count > RADAR_RING_MAX) count = RADAR_RING_MAX;
+    int i = -1;
+    for (int k = 0; k < count; k++) {
+        if (r->slots[k].stamp == stamp) { i = k; break; }
+    }
+    if (count <= 1 || i < 0) {             /* both re-tested under the lock */
+        bsp_display_unlock();
+        return false;
+    }
+    ring_free_slot(p, r, i);               /* lands the dissolve, detaches LVGL, frees both allocations */
+    for (int k = i; k < count - 1; k++) r->slots[k] = r->slots[k + 1];
+    memset(&r->slots[count - 1], 0, sizeof(r->slots[0]));
+    count--;
+    atomic_store(&r->count, count);
+    if (r->play_idx > i) r->play_idx--;    /* the cursor's slot shifted down with the rest */
+    if (r->play_idx >= count) r->play_idx = 0;
+    /* ring_free_slot() clears `shown` when it had to detach the descriptors, so
+     * this is exactly the "nothing is on screen any more" test the same-stamp
+     * replace in _add uses. */
+    if (!r->shown && atomic_load(&p->active)) ring_show_idx(p, r->play_idx, false);
+    ring_timer_sync(p);
+    bsp_display_unlock();
+    return true;
+}
+
 void image_page_ring_reset(image_page_t *p)
 {
     image_ring_t *r = ring_of(p);
@@ -2022,6 +2379,10 @@ void image_page_ring_reset(image_page_t *p)
         r->timer = NULL;
     }
     for (int i = 0; i < RADAR_RING_MAX; i++) ring_free_slot(p, r, i);
+    /* The playback scratch is the ring's other display resource (3 MB): it goes
+     * with the frames, on the same page-leave / invalidate paths, and is rebuilt
+     * on the first show after the next activation. */
+    ring_scratch_free(p, r);
     atomic_store(&r->count, 0);
     r->play_idx = 0;
     r->shown    = NULL;
@@ -2161,9 +2522,13 @@ static bool radar_crop_frame(image_frame_t *f, uint8_t mode)
  * `cfg` and `red` are passed in rather than read here so the re-transform can
  * bake a whole ring from ONE snapshot of the settings.
  *
- * NOT ACCELERATED, deliberately: the PPA offers SRM (scale/rotate/mirror),
- * BLEND and FILL only — there is no colour-transform unit for the invert — and
- * the crop is already a row-wise memcpy. Software is correct for both. */
+ * CROP AND INVERT ARE NOT ACCELERATED, deliberately: the PPA offers SRM
+ * (scale/rotate/mirror), BLEND and FILL only — there is no colour-transform
+ * unit for the invert — and the crop is already a row-wise memcpy. Software is
+ * correct for both, and they stay cheap because the frame is still at its
+ * NATIVE size here: a ring slot is stored as decoded (and cropped), never
+ * scaled to the panel. Playback does the scale, once per step, on the PPA
+ * (ring_fit_into). */
 static void ring_bake(image_page_t *p, image_frame_t *f, const app_config_t *cfg, bool red)
 {
     if (p->src == IMG_SRC_RADAR) {

--- a/main/ui/nina_image_page.h
+++ b/main/ui/nina_image_page.h
@@ -210,6 +210,21 @@ bool image_page_ring_has_stamp(image_page_t *p, uint32_t stamp);   /* lock-free;
 bool image_page_ring_with_neighbour(image_page_t *p, uint32_t stamp,
                                     bool (*fn)(const uint16_t *ref, int w, int h, void *arg),
                                     void *arg);
+/* Re-judge the HEAD slot (index 0, the newest) with @p fn — the one frame the
+ * insert gate cannot judge, because every page entry frees the ring and the head
+ * lands in it with no neighbour. @p fn is handed the NEIGHBOUR's pixels and, as
+ * its `arg`, an image_frame_t view of the head slot, so the caller reuses its
+ * insert-time adapter unchanged; the display lock is held for the duration.
+ * Returns the head's stamp when fn says the head is bad (feed it to
+ * image_page_ring_drop_stamp()), 0 otherwise. */
+uint32_t image_page_ring_judge_head(image_page_t *p,
+                                    bool (*fn)(const uint16_t *ref, int w, int h, void *arg));
+/* Free the slot carrying @p stamp so the next newest fetch re-downloads it and
+ * the same-stamp path in _add installs the completed frame. Takes the display
+ * lock itself; the page's poll task only. Compacts the slots above it down and
+ * moves the playback cursor with them. false when @p stamp is 0, no slot carries
+ * it, or the ring holds one frame or none. Does NOT re-arm the backfill. */
+bool image_page_ring_drop_stamp(image_page_t *p, uint32_t stamp);
 /* Free the OLDEST resident frame (pixels + retained source) to give the next
  * decode room. Takes the display lock itself; the page's poll task only, same as
  * image_page_ring_add(). Returns false — freeing nothing — when the ring holds

--- a/main/ui/nina_octoprint.c
+++ b/main/ui/nina_octoprint.c
@@ -1032,13 +1032,17 @@ typedef struct {
  * what showed as repeating horizontal seams -- PPA only accelerates 1.0x, so a
  * zoomed lv_image is always the software path).
  *
- * Software, not ppa_scale_rgb565_into(): on device the SRM path both mirrors
- * the frame vertically and resamples by pixel drop/duplicate, which banded the
- * hero worse than LVGL's own zoom. The GOES/moon callers are calibrated around
- * that behaviour, so it is left alone.
+ * Software, not ppa_scale_rgb565_into(): the PPA SRM engine truncates its
+ * scale factor to 1/16 steps, so an arbitrary fit into the hero box lands
+ * short (a 1024-wide webcam, the largest decode_image() accepts, into a
+ * 676-wide box quantises 0.660 down to 10/16 = 0.625 and leaves a 36 px strip
+ * uncovered), and it resamples by pixel drop/duplicate, which banded the hero
+ * worse than LVGL's own zoom at the ~1.5:1 downscale a webcam frame needs.
+ * Bilinear in software hits the box exactly and filters. SRM does NOT mirror: mirror_x/mirror_y are zero on that call, and
+ * every mirror sighting of that era was the stb bug described below.
  *
- * Row order: jpeg_sw_decode_rgb565 converts stb output TOP-DOWN, so a straight
- * copy renders upright. NO row reversal belongs on this path. Every past
+ * Row order: the client's decode (jpeg_decode_rgb565, HW engine or stb) emits
+ * rows TOP-DOWN, so a straight copy renders upright. NO row reversal belongs on this path. Every past
  * "mirrored with a straight copy" sighting was stb's flip-on-load flag reading
  * uninitialized TLS garbage on this task (proven on-device 2026-08-14; see
  * STBI_NO_THREAD_LOCALS in stb_image.c), which vertically mirrored decodes per

--- a/main/ui/nina_thumbnail.c
+++ b/main/ui/nina_thumbnail.c
@@ -295,6 +295,14 @@ void nina_dashboard_clear_thumbnail_request(void) {
     thumbnail_requested = false;
 }
 
+bool nina_dashboard_thumbnail_wants_data(void) {
+    /* Exactly the condition under which nina_dashboard_set_thumbnail() KEEPS the
+     * buffer it is handed. False means it would free it on arrival, so the
+     * caller can give that buffer to another owner instead of copying. */
+    return thumbnail_overlay && thumbnail_img
+           && !lv_obj_has_flag(thumbnail_overlay, LV_OBJ_FLAG_HIDDEN);
+}
+
 void nina_dashboard_set_thumbnail(const uint8_t *rgb565_data, uint32_t w, uint32_t h, uint32_t data_size) {
     if (!thumbnail_overlay || !thumbnail_img) return;
 

--- a/main/ui/nina_thumbnail.h
+++ b/main/ui/nina_thumbnail.h
@@ -21,6 +21,12 @@ bool nina_dashboard_thumbnail_requested(void);
 /** Clear the thumbnail request flag. */
 void nina_dashboard_clear_thumbnail_request(void);
 
+/** True when nina_dashboard_set_thumbnail() would KEEP the buffer (overlay
+ *  built and visible). False means it would free it on arrival, so the caller
+ *  can hand that buffer to a different owner instead of copying it.
+ *  Call under the LVGL display lock. */
+bool nina_dashboard_thumbnail_wants_data(void);
+
 /** Set decoded thumbnail image data for display. Ownership of rgb565_data is transferred. */
 void nina_dashboard_set_thumbnail(const uint8_t *rgb565_data, uint32_t w, uint32_t h, uint32_t data_size);
 

--- a/test/host/CMakeLists.txt
+++ b/test/host/CMakeLists.txt
@@ -271,3 +271,16 @@ add_nina_host_test(test_adsb_geom
     SOURCES
         ${CMAKE_CURRENT_SOURCE_DIR}/test_adsb_geom.c
 )
+
+# ---------------------------------------------------------------------------
+# test_image_fit -- the PPA SRM fit geometry for the image pages
+# (main/image_fit.h): the n/16 scale pick (round up and centre-crop while the
+# crop is under 4 %, otherwise round down and band), the symmetric block trim,
+# and the logical->source window mapping for each 0/90/180/270 rotation.
+# Header-only, integer-only, no ESP-IDF dependency; the PPA job it feeds lives
+# in ui/nina_image_page.c and cannot be host-compiled.
+# ---------------------------------------------------------------------------
+add_nina_host_test(test_image_fit
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/test_image_fit.c
+)

--- a/test/host/test_clouds_wms.c
+++ b/test/host/test_clouds_wms.c
@@ -47,6 +47,38 @@ static void check_near(const char *label, float got, float expect, float tol) {
     if (!ok) fails++;
 }
 
+/* ---- synthetic frames for clouds_frame_holes() ----
+ * LIT_PX is imagery, DARK_PX is night sky just under the near-black gate, and
+ * LINE_PX (~40 grey) is a basemap vector line: GIBS draws those over the whole
+ * canvas, holes included, so they survive inside a missing tile. */
+#define LIT_PX  0x5aacu
+#define DARK_PX 0x0841u
+#define LINE_PX 0x2945u
+
+/* Night GeoColor stand-in: ~45 % of samples lit (city glow, cloud, basemap)
+ * over near-black sky, matching the 42.4 % lit measured on the device's own
+ * complete night frame. Patterned on the 8 px JPEG block so the stride-8
+ * sample grid sees the same mix a whole cell does. */
+static void fill_night(uint16_t *p, int w, int h) {
+    for (int y = 0; y < h; y++)
+        for (int x = 0; x < w; x++)
+            p[y * w + x] = ((((x >> 3) * 37 + (y >> 3) * 17) & 0xFF) < 115) ? LIT_PX : DARK_PX;
+}
+
+/* Darken @p k of every 5 blocks inside cell (@p cx, @p cy): k/5 of that cell's
+ * samples, independent of the fill_night pattern. */
+static void darken_cell(uint16_t *p, int w, int cx, int cy, int cell, int k) {
+    for (int y = cy * cell; y < (cy + 1) * cell; y++)
+        for (int x = cx * cell; x < (cx + 1) * cell; x++)
+            if (((x >> 3) + (y >> 3)) % 5 < k) p[y * w + x] = DARK_PX;
+}
+
+/* A missing tile: the whole cell rendered flat black. */
+static void black_cell(uint16_t *p, int w, int cx, int cy, int cell) {
+    for (int y = cy * cell; y < (cy + 1) * cell; y++)
+        for (int x = cx * cell; x < (cx + 1) * cell; x++) p[y * w + x] = 0x0000u;
+}
+
 /* Parse "&BBOX=a,b,c,d" out of a URL. */
 static bool url_bbox(const char *url, long *a, long *b, long *c, long *d) {
     const char *p = strstr(url, "&BBOX=");
@@ -327,21 +359,69 @@ int main(void) {
         px[0] = 0;
         check_bool("incomplete: 1% black", clouds_frame_incomplete(px, W, H, W, 0), false);
         check_bool("incomplete: NULL is not incomplete", clouds_frame_incomplete(NULL, W, H, W, 0), false);
-        /* missing tiles vs the neighbouring frame */
-        static uint16_t ref[W * H];
-        for (int i = 0; i < W * H; i++) { ref[i] = 0x5aac; px[i] = 0x5aac; }   /* both lit */
-        check_bool("holes: identical lit frames", clouds_frame_holes(px, ref, W, H, W), false);
-        for (int y = 0; y < H / 2; y++)
-            for (int x = 0; x < W / 2; x++) px[y * W + x] = 0;            /* one tile: 25% < 30% bar */
-        check_bool("holes: single quadrant is under the bar", clouds_frame_holes(px, ref, W, H, W), false);
-        for (int y = 0; y < H / 2; y++)
-            for (int x = 0; x < W; x++) px[y * W + x] = 0;                /* top half: 50% */
-        check_bool("holes: black half where ref is lit", clouds_frame_holes(px, ref, W, H, W), true);
-        for (int y = 0; y < H / 2; y++)
-            for (int x = 0; x < W; x++) ref[y * W + x] = 0x0841;          /* same area dark in ref too (night) */
-        check_bool("holes: dark in both is not a hole", clouds_frame_holes(px, ref, W, H, W), false);
-        for (int i = 0; i < W * H; i++) ref[i] = 0;
-        check_bool("holes: blank reference says nothing", clouds_frame_holes(px, ref, W, H, W), false);
+    }
+
+    /* ---- missing-tile (partial ingest) detection, per cell ---- */
+    {
+        /* Full 720x720, so a cell is the real 120 px and one missing tile fills
+         * one, as on the device. Static, not stack: 1 MB each. */
+        enum { FW = 720, FH = 720, CELL = FW / CLOUDS_HOLE_CELLS };
+        static uint16_t cand[FW * FH], base[FW * FH];
+
+        fill_night(base, FW, FH);
+        memcpy(cand, base, sizeof(base));
+        check_bool("holes: identical night frames", clouds_frame_holes(cand, base, FW, FH, FW), false);
+
+        /* 10 min of weather motion: 1 sample in 8 goes dark, scattered. */
+        for (int y = 0; y < FH; y++)
+            for (int x = 0; x < FW; x++)
+                if ((((x >> 3) + (y >> 3)) & 7) == 0) cand[y * FW + x] = DARK_PX;
+        check_bool("holes: night frame, 12% scattered dimming", clouds_frame_holes(cand, base, FW, FH, FW), false);
+
+        /* Terminator crossing one whole cell. It takes the imagery with it, but
+         * the night side keeps the ~42 % lit measured on the device, so about
+         * 60 % of that cell's ref-lit samples go dark: under the bar. */
+        memcpy(cand, base, sizeof(base));
+        darken_cell(cand, FW, 4, 1, CELL, 3);            /* 3 blocks in 5 = 60 % */
+        check_bool("holes: terminator, 60% of a cell dimmed", clouds_frame_holes(cand, base, FW, FH, FW), false);
+        memcpy(cand, base, sizeof(base));
+        darken_cell(cand, FW, 4, 1, CELL, 4);            /* 80 % */
+        check_bool("holes: 80% of a cell dark is a hole", clouds_frame_holes(cand, base, FW, FH, FW), true);
+
+        /* One missing 120 px tile, rendered flat black. */
+        memcpy(cand, base, sizeof(base));
+        black_cell(cand, FW, 4, 1, CELL);
+        check_bool("holes: one 120px cell zeroed", clouds_frame_holes(cand, base, FW, FH, FW), true);
+
+        /* Same cell, dark in the REFERENCE too (ocean at night, or a reference
+         * that is itself holed there): the per-cell lit floor says nothing. */
+        black_cell(base, FW, 4, 1, CELL);
+        check_bool("holes: cell dark in the reference too", clouds_frame_holes(cand, base, FW, FH, FW), false);
+
+        /* The real device case: GIBS composites the vector basemap over the
+         * whole canvas, so a hole keeps its border/road/graticule lines (~40
+         * grey) drawn over black. Those survivors must not dilute the cell
+         * below the bar. One sample column in 13 here, the density of 1-2 px
+         * vectors on a 720 px frame. */
+        fill_night(base, FW, FH);
+        memcpy(cand, base, sizeof(base));
+        black_cell(cand, FW, 4, 1, CELL);
+        for (int y = CELL; y < 2 * CELL; y++)
+            for (int x = 4 * CELL; x < 5 * CELL; x++)
+                if (((x >> 3) % 13) == 0) cand[y * FW + x] = LINE_PX;
+        check_bool("holes: hole keeps its overlay lines", clouds_frame_holes(cand, base, FW, FH, FW), true);
+
+        /* Day frame (fully lit) missing a whole quadrant. */
+        for (int i = 0; i < FW * FH; i++) { base[i] = LIT_PX; cand[i] = LIT_PX; }
+        for (int y = 0; y < FH / 2; y++)
+            for (int x = 0; x < FW / 2; x++) cand[y * FW + x] = 0x0000;
+        check_bool("holes: day frame missing a quadrant", clouds_frame_holes(cand, base, FW, FH, FW), true);
+
+        /* Degenerate inputs. */
+        memset(base, 0, sizeof(base));
+        check_bool("holes: blank reference says nothing", clouds_frame_holes(cand, base, FW, FH, FW), false);
+        check_bool("holes: NULL frame", clouds_frame_holes(NULL, base, FW, FH, FW), false);
+        check_bool("holes: NULL reference", clouds_frame_holes(cand, NULL, FW, FH, FW), false);
     }
 
     printf("\n%s (%d failures)\n", fails == 0 ? "ALL PASSED" : "FAILED", fails);

--- a/test/host/test_image_fit.c
+++ b/test/host/test_image_fit.c
@@ -1,0 +1,211 @@
+/* Host test for main/image_fit.h -- the pure geometry behind the single PPA SRM
+ * pass that lands every image page on a 720 px wide picture at LVGL scale 256.
+ * Header-only, integer-only, no ESP-IDF dependency; assert-style like
+ * test/host/test_radar_play.c. The buffer ownership and PPA plumbing it feeds
+ * live in ui/nina_image_page.c and cannot be host-compiled. */
+#include "image_fit.h"
+#include <stdio.h>
+
+#define TARGET 720u
+
+static int fails = 0;
+
+static void check_bool(const char *label, bool got, bool expect) {
+    printf("%-64s got=%-6s expect=%-6s %s\n", label,
+           got ? "true" : "false", expect ? "true" : "false",
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+static void check_u32(const char *label, uint32_t got, uint32_t expect) {
+    printf("%-64s got=%-10u expect=%-10u %s\n", label, got, expect,
+           got == expect ? "OK" : "FAIL");
+    if (got != expect) fails++;
+}
+
+/* Every invariant image_fit_pick() promises, for one logical size. */
+static void check_pick(uint32_t lw, uint32_t lh) {
+    char label[96];
+    image_fit_t f;
+    snprintf(label, sizeof(label), "pick %ux%u: succeeds", lw, lh);
+    if (!image_fit_pick(lw, lh, TARGET, &f)) {
+        check_bool(label, false, true);
+        return;
+    }
+
+    uint32_t n_up = (TARGET * 16u + lw - 1u) / lw;
+    bool ceil_branch = (f.n16 == n_up);
+    uint32_t w_up = TARGET * 16u / n_up;
+    uint32_t crop_permille = (lw > w_up) ? (lw - w_up) * 1000u / lw : 0u;
+    /* Same exact comparison the header makes (products, not the floored
+     * permille above, which is display only: 1080 rounds 30.5 down to 30). */
+    bool over_budget = lw > w_up &&
+                       (lw - w_up) * 1000u > IMAGE_FIT_MAX_CROP_PERMILLE * lw;
+
+    printf("  lw=%-5u lh=%-5u n16=%-4u block=%ux%u@(%u,%u) out=%ux%u dst_x=%-3u %s crop=%u.%u%%\n",
+           lw, lh, f.n16, f.block_w, f.block_h, f.block_x, f.block_y,
+           f.out_w, f.out_h, f.dst_x, ceil_branch ? "fill " : "bands",
+           crop_permille / 10u, crop_permille % 10u);
+
+    /* The upper bound is the uint8_t itself (the PPA register is 8 bit), so
+     * only the lower one is worth asserting: a 0 scale would write nothing. */
+    snprintf(label, sizeof(label), "pick %ux%u: n16 >= 1", lw, lh);
+    check_bool(label, f.n16 >= 1u, true);
+    snprintf(label, sizeof(label), "pick %ux%u: out_w <= 720", lw, lh);
+    check_bool(label, f.out_w <= TARGET, true);
+    snprintf(label, sizeof(label), "pick %ux%u: out_h <= 720", lw, lh);
+    check_bool(label, f.out_h <= TARGET, true);
+    snprintf(label, sizeof(label), "pick %ux%u: out_w = block_w*n/16", lw, lh);
+    check_u32(label, f.out_w, f.block_w * f.n16 / 16u);
+    snprintf(label, sizeof(label), "pick %ux%u: out_h = block_h*n/16", lw, lh);
+    check_u32(label, f.out_h, f.block_h * f.n16 / 16u);
+    snprintf(label, sizeof(label), "pick %ux%u: block inside logical picture", lw, lh);
+    check_bool(label, f.block_x + f.block_w <= lw && f.block_y + f.block_h <= lh, true);
+    snprintf(label, sizeof(label), "pick %ux%u: block centred", lw, lh);
+    check_bool(label, f.block_x == (lw - f.block_w) / 2u &&
+                      f.block_y == (lh - f.block_h) / 2u, true);
+    snprintf(label, sizeof(label), "pick %ux%u: dst_x centres the bands", lw, lh);
+    check_u32(label, f.dst_x, (TARGET - f.out_w) / 2u);
+    /* The whole point of the rule: when the round-up branch was taken, the
+     * centre crop it paid for must be within budget. */
+    if (ceil_branch) {
+        snprintf(label, sizeof(label), "pick %ux%u: fill branch crop <= 4%%", lw, lh);
+        check_bool(label, !over_budget, true);
+    } else {
+        snprintf(label, sizeof(label), "pick %ux%u: bands branch was over budget", lw, lh);
+        check_bool(label, over_budget, true);
+    }
+}
+
+/* Map the logical trim back through each rotation and check it stays inside the
+ * source crop window with the axes swapped where the rotation swaps them. */
+static void check_map(uint32_t cw, uint32_t ch, uint8_t rot) {
+    char label[96];
+    uint32_t lw = (rot & 1u) ? ch : cw;
+    uint32_t lh = (rot & 1u) ? cw : ch;
+    image_fit_t f;
+    if (!image_fit_pick(lw, lh, TARGET, &f)) {
+        snprintf(label, sizeof(label), "map %ux%u rot%u: pick succeeds", cw, ch, rot);
+        check_bool(label, false, true);
+        return;
+    }
+    uint32_t x, y, w, h;
+    snprintf(label, sizeof(label), "map %ux%u rot%u: maps", cw, ch, rot);
+    check_bool(label, image_fit_logical_to_source(&f, cw, ch, rot, &x, &y, &w, &h), true);
+    printf("  src %ux%u rot%u -> block %ux%u@(%u,%u)\n", cw, ch, rot, w, h, x, y);
+
+    snprintf(label, sizeof(label), "map %ux%u rot%u: window inside source", cw, ch, rot);
+    check_bool(label, x + w <= cw && y + h <= ch, true);
+    snprintf(label, sizeof(label), "map %ux%u rot%u: extents match the logical block", cw, ch, rot);
+    check_bool(label, (rot & 1u) ? (w == f.block_h && h == f.block_w)
+                                 : (w == f.block_w && h == f.block_h), true);
+}
+
+int main(void) {
+    printf("== image_fit_pick: square sources ==\n");
+    const uint32_t sizes[] = {500, 600, 720, 900, 1024, 1080};
+    for (unsigned i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+        check_pick(sizes[i], sizes[i]);
+    }
+
+    printf("\n== image_fit_pick: non-square sources ==\n");
+    check_pick(600, 300);       /* 2:1 wide */
+    check_pick(300, 600);       /* 1:2 tall: the height needs its own trim */
+    check_pick(600, 392);       /* the CONUS radar tile */
+
+    printf("\n== exact values the render path depends on ==\n");
+    {
+        image_fit_t f;
+        /* 720 wide is already a whole 1.0x: no scale, no crop, no bands. */
+        check_bool("720x720: picks", image_fit_pick(720, 720, TARGET, &f), true);
+        check_u32 ("720x720: n16 = 16 (1.0x)", f.n16, 16u);
+        check_u32 ("720x720: out_w = 720", f.out_w, 720u);
+        check_u32 ("720x720: out_h = 720", f.out_h, 720u);
+        check_u32 ("720x720: dst_x = 0", f.dst_x, 0u);
+        check_u32 ("720x720: no crop", f.block_w, 720u);
+
+        /* 900: ceil(11520/900) = 13, floor(11520/13) = 886, crop 1.5 % -> fill. */
+        check_bool("900x900: picks", image_fit_pick(900, 900, TARGET, &f), true);
+        check_u32 ("900x900: n16 = 13", f.n16, 13u);
+        check_u32 ("900x900: block_w = 886", f.block_w, 886u);
+        check_u32 ("900x900: block_x = 7", f.block_x, 7u);
+
+        /* 600: ceil = 20 would cost a 4 % crop -> bands at n = 19. */
+        check_bool("600x600: picks", image_fit_pick(600, 600, TARGET, &f), true);
+        /* 4 % budget: 600 -> n16 20 (1.25x), block 576 = exactly 4 % trim, fills 720 */
+        check_u32 ("600x600: n16 = 20", f.n16, 20u);
+        check_u32 ("600x600: out_w = 720", f.out_w, 720u);
+        check_u32 ("600x600: dst_x = 0", f.dst_x, 0u);
+        check_u32 ("600x600: crop to 576", f.block_w, 576u);
+
+        /* Tall source: the width fills the panel (n = 39, a 1.7 % centre crop)
+         * and the height is centre-cropped to what that scale can show. */
+        check_bool("300x600: picks", image_fit_pick(300, 600, TARGET, &f), true);
+        check_u32 ("300x600: n16 = 39", f.n16, 39u);
+        check_u32 ("300x600: block_h = 295 (centre-cropped)", f.block_h, 295u);
+        check_u32 ("300x600: block_y = 152", f.block_y, 152u);
+        check_u32 ("300x600: out_h = 719", f.out_h, 719u);
+    }
+
+    printf("\n== degenerate inputs ==\n");
+    {
+        image_fit_t f;
+        check_bool("zero width rejected",  image_fit_pick(0, 720, TARGET, &f), false);
+        check_bool("zero height rejected", image_fit_pick(720, 0, TARGET, &f), false);
+        check_bool("zero target rejected", image_fit_pick(720, 720, 0, &f), false);
+        /* Absurdly large source: clamps to 1/16 and centre-crops instead. */
+        check_bool("12000 wide picks", image_fit_pick(12000, 12000, TARGET, &f), true);
+        check_u32 ("12000 wide: n16 = 1", f.n16, 1u);
+        check_u32 ("12000 wide: out_w = 720", f.out_w, 720u);
+        /* Tiny source: n would exceed the register, so it clamps and bands. */
+        check_bool("40 wide picks", image_fit_pick(40, 40, TARGET, &f), true);
+        check_u32 ("40 wide: n16 = 255", f.n16, 255u);
+        check_bool("40 wide: out_w <= 720", f.out_w <= TARGET, true);
+    }
+
+    printf("\n== image_fit_logical_to_source: every rotation ==\n");
+    for (uint8_t rot = 0; rot < 4; rot++) {
+        for (unsigned i = 0; i < sizeof(sizes) / sizeof(sizes[0]); i++) {
+            check_map(sizes[i], sizes[i], rot);
+        }
+        check_map(600, 300, rot);
+        check_map(300, 600, rot);
+    }
+
+    printf("\n== rotation mapping: known corners ==\n");
+    {
+        /* 1024 square: n = 11 (bands), no trim at all, so every rotation must
+         * map to the whole source block. */
+        image_fit_t f;
+        uint32_t x, y, w, h;
+        check_bool("1024: picks", image_fit_pick(1024, 1024, TARGET, &f), true);
+        check_u32 ("1024: block_w = 1024 (untrimmed)", f.block_w, 1024u);
+        for (uint8_t rot = 0; rot < 4; rot++) {
+            char label[96];
+            image_fit_logical_to_source(&f, 1024, 1024, rot, &x, &y, &w, &h);
+            snprintf(label, sizeof(label), "1024 rot%u: origin (0,0)", rot);
+            check_bool(label, x == 0u && y == 0u, true);
+        }
+        /* 900 square: trimmed by 14 px, 7 each side, so the origin is (7,7)
+         * whichever way it is turned (the trim is symmetric). */
+        check_bool("900: picks", image_fit_pick(900, 900, TARGET, &f), true);
+        for (uint8_t rot = 0; rot < 4; rot++) {
+            char label[96];
+            image_fit_logical_to_source(&f, 900, 900, rot, &x, &y, &w, &h);
+            snprintf(label, sizeof(label), "900 rot%u: origin (7,7)", rot);
+            check_bool(label, x == 7u && y == 7u, true);
+        }
+        /* Wide 600x300 turned 90 CW: logical is 300x600, so the logical WIDTH
+         * (the 300 px source height) sets the scale and the logical HEIGHT (the
+         * 600 px source width) is what gets centre-cropped. The mapped window is
+         * therefore taller than it is wide in source terms: src_w = block_h. */
+        check_bool("600x300 rot1: picks", image_fit_pick(300, 600, TARGET, &f), true);
+        image_fit_logical_to_source(&f, 600, 300, 1, &x, &y, &w, &h);
+        check_u32 ("600x300 rot1: src_w = block_h (295)", w, f.block_h);
+        check_u32 ("600x300 rot1: src_h = block_w (295)", h, f.block_w);
+        check_bool("600x300 rot1: window inside source", x + w <= 600u && y + h <= 300u, true);
+    }
+
+    printf("\n%s (%d failures)\n", fails ? "FAILED" : "PASSED", fails);
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
### Summary
This PR significantly reduces SoC load on image-heavy pages by offloading image fitting, ring dissolve effects, and JPEG decoding to a hardware PPA. This improves performance and efficiency for displaying images and animations, and refines how partial image frames are handled for better data quality.

### Changes
*   Offloaded image fitting, rotation, mirroring, and scaling to the PPA, removing software loops for image pages.
*   Moved ring playback dissolve effects to the PPA Blend engine, using an `lv_timer` instead of software opacity animations.
*   Enabled PPA-accelerated JPEG decoding for thumbnails, Spotify art, splash screens, and OctoPrint webcam streams.
*   Added `image_fit.h` to define image fitting rules, applying a center crop for small differences or side bands.
*   Improved handling of partial GIBS/NCEP image frames with a per-cell "holes gate" and refined re-fetch logic.
*   Optimized Clouds page decode memory by using a 512 KB hardware-path transient buffer to prevent freezes.
*   Configured PPA SRM and Blend clients at boot and updated the loading placeholder to count down on its own line.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-25T11:59:42.386Z | Generated by GitHub Actions</sub>