### PR TITLE
fix(perf): track up to 64 tasks so CPU load stops reading 0%

### DIFF
--- a/main/perf_monitor.h
+++ b/main/perf_monitor.h
@@ -22,7 +22,7 @@ int64_t  perf_timer_stop(perf_timer_t *t);
 
 // ── CPU Utilization ────────────────────────────────────────────────
 
-#define CPU_MAX_TRACKED_TASKS 40
+#define CPU_MAX_TRACKED_TASKS 64
 
 // Low-DMA-heap watchdog: when the largest contiguous DMA-capable internal
 // block (MALLOC_CAP_INTERNAL|MALLOC_CAP_DMA|MALLOC_CAP_8BIT) drops below this,


### PR DESCRIPTION
### Summary
The system was incorrectly showing 0% CPU load because it could not track all running tasks. This change increases the maximum number of tasks monitored, allowing accurate CPU load readings to be displayed on the status and performance APIs.

### Changes
*   Increased the maximum number of tasks the performance monitor tracks from 40 to 64 in `main/perf_monitor.h`.
*   This change resolves an issue where CPU load was incorrectly reported as 0% on status and performance APIs.
*   The increased task tracking ensures all active tasks, including image pollers, ADS-B, OctoPrint, and voice, are monitored.
*   The memory cost for this increase is approximately 1.1 KB per `TaskStatus_t` array.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-31T13:27:14.896Z | Generated by GitHub Actions</sub>