### PR TITLE
fix: stop repeating stale unsafe alerts

### DIFF
--- a/main/image_page_poll.c
+++ b/main/image_page_poll.c
@@ -827,13 +827,15 @@ static void anim_rejudge_head(image_page_t *p, const app_config_t *cfg, uint32_t
  * (~1.04 MB) at the same time. The hardware JPEG path needs only the latter;
  * the conservative figure is the one that has to hold. */
 #define ANIM_DECODE_TRANSIENT_BYTES ((size_t)2600 * 1024)
-/* Cloud Cover frames are baseline JPEG and decode on the hardware engine: the
- * decoder writes straight into the frame-sized buffer, so the only extra is the
- * compressed download (~150-300 KB). 2.6 MB here was the stb figure, and with
- * the three 1 MB playback scratch buffers resident it left the largest free
- * block (~3.3 MB on dash4) permanently under the bar: every optional fetch was
- * refused, the newest slot was a GIBS blank, and the page froze on one frame. */
-#define ANIM_DECODE_TRANSIENT_HW_BYTES ((size_t)512 * 1024)
+/* Cloud Cover frames are baseline JPEG and decode on the hardware engine, which
+ * now writes RGB888 (1.5x the frame) that is packed to RGB565 in place and
+ * trimmed, so the extra over the frame itself is half a frame (~520 KB at
+ * 720x720) plus the compressed download (~150-300 KB). 2.6 MB here was the
+ * stb figure, and with the three 1 MB playback scratch buffers resident it
+ * left the largest free block (~3.3 MB on dash4) permanently under the bar:
+ * every optional fetch was refused, the newest slot was a GIBS blank, and the
+ * page froze on one frame. */
+#define ANIM_DECODE_TRANSIENT_HW_BYTES ((size_t)1024 * 1024)
 
 /* PSRAM headroom for one more animated frame, and the ONE place the ring is
  * allowed to shrink. Without it the ring grows until the largest free block no

--- a/main/jpeg_utils.c
+++ b/main/jpeg_utils.c
@@ -387,7 +387,7 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
         .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
     };
     size_t alloc_size = 0;
-    uint8_t *buf = jpeg_alloc_decoder_mem((size_t)pad_w * pad_h * (is_gray ? 1 : 2),
+    uint8_t *buf = jpeg_alloc_decoder_mem((size_t)pad_w * pad_h * (is_gray ? 1 : 3),
                                           &mem_cfg, &alloc_size);
     if (!buf) return ESP_ERR_NO_MEM;
 
@@ -408,11 +408,12 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
      * NOW so no dirty line outlives the transfer. */
     esp_cache_msync(buf, alloc_size, ESP_CACHE_MSYNC_FLAG_DIR_C2M);
 
-    /* BGR element order gives the same in-memory RGB565 layout the SW path
-     * produces (R high, B low) -- see the packing comment above. */
+    /* Colour decodes as RGB888 so the 565 pack below can dither it; rgb_order
+     * BGR is the engine's little-endian order, so the bytes land B, G, R (the
+     * IDF jpeg_decode example uses the same pair). */
     jpeg_decode_cfg_t decode_cfg = {
         .output_format = is_gray ? JPEG_DECODE_OUT_FORMAT_GRAY
-                                 : JPEG_DECODE_OUT_FORMAT_RGB565,
+                                 : JPEG_DECODE_OUT_FORMAT_RGB888,
         .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,
     };
     uint32_t decoded_size = 0;
@@ -424,22 +425,22 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
         return (err != ESP_OK) ? err : ESP_FAIL;
     }
 
-    /* Diagnostic: fraction of sampled pixels exactly 0x0000 in the raw DMA
-     * output. Confirmed 2026-08-24 on dash4: the HW colour conversion crushes
+    /* Diagnostic: fraction of sampled pixels exactly 0,0,0 in the raw RGB888
+     * DMA output. Confirmed 2026-08-24 on dash4: the HW colour conversion crushes
      * dark values to 0 (7-8 % of a night GeoColor frame vs <1 % from stb),
      * which is why clouds_frame_incomplete() tests NEAR black. Debug only. */
     if (!is_gray) {
-        const uint16_t *px = (const uint16_t *)buf;
         uint32_t n = 0, z = 0;
         for (uint32_t y = 0; y < h; y += 8) {
+            const uint8_t *row = buf + (size_t)y * pad_w * 3;
             for (uint32_t x = 0; x < w; x += 8) {
+                const uint8_t *px = row + (size_t)x * 3;
                 n++;
-                if (px[(size_t)y * pad_w + x] == 0) z++;
+                if (px[0] == 0 && px[1] == 0 && px[2] == 0) z++;
             }
         }
-        ESP_LOGD(TAG, "HW JPEG raw: %lu/%lu samples zero, px[0]=%04x mid=%04x",
-                 (unsigned long)z, (unsigned long)n, px[0],
-                 px[(size_t)(h / 2) * pad_w + w / 2]);
+        ESP_LOGD(TAG, "HW JPEG raw: %lu/%lu samples zero",
+                 (unsigned long)z, (unsigned long)n);
     }
 
     /* GRAY8 -> RGB565 into a tight w*h*2 buffer (the padded GRAY8 one is freed).
@@ -474,14 +475,49 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
         return ESP_OK;
     }
 
-    /* Callers expect tightly packed w*h*2 rows, so drop the MCU pad in place.
-     * Destination row y starts at or before source row y, and we walk top-down,
-     * so no row is overwritten before it is copied. */
-    if (pad_w != w) {
-        for (uint32_t y = 1; y < h; y++) {
-            memmove(buf + (size_t)y * w * 2,
-                    buf + (size_t)y * pad_w * 2,
-                    (size_t)w * 2);
+    /* RGB888 -> RGB565 in place, ordered-dithered like the grey path, with the
+     * MCU pad dropped in the same pass. In place is safe: the destination
+     * bytes of pixel (y, x) end at y*w*2 + 2x + 1, always below the first
+     * byte of the next unread source pixel at y*pad_w*3 + 3x + 3, and each
+     * pixel is read before it is written. */
+    for (uint32_t y = 0; y < h; y++) {
+        const uint8_t *srow = buf + (size_t)y * pad_w * 3;
+        const uint8_t *th   = s_bayer4[y & 3];
+        uint16_t *drow = (uint16_t *)(buf + (size_t)y * w * 2);
+        for (uint32_t x = 0; x < w; x++) {
+            const uint8_t *px = srow + (size_t)x * 3;
+            int t  = th[x & 3];
+            int b5 = px[0] + (t >> 1);          /* +0..7 before the >> 3 */
+            int g6 = px[1] + (t >> 2);          /* +0..3 before the >> 2 */
+            int r5 = px[2] + (t >> 1);
+            if (b5 > 255) b5 = 255;
+            if (g6 > 255) g6 = 255;
+            if (r5 > 255) r5 = 255;
+            drow[x] = (uint16_t)(((r5 >> 3) << 11) | ((g6 >> 2) << 5) | (b5 >> 3));
+        }
+    }
+
+    /* Give the unused half of the 3-byte decode buffer back. TLSF trims a
+     * shrinking block in place (block_trim_used), so the address and its
+     * 128 B alignment normally survive; if the heap ever moves it, the data
+     * moved too, and a misaligned home is fixed by one aligned copy because
+     * the PPA refuses unaligned input. */
+    {
+        size_t tight = (((size_t)w * h * 2) + 127) & ~(size_t)127;
+        if (tight < alloc_size) {
+            uint8_t *shrunk = heap_caps_realloc(buf, tight, MALLOC_CAP_SPIRAM);
+            if (shrunk) {
+                buf = shrunk;
+                alloc_size = tight;
+                if (((uintptr_t)buf & 127) != 0) {
+                    uint8_t *aligned = heap_caps_aligned_alloc(128, tight, MALLOC_CAP_SPIRAM);
+                    if (aligned) {
+                        memcpy(aligned, buf, (size_t)w * h * 2);
+                        heap_caps_free(buf);
+                        buf = aligned;
+                    }
+                }
+            }
         }
     }
 

--- a/main/jpeg_utils.c
+++ b/main/jpeg_utils.c
@@ -334,6 +334,20 @@ static bool jpeg_scan_sof0(const uint8_t *d, size_t n, uint32_t *w, uint32_t *h,
     return false;
 }
 
+/* 4x4 Bayer thresholds for the GRAY8 -> RGB565 expansion below. A NINA
+ * prepared thumbnail is a grey JPEG whose stretched sky spans about 15 grey
+ * levels; plain truncation collapses that to 2 red/blue steps and 4 green
+ * steps and the disc shows tinted concentric bands (seen on the 4C, hidden
+ * on a star-noisy frame). The offsets run 0..7 (5-bit channels) and 0..3
+ * (6-bit), so the rounded-down result averages to the source value instead
+ * of sitting half a quantum dark. */
+static const uint8_t s_bayer4[4][4] = {
+    { 0,  8,  2, 10 },
+    { 12, 4, 14,  6 },
+    { 3, 11,  1,  9 },
+    { 15, 7, 13,  5 },
+};
+
 static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
                                        uint8_t **out_buf, uint32_t *out_w,
                                        uint32_t *out_h, size_t *out_size)
@@ -428,8 +442,8 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
                  px[(size_t)(h / 2) * pad_w + w / 2]);
     }
 
-    /* GRAY8 -> RGB565 into a tight w*h*2 buffer (the padded GRAY8 one is freed),
-     * using the same grey expansion the thumbnail path uses. */
+    /* GRAY8 -> RGB565 into a tight w*h*2 buffer (the padded GRAY8 one is freed).
+     * The expansion is ordered-dithered with s_bayer4 above, not truncated. */
     if (is_gray) {
         size_t rgb_sz = (((size_t)w * h * 2) + 127) & ~(size_t)127;
         uint8_t *rgb = heap_caps_aligned_calloc(128, 1, rgb_sz, MALLOC_CAP_SPIRAM);
@@ -440,10 +454,16 @@ static esp_err_t jpeg_hw_decode_rgb565(const uint8_t *jpg, size_t len,
         uint16_t *d = (uint16_t *)rgb;
         for (uint32_t y = 0; y < h; y++) {
             const uint8_t *srow = buf + (size_t)y * pad_w;
+            const uint8_t *th   = s_bayer4[y & 3];
             uint16_t *drow = d + (size_t)y * w;
             for (uint32_t x = 0; x < w; x++) {
-                uint8_t g = srow[x];
-                drow[x] = (uint16_t)(((g >> 3) << 11) | ((g >> 2) << 5) | (g >> 3));
+                int g  = srow[x];
+                int t  = th[x & 3];
+                int r5 = g + (t >> 1);          /* +0..7 before the >> 3 */
+                int g6 = g + (t >> 2);          /* +0..3 before the >> 2 */
+                if (r5 > 255) r5 = 255;
+                if (g6 > 255) g6 = 255;
+                drow[x] = (uint16_t)(((r5 >> 3) << 11) | ((g6 >> 2) << 5) | (r5 >> 3));
             }
         }
         heap_caps_free(buf);

--- a/main/jpeg_utils.h
+++ b/main/jpeg_utils.h
@@ -40,15 +40,19 @@ bool jpeg_sw_decode_rgb565(const uint8_t *jpg_data, size_t jpg_size,
  * Tries the HW decoder for baseline JPEG and falls back to
  * jpeg_sw_decode_rgb565() for anything it refuses (progressive, CMYK, grayscale,
  * odd sampling, engine busy/out of memory) and for the non-JPEG formats stb
- * handles (PNG, GIF). The HW path avoids stb's RGB888 intermediate (~1.55 MB at
- * 720x720), which is what makes the image pages fit in a fragmented PSRAM heap.
+ * handles (PNG, GIF). The HW path decodes RGB888 (~1.55 MB at 720x720) but packs
+ * it to RGB565 in place and trims the block, so unlike stb it never holds the
+ * two at once, which is what makes the image pages fit in a fragmented PSRAM heap.
  *
  * Output contract is identical to jpeg_sw_decode_rgb565(): tightly packed
  * RGB565 rows top-down, out_w/out_h are the image's real pixel dimensions (the
  * HW MCU padding is removed), 128-byte aligned PSRAM, caller frees with free().
- * *out_size is the ALLOCATION size, which on the HW path is the MCU-padded
- * decoder buffer (larger than w*h*2); never derive a stride or a pixel count
- * from it, use out_w/out_h. Needs about 10 KB of caller stack.
+ * *out_size is the ALLOCATION size (w*h*2 rounded up to 128 B once the HW
+ * path has packed and trimmed its decode buffer, but never assume that);
+ * never derive a stride or a pixel count from it, use out_w/out_h. Both HW
+ * paths (GRAY8 and RGB888) pack to RGB565 through a 4x4 ordered dither, so a
+ * smooth gradient does not band on the 5/6-bit panel. Needs about 10 KB of
+ * caller stack.
  *
  * @return true on success (from either path)
  */

--- a/main/nina_client.c
+++ b/main/nina_client.c
@@ -787,6 +787,11 @@ void nina_client_poll_background(const char *base_url, nina_client_t *data, nina
     } else {
         // Camera-only heartbeat for connection status
         fetch_camera_info_robust(base_url, data);
+        /* Plus the safety monitor (~1 KB): the breach engine in tasks.c evaluates
+         * every connected rig, and a WS SAFETY-CHANGED safe edge is not
+         * guaranteed after a monitor reconnect, so a background rig must refresh
+         * its own state or it re-announces a stale "unsafe" forever. */
+        fetch_safety_monitor_info(base_url, data);
     }
 
     nina_client_register(instance, data);

--- a/main/nina_websocket.c
+++ b/main/nina_websocket.c
@@ -293,6 +293,18 @@ static void record_disconnect_event(int index, equipment_type_t eq) {
     const app_config_t *cfg = app_config_get();
     int64_t now = esp_timer_get_time() / 1000;
 
+    /* Safety monitor gone: stop feeding the breach engine (tasks.c) a state
+     * that no longer exists.  Done before the aggregation branch so both the
+     * deferred and the immediate path clear it; the next successful safety
+     * fetch (active bundle or background poll) re-sets safety_connected. */
+    if (eq == EQ_SAFETY) {
+        nina_client_t *sd = ws_client_data[index];
+        if (sd && nina_client_lock(sd, 50)) {
+            sd->safety_connected = false;
+            nina_client_unlock(sd);
+        }
+    }
+
     /* When aggregation is enabled, defer disconnects to the window boundary */
     if (cfg->toast_aggregation_window_s > 0) {
         bool start_timer = false;

--- a/main/ui/nina_dashboard_internal.h
+++ b/main/ui/nina_dashboard_internal.h
@@ -228,8 +228,9 @@ typedef struct dashboard_page_s {
             lv_obj_t *row_vals;      /* row 2: RMS | hero seconds | HFR */
             lv_obj_t *lbl_rms_cap;
             lv_obj_t *lbl_rms;
-            lv_obj_t *lbl_hero;      /* hero digits, hanken_bold_64 */
+            lv_obj_t *lbl_hero;      /* hero digits, hanken_bold_64, steps to _44 when the row is tight */
             lv_obj_t *lbl_hero_unit; /* "s", and the idle "--" */
+            int       hero_avail;    /* px the hero digits may take before the face steps down */
             lv_obj_t *lbl_hfr_cap;
             lv_obj_t *lbl_hfr;
             lv_obj_t *row_meta;      /* row 3: filter name + sub counter */

--- a/main/ui/nina_round_overlay.c
+++ b/main/ui/nina_round_overlay.c
@@ -26,6 +26,7 @@
 LV_FONT_DECLARE(lv_font_material_safety);
 LV_FONT_DECLARE(lv_font_hanken_bold_64);
 LV_FONT_DECLARE(lv_font_hanken_bold_28);
+LV_FONT_DECLARE(lv_font_hanken_bold_44);
 
 /* ---- design tokens ------------------------------------------------------ */
 
@@ -43,7 +44,7 @@ LV_FONT_DECLARE(lv_font_hanken_bold_28);
 #define ROV_ROW3_DY       122    /* filter + counter */
 
 #define ROV_NAME_PAD       48    /* chord at the name row minus this */
-#define ROV_VALS_PAD       60    /* chord at the value row minus this */
+#define ROV_VALS_PAD       44    /* chord at the value row minus this; 44 keeps the 64 px hero for three digits on the 720 disc */
 #define ROV_META_GAP       18
 #define ROV_HERO_GAP        4    /* digits to the "s" */
 #define ROV_CAP_GAP         6    /* caption to its value, on one baseline */
@@ -60,6 +61,16 @@ LV_FONT_DECLARE(lv_font_hanken_bold_28);
 #define ROV_LADDER_FILTER_N 2
 static const lv_font_t *const ROV_LADDER_FILTER[ROV_LADDER_FILTER_N] = {
     &lv_font_montserrat_28, &lv_font_montserrat_24,
+};
+
+/* The hero digits step down one face when they would run into the RMS and
+ * HFR cells: three digits fit the 64 px face on both discs, four digits fit
+ * it on the 800 disc only. hanken_bold_44 is a DIGIT-ONLY subset, which is
+ * fine here because the digit cell never holds anything but digits (the idle
+ * "--" lives in the unit label); never put a mixed string in it. */
+#define ROV_LADDER_HERO_N 2
+static const lv_font_t *const ROV_LADDER_HERO[ROV_LADDER_HERO_N] = {
+    &lv_font_hanken_bold_64, &lv_font_hanken_bold_44,
 };
 
 /* Material Symbols codepoints (UTF-8), the same glyphs every other page uses. */
@@ -213,6 +224,16 @@ static void rov_elapsed_cb(dashboard_page_t *p, int secs)
             snprintf(buf, sizeof(buf), "%d", secs);
         }
         ui_label_set_text(p->alt.ov.lbl_hero, buf);
+        /* Step the face down before the digits reach the side cells. Every
+         * face is kept on the 64 px baseline the unit and the side cells are
+         * already lifted to, so the row never wobbles when the face changes. */
+        ui_fit_label_font(p->alt.ov.lbl_hero, ROV_LADDER_HERO, ROV_LADDER_HERO_N,
+                          p->alt.ov.hero_avail);
+        const lv_font_t *pick = lv_obj_get_style_text_font(p->alt.ov.lbl_hero, 0);
+        int lift = pick->base_line - ROV_FONT_HERO->base_line;
+        if (lv_obj_get_style_translate_y(p->alt.ov.lbl_hero, 0) != lift) {
+            lv_obj_set_style_translate_y(p->alt.ov.lbl_hero, lift, 0);
+        }
     }
     /* The unit carries the idle marker, so the digit cell only ever holds
      * digits and a layout hero in a digits-only face can mirror it verbatim. */
@@ -315,6 +336,20 @@ void nina_round_overlay_create(dashboard_page_t *p, lv_obj_t *parent, int page_i
          * the rim arc (seen on the 800 panel). */
         const int avail = rov_row_avail(plate_top + ROV_ROW2_DY + row_h,
                                         ROV_VALS_PAD);
+        /* Width left for the hero once both side cells hold their widest
+         * sane reading ("HFR" is the wider caption, 9.99" the widest value a
+         * guided rig shows), with one ROV_HERO_GAP of air on each side. */
+        {
+            lv_point_t cap = { 0, 0 }, val = { 0, 0 };
+            lv_text_get_size(&cap, "HFR", ROV_FONT_CAP, 0, 0, LV_COORD_MAX,
+                             LV_TEXT_FLAG_NONE);
+            lv_text_get_size(&val, "9.99\"", ROV_FONT_VAL, 0, 0, LV_COORD_MAX,
+                             LV_TEXT_FLAG_NONE);
+            p->alt.ov.hero_avail = avail
+                - 2 * ((int)cap.x + ROV_CAP_GAP + (int)val.x)
+                - 2 * ROV_HERO_GAP;
+            if (p->alt.ov.hero_avail < 60) p->alt.ov.hero_avail = 60;
+        }
         p->alt.ov.row_vals = lv_obj_create(parent);
         lv_obj_remove_style_all(p->alt.ov.row_vals);
         lv_obj_remove_flag(p->alt.ov.row_vals, LV_OBJ_FLAG_SCROLLABLE);

--- a/main/ui/nina_summary.c
+++ b/main/ui/nina_summary.c
@@ -88,6 +88,72 @@ static inline void set_bg_opa_cached(lv_obj_t *obj, lv_opa_t *cached, lv_opa_t o
     }
 }
 
+/* ── Round band: name shortening and the composed reading row ──────── */
+
+/* Recolour pieces for the round reading row. The separator is the built-in
+ * Montserrat bullet U+2022; U+00B7 is NOT in the built-in faces' glyph set. */
+#define SR_ROW_DIM  "#55555C "
+#define SR_ROW_SEP  " #55555C \xE2\x80\xA2# "
+
+/**
+ * @brief Shorten a rig name for the round band.
+ *
+ * Takes the telescope name (falling back the same way the square card does),
+ * cuts it at the SECOND underscore when there is one, then spells the rest with
+ * spaces: Askar_140APO_ASI2600MM reads "Askar 140APO", RedCat51_ASI183MM reads
+ * "RedCat51".
+ */
+static void summary_round_short_name(const nina_client_t *d,
+                                     const char *fallback_host,
+                                     char *out, size_t n) {
+    if (!out || n == 0) return;
+    const char *src;
+    if (d->telescope_name[0])      src = d->telescope_name;
+    else if (d->camera_name[0])    src = d->camera_name;
+    else if (d->profile_name[0])   src = d->profile_name;
+    else if (fallback_host && fallback_host[0]) src = fallback_host;
+    else                           src = "N.I.N.A.";
+
+    strlcpy(out, src, n);
+
+    char *u = strchr(out, '_');
+    if (u) {
+        u = strchr(u + 1, '_');
+        if (u) *u = '\0';
+    }
+    for (char *p = out; *p; p++) {
+        if (*p == '_') *p = ' ';
+    }
+}
+
+#if CONFIG_NINA_FAMILY_ROUND
+/**
+ * @brief Build the round band's one reading row from its four cached parts.
+ *
+ * "RMS" and the separators are dim, the sub count and the exposure seconds take
+ * the theme text colour, the filter name arrives already recoloured, and HFR
+ * falls through to the label's own colour.
+ */
+static void summary_round_compose_row(summary_card_t *sc) {
+    if (!sc->lbl_row || !current_theme) return;
+    int gb = app_config_get()->color_brightness;
+    unsigned long tc = (unsigned long)app_config_apply_brightness(
+        current_theme->text_color, gb);
+
+    char buf[256];
+    snprintf(buf, sizeof(buf),
+             SR_ROW_DIM "RMS#" SR_ROW_SEP "#%06lX %s#" SR_ROW_SEP "#%06lX %s#"
+             SR_ROW_SEP "%s" SR_ROW_SEP "%s",
+             tc, sc->round_subs, tc, sc->round_time,
+             sc->round_filter, sc->round_hfr);
+
+    set_label_if_changed(sc->lbl_row, buf);
+    nina_summary_round_fit_row(sc, buf);
+}
+#else
+static inline void summary_round_compose_row(summary_card_t *sc) { (void)sc; }
+#endif
+
 /* ── Safety icon glyphs (Material Symbols, UTF-8) ─────────────────── */
 #define ICON_VERIFIED_USER  "\xee\xa3\xa8"  /* U+E8E8 — shield + check */
 #define ICON_GPP_BAD        "\xef\x80\x92"  /* U+F012 — shield + X     */
@@ -192,6 +258,7 @@ static void bar_reset_exposure_state(summary_card_t *sc) {
     sc->cached_nina_mono_us = 0;
     if (sc->bar_progress) set_bar_if_changed(sc->bar_progress, 0, LV_ANIM_OFF);
     if (sc->lbl_pct)      set_label_if_changed(sc->lbl_pct, "");
+    strlcpy(sc->round_time, "--", sizeof(sc->round_time));
 }
 
 /* Scaled copy of arc_start_exposure_anim (nina_dashboard_update.c). Drives one
@@ -265,6 +332,21 @@ static void summary_bar_interp_cb(lv_timer_t *timer) {
          * card's bar, from this one timer. */
         if (sc->ring.cont) {
             nina_subbar_set_progress(&sc->ring, elapsed / sc->cached_total);
+
+            /* The round band's exposure seconds. Recomposed only when the whole
+             * integer second moves, not on every 200 ms tick. */
+            int es = (int)elapsed;
+            int ts = (int)sc->cached_total;
+            if (es < 0) es = 0;
+            if (es > 9999) es = 9999;
+            if (ts < 0) ts = 0;
+            if (ts > 9999) ts = 9999;
+            char t[28];
+            snprintf(t, sizeof(t), "%d/%d s", es, ts);
+            if (strcmp(t, sc->round_time) != 0) {
+                strlcpy(sc->round_time, t, sizeof(sc->round_time));
+                summary_round_compose_row(sc);
+            }
         }
 
         if (!sc->bar_progress) continue;
@@ -1120,8 +1202,17 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
             continue;
         }
 
-        /* Instance name — telescope + camera, fallback to profile, then host */
-        if (d->telescope_name[0] && d->camera_name[0]) {
+        /* Instance name: telescope + camera, fallback to profile, then host.
+         * The round band has one short line instead: the scope, cut at its
+         * second underscore. */
+        if (sc->ring.cont) {
+            const char *url = app_config_get_instance_url(i);
+            char host[64] = {0};
+            extract_host_from_url(url, host, sizeof(host));
+            char shortname[72];
+            summary_round_short_name(d, host, shortname, sizeof(shortname));
+            set_label_if_changed(sc->lbl_name, shortname);
+        } else if (d->telescope_name[0] && d->camera_name[0]) {
             char combined[128];
             snprintf(combined, sizeof(combined), "%s | %s", d->telescope_name, d->camera_name);
             set_label_if_changed(sc->lbl_name, combined);
@@ -1139,13 +1230,11 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
         }
 
         /* Name color: theme header color (always connected at this point).
-         * The radial card draws the identity dim and the target bright, so the
-         * hierarchy reads on a 326 px chord; ring.cont is the round marker. */
-        if (current_theme) {
-            uint32_t name_color = app_config_apply_brightness(
-                sc->ring.cont ? current_theme->label_color
-                              : current_theme->header_text_color, gb);
-            set_text_color_cached(sc->lbl_name, &sc->cached_name_color, name_color);
+         * The round band takes the ring colour instead, written further down
+         * where the ring has just told us what it drew with. */
+        if (current_theme && !sc->ring.cont) {
+            set_text_color_cached(sc->lbl_name, &sc->cached_name_color,
+                app_config_apply_brightness(current_theme->header_text_color, gb));
         }
 
         /* Filter badge. The round card has none: its ring carries the filter
@@ -1177,6 +1266,15 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                     current_theme ? current_theme->bento_bg : 0x000000, 0);
                 set_bg_opa_cached(sc->filter_box, &sc->cached_filter_bg_opa, LV_OPA_50, 0);
             }
+        } else if (sc->ring.cont && current_theme) {
+            /* The round band spends the filter as one recoloured word inside
+             * its reading row, on the same colour rule as the badge. */
+            uint32_t fc = theme_is_red_night(current_theme)
+                ? 0 : app_config_get_filter_color(d->current_filter, i);
+            if (fc == 0 || !d->current_filter[0]) fc = current_theme->label_color;
+            snprintf(sc->round_filter, sizeof(sc->round_filter), "#%06lX %s#",
+                     (unsigned long)app_config_apply_brightness(fc, gb),
+                     d->current_filter[0] ? d->current_filter : "--");
         }
 
         /* Target name */
@@ -1185,6 +1283,9 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
         } else {
             set_label_if_changed(sc->lbl_target, "Idle");
         }
+#if CONFIG_NINA_FAMILY_ROUND
+        if (sc->ring.cont) nina_summary_round_fit_target(sc);
+#endif
 
         if (current_theme) {
             uint32_t tgt_color = app_config_apply_brightness(
@@ -1241,6 +1342,13 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                     lv_anim_start(&a);
                 }
                 if (sc->lbl_pct) SET_LABEL_FMT_IF_CHANGED(sc->lbl_pct, 8, "%d%%", 100);
+                if (sc->ring.cont) {
+                    int ts = (int)sc->cached_total;
+                    if (ts < 0) ts = 0;
+                    if (ts > 9999) ts = 9999;
+                    snprintf(sc->round_time, sizeof(sc->round_time),
+                             "%d/%d s", ts, ts);
+                }
             }
 
             if (d->exposure_total > 0 && d->exposure_end_epoch > 0 && d->is_exposing) {
@@ -1355,6 +1463,9 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                             lv_anim_start(&a);
                         }
                         if (sc->lbl_pct) set_label_if_changed(sc->lbl_pct, "");
+                        if (sc->ring.cont) {
+                            strlcpy(sc->round_time, "--", sizeof(sc->round_time));
+                        }
                     }
                     /* else: within grace — hold, do nothing. */
                 } else {
@@ -1368,6 +1479,9 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                         set_bar_if_changed(sc->bar_progress, 0, LV_ANIM_OFF);
                     }
                     if (sc->lbl_pct) set_label_if_changed(sc->lbl_pct, "");
+                    if (sc->ring.cont) {
+                        strlcpy(sc->round_time, "--", sizeof(sc->round_time));
+                    }
                 }
             }
         }
@@ -1377,6 +1491,23 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
          * snap lands before this update moves the fill on (I-1), matching the
          * Dashboard's order in nina_dashboard_update.c. */
         if (sc->ring.cont) nina_subbar_update(&sc->ring, d, i, gb);
+
+        /* The band's colour line and rig name carry the ring colour, so the
+         * band and its ring read as one rig. The subbar has just resolved the
+         * filter colour it drew with, so take it from there rather than
+         * computing a second answer that could disagree. */
+        if (sc->ring.cont && current_theme) {
+            uint32_t ring_col = sc->ring.cached_block_color;
+            if (ring_col == 0) {
+                ring_col = app_config_apply_brightness(current_theme->label_color, gb);
+            }
+            if (sc->tick) {
+                set_bg_color_cached(sc->tick, &sc->cached_tick_color, ring_col, 0);
+            }
+            if (sc->lbl_name) {
+                set_text_color_cached(sc->lbl_name, &sc->cached_name_color, ring_col);
+            }
+        }
 
         /* Progress bar color: filter color or theme progress */
         if (sc->bar_progress) {
@@ -1447,10 +1578,27 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
             }
         }
 
-        /* RMS */
+        /* Sub count on the round band, the figure the square card spends on
+         * lbl_exp_val. Clamped so the format cannot outrun the buffer. */
+        if (sc->ring.cont) {
+            int done = d->exposure_count;
+            int want = d->exposure_iterations;
+            if (done < 0) done = 0;
+            if (done > 9999) done = 9999;
+            if (want < 0) want = 0;
+            if (want > 9999) want = 9999;
+            snprintf(sc->round_subs, sizeof(sc->round_subs), "%d/%d", done, want);
+        }
+
+        /* RMS. The round band drops the arcsecond mark: the row already says
+         * RMS, and the mark costs width the rest of the row needs. */
         if (d->guider.rms_total > 0.001f) {
             char buf[16];
-            snprintf(buf, sizeof(buf), "%.2f\"", d->guider.rms_total);
+            if (sc->ring.cont) {
+                snprintf(buf, sizeof(buf), "%.2f", d->guider.rms_total);
+            } else {
+                snprintf(buf, sizeof(buf), "%.2f\"", d->guider.rms_total);
+            }
             set_label_if_changed(sc->lbl_rms_val, buf);
             uint32_t rms_col = theme_is_red_night(current_theme)
                 ? 0 : app_config_get_rms_color(d->guider.rms_total, i);
@@ -1469,18 +1617,7 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
             }
         }
 
-        /* Bullseye dot: distance from centre is the value against its
-         * configured tolerance (ok_max), clamped by ui_dial_place_dot so an
-         * out-of-tolerance value stays on the card. */
-        if (sc->rms_dot && sc->rms_bull) {
-            threshold_config_t t;
-            app_config_get_rms_threshold_config(i, &t);
-            float lim = (t.ok_max > 0.01f) ? t.ok_max : 1.0f;
-            float ratio = (d->guider.rms_total > 0.0f) ? d->guider.rms_total / lim : 0.0f;
-            ui_dial_place_dot(sc->rms_dot, sc->rms_bull, ratio, SR_BEARING_RMS);
-        }
-
-        /* HFR. The round card shows it as a bullseye only, with no figure. */
+        /* HFR. The round band writes it into the reading row instead. */
         if (sc->lbl_hfr_val) {
             if (d->hfr > 0.001f) {
                 char buf[16];
@@ -1502,15 +1639,18 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                         app_config_apply_brightness(current_theme->text_color, gb));
                 }
             }
+        } else if (sc->ring.cont) {
+            if (d->hfr > 0.001f) {
+                snprintf(sc->round_hfr, sizeof(sc->round_hfr), "HFR %.2f", d->hfr);
+            } else {
+                strlcpy(sc->round_hfr, "HFR --", sizeof(sc->round_hfr));
+            }
         }
 
-        if (sc->hfr_dot && sc->hfr_bull) {
-            threshold_config_t t;
-            app_config_get_hfr_threshold_config(i, &t);
-            float lim = (t.ok_max > 0.01f) ? t.ok_max : 3.5f;
-            float ratio = (d->hfr > 0.0f) ? d->hfr / lim : 0.0f;
-            ui_dial_place_dot(sc->hfr_dot, sc->hfr_bull, ratio, SR_BEARING_HFR);
-        }
+        /* The round band's reading row is composed last: the RMS figure, the
+         * sub count, the filter and HFR are all settled by here, and the row is
+         * fitted against whatever width the RMS figure left. */
+        if (sc->ring.cont) summary_round_compose_row(sc);
 
         /* Time to flip, "HH:MM:SS" formatted as "Xh XXm". The round card has no
          * figure: the parsed minutes go to the tick on its rim ring. */
@@ -1614,27 +1754,6 @@ void summary_page_update(const nina_client_t *instances, int count, const bool *
                     theme_is_red_night(current_theme) ? current_theme->label_color : 0x999999);
             }
         }
-
-        /* Safety crown. A sibling of the block above, never inside it: the
-         * round card draws the crown INSTEAD of lbl_safety, so a crown paint
-         * nested in that branch would never run. */
-        if (sc->ring_crown && current_theme) {
-            uint32_t crown;
-            if (!d->safety_connected)   crown = theme_is_red_night(current_theme)
-                                                ? current_theme->label_color : 0x999999;
-            else if (d->safety_is_safe) crown = theme_is_red_night(current_theme)
-                                                ? 0x7f1d1d : 0x4CAF50;
-            else                        crown = theme_is_red_night(current_theme)
-                                                ? 0xff0000 : 0xF44336;
-            crown = app_config_apply_brightness(crown, gb);
-            /* Every lv_obj_set_style_* call invalidates whether or not the
-             * value changed, and an invalidation is a full-frame redraw here. */
-            if (sc->cached_safety_color != crown) {
-                sc->cached_safety_color = crown;
-                lv_obj_set_style_arc_color(sc->ring_crown, lv_color_hex(crown),
-                                           LV_PART_MAIN);
-            }
-        }
     }
 }
 
@@ -1668,6 +1787,7 @@ void summary_page_apply_theme(void) {
         sc->cached_flip_color       = UINT32_MAX;
         sc->cached_detail_color     = UINT32_MAX;
         sc->cached_safety_color     = UINT32_MAX;
+        sc->cached_tick_color       = UINT32_MAX;
     }
 
     /* Update per-card widgets */
@@ -1693,21 +1813,19 @@ void summary_page_apply_theme(void) {
                 lv_color_hex(current_theme->bento_border), 0);
         }
 
-        /* Round shape handles (radial board 3). All NULL on square. The crown
-         * repaints on the next poll, from the cache cleared above. */
+        /* Round shape handles. All NULL on square. The band's colour line and
+         * rig name repaint on the next poll, from the caches cleared above. */
         if (sc->ring.cont) nina_subbar_apply_theme(&sc->ring);
         if (sc->ring_flip_tick) {
             lv_obj_set_style_arc_color(sc->ring_flip_tick,
                 lv_color_hex(app_config_apply_brightness(current_theme->text_color, gb)),
                 LV_PART_MAIN);
         }
-        if (sc->rms_dot) {
-            lv_obj_set_style_bg_color(sc->rms_dot,
-                lv_color_hex(app_config_apply_brightness(current_theme->rms_color, gb)), 0);
-        }
-        if (sc->hfr_dot) {
-            lv_obj_set_style_bg_color(sc->hfr_dot,
-                lv_color_hex(app_config_apply_brightness(current_theme->hfr_color, gb)), 0);
+        if (sc->lbl_row) {
+            /* The row's own colour is what HFR falls through to; every other
+             * part of it carries a recolour tag rebuilt on the next compose. */
+            lv_obj_set_style_text_color(sc->lbl_row,
+                lv_color_hex(app_config_apply_brightness(current_theme->label_color, gb)), 0);
         }
     }
 

--- a/main/ui/nina_summary_internal.h
+++ b/main/ui/nina_summary_internal.h
@@ -11,17 +11,11 @@
  * tell. Only included by nina_summary.c and nina_summary_round.c.
  */
 
+#include <stdint.h>
+
 #include "lvgl.h"
 
 #include "nina_subbar.h"
-
-/* Bullseye bearings on the round card, degrees clockwise from twelve o'clock
- * (radial.html board 3). Single owner shared by the builder
- * (nina_summary_round.c) and the update path (nina_summary.c); the round
- * Dashboard uses the same pair under its own name, so a dot's direction means
- * the same thing on both boards. */
-#define SR_BEARING_RMS  305
-#define SR_BEARING_HFR  125
 
 /* ── Per-card widget references ────────────────────────────────────── */
 typedef struct {
@@ -80,20 +74,28 @@ typedef struct {
     uint32_t cached_hfr_color;
     uint32_t cached_flip_color;
     uint32_t cached_detail_color;
-    /* Safety state colour. The square card spends it on lbl_safety, the round
-     * card on ring_crown; exactly one of the two handles exists per card, so
-     * the two writers never collide. */
+    /* Safety state colour, for the square card's lbl_safety. The round band
+     * draws no safety glyph of its own. */
     uint32_t cached_safety_color;
 
-    /* Round shape handles (radial board 3). NULL on the square card; the
+    /* Round shape handles (board "Bands A"). NULL on the square card; the
      * update path drives each one only when it is set. */
     nina_subbar_t ring;            /* this rig's concentric sub-block ring */
-    lv_obj_t *ring_crown;          /* safety crown at twelve o'clock */
+    lv_obj_t *ring_crown;          /* retired: never built, kept as a null check */
     lv_obj_t *ring_flip_tick;      /* meridian flip tick on the same ring */
-    lv_obj_t *rms_bull;
-    lv_obj_t *rms_dot;
-    lv_obj_t *hfr_bull;
-    lv_obj_t *hfr_dot;
+    lv_obj_t *tick;                /* colour line at the top of the band */
+    lv_obj_t *lbl_row;             /* the recoloured reading row */
+    uint32_t  cached_tick_color;
+    int       round_target_w;      /* target line width: the chord at that line's far edge */
+    int       round_row_w;         /* reading row width: the chord at that row's far edge */
+    /* Reading-row parts, filled by the update path under the data lock and by
+     * the interpolation tick, then composed into lbl_row's one recoloured
+     * string. The round card leaves lbl_exp_val, lbl_filter and lbl_hfr_val
+     * NULL and fills these instead. */
+    char round_subs[24];           /* "4/10" */
+    char round_filter[48];         /* already recoloured, e.g. "#00E5FF Oiii#" */
+    char round_hfr[24];            /* "HFR 1.67" */
+    char round_time[28];           /* "137/300 s", or "--" when not exposing */
 } summary_card_t;
 
 /* The shipped glass card style, owned and re-themed by nina_summary.c. */
@@ -112,10 +114,30 @@ void summary_bind_card_tap(lv_obj_t *card, int instance_index);
 void nina_summary_round_create_card(summary_card_t *sc, lv_obj_t *parent, int slot);
 
 /**
- * @brief Rank the shown rigs outward (round family only).
+ * @brief Rank the shown rigs outward and stack their bands (round family only).
  *
  * Online rigs take the outermost rings in slot order: with rigs 1 and 2
- * offline, rig 3 sits on the rim ring instead of two pitches in. Called once
- * per summary update after visibility is settled; @p shown is indexed by slot.
+ * offline, rig 3 sits on the rim ring instead of two pitches in. The same rank
+ * places that rig's band on the vertical centre line and cuts each text line
+ * to the chord at its own far edge. Called once per summary update after visibility is
+ * settled; @p shown is indexed by slot.
  */
 void nina_summary_round_place_rings(summary_card_t *cards, const bool *shown);
+
+/**
+ * @brief Fit the target line to the band width (round family only).
+ *
+ * Call right after writing sc->lbl_target. Bold 28 down to regular 20, then
+ * dots. LVGL lock held by caller.
+ */
+void nina_summary_round_fit_target(summary_card_t *sc);
+
+/**
+ * @brief Fit the reading row beside the RMS figure (round family only).
+ *
+ * @p text is the string just written to sc->lbl_row. It is passed in rather
+ * than read back because the row carries recolour tags (which the shared
+ * fitter would measure as glyphs) and because LVGL rewrites an ellipsised
+ * label's text in place. LVGL lock held by caller.
+ */
+void nina_summary_round_fit_row(summary_card_t *sc, const char *text);

--- a/main/ui/nina_summary_round.c
+++ b/main/ui/nina_summary_round.c
@@ -1,14 +1,17 @@
 /**
  * @file nina_summary_round.c
- * @brief Summary page on a round panel: radial board 3.
+ * @brief Summary page on a round panel: stacked bands (board "Bands A").
  *
- * Three stacked cards on a circle would hand the top and bottom rigs the two
- * worst chords, so every quantity moves to a ring instead: one concentric ring
- * per rig, outermost is slot 0, carrying sub blocks for progress, the filter
- * colour, a crown at twelve o'clock for safety and a tick for meridian flip.
- * The cards keep their glass and their tap to open but shed every number the
- * ring already tells, and each is cut to the chord it sits on, so the stack
- * reads as a diamond: narrow, wide, narrow.
+ * Three thin rings sit tight to the glass, one per shown rig, outermost first,
+ * each carrying that rig's exposure progress in its filter colour with the sub
+ * blocks the subbar draws plus a meridian flip tick. Everything else is text,
+ * stacked on the vertical centre line as one band per rig: a short colour line,
+ * the rig name in the ring colour, the target as the big line, and one reading
+ * row holding RMS, sub count, exposure seconds, filter and HFR.
+ *
+ * A band is a plain transparent container. It is still the tap target that
+ * opens that rig's page, it just draws nothing of its own; the picture is the
+ * text and the rings.
  *
  * The page owns the data and the colours; this file creates and places widgets.
  * Runs with the LVGL display lock held by the caller.
@@ -24,48 +27,79 @@
 #include "ui_dial.h"
 #include "ui_helpers.h"
 #include "ui_round.h"
+#include "ui_text_fit.h"
+
+LV_FONT_DECLARE(lv_font_montserrat_bold_22);
+LV_FONT_DECLARE(lv_font_montserrat_bold_28);
+LV_FONT_DECLARE(lv_font_hanken_bold_28);
 
 /* -- design tokens -------------------------------------------------------- */
 
-#define SR_RING_PITCH     28    /* between ring centre lines */
-#define SR_RING_OFF       12    /* outermost ring, offset from the rim radius */
-#define SR_RING_W         14
-#define SR_CROWN_DEG      30
-#define SR_TICK_W         24
+#define SR_RING_PITCH     16    /* between ring centre lines */
+#define SR_RING_OFF        6    /* outermost ring, offset from the rim radius */
+#define SR_RING_W         10
+#define SR_TICK_W         18    /* meridian flip tick, stroke width */
 
-#define SR_CARD_H        120
-#define SR_CARD_GAP       12
-#define SR_CARD_PAD       22
-#define SR_CARD_EDGE      12    /* keep a card's corners off the inner ring */
+/* Band stack. The pitch is the same on both panel sizes: the 800 px panel has
+ * 40 px more radius, and it spends all of it on chord width, not on taller
+ * bands. Three bands span 2 * 158 + 124 = 440 px, which fits inside the
+ * innermost ring on both (2 * 306 = 612 at 720, 2 * 346 = 692 at 800).
+ * At 720 the top band's target line gets 470 px and its reading row 524; the
+ * bottom band 484 and 424; the centre band 576 (800: 566/612, 578/528, 658). */
+#define SR_BAND_PITCH    158
+#define SR_BAND_H        112    /* the band's nominal height; each line is cut to its own chord */
+#define SR_BAND_BOX      124    /* the object: 12 px taller so the 28 px reading
+                                 * row is not clipped by the parent's edge */
+#define SR_BAND_EDGE      12    /* keep a band's corners off the inner ring */
+#define SR_BAND_MIN_W    120
 
-#define SR_BULL_R         26
-#define SR_BULL_DOT       10
-#define SR_BULL_INSET     48    /* bullseye centre from the card's near edge */
-#define SR_ROW1_DY        20    /* identity row top, from the card top */
-#define SR_BULL_DY        76    /* bullseye centre, from the card top */
+#define SR_LINE_W        150    /* the colour line at the top of a band */
+#define SR_LINE_H          2
 
-#define SR_FONT_IDENT    (&lv_font_montserrat_28)
-#define SR_FONT_TARGET   (&lv_font_montserrat_28)
-#define SR_FONT_VALUE    (&lv_font_montserrat_40)
+#define SR_NAME_DY         8
+#define SR_TGT_DY         34
+#define SR_ROW_DY         78
+#define SR_ROW_GAP        10    /* between the RMS figure and the rest of the row */
 
-#define SR_RING_BORDER    0x262a30
+/* Target ladder: bold first, then the regular faces below it. */
+#define SR_LADDER_TARGET_N 3
+static const lv_font_t *const SR_LADDER_TARGET[SR_LADDER_TARGET_N] = {
+    &lv_font_montserrat_bold_28, &lv_font_montserrat_24, &lv_font_montserrat_20,
+};
 
-/* Inner edge of the innermost ring: every card corner stays inside it. */
+/* Reading row ladder. HFR sits at the end of the row, so it is what the dots
+ * eat when even the smallest face overflows. */
+#define SR_LADDER_ROW_N 3
+static const lv_font_t *const SR_LADDER_ROW[SR_LADDER_ROW_N] = {
+    &lv_font_montserrat_20, &lv_font_montserrat_18, &lv_font_montserrat_16,
+};
+
+/* -- geometry ------------------------------------------------------------- */
+
+/* Inner edge of the innermost ring: every band corner stays inside it. */
 static int sr_inner_radius(void) {
     return ui_rim_radius() - SR_RING_OFF - 2 * SR_RING_PITCH - SR_RING_W;
 }
 
-/* Half width of a card whose furthest corner is dy_max from the panel centre. */
-static int sr_card_half(int dy_max) {
+/* Half chord of the inner circle at vertical offset dy from the panel centre. */
+static int sr_inner_half(int dy) {
     int rc = sr_inner_radius();
-    if (dy_max < 0) dy_max = -dy_max;
-    if (dy_max >= rc) return 0;
-    return (int)sqrtf((float)(rc * rc - dy_max * dy_max)) - SR_CARD_EDGE;
+    if (dy < 0) dy = -dy;
+    if (dy >= rc) return 0;
+    return (int)sqrtf((float)(rc * rc - dy * dy));
 }
 
 /* Ring radius for the k-th shown rig, outermost first. */
 static int sr_ring_radius(int rank) {
     return ui_rim_radius() - SR_RING_OFF - rank * SR_RING_PITCH;
+}
+
+/* Band centre offset from the panel centre for the k-th shown rig of n.
+ * One rig sits on the centre line, two straddle it, three stack on the pitch. */
+static int sr_band_dy(int rank, int n) {
+    if (n <= 1) return 0;
+    if (n == 2) return (rank == 0) ? -SR_BAND_PITCH / 2 : SR_BAND_PITCH / 2;
+    return (rank - 1) * SR_BAND_PITCH;
 }
 
 static void sr_arc_set_radius(lv_obj_t *arc, int r, int width) {
@@ -75,66 +109,141 @@ static void sr_arc_set_radius(lv_obj_t *arc, int r, int width) {
     lv_obj_center(arc);
 }
 
-void nina_summary_round_place_rings(summary_card_t *cards, const bool *shown) {
-    int rank = 0;
-    for (int slot = 0; slot < MAX_NINA_INSTANCES; slot++) {
-        if (!shown[slot]) continue;
-        int r = sr_ring_radius(rank++);
-        nina_subbar_ring_set_radius(&cards[slot].ring, r);
-        sr_arc_set_radius(cards[slot].ring_crown, r, SR_RING_W);
-        sr_arc_set_radius(cards[slot].ring_flip_tick, r, SR_TICK_W);
+/* Move a band to @p dy and cut each text line to the chord at its own far
+ * edge. Every child that spans a line's width is re-widened with it. */
+static void sr_band_place(summary_card_t *sc, int dy) {
+    if (!sc->card) return;
+    /* Each line is cut to the chord at its own far edge: for a band above the
+     * centre the far edge of a line is its top, below the centre its bottom,
+     * and the centre band is widest at the band's own edge either way. */
+    const int a      = (dy < 0) ? -dy : dy;
+    const int half_h = SR_BAND_H / 2;
+    const int tgt_h  = lv_font_get_line_height(SR_LADDER_TARGET[0]);
+    const int row_h  = lv_font_get_line_height(&lv_font_hanken_bold_28);
+    int tgt_far, row_far;
+    if (dy < 0) {
+        tgt_far = a + half_h - SR_TGT_DY;
+        row_far = a + half_h - SR_ROW_DY;
+    } else if (dy > 0) {
+        tgt_far = a - half_h + SR_TGT_DY + tgt_h;
+        row_far = a - half_h + SR_ROW_DY + row_h;
+    } else {
+        tgt_far = half_h;
+        row_far = half_h;
+    }
+    int tw = 2 * sr_inner_half(tgt_far) - 2 * SR_BAND_EDGE;
+    int rw = 2 * sr_inner_half(row_far) - 2 * SR_BAND_EDGE;
+    if (tw < SR_BAND_MIN_W) tw = SR_BAND_MIN_W;
+    if (rw < SR_BAND_MIN_W) rw = SR_BAND_MIN_W;
+    sc->round_target_w = tw;
+    sc->round_row_w    = rw;
+
+    /* The band object is only the tap target, so it takes the wider of the two
+     * and may poke past the disc: nothing is drawn there. */
+    lv_obj_set_size(sc->card, (tw > rw) ? tw : rw, SR_BAND_BOX);
+    lv_obj_align(sc->card, LV_ALIGN_CENTER, 0, dy);
+
+    if (sc->lbl_name)   lv_obj_set_width(sc->lbl_name, tw);
+    if (sc->lbl_target) lv_obj_set_width(sc->lbl_target, tw);
+    if (sc->lbl_row) {
+        lv_obj_t *row = lv_obj_get_parent(sc->lbl_row);
+        if (row && row != sc->card) lv_obj_set_width(row, rw);
     }
 }
 
-static lv_obj_t *sr_label(lv_obj_t *parent, const lv_font_t *font,
-                          uint32_t color, const char *text);
-static lv_obj_t *sr_bullseye(lv_obj_t *parent, int x, int y, uint32_t dot_color,
-                             lv_obj_t **out_dot);
+void nina_summary_round_place_rings(summary_card_t *cards, const bool *shown) {
+    int n = 0;
+    for (int slot = 0; slot < MAX_NINA_INSTANCES; slot++) {
+        if (shown[slot]) n++;
+    }
 
-static lv_obj_t *sr_label(lv_obj_t *parent, const lv_font_t *font,
-                          uint32_t color, const char *text) {
-    lv_obj_t *l = lv_label_create(parent);
-    lv_obj_set_style_text_font(l, font, 0);
-    lv_obj_set_style_text_color(l, lv_color_hex(color), 0);
-    lv_label_set_long_mode(l, LV_LABEL_LONG_DOT);
-    /* One line, always: LONG_DOT only ellipsises once the text runs out of
-     * height as well as width, and a content-sized height lets a long rig
-     * name wrap to four lines and over the bullseye row (bench B1, 3.4C). */
-    lv_obj_set_height(l, lv_font_get_line_height(font));
-    lv_label_set_text(l, text ? text : "");
-    return l;
+    int rank = 0;
+    for (int slot = 0; slot < MAX_NINA_INSTANCES; slot++) {
+        if (!shown[slot]) continue;
+        int r = sr_ring_radius(rank);
+        nina_subbar_ring_set_radius(&cards[slot].ring, r);
+        sr_arc_set_radius(cards[slot].ring_flip_tick, r, SR_TICK_W);
+        sr_band_place(&cards[slot], sr_band_dy(rank, n));
+        rank++;
+    }
 }
 
-/* Tolerance ring plus a dot placed as its sibling, so an out-of-tolerance
- * value can sit outside the ring without being clipped. x and y are the ring
- * box's top-left in the card. */
-static lv_obj_t *sr_bullseye(lv_obj_t *parent, int x, int y, uint32_t dot_color,
-                             lv_obj_t **out_dot) {
-    lv_obj_t *ring = lv_obj_create(parent);
-    lv_obj_remove_style_all(ring);
-    lv_obj_remove_flag(ring, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_remove_flag(ring, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_size(ring, 2 * SR_BULL_R, 2 * SR_BULL_R);
-    lv_obj_set_pos(ring, x, y);
-    lv_obj_set_style_radius(ring, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_bg_opa(ring, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(ring, 2, 0);
-    lv_obj_set_style_border_color(ring, lv_color_hex(SR_RING_BORDER), 0);
-    lv_obj_set_style_border_opa(ring, LV_OPA_COVER, 0);
+/* -- fitting -------------------------------------------------------------- */
 
-    lv_obj_t *dot = lv_obj_create(parent);
-    lv_obj_remove_style_all(dot);
-    lv_obj_remove_flag(dot, LV_OBJ_FLAG_SCROLLABLE);
-    lv_obj_remove_flag(dot, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_size(dot, SR_BULL_DOT, SR_BULL_DOT);
-    lv_obj_set_style_radius(dot, LV_RADIUS_CIRCLE, 0);
-    lv_obj_set_style_bg_opa(dot, LV_OPA_COVER, 0);
-    lv_obj_set_style_bg_color(dot, lv_color_hex(dot_color), 0);
-    *out_dot = dot;
-    return ring;
+void nina_summary_round_fit_target(summary_card_t *sc) {
+    if (!sc || !sc->lbl_target) return;
+    ui_fit_label(sc->lbl_target, SR_LADDER_TARGET, SR_LADDER_TARGET_N,
+                 sc->round_target_w);
+}
+
+void nina_summary_round_fit_row(summary_card_t *sc, const char *text) {
+    if (!sc || !sc->lbl_row || !text) return;
+
+    /* The RMS figure and the rest of the row are one centred pair, so whatever
+     * the figure costs comes off the rest. */
+    int32_t rms_w = 0;
+    if (sc->lbl_rms_val) {
+        lv_point_t sz;
+        lv_text_get_size(&sz, lv_label_get_text(sc->lbl_rms_val),
+                         &lv_font_hanken_bold_28,
+                         lv_obj_get_style_text_letter_space(sc->lbl_rms_val, 0),
+                         0, LV_COORD_MAX, LV_TEXT_FLAG_NONE);
+        rms_w = sz.x;
+    }
+    int avail = sc->round_row_w - (int)rms_w - SR_ROW_GAP;
+    if (avail < 60) avail = 60;
+
+    /* Measured here rather than through ui_fit_label(): that one measures with
+     * LV_TEXT_FLAG_NONE, which counts every "#RRGGBB " recolour tag in this row
+     * as glyphs and would shrink the row to its smallest face on every write.
+     * The text comes in as an argument for the same reason the measurement
+     * cannot read the label: once LVGL has ellipsised a label it has rewritten
+     * the label's own text in place, so measuring that back would pick a bigger
+     * face, undot, overflow and dot again on the next poll. */
+    int32_t ls = lv_obj_get_style_text_letter_space(sc->lbl_row, 0);
+    const lv_font_t *pick = SR_LADDER_ROW[0];
+    int32_t w = 0;
+    for (int i = 0; i < SR_LADDER_ROW_N; i++) {
+        lv_point_t sz;
+        lv_text_get_size(&sz, text, SR_LADDER_ROW[i], ls, 0, LV_COORD_MAX,
+                         LV_TEXT_FLAG_RECOLOR);
+        pick = SR_LADDER_ROW[i];
+        w = sz.x;
+        if (w <= avail) break;
+    }
+    if (lv_obj_get_style_text_font(sc->lbl_row, 0) != pick) {
+        lv_obj_set_style_text_font(sc->lbl_row, pick, 0);
+    }
+
+    if (w > avail) {
+        /* Even the smallest face overflows: bound the box so it dots. LVGL only
+         * inserts dots when the height is bounded too. */
+        if (lv_label_get_long_mode(sc->lbl_row) != LV_LABEL_LONG_DOT) {
+            lv_label_set_long_mode(sc->lbl_row, LV_LABEL_LONG_DOT);
+        }
+        lv_obj_set_width(sc->lbl_row, avail);
+        lv_obj_set_height(sc->lbl_row, lv_font_get_line_height(pick));
+    } else {
+        /* Content sized while it fits, so the pair stays centred in the band. */
+        if (lv_label_get_long_mode(sc->lbl_row) != LV_LABEL_LONG_CLIP) {
+            lv_label_set_long_mode(sc->lbl_row, LV_LABEL_LONG_CLIP);
+        }
+        lv_obj_set_width(sc->lbl_row, LV_SIZE_CONTENT);
+        lv_obj_set_height(sc->lbl_row, LV_SIZE_CONTENT);
+    }
 }
 
 /* -- build ---------------------------------------------------------------- */
+
+static lv_obj_t *sr_plain_label(lv_obj_t *parent, const lv_font_t *font,
+                                uint32_t color, const char *text) {
+    lv_obj_t *l = lv_label_create(parent);
+    lv_obj_set_style_text_font(l, font, 0);
+    lv_obj_set_style_text_color(l, lv_color_hex(color), 0);
+    lv_label_set_long_mode(l, LV_LABEL_LONG_CLIP);
+    lv_label_set_text(l, text ? text : "");
+    return l;
+}
 
 void nina_summary_round_create_card(summary_card_t *sc, lv_obj_t *parent, int slot) {
     if (!sc || !parent || !current_theme) return;
@@ -157,81 +266,79 @@ void nina_summary_round_create_card(summary_card_t *sc, lv_obj_t *parent, int sl
     sc->cached_flip_color        = UINT32_MAX;
     sc->cached_detail_color      = UINT32_MAX;
     sc->cached_safety_color      = UINT32_MAX;
+    sc->cached_tick_color        = UINT32_MAX;
 
     int gb = app_config_get()->color_brightness;
+    uint32_t label_col = app_config_apply_brightness(current_theme->label_color, gb);
 
-    /* 1: this rig's ring set. Slot 0 outermost. */
-    int r = sr_ring_radius(slot);   /* re-ranked outward by nina_summary_round_place_rings() */
-    nina_subbar_create_ring(&sc->ring, parent, r, SR_RING_W, SR_CROWN_DEG);
-    sc->ring_crown = ui_dial_arc(parent, r, SR_RING_W,
-                                 -SR_CROWN_DEG / 2, SR_CROWN_DEG / 2);
-    lv_obj_set_style_arc_color(sc->ring_crown, lv_color_hex(0x2a2a2a), LV_PART_MAIN);
+    /* 1: this rig's ring. Slot 0 outermost until the ranking moves it. The ring
+     * closes at twelve o'clock (gap 0): this board has no safety crown. */
+    int r = sr_ring_radius(slot);
+    nina_subbar_create_ring(&sc->ring, parent, r, SR_RING_W, 0);
     sc->ring_flip_tick = ui_dial_arc(parent, r, SR_TICK_W, 0, 2);
     lv_obj_set_style_arc_color(sc->ring_flip_tick,
         lv_color_hex(app_config_apply_brightness(current_theme->text_color, gb)),
         LV_PART_MAIN);
     lv_obj_add_flag(sc->ring_flip_tick, LV_OBJ_FLAG_HIDDEN);
 
-    /* 2: the card, on a fixed slot line and cut to the chord at its furthest
-     * corner. Slot identity is fixed across the fleet, so a card does not move
-     * when a neighbouring rig goes offline; it is simply not shown. */
-    int dy   = (slot - 1) * (SR_CARD_H + SR_CARD_GAP);
-    int half = sr_card_half((dy < 0 ? -dy : dy) + SR_CARD_H / 2);
+    /* 2: the band. Invisible, but still the tap target that opens the rig's
+     * page; the picture is the text inside it and the ring outside it. */
     sc->card = lv_obj_create(parent);
     lv_obj_remove_style_all(sc->card);
-    lv_obj_add_style(sc->card, &style_glass_card, 0);
-    ui_styles_set_widget_draw_cbs(sc->card);
     lv_obj_set_layout(sc->card, LV_LAYOUT_NONE);
-    lv_obj_set_size(sc->card, 2 * half, SR_CARD_H);
-    lv_obj_align(sc->card, LV_ALIGN_CENTER, 0, dy);
     lv_obj_remove_flag(sc->card, LV_OBJ_FLAG_SCROLLABLE);
-    /* Pad 0, not SR_CARD_PAD: every child below is placed absolutely and its
-     * coordinates are measured from the card EDGE, while lv_obj_set_pos() is
-     * relative to the content area. A pad here would be counted twice and
-     * clip both bullseyes (review C I-3). */
+    lv_obj_set_style_bg_opa(sc->card, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(sc->card, 0, 0);
     lv_obj_set_style_pad_all(sc->card, 0, 0);
     summary_bind_card_tap(sc->card, slot);
 
-    /* 3: identity and target on one line. The ring says everything else. */
+    /* 3: the colour line at the top of the band, in the ring colour. */
+    sc->tick = lv_obj_create(sc->card);
+    lv_obj_remove_style_all(sc->tick);
+    lv_obj_remove_flag(sc->tick, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_remove_flag(sc->tick, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_set_size(sc->tick, SR_LINE_W, SR_LINE_H);
+    lv_obj_align(sc->tick, LV_ALIGN_TOP_MID, 0, 0);
+    lv_obj_set_style_radius(sc->tick, SR_LINE_H / 2, 0);
+    lv_obj_set_style_bg_opa(sc->tick, LV_OPA_COVER, 0);
+    lv_obj_set_style_bg_color(sc->tick, lv_color_hex(label_col), 0);
+
+    /* 4: the rig name, also in the ring colour. */
+    sc->lbl_name = sr_plain_label(sc->card, &lv_font_montserrat_bold_22,
+                                  label_col, "N.I.N.A.");
+    lv_label_set_long_mode(sc->lbl_name, LV_LABEL_LONG_DOT);
+    lv_obj_set_style_text_align(sc->lbl_name, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_height(sc->lbl_name,
+                      lv_font_get_line_height(&lv_font_montserrat_bold_22));
+    lv_obj_align(sc->lbl_name, LV_ALIGN_TOP_MID, 0, SR_NAME_DY);
+
+    /* 5: the target, the big line, fitted to the band on every write. */
+    sc->lbl_target = sr_plain_label(sc->card, SR_LADDER_TARGET[0],
+        app_config_apply_brightness(current_theme->target_name_color, gb), "----");
+    lv_label_set_long_mode(sc->lbl_target, LV_LABEL_LONG_DOT);
+    lv_obj_set_style_text_align(sc->lbl_target, LV_TEXT_ALIGN_CENTER, 0);
+    lv_obj_set_height(sc->lbl_target,
+                      lv_font_get_line_height(SR_LADDER_TARGET[0]));
+    lv_obj_align(sc->lbl_target, LV_ALIGN_TOP_MID, 0, SR_TGT_DY);
+
+    /* 6: the reading row: the RMS figure and everything else, centred as one
+     * pair. The row's own text is composed and recoloured by nina_summary.c. */
     lv_obj_t *row = lv_obj_create(sc->card);
     lv_obj_remove_style_all(row);
     lv_obj_remove_flag(row, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_remove_flag(row, LV_OBJ_FLAG_CLICKABLE);
-    lv_obj_set_size(row, 2 * half - 2 * SR_CARD_PAD, LV_SIZE_CONTENT);
-    lv_obj_set_pos(row, SR_CARD_PAD, SR_ROW1_DY);
+    lv_obj_set_height(row, LV_SIZE_CONTENT);
+    lv_obj_align(row, LV_ALIGN_TOP_MID, 0, SR_ROW_DY);
     lv_obj_set_flex_flow(row, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,
+    lv_obj_set_flex_align(row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_END,
                           LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_gap(row, 10, 0);
+    lv_obj_set_style_pad_gap(row, SR_ROW_GAP, 0);
 
-    sc->lbl_name = sr_label(row, SR_FONT_IDENT,
-        app_config_apply_brightness(current_theme->label_color, gb), "N.I.N.A.");
-    lv_obj_set_flex_grow(sc->lbl_name, 1);
-
-    lv_obj_t *sep = sr_label(row, SR_FONT_IDENT, 0x3a3f47, "/");
-    lv_obj_remove_flag(sep, LV_OBJ_FLAG_CLICKABLE);
-
-    sc->lbl_target = sr_label(row, SR_FONT_TARGET,
-        app_config_apply_brightness(current_theme->target_name_color, gb), "----");
-    /* Both halves grow, so a long identity and a long target ellipsise instead
-     * of one collapsing to nothing and the other overflowing (review C M-9). */
-    lv_obj_set_flex_grow(sc->lbl_target, 1);
-
-    /* 4: guiding RMS, the one figure a ring cannot express, beside its
-     * bullseye; HFR is the bullseye alone. */
-    sc->rms_bull = sr_bullseye(sc->card, SR_BULL_INSET - SR_BULL_R,
-                               SR_BULL_DY - SR_BULL_R,
-        app_config_apply_brightness(current_theme->rms_color, gb), &sc->rms_dot);
-    sc->lbl_rms_val = sr_label(sc->card, SR_FONT_VALUE,
+    sc->lbl_rms_val = sr_plain_label(row, &lv_font_hanken_bold_28,
         app_config_apply_brightness(current_theme->rms_color, gb), "--");
-    lv_obj_set_pos(sc->lbl_rms_val, SR_BULL_INSET + SR_BULL_R + 12, SR_BULL_DY - 22);
 
-    sc->hfr_bull = sr_bullseye(sc->card, 2 * half - SR_BULL_INSET - SR_BULL_R,
-                               SR_BULL_DY - SR_BULL_R,
-        app_config_apply_brightness(current_theme->hfr_color, gb), &sc->hfr_dot);
+    sc->lbl_row = sr_plain_label(row, SR_LADDER_ROW[0], label_col, "");
+    lv_label_set_recolor(sc->lbl_row, true);
 
-    /* ui_dial_place_dot() reads the rings' resolved coordinates. */
-    lv_obj_update_layout(sc->card);
-    ui_dial_place_dot(sc->rms_dot, sc->rms_bull, 0.0f, SR_BEARING_RMS);
-    ui_dial_place_dot(sc->hfr_dot, sc->hfr_bull, 0.0f, SR_BEARING_HFR);
+    sr_band_place(sc, sr_band_dy(slot, MAX_NINA_INSTANCES));
 }


### PR DESCRIPTION
### Summary
This PR resolves an issue where background safety alerts would repeat indefinitely if a rig's safety status became stale. It also improves the display quality of NINA greyscale image thumbnails by preventing banding and refines the layout of UI values.

### Changes
*   The system now refreshes safety monitor information for background rigs and clears safety connection status on disconnect, preventing repeated "unsafe conditions" alerts from stale data.
*   NINA greyscale image thumbnails are now processed with a 4x4 Bayer ordered dither when converting to RGB565, eliminating visible banding.
*   The display of "seconds" values in the UI is adjusted to fit correctly within its designated area, preventing overlap with other metrics.
*   The hardware JPEG color path now packs RGB888 to RGB565 using ordered dither, and Cloud Cover decode headroom is increased to 1 MB.
*   Ongoing development for the round Summary page includes updates for per-rig rings and stacked text bands.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-09-01T04:43:58.364Z | Generated by GitHub Actions</sub>