### PR TITLE
fix(audio): widen volume taper for better control

### DIFF
--- a/main/audio_alert.c
+++ b/main/audio_alert.c
@@ -374,6 +374,51 @@ static void enqueue(const sentence_t *s) {
 }
 
 /* ── Playback ───────────────────────────────────────────────────────────── */
+/* esp_codec_dev's DEFAULT volume curve maps the 0-100 setting linearly onto
+ * -50..0 dB, which is 0.5 dB per step. That is technically a log taper, but the
+ * span is far too wide for a small panel speaker in a room: 50 % lands on
+ * -25 dB, about a fifth of full loudness, and 40 % on -30 dB, roughly an
+ * eighth, which is lost under ambient noise. Loudness halves about every 10 dB,
+ * so the default spends five perceptual halvings across the slider and wastes
+ * the bottom half of its travel.
+ *
+ * This curve spends 40 dB instead of 50 and bends at the midpoint, so half the
+ * slider is about half the loudness, which is what a volume control is expected
+ * to do. Piecewise linear in dB between the points below:
+ *
+ *     slider     0     20     40     50     60     80    100
+ *     dB       mute   -28    -16    -10     -8     -4      0
+ *
+ * A setting of 0 never reaches the curve: esp_codec_dev short-circuits it to
+ * -96 dB, so silence is still silence. The ES8311 DAC covers -95.5 dB upward in
+ * 0.5 dB steps, so every point here is representable.
+ *
+ * The curve changes only what the codec does with the number, never the number
+ * itself: alert_voice_volume stays the 0-100 the web UI and the Control API
+ * exchange, so no config migration is involved. */
+static const esp_codec_dev_vol_map_t s_vol_map[] = {
+    {   0, -40.0f },
+    {  50, -10.0f },
+    { 100,   0.0f },
+};
+
+/* Installed on the first successful open and remembered: esp_codec_dev copies
+ * the map onto the device handle, and the handle outlives every close. */
+static void codec_apply_vol_curve(void) {
+    static bool applied = false;
+    if (applied) return;
+    esp_codec_dev_vol_curve_t curve = {
+        .vol_map = (esp_codec_dev_vol_map_t *)s_vol_map,
+        .count   = (int)(sizeof(s_vol_map) / sizeof(s_vol_map[0])),
+    };
+    int rc = esp_codec_dev_set_vol_curve(s_codec, &curve);
+    if (rc != ESP_CODEC_DEV_OK) {
+        ESP_LOGW(TAG, "Volume curve rejected (%d); default -50..0 dB taper stands", rc);
+        return;   /* retried on the next open */
+    }
+    applied = true;
+}
+
 static bool codec_open(void) {
     if (s_codec_dead) return false;
     if (!s_codec) {
@@ -397,7 +442,11 @@ static bool codec_open(void) {
         return false;
     }
 
-    /* Volume must be set after open (the codec driver rejects it otherwise). */
+    /* Both of these are rejected before open, so they live here rather than in
+     * the one-time init above. The curve is stored on the device handle, which
+     * outlives the open/close cycle, so it is installed once. */
+    codec_apply_vol_curve();
+
     int vol = app_config_get()->alert_voice_volume;
     if (vol < 0)   vol = 0;
     if (vol > 100) vol = 100;

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -226,6 +226,17 @@ esp_err_t ota_github_ensure_can_update(void) {
  * the same base version since this project's pre-release tags
  * use the latest main release as their base.
  */
+/* Does this string carry a version compare_versions() can actually read?
+ * compare_versions() sscanf's "%d.%d.%d" and silently leaves 0.0.0 behind when
+ * that fails, so anything unparseable compares as older than every release ever
+ * published. Require all three numbers before trusting a tag. */
+static bool version_is_comparable(const char *tag) {
+    if (!tag || tag[0] == '\0') return false;
+    if (tag[0] == 'v' || tag[0] == 'V') tag++;
+    int maj = 0, min = 0, pat = 0;
+    return sscanf(tag, "%d.%d.%d", &maj, &min, &pat) == 3;
+}
+
 static int compare_versions(const char *v1, const char *v2) {
     if (v1[0] == 'v' || v1[0] == 'V') v1++;
     if (v2[0] == 'v' || v2[0] == 'V') v2++;
@@ -1233,6 +1244,21 @@ const char *ota_github_get_current_version(void) {
             ESP_LOGI(TAG, "Using OTA-installed version for comparison: %s", tag);
             return tag;
         }
+    }
+    /* BUILD_GIT_TAG is `git describe --tags --always --dirty`. It is a release
+     * tag only when HEAD is at one: on a working branch it comes back as
+     * "<nearest-tag>-<n>-g<sha>", and when the nearest tag is not a version at
+     * all -- the rolling snd-alpha tag, or a bare sha in a repo with no tags --
+     * there is no version in it to read. compare_versions() then scores the
+     * device 0.0.0, which puts it below every full-erase floor ever published,
+     * so a hand-flashed board is told its update needs a manual reflash over a
+     * floor it passed long ago. PROJECT_VER (version.txt) is always
+     * major.minor.patch and is what the UI already shows as the version, so a
+     * tag that carries no version defers to it. */
+    if (!version_is_comparable(BUILD_GIT_TAG)) {
+        ESP_LOGI(TAG, "Build tag \"%s\" carries no version; comparing as %s",
+                 BUILD_GIT_TAG, BUILD_VERSION);
+        return BUILD_VERSION;
     }
     return BUILD_GIT_TAG;
 }


### PR DESCRIPTION
### Summary
This PR adjusts the audio volume curve to make the slider more intuitive, so 50% volume feels like half the loudness. It also fixes an issue where devices built from non-versioned Git tags incorrectly reported their version as 0.0.0 for over-the-air updates, preventing incorrect update prompts.

### Changes
*   Adjusted the audio volume curve to provide a more intuitive loudness experience, where 50% on the slider corresponds to roughly half the perceived loudness.
*   The new volume curve maps slider values to a 40 dB span with a bend at the midpoint, making the lower half of the slider more usable.
*   Corrected an issue where devices built from non-versioned Git tags incorrectly reported their version as 0.0.0 for over-the-air updates.
*   The system now requires a full major.minor.patch version from a build tag before trusting it for OTA comparisons, deferring to `BUILD_VERSION` otherwise.
*   This prevents devices from being incorrectly flagged for manual factory reflash due to a perceived 0.0.0 version.

---
<sub>Analyzed **3** commit(s) | Updated: 2026-08-29T21:42:11.346Z | Generated by GitHub Actions</sub>