### PR TITLE
fix: read crash summary from crash_log, not coredump

### DIFF
--- a/main/crash_log.c
+++ b/main/crash_log.c
@@ -304,6 +304,32 @@ static void append_crash_record(uint32_t reason)
  * dump read, record write) is deferred. */
 static bool      s_crash_pending = false;     /* a crash record is waiting to be written */
 static uint32_t  s_pending_reason = 0;
+static crash_log_summary_t s_summary;         /* filled once by the worker, read-only after */
+
+const crash_log_summary_t *crash_log_get_summary(void)
+{
+    return &s_summary;
+}
+
+/* Read the coredump summary + panic note into s_summary. Flash mmap inside:
+ * internal-RAM stack only (see crash_log_deferred_worker). */
+static void cache_core_summary(void)
+{
+    size_t cd_addr = 0, cd_size = 0;
+    if (esp_core_dump_image_get(&cd_addr, &cd_size) != ESP_OK) {
+        return;
+    }
+    esp_core_dump_summary_t *sum = heap_caps_calloc(1, sizeof(*sum), MALLOC_CAP_SPIRAM);
+    if (sum) {
+        if (esp_core_dump_get_summary(sum) == ESP_OK) {
+            strlcpy(s_summary.task, sum->exc_task, sizeof(s_summary.task));
+            s_summary.pc = sum->exc_pc;
+        }
+        heap_caps_free(sum);
+    }
+    (void)esp_core_dump_get_panic_reason(s_summary.detail, sizeof(s_summary.detail));
+    s_summary.valid = true;
+}
 
 /**
  * One-shot background worker: performs the littlefs mount/format off the boot
@@ -320,6 +346,12 @@ static uint32_t  s_pending_reason = 0;
 static void crash_log_deferred_worker(void *arg)
 {
     (void)arg;
+
+    /* Before the mount: the summary cache must exist even when littlefs is
+     * unavailable, because telemetry reads it in place of the flash. */
+    if (s_crash_pending) {
+        cache_core_summary();
+    }
 
     if (!ensure_mounted()) {
         s_crash_pending = false;
@@ -354,5 +386,5 @@ void crash_log_init(void)
      * stack is mandatory (see crash_log_deferred_worker). Low priority on Core 0
      * keeps it out of the way of UI/network bring-up. */
     xTaskCreatePinnedToCore(crash_log_deferred_worker, "crash_log_def",
-                            8192, NULL, tskIDLE_PRIORITY + 2, NULL, 0);
+                            10240, NULL, tskIDLE_PRIORITY + 2, NULL, 0);
 }

--- a/main/crash_log.h
+++ b/main/crash_log.h
@@ -74,6 +74,25 @@ esp_err_t crash_log_clear(void);
  */
 void crash_log_purge_old(uint8_t days);
 
+/**
+ * Core dump summary of the crash this boot followed, read ONCE by the
+ * internal-RAM boot worker. esp_core_dump_get_summary() and
+ * esp_core_dump_get_panic_reason() mmap the coredump partition, which runs
+ * with the data cache disabled and asserts when the calling task's stack is
+ * in PSRAM (cache_utils.c: esp_task_stack_is_sane_cache_disabled). Every
+ * PSRAM-stacked task (telemetry) must read this cache instead of the flash.
+ * `valid` is false until the worker has run, and stays false on a normal
+ * reset or when no image is present.
+ */
+typedef struct {
+    bool     valid;
+    char     task[17];
+    uint32_t pc;
+    char     detail[256];
+} crash_log_summary_t;
+
+const crash_log_summary_t *crash_log_get_summary(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/telemetry.c
+++ b/main/telemetry.c
@@ -19,7 +19,6 @@
 #include "esp_crt_bundle.h"
 #include "esp_ota_ops.h"
 #include "esp_wifi.h"
-#include "esp_core_dump.h"
 #include "nvs.h"
 #include "driver/temperature_sensor.h"
 
@@ -27,6 +26,7 @@
 #include "build_version.h"
 #include "perf_monitor.h"
 #include "power_mgmt.h"
+#include "crash_log.h"
 #include "net_trace.h"
 #include "tasks.h"   /* s_wifi_event_group + WIFI_CONNECTED_BIT */
 
@@ -186,21 +186,15 @@ int telemetry_build_payload(char *buf, size_t cap, bool include_crash)
         char task_name[17] = "";
         char detail[121] = "";
         uint32_t pc = 0;
-        size_t cd_addr = 0, cd_size = 0;
-        if (esp_core_dump_image_get(&cd_addr, &cd_size) == ESP_OK) {
-            esp_core_dump_summary_t *sum =
-                heap_caps_calloc(1, sizeof(*sum), MALLOC_CAP_SPIRAM);
-            if (sum) {
-                if (esp_core_dump_get_summary(sum) == ESP_OK) {
-                    json_sanitize_copy(task_name, sizeof(task_name), sum->exc_task);
-                    pc = sum->exc_pc;
-                }
-                heap_caps_free(sum);
-            }
-            char raw[256] = "";
-            if (esp_core_dump_get_panic_reason(raw, sizeof(raw)) == ESP_OK) {
-                json_sanitize_copy(detail, sizeof(detail), raw);
-            }
+        /* From crash_log's boot-time cache, never from the coredump partition:
+         * esp_core_dump_get_summary() mmaps flash with the cache disabled and
+         * asserts on this task's PSRAM stack (cache_utils.c:127), which turned
+         * every panic into a reboot loop (allskyesp3236, 2026-08-31). */
+        const crash_log_summary_t *cs = crash_log_get_summary();
+        if (cs->valid) {
+            json_sanitize_copy(task_name, sizeof(task_name), cs->task);
+            json_sanitize_copy(detail, sizeof(detail), cs->detail);
+            pc = cs->pc;
         }
         n = snprintf(buf + pos, cap - pos,
             "\"crash\":{\"reason\":\"%s\",\"count\":%lu,\"task\":\"%s\","


### PR DESCRIPTION
### Summary
Telemetry reporting could cause devices to enter a reboot loop after a crash due to how it accessed coredump data from a PSRAM stack. Crash log now reads and caches crash summary details once during boot, and telemetry retrieves this cached information instead of directly accessing the coredump partition. This prevents the reboot loop on devices with telemetry enabled after a crash.

### Changes
*   `crash_log` now reads and caches the crash summary (task, program counter, panic note) once during boot.
*   `crash_log` makes this cached summary available via a new `crash_log_get_summary()` function.
*   `telemetry_build_payload()` retrieves crash information from `crash_log_get_summary()`.
*   Telemetry no longer directly accesses the coredump partition.
*   Removed direct calls to `esp_core_dump_get_summary()` and `esp_core_dump_get_panic_reason()` from telemetry.
*   Increased the `crash_log` boot worker stack size from 8192 to 10240 bytes.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-08-31T14:11:58.401Z | Generated by GitHub Actions</sub>