### PR TITLE
feat: add detailed crash info to telemetry

### DIFF
--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -434,7 +434,7 @@
       background: rgba(255, 255, 255, 0.02);
     }
     .top-nav .github-link:hover { color: #f4f4f5; border-color: rgba(var(--accent-rgb), 0.3); background: rgba(255, 255, 255, 0.04); }
-    /* quick controls: instant device toggles, right of the GitHub link; grows later */
+    /* quick controls: instant device toggles, left of the GitHub link; grows later */
     .top-nav .quick-controls { display: flex; align-items: center; gap: 8px; }
     .top-nav .qc-btn {
       color: var(--text-hint); font-family: inherit; font-size: 0.75rem; font-weight: 500;
@@ -1038,16 +1038,16 @@
       </div>
       <div class="nav-right">
         <button class="update-pill" id="updatePill" style="display:none" title="Update available - click to install"></button>
-        <a class="github-link" href="https://github.com/chvvkumar/ESP32-P4-NINA-Display" target="_blank" rel="noopener">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
-          GitHub
-        </a>
         <span class="quick-controls" id="quickControls">
           <button type="button" class="qc-btn" id="muteBtn" title="Mute all audio">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="11 5 6 9 2 9 2 15 6 15 11 19 11 5"/><path id="muteIconOn" d="M15.5 8.5a5 5 0 0 1 0 7M18.5 5.5a9 9 0 0 1 0 13"/><path id="muteIconOff" style="display:none" d="M16 9l6 6M22 9l-6 6"/></svg>
             <span id="muteLabel">Mute</span>
           </button>
         </span>
+        <a class="github-link" href="https://github.com/chvvkumar/ESP32-P4-NINA-Display" target="_blank" rel="noopener">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>
+          GitHub
+        </a>
       </div>
     </div>
     <div class="nav-row2">

--- a/main/telemetry.c
+++ b/main/telemetry.c
@@ -19,6 +19,7 @@
 #include "esp_crt_bundle.h"
 #include "esp_ota_ops.h"
 #include "esp_wifi.h"
+#include "esp_core_dump.h"
 #include "nvs.h"
 #include "driver/temperature_sensor.h"
 
@@ -92,6 +93,23 @@ float telemetry_read_temp_c(void)
     return s_last_c;
 }
 
+/* JSON-safe copy: printable ASCII only; quotes and backslashes become
+ * apostrophes, everything else non-printable becomes a space. */
+static void json_sanitize_copy(char *dst, size_t cap, const char *src)
+{
+    size_t o = 0;
+    for (const char *p = src; *p != '\0' && o + 1 < cap; p++) {
+        unsigned char c = (unsigned char)*p;
+        if (c == '"' || c == '\\') {
+            c = '\'';
+        } else if (c < 0x20 || c > 0x7e) {
+            c = ' ';
+        }
+        dst[o++] = (char)c;
+    }
+    dst[o] = '\0';
+}
+
 int telemetry_build_payload(char *buf, size_t cap, bool include_crash)
 {
     if (!buf || cap == 0) {
@@ -160,11 +178,35 @@ int telemetry_build_payload(char *buf, size_t cap, bool include_crash)
 
     /* Crash block only after an abnormal reset (panic, WDTs, brownout,
      * CPU lockup: power_mgmt_reset_is_abnormal, the existing classifier),
-     * and only when the caller wants it (first report of the boot). */
+     * and only when the caller wants it (first report of the boot).
+     * task/pc/detail come from the coredump the crash just wrote; on an
+     * abnormal reset the image is fresh (the crash overwrote any older one),
+     * so a stale image cannot be attributed to this reboot. */
     if (include_crash && power_mgmt_reset_is_abnormal(reset_reason)) {
+        char task_name[17] = "";
+        char detail[121] = "";
+        uint32_t pc = 0;
+        size_t cd_addr = 0, cd_size = 0;
+        if (esp_core_dump_image_get(&cd_addr, &cd_size) == ESP_OK) {
+            esp_core_dump_summary_t *sum =
+                heap_caps_calloc(1, sizeof(*sum), MALLOC_CAP_SPIRAM);
+            if (sum) {
+                if (esp_core_dump_get_summary(sum) == ESP_OK) {
+                    json_sanitize_copy(task_name, sizeof(task_name), sum->exc_task);
+                    pc = sum->exc_pc;
+                }
+                heap_caps_free(sum);
+            }
+            char raw[256] = "";
+            if (esp_core_dump_get_panic_reason(raw, sizeof(raw)) == ESP_OK) {
+                json_sanitize_copy(detail, sizeof(detail), raw);
+            }
+        }
         n = snprintf(buf + pos, cap - pos,
-            "\"crash\":{\"reason\":\"%s\",\"count\":%lu},",
-            reason_str, (unsigned long)ci.crash_count);
+            "\"crash\":{\"reason\":\"%s\",\"count\":%lu,\"task\":\"%s\","
+            "\"pc\":\"0x%08lx\",\"detail\":\"%s\"},",
+            reason_str, (unsigned long)ci.crash_count, task_name,
+            (unsigned long)pc, detail);
         if (n < 0 || pos + (size_t)n >= cap) {
             return -1;
         }

--- a/main/telemetry.c
+++ b/main/telemetry.c
@@ -92,7 +92,7 @@ float telemetry_read_temp_c(void)
     return s_last_c;
 }
 
-int telemetry_build_payload(char *buf, size_t cap)
+int telemetry_build_payload(char *buf, size_t cap, bool include_crash)
 {
     if (!buf || cap == 0) {
         return -1;
@@ -159,8 +159,9 @@ int telemetry_build_payload(char *buf, size_t cap)
     size_t pos = (size_t)n;
 
     /* Crash block only after an abnormal reset (panic, WDTs, brownout,
-     * CPU lockup: power_mgmt_reset_is_abnormal, the existing classifier). */
-    if (power_mgmt_reset_is_abnormal(reset_reason)) {
+     * CPU lockup: power_mgmt_reset_is_abnormal, the existing classifier),
+     * and only when the caller wants it (first report of the boot). */
+    if (include_crash && power_mgmt_reset_is_abnormal(reset_reason)) {
         n = snprintf(buf + pos, cap - pos,
             "\"crash\":{\"reason\":\"%s\",\"count\":%lu},",
             reason_str, (unsigned long)ci.crash_count);
@@ -188,13 +189,13 @@ int telemetry_build_payload(char *buf, size_t cap)
 }
 
 /* One POST, no retry; success and failure alike are a single debug line. */
-static void telemetry_send_report(void)
+static void telemetry_send_report(bool include_crash)
 {
     char *payload = heap_caps_malloc(TELEMETRY_PAYLOAD_CAP, MALLOC_CAP_SPIRAM);
     if (!payload) {
         return;
     }
-    int len = telemetry_build_payload(payload, TELEMETRY_PAYLOAD_CAP);
+    int len = telemetry_build_payload(payload, TELEMETRY_PAYLOAD_CAP, include_crash);
     if (len <= 0) {
         heap_caps_free(payload);
         return;
@@ -239,12 +240,22 @@ void telemetry_task(void *arg)
                         pdFALSE, pdFALSE, portMAX_DELAY);
     vTaskDelay(pdMS_TO_TICKS(TELEMETRY_START_DELAY_MS));
 
+    /* One panic must reach the server once, not once per daily report: the
+     * crash block rides only the first report of this boot. */
+    bool first_report = true;
     while (1) {
         if (app_config_get()->telemetry_enabled) {
-            telemetry_send_report();
+            telemetry_send_report(first_report);
+            first_report = false;
         }
         uint32_t sleep_s = TELEMETRY_PERIOD_S +
                            (esp_random() % (TELEMETRY_JITTER_MAX_S + 1u));
-        vTaskDelay(pdMS_TO_TICKS(sleep_s * 1000u));
+        /* Chunked delay: pdMS_TO_TICKS overflows 32-bit tick math for any
+         * span past about 71 minutes at the 1000 Hz tick (ms * tick rate
+         * wraps uint32), which turned the daily period into 8-68 minutes.
+         * One-minute chunks keep every conversion far below the wrap. */
+        for (uint32_t slept = 0; slept < sleep_s; slept += 60u) {
+            vTaskDelay(pdMS_TO_TICKS(60u * 1000u));
+        }
     }
 }

--- a/main/telemetry.h
+++ b/main/telemetry.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /* Anonymous telemetry: one small JSON health report a day, POSTed to
@@ -30,8 +31,12 @@
 void telemetry_init(void);
 
 /* Render the exact report JSON into @p buf. Returns the length written
- * (excluding the NUL) or a negative value when @p buf cannot hold it. */
-int telemetry_build_payload(char *buf, size_t cap);
+ * (excluding the NUL) or a negative value when @p buf cannot hold it.
+ * @p include_crash gates the crash{} block (still subject to the last reset
+ * actually being abnormal): the sender passes true only for the FIRST report
+ * of a boot so one panic is counted once server-side, not once per daily
+ * report; the preview endpoint always passes true. */
+int telemetry_build_payload(char *buf, size_t cap, bool include_crash);
 
 /* Sole owner/installer of the ESP32-P4 SoC temperature sensor (range -10..80).
  * Returns the last known reading in Celsius, 0 until the first success. */

--- a/main/telemetry.h
+++ b/main/telemetry.h
@@ -35,7 +35,10 @@ void telemetry_init(void);
  * @p include_crash gates the crash{} block (still subject to the last reset
  * actually being abnormal): the sender passes true only for the FIRST report
  * of a boot so one panic is counted once server-side, not once per daily
- * report; the preview endpoint always passes true. */
+ * report; the preview endpoint always passes true. The crash block carries
+ * reason, cumulative count, crashed task name, faulting PC and the panic
+ * text (sanitized, truncated to 120 chars), all read from the coredump the
+ * crash wrote; task/pc/detail are empty when no coredump is readable. */
 int telemetry_build_payload(char *buf, size_t cap, bool include_crash);
 
 /* Sole owner/installer of the ESP32-P4 SoC temperature sensor (range -10..80).

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -995,7 +995,7 @@ esp_err_t telemetry_preview_get_handler(httpd_req_t *req)
         httpd_resp_send_500(req);
         return ESP_FAIL;
     }
-    int len = telemetry_build_payload(buf, 1024);
+    int len = telemetry_build_payload(buf, 1024, true);
     if (len <= 0) {
         heap_caps_free(buf);
         httpd_resp_send_500(req);


### PR DESCRIPTION
### Summary
This PR improves telemetry by adding detailed crash information, including the crashed task, program counter, and panic message, to reports. It also fixes an issue where daily telemetry reports were sent too frequently due to a calculation error and ensures crash reports are sent only once per boot. A minor UI adjustment moves the mute button.

### Changes
*   Telemetry reports now include the name of the crashed task, the program counter at the time of the fault, and a sanitized panic message.
*   Corrected the daily telemetry sleep calculation to prevent an overflow, ensuring reports are sent daily instead of every few minutes.
*   Ensured crash blocks are included in telemetry reports only once after a device boots, preventing duplicate reporting.
*   Moved the mute button on the web configuration interface to the left of the GitHub link.

---
<sub>Analyzed **3** commit(s) | Updated: 2026-08-26T21:16:46.770Z | Generated by GitHub Actions</sub>