### PR TITLE
fix: image crossfade dark dip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -403,7 +403,7 @@ jobs:
 
       - name: Upload firmware artifacts
         if: steps.check_skip.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: firmware-${{ steps.version.outputs.branch }}-${{ steps.version.outputs.short_sha }}
           path: firmware/

--- a/.github/workflows/pr-summary.yml
+++ b/.github/workflows/pr-summary.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Update PR title and body with summary
         if: steps.collect.outputs.skip_summary == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/verify-multiboard.yml
+++ b/.github/workflows/verify-multiboard.yml
@@ -400,7 +400,7 @@ jobs:
 
       - name: Upload firmware artifacts
         if: steps.check_skip.outputs.skip != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: multiboard-verify-${{ steps.tag.outputs.short_sha }}
           path: firmware/

--- a/main/ui/nina_dashboard_internal.h
+++ b/main/ui/nina_dashboard_internal.h
@@ -115,10 +115,10 @@ typedef struct {
      * spine only zeroes it. Add fields here rather than as loose
      * dashboard_page_t members.
      *
-     * OBJECT CLASS WARNING. lbl_target, lbl_seq_step and lbl_safety are plain
-     * lv_label objects only on layout 0 and on the SQUARE layout 1. On ROUND
-     * layout 1 (nina_layout_image_round.c) lbl_target and lbl_seq_step are
-     * lv_arclabel objects and lbl_safety is an lv_arc. The spine's
+     * OBJECT CLASS WARNING. lbl_target and lbl_seq_step are plain lv_label
+     * objects only on layout 0 and on the SQUARE layout 1. On ROUND layout 1
+     * (nina_layout_image_round.c) they are lv_arclabel objects. lbl_safety is
+     * a plain lv_label on every layout. The spine's
      * set_label_if_changed() calls lv_label_get_text() on lbl_target, and they
      * are safe today only because every one of them is reached after the
      * layout guard has already returned: update_nina_dashboard_page() hands
@@ -126,7 +126,7 @@ typedef struct {
      * apply_theme_to_page() returns after nina_layout_alt_apply_theme() when
      * p->layout != 0. LV_USE_ASSERT_OBJ is off on round, so a reshuffle of
      * those guards would silently reinterpret an lv_arclabel as an lv_label.
-     * Never write these three from the spine outside a layout == 0 path. */
+     * Never write these two from the spine outside a layout == 0 path. */
     struct {
         lv_obj_t *lbl_target;       /* target name (layout 1 and round layout 0);
                                       * lv_arclabel on round layout 1 */
@@ -136,7 +136,7 @@ typedef struct {
         lv_obj_t *tile_ident;       /* top text group: identity (two rows) */
         lv_obj_t *tile_hero;        /* bottom group: value row + 12 px block ledge */
         lv_obj_t *row_seq;          /* row 1: identity | shield | step */
-        lv_obj_t *lbl_safety;       /* lv_arc on round layout 1 */
+        lv_obj_t *lbl_safety;       /* safety shield glyph; lv_label everywhere */
         lv_obj_t *lbl_seq_step;     /* lv_arclabel on round layout 1 */
         lv_obj_t *row_vals;         /* bottom value row (one 64 px baseline); also
                                       * round layout 0's elapsed+unit row */

--- a/main/ui/nina_image_page.c
+++ b/main/ui/nina_image_page.c
@@ -1046,25 +1046,35 @@ void image_page_render_frame(image_page_t *p)
     } else {
         p->crossfade_active = true;
 
-        lv_anim_t a_in;
-        lv_anim_init(&a_in);
-        lv_anim_set_var(&a_in, p->img_back);
-        lv_anim_set_values(&a_in, 0, 255);
-        lv_anim_set_duration(&a_in, 500);
-        lv_anim_set_path_cb(&a_in, lv_anim_path_ease_in_out);
-        lv_anim_set_exec_cb(&a_in, anim_opa_cb);
-        lv_anim_set_user_data(&a_in, p);
-        lv_anim_set_completed_cb(&a_in, crossfade_done_cb);
-        lv_anim_start(&a_in);
+        /* Only ONE image animates; the other is held fully opaque underneath so
+         * the composite is a true lerp(old, new). Fading both at once darkens
+         * the midpoint (top*0.5 over bottom*0.5 over the black container is
+         * about 75% brightness) and reads as a pulse on every update - the same
+         * dip the Moon source works around by swapping instantly, above.
+         *
+         * Which object is on top alternates with front_is_a (child 0 = image A,
+         * child 1 = image B), and the child order must NOT be reordered here:
+         * crossfade_done_cb and release_lvgl index children 0 and 1. So pick the
+         * fade direction from the existing z-order instead:
+         *   front_is_a  -> img_back is child 1, on top: fade the NEW image IN.
+         *   !front_is_a -> img_front is child 1, on top: fade the OLD image OUT.
+         * Either way crossfade_done_cb retires img_front when the anim ends. */
+        bool back_on_top = p->front_is_a;
 
-        lv_anim_t a_out;
-        lv_anim_init(&a_out);
-        lv_anim_set_var(&a_out, p->img_front);
-        lv_anim_set_values(&a_out, 255, 0);
-        lv_anim_set_duration(&a_out, 500);
-        lv_anim_set_path_cb(&a_out, lv_anim_path_ease_in_out);
-        lv_anim_set_exec_cb(&a_out, anim_opa_cb);
-        lv_anim_start(&a_out);
+        lv_obj_set_style_opa(p->img_front, LV_OPA_COVER, 0);
+        lv_obj_set_style_opa(p->img_back,
+                             back_on_top ? LV_OPA_TRANSP : LV_OPA_COVER, 0);
+
+        lv_anim_t a;
+        lv_anim_init(&a);
+        lv_anim_set_var(&a, back_on_top ? p->img_back : p->img_front);
+        lv_anim_set_values(&a, back_on_top ? 0 : 255, back_on_top ? 255 : 0);
+        lv_anim_set_duration(&a, 1000);
+        lv_anim_set_path_cb(&a, lv_anim_path_ease_in_out);
+        lv_anim_set_exec_cb(&a, anim_opa_cb);
+        lv_anim_set_user_data(&a, p);
+        lv_anim_set_completed_cb(&a, crossfade_done_cb);
+        lv_anim_start(&a);
     }
 
     if (p->src == IMG_SRC_MOON) {

--- a/main/ui/nina_layout_image_round.c
+++ b/main/ui/nina_layout_image_round.c
@@ -4,14 +4,14 @@
  *
  * A circle has no bottom edge, so the 12 px block ledge becomes the panel's
  * outermost ring, one block per sub, flush with the glass the way the OctoPrint
- * round layout puts its progress rim there, and its notch at twelve o'clock is
- * the safety crown, which is where the shield used to sit beside the step.
+ * round layout puts its progress rim there, closing the full circle with no
+ * notch; safety is a Material shield glyph in the value row instead.
  *
  * Everything the square layout kept on one baseline now reads as one bottom
  * stack, top to bottom, the same shape octoprint_layout_glass_round.c uses:
  *
  *   rim top     target name (arclabel, guideline G1)
- *   row         TOTAL RMS | sub counter | filter name, on one 64 px baseline
+ *   row         TOTAL RMS | shield | sub counter | filter name
  *   rule        hairline separating the row from the hero
  *   hero        elapsed seconds, centred, 64 px Hanken
  *   rim bottom  sequence step (arclabel), between the hero and the ring
@@ -36,11 +36,11 @@
 #include "app_config.h"
 #include "themes.h"
 #include "ui_arclabel.h"
-#include "ui_dial.h"
 #include "ui_round.h"
 
 LV_FONT_DECLARE(lv_font_hanken_bold_64);
 LV_FONT_DECLARE(lv_font_hanken_bold_28);
+LV_FONT_DECLARE(lv_font_material_safety);
 
 /* ---- design tokens ------------------------------------------------------ */
 
@@ -50,7 +50,6 @@ LV_FONT_DECLARE(lv_font_hanken_bold_28);
  * replaces the old ui_rim_radius() - 12 inset, which left an 11 px black band
  * outside the ring. */
 #define IFR_W_LEDGE       14
-#define IFR_CROWN_DEG     40
 
 static inline int ifr_ring_r(void)  { return screen_center() - IFR_W_LEDGE / 2; }
 
@@ -63,11 +62,10 @@ static inline int ifr_text_r(void)
     return screen_center() - IFR_W_LEDGE - IFR_TEXT_GAP;
 }
 
-/* Bottom stack, measured upward from the step cell on the rim. IFR_STEP_H is
- * lv_font_montserrat_28's line height; the rest are gaps. At 720 this puts the
- * step cell at dy 310..340, the hero's baseline row at 234..300, the rule at
- * 224 and the value row's bottom at 214; at 800 each lands 40 px lower. */
-#define IFR_STEP_H        30
+/* Bottom stack, measured upward from the step cell on the rim. The step cell
+ * height comes from lv_font_get_line_height(IFR_FONT_STEP); the rest are
+ * gaps, so a font swap moves the whole stack instead of overlapping the rim
+ * text. */
 #define IFR_STEP_GAP      10    /* hero bottom to the step cell top */
 #define IFR_RULE_GAP      10    /* rule to the row above and the hero below */
 #define IFR_RULE_W         2
@@ -76,17 +74,21 @@ static inline int ifr_text_r(void)
 /* The value row's ends must stay inside the ring. ui_chord_half() measures on
  * ui_rim_radius() (Rs = 0.985 R), which is about 10 px wider than the ring's
  * inner edge now that the ring sits on the glass, so the pad covers that and
- * leaves margin: a worst case of RMS 99.99" (182 px) + counter 999 / 999
- * (122 px) + a filter name (about 170 px) is 474 px against the 512 px the
- * chord gives at 720. */
+ * leaves margin: a worst case of RMS 99.99" (about 80 px now that it is in
+ * the 28 px row font) + the 40 px shield + counter 999 / 999 (122 px) + a
+ * filter name (about 170 px) is about 412 px against the 512 px the chord
+ * gives at 720. */
 #define IFR_ROW_PAD       26
 
-#define IFR_CROWN_IDLE    0x2a2a2a
 #define IFR_TARGET_FG     0xf2f2f4
 
-#define IFR_FONT_TARGET   (&lv_font_montserrat_40)
-#define IFR_FONT_STEP     (&lv_font_montserrat_28)
-#define IFR_FONT_ELAPSED  (&lv_font_hanken_bold_64)   /* also the RMS value's font */
+#define IFR_ICON_SAFE     "\xee\xa3\xa8"  /* U+E8E8 verified_user */
+#define IFR_ICON_UNSAFE   "\xef\x80\x92"  /* U+F012 gpp_bad       */
+#define IFR_ICON_UNKNOWN  "\xef\x80\x94"  /* U+F014 gpp_maybe     */
+
+#define IFR_FONT_TARGET   (&lv_font_montserrat_28)
+#define IFR_FONT_STEP     (&lv_font_montserrat_24)
+#define IFR_FONT_ELAPSED  (&lv_font_hanken_bold_64)
 #define IFR_FONT_COUNT    (&lv_font_hanken_bold_28)
 #define IFR_FONT_FILTER   (&lv_font_montserrat_24)
 
@@ -106,7 +108,6 @@ static lv_obj_t *ifr_label(lv_obj_t *parent, const lv_font_t *font, const char *
 static lv_obj_t *ifr_value_label(lv_obj_t *parent);
 static void      ifr_set_text(lv_obj_t *lbl, const char *text);
 static void      ifr_set_arc_text(lv_obj_t *al, char *shadow, size_t n, const char *text);
-static void      ifr_set_arc_color(lv_obj_t *arc, uint32_t color);
 static void      ifr_elapsed_cb(void *ud, int secs);
 static void      ifr_theme_page(dashboard_page_t *p, int gb);
 
@@ -137,12 +138,11 @@ static lv_obj_t *ifr_label(lv_obj_t *parent, const lv_font_t *font, const char *
     return l;
 }
 
-/* Value-row label, always in the 64 px elapsed font. LVGL has no baseline, so
- * the row bottom-aligns its children (flex cross END); both callers use the
- * same font, so there is no other baseline to nudge onto (review C3 minor
- * M-3: the previous per-font translate_y was always zero here). */
+/* RMS value label, in the row's own font so it matches the other readings on
+ * that row. LVGL has no baseline, so the row bottom-aligns its children (flex
+ * cross END). */
 static lv_obj_t *ifr_value_label(lv_obj_t *parent) {
-    return ifr_label(parent, IFR_FONT_ELAPSED, "--");
+    return ifr_label(parent, IFR_FONT_COUNT, "--");
 }
 
 static void ifr_set_text(lv_obj_t *lbl, const char *text) {
@@ -158,17 +158,6 @@ static void ifr_set_arc_text(lv_obj_t *al, char *shadow, size_t n, const char *t
     if (strcmp(shadow, text) == 0) return;
     snprintf(shadow, n, "%s", text);
     lv_arclabel_set_text(al, text);
-}
-
-/* A local style write always refreshes the object and every invalidation on
- * this display is a full-frame redraw, so the per-poll crown paint compares
- * first (review C minor M-4). */
-static void ifr_set_arc_color(lv_obj_t *arc, uint32_t color) {
-    if (!arc) return;
-    lv_color_t c = lv_color_hex(color);
-    if (!lv_color_eq(lv_obj_get_style_arc_color(arc, LV_PART_MAIN), c)) {
-        lv_obj_set_style_arc_color(arc, c, LV_PART_MAIN);
-    }
 }
 
 /* Sole writer of the elapsed label: the 200 ms tick through the sub ring, and
@@ -213,16 +202,12 @@ void nina_layout_image_create(dashboard_page_t *p, lv_obj_t *parent, int page_in
     lv_image_set_src(p->alt.cap_img, NULL);
     nina_dashboard_bind_tap(p->alt.cap_img, NINA_TAP_CAPTURE);
 
-    /* 2: the ledge, now the outermost ring and flush with the glass, plus its
-     * crown at twelve o'clock. lbl_safety names the crown: the Material shield
-     * is not drawn here. */
+    /* 2: the ledge, now the outermost ring and flush with the glass, closing
+     * the full circle with no notch. Safety moves to a shield glyph in the
+     * value row (see lbl_safety below). */
     nina_subbar_create_ring(&p->subbar, parent, ifr_ring_r(),
-                            IFR_W_LEDGE, IFR_CROWN_DEG);
+                            IFR_W_LEDGE, 0);
     nina_subbar_set_elapsed_cb(&p->subbar, ifr_elapsed_cb, p);
-    p->alt.lbl_safety = ui_dial_arc(parent, ifr_ring_r(),
-                                    IFR_W_LEDGE, -IFR_CROWN_DEG / 2, IFR_CROWN_DEG / 2);
-    lv_obj_set_style_arc_color(p->alt.lbl_safety, lv_color_hex(IFR_CROWN_IDLE),
-                               LV_PART_MAIN);
 
     /* 3: identity on the rim (guideline G1). The target keeps twelve o'clock;
      * the sequence step moves to the BOTTOM rim, under the elapsed hero and
@@ -236,24 +221,25 @@ void nina_layout_image_create(dashboard_page_t *p, lv_obj_t *parent, int page_in
      * hard-coding it, so a font swap moves the whole stack instead of
      * overlapping the rim text. */
     const int el_h      = lv_font_get_line_height(IFR_FONT_ELAPSED);
-    const int el_bottom = ifr_text_r() - IFR_STEP_H - IFR_STEP_GAP;
+    const int step_h    = lv_font_get_line_height(IFR_FONT_STEP);
+    const int el_bottom = ifr_text_r() - step_h - IFR_STEP_GAP;
     const int el_top    = el_bottom - el_h;
     const int rule_dy   = el_top - IFR_RULE_GAP;
     const int row_bottom = rule_dy - IFR_RULE_GAP;
     const int row_w     = 2 * ui_chord_half(row_bottom) - 2 * IFR_ROW_PAD;
+    const int row_h     = LV_MAX(lv_font_get_line_height(IFR_FONT_COUNT),
+                                 lv_font_get_line_height(&lv_font_material_safety));
 
-    /* Row: TOTAL RMS, the sub counter and the filter name on one 64 px
-     * baseline. The elapsed seconds used to hold this row's right slot and are
-     * now the hero below it, so the three readings that are left spread across
-     * the chord. Children are bottom aligned: LVGL has no baseline, and the
-     * three faces differ. */
+    /* Row: TOTAL RMS, the shield, the sub counter and the filter name, all in
+     * the row's own font. Children are bottom aligned: LVGL has no baseline,
+     * and the shield's face differs from the text faces. */
     p->alt.row_vals = lv_obj_create(parent);
     lv_obj_remove_style_all(p->alt.row_vals);
     lv_obj_remove_flag(p->alt.row_vals, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_remove_flag(p->alt.row_vals, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_size(p->alt.row_vals, row_w, el_h);
+    lv_obj_set_size(p->alt.row_vals, row_w, row_h);
     lv_obj_align(p->alt.row_vals, LV_ALIGN_TOP_MID, 0,
-                 screen_center() + row_bottom - el_h);
+                 screen_center() + row_bottom - row_h);
     lv_obj_set_style_pad_all(p->alt.row_vals, 0, 0);
     lv_obj_set_style_pad_gap(p->alt.row_vals, 0, 0);
     lv_obj_set_flex_flow(p->alt.row_vals, LV_FLEX_FLOW_ROW);
@@ -262,6 +248,8 @@ void nina_layout_image_create(dashboard_page_t *p, lv_obj_t *parent, int page_in
 
     p->alt.lbl_rms = ifr_value_label(p->alt.row_vals);
     nina_dashboard_bind_tap(p->alt.lbl_rms, NINA_TAP_RMS);
+
+    p->alt.lbl_safety = ifr_label(p->alt.row_vals, &lv_font_material_safety, IFR_ICON_UNKNOWN);
 
     p->alt.lbl_count = ifr_label(p->alt.row_vals, IFR_FONT_COUNT, "--");
     lv_obj_set_style_text_align(p->alt.lbl_count, LV_TEXT_ALIGN_CENTER, 0);
@@ -342,13 +330,25 @@ void nina_layout_image_update(dashboard_page_t *p, const nina_client_t *d,
     p->alt.inst = instance_idx;
     bool red = ifr_red();
 
-    /* Safety is the rim crown, not a glyph beside the step. */
+    /* Shield glyph in the value row. */
     {
-        uint32_t crown;
-        if (!d->safety_connected)     crown = red ? current_theme->label_color : 0x999999;
-        else if (d->safety_is_safe)   crown = red ? 0x7f1d1d : 0x4CAF50;
-        else                          crown = red ? 0xff0000 : 0xF44336;
-        ifr_set_arc_color(p->alt.lbl_safety, ifr_dim(crown, gb));
+        const char *icon;
+        uint32_t icon_color;
+        if (!d->safety_connected) {
+            icon = IFR_ICON_UNKNOWN;
+            icon_color = red ? current_theme->label_color : 0x999999;
+        } else if (d->safety_is_safe) {
+            icon = IFR_ICON_SAFE;
+            icon_color = red ? 0x7f1d1d : 0x4CAF50;
+        } else {
+            icon = IFR_ICON_UNSAFE;
+            icon_color = red ? 0xff0000 : 0xF44336;
+        }
+        ifr_set_text(p->alt.lbl_safety, icon);
+        if (p->alt.lbl_safety) {
+            lv_obj_set_style_text_color(p->alt.lbl_safety,
+                lv_color_hex(ifr_dim(icon_color, gb)), 0);
+        }
     }
 
     if (instance_idx >= 0 && instance_idx < MAX_NINA_INSTANCES) {


### PR DESCRIPTION
### Summary
The image page crossfade animation now transitions smoothly between images without a dark dip. The round layout also displays the safety shield in the value row, consistent with the square layout.

### Changes
- The image page crossfade animation now smoothly blends between images, eliminating a dark dip during the transition.
- The image crossfade transition duration increased from 500 ms to 1000 ms.
- The round layout now shows the safety shield as a Material glyph in the value row, matching the square layout.
- RMS reading font size on the round layout changed to 28 px.
- Target and step rim text font sizes on the round layout changed to 28 px and 24 px.
- Step cell height now dynamically determined by font line height instead of a fixed value.
- `lbl_safety` is now a standard `lv_label` object across all layouts.

---
<sub>Analyzed **3** commit(s) | Updated: 2026-08-30T03:14:54.182Z | Generated by GitHub Actions</sub>