### PR TITLE
feat: add notification scope selection

### DIFF
--- a/main/app_config.c
+++ b/main/app_config.c
@@ -940,6 +940,8 @@ static void set_defaults(app_config_t *cfg) {
     // for every upgrader (opt in for existing installs).
     cfg->telemetry_enabled = true;
     cfg->moon_round_size_pct = 100;     // v79: round Moon disc fills the rim
+    // v80 addition (NINA notification scope). Also a SETTINGS_TABLE row.
+    cfg->nina_notify_scope = 0;         // 0 = every online rig may notify
 
     // Spotify client ID: secret-like sentinel, not table-driven
     cfg->spotify_client_id[0] = '\0';
@@ -3165,6 +3167,20 @@ static void migrate_from_v78(const void *raw, size_t raw_size, app_config_t *cfg
     ESP_LOGI(TAG, "Migrated config from v78 to v%d", APP_CONFIG_VERSION);
 }
 
+/* --- v79 -> v80 migration: appends nina_notify_scope (which rigs may raise
+ * notifications). The prefix through moon_round_size_pct is the v79 layout
+ * byte for byte. --- */
+static void migrate_from_v79(const void *raw, size_t raw_size, app_config_t *cfg)
+{
+    set_defaults(cfg);
+    size_t v79_size = offsetof(app_config_t, nina_notify_scope);
+    size_t copy = raw_size < v79_size ? raw_size : v79_size;
+    memcpy(cfg, raw, copy);
+    cfg->nina_notify_scope = 0;
+    cfg->config_version = APP_CONFIG_VERSION;
+    ESP_LOGI(TAG, "Migrated config from v79 to v%d", APP_CONFIG_VERSION);
+}
+
 static void migrate_from_v77(const void *raw, size_t raw_size, app_config_t *cfg)
 {
     set_defaults(cfg);
@@ -4141,6 +4157,14 @@ void app_config_init(void) {
             nvs_commit(handle);
         }
         /* tiles_loaded stays false -> tail loads "json_tiles"/"ha_tiles" keys */
+    } else if (version_check == 79) {
+        /* v79 -> v80: appended nina_notify_scope. tiles_loaded stays false:
+         * a v79 device already keeps its tiles in the "json_tiles"/"ha_tiles"
+         * NVS keys, so the tail loads them. */
+        migrate_from_v79(raw, stored_size, &s_config);
+        validate_config(&s_config);
+        nvs_set_blob(handle, "config", &s_config, sizeof(app_config_t));
+        nvs_commit(handle);
     } else if (version_check == 78) {
         /* v78 -> v79: appended moon_round_size_pct. tiles_loaded stays false:
          * a v78 device already keeps its tiles in the "json_tiles"/"ha_tiles"

--- a/main/app_config.h
+++ b/main/app_config.h
@@ -83,7 +83,7 @@ extern "C" {
 #define ARP_ORDER_CAPACITY_RETIRED 16
 
 // Current config struct version — bump on every layout change.
-#define APP_CONFIG_VERSION 79
+#define APP_CONFIG_VERSION 80
 
 /* Tiles-config blobs no longer live inside app_config_t (v52 split them out to
  * dedicated NVS string keys "json_tiles"/"ha_tiles"). These bound the value
@@ -585,6 +585,14 @@ typedef struct {
                                        // (default 100). With the text shown the
                                        // disc is capped so it clears the rim
                                        // rows. Square panels ignore it.
+
+    // Added after v79 (NINA notification scope) -- must stay at end to preserve NVS binary compatibility
+    uint8_t  nina_notify_scope;        // v80: which rigs may raise toasts,
+                                       // border flashes and spoken alerts.
+                                       // 0 = every online rig (default),
+                                       // 1 = only the rig whose page is on
+                                       // screen (Summary counts as every rig;
+                                       // any other page fires none).
 } app_config_t;
 
 /* ── Version 43 config struct — used only for NVS migration to v44 ────── */
@@ -5983,6 +5991,10 @@ _Static_assert(offsetof(app_config_t, moon_round_size_pct) ==
                    offsetof(app_config_t, telemetry_enabled) +
                        sizeof(((app_config_t *)0)->telemetry_enabled),
                "moon_round_size_pct must directly follow telemetry_enabled (v78 prefix rule)");
+_Static_assert(offsetof(app_config_t, nina_notify_scope) ==
+                   offsetof(app_config_t, moon_round_size_pct) +
+                       sizeof(((app_config_t *)0)->moon_round_size_pct),
+               "nina_notify_scope must directly follow moon_round_size_pct (v79 prefix rule)");
 
 
 

--- a/main/audio_alert.c
+++ b/main/audio_alert.c
@@ -16,6 +16,7 @@
 
 #include "audio_alert.h"
 #include "app_config.h"
+#include "ui/nina_dashboard.h"
 #include "bsp/esp-bsp.h"        /* bsp_audio_codec_speaker_init */
 #include "esp_codec_dev.h"
 #include "esp_heap_caps.h"
@@ -591,13 +592,18 @@ void audio_alert_set_override(int idx, const uint8_t *pcm, size_t len) {
     }
 }
 
+/* Per-instance mute plus the on-screen rig scope, live path only; the test
+ * and preview entry points bypass both so the speaker stays testable while an
+ * instance is muted or off screen. */
+static bool voice_instance_silenced(const app_config_t *cfg, int idx) {
+    return cfg->alert_voice_muted[idx] || !nina_dashboard_instance_notifies(idx);
+}
+
 void audio_alert_speak(alert_type_t type, int instance_idx, float value) {
     if (!s_queue) return;
     app_config_t *cfg = app_config_get();
     if (!cfg->alert_voice_enabled) return;
-    /* Per-instance mute — live path only; the test endpoints bypass it so the
-     * speaker stays testable while an instance is muted. */
-    if (instance_idx >= 0 && instance_idx < 3 && cfg->alert_voice_muted[instance_idx]) return;
+    if (instance_idx >= 0 && instance_idx < 3 && voice_instance_silenced(cfg, instance_idx)) return;
 
     sentence_t s;
     if (build_sentence(&s, type, instance_idx, value)) enqueue(&s);
@@ -610,7 +616,7 @@ void audio_alert_speak_event(int category_bit, int instance_idx, int equipment_i
 
     app_config_t *cfg = app_config_get();
     if (!cfg->alert_voice_enabled) return;
-    if (cfg->alert_voice_muted[instance_idx]) return;
+    if (voice_instance_silenced(cfg, instance_idx)) return;
     if (!(cfg->voice_notify_mask & (1u << category_bit))) return;
     if (!event_cooldown_pass(category_bit, instance_idx)) return;
 
@@ -627,7 +633,7 @@ void audio_alert_speak_equipment_group(int category_bit, int instance_idx,
 
     app_config_t *cfg = app_config_get();
     if (!cfg->alert_voice_enabled) return;
-    if (cfg->alert_voice_muted[instance_idx]) return;
+    if (voice_instance_silenced(cfg, instance_idx)) return;
     if (!(cfg->voice_notify_mask & (1u << category_bit))) return;
     if (!event_cooldown_pass(category_bit, instance_idx)) return;
 
@@ -642,7 +648,7 @@ void audio_alert_speak_event_id(voice_event_t ev, int instance_idx) {
 
     app_config_t *cfg = app_config_get();
     if (!cfg->alert_voice_enabled) return;
-    if (cfg->alert_voice_muted[instance_idx]) return;
+    if (voice_instance_silenced(cfg, instance_idx)) return;
     /* The per-event bit is checked ALONE, deliberately NOT ANDed with the
      * event's category bit: ticking "Sequence finished" must be enough to hear
      * it.  The category bits keep governing only the generic fallback clips. */
@@ -672,7 +678,7 @@ void audio_alert_speak_conn(int instance_idx, bool connected) {
 
     app_config_t *cfg = app_config_get();
     if (!cfg->alert_voice_enabled) return;
-    if (cfg->alert_voice_muted[instance_idx]) return;
+    if (voice_instance_silenced(cfg, instance_idx)) return;
     if (!(connected ? cfg->alert_voice_conn : cfg->alert_voice_disc)) return;
 
     sentence_t s;

--- a/main/audio_alert.h
+++ b/main/audio_alert.h
@@ -42,7 +42,8 @@ void audio_alert_speak(alert_type_t type, int instance_idx, float value);
 
 /**
  * Queue a spoken event announcement (live path).  Thread-safe; gated on
- * alert_voice_enabled, alert_voice_muted[instance], the voice_notify_mask
+ * alert_voice_enabled, alert_voice_muted[instance] and the on-screen rig
+ * scope, the voice_notify_mask
  * category bit, and a per-(category,instance) 30 s cooldown.
  */
 void audio_alert_speak_event(int category_bit, int instance_idx, int equipment_idx);
@@ -111,7 +112,7 @@ typedef enum {
 
 /**
  * Queue a spoken per-event phrase (live path).  Thread-safe.  Gated on
- * alert_voice_enabled, alert_voice_muted[instance], the
+ * alert_voice_enabled, alert_voice_muted[instance] and the on-screen rig scope, the
  * (VOICE_EVENT_BIT_BASE + ev) bit of voice_notify_mask, and a per-(event,
  * instance) 30 s cooldown that is INDEPENDENT of the category cooldown.
  *
@@ -138,8 +139,8 @@ const char *audio_alert_event_clip_name(voice_event_t ev);
 
 /**
  * Queue a spoken NINA link connect/disconnect announcement (live path).
- * Thread-safe; gated on alert_voice_enabled, alert_voice_muted[instance] and
- * the alert_voice_conn / alert_voice_disc toggle for the given edge.
+ * Thread-safe; gated on alert_voice_enabled, alert_voice_muted[instance], the
+ * on-screen rig scope and the alert_voice_conn / alert_voice_disc toggle for the given edge.
  */
 void audio_alert_speak_conn(int instance_idx, bool connected);
 

--- a/main/config_ui.html
+++ b/main/config_ui.html
@@ -2619,6 +2619,7 @@
       data.alert_voice_disc=$('alert_voice_disc').checked?1:0;
       data.boot_jingle_enabled=$('boot_jingle_enabled').checked?1:0;
       data.toast_aggregation_window_s=parseInt($('toast_aggregation_window').value)||0;
+      data.nina_notify_scope=parseInt($('nina_notify_scope').value,10)||0;
       data.toast_notify_mask=(function(){var m=0;for(var i=0;i<12;i++){if($('notify_cat_'+i).checked) m|=(1<<i);}return m>>>0;})();
       /* One value carries both voice switches: the 12 category switches in the
          low bits, then one switch per named event starting at bit 12. The
@@ -3183,6 +3184,7 @@
       $('alert_voice_brief').checked=!!data.alert_voice_brief;
       $('alert_voice_conn').checked=!!data.alert_voice_conn;
       $('alert_voice_disc').checked=data.alert_voice_disc!=null?!!data.alert_voice_disc:true;
+      $('nina_notify_scope').value=String(data.nina_notify_scope||0);
       var aggWin=data.toast_aggregation_window_s!=null?data.toast_aggregation_window_s:5;
       $('toast_aggregation_window').value=aggWin;
       updateAggregationLabel(aggWin);

--- a/main/fragment_behavior.html
+++ b/main/fragment_behavior.html
@@ -122,6 +122,14 @@
           </div>
           <div class="field-hint">Combine rapid-fire notifications within this window. 0 = Off (show each individually).</div>
         </div>
+        <div class="field" style="margin-top:16px">
+          <label class="field-label">Notify for</label>
+          <select class="input" id="nina_notify_scope" onchange="checkDirty()">
+            <option value="0">Every online rig</option>
+            <option value="1">Only the rig on screen</option>
+          </select>
+          <div class="field-hint">Only the rig on screen: pop-ups, border flashes and spoken alerts come from the rig whose page is showing. The Summary page counts as every rig; other pages show no rig alerts.</div>
+        </div>
         </div>
         <div class="subsection">
         <div class="subsection-title">Voice Alerts</div>

--- a/main/nina_connection.c
+++ b/main/nina_connection.c
@@ -13,6 +13,7 @@
 #include "audio_alert.h"
 #include "net_diag.h"
 #include "ui/nina_toast.h"
+#include "ui/nina_dashboard.h"
 #include "esp_timer.h"
 #include "esp_log.h"
 #include <string.h>
@@ -32,10 +33,12 @@ static bool valid_index(int i) {
 }
 
 /* Outage toasts use the same gate as the WebSocket connect toasts in
- * nina_websocket.c: notify-mask bit 0 plus the per-instance mute switch. */
+ * nina_websocket.c: notify-mask bit 0, the per-instance mute switch and the
+ * on-screen rig scope. */
 static bool outage_toasts_enabled(int instance) {
     const app_config_t *cfg = app_config_get();
-    return (cfg->toast_notify_mask & (1 << 0)) && !cfg->toast_instance_muted[instance];
+    return (cfg->toast_notify_mask & (1 << 0)) && !cfg->toast_instance_muted[instance] &&
+           nina_dashboard_instance_notifies(instance);
 }
 
 /* Display name for an instance ("astromele2.lan"), with a generic fallback so

--- a/main/nina_websocket.c
+++ b/main/nina_websocket.c
@@ -26,6 +26,7 @@
 #include "nina_connection.h"
 #include "tasks.h"
 #include "ui/nina_toast.h"
+#include "ui/nina_dashboard.h"
 #include "ui/nina_event_log.h"
 #include "ui/nina_alerts.h"
 #include "ui/nina_safety.h"
@@ -139,6 +140,15 @@ static void ws_toast_fmt(int index, toast_severity_t sev, const char *fmt, ...) 
     ws_toast(index, sev, msg);
 }
 
+/* Check if a notification category is enabled for this instance: the
+ * notify-mask bit, the per-instance mute switch and the on-screen rig scope. */
+static bool toast_allowed(int index, int category_bit) {
+    const app_config_t *cfg = app_config_get();
+    return (cfg->toast_notify_mask & (1 << category_bit)) &&
+           !cfg->toast_instance_muted[index] &&
+           nina_dashboard_instance_notifies(index);
+}
+
 /* ── Aggregation timer callback ──────────────────────────────────────── */
 static void agg_timer_cb(void *arg) {
     int index = (int)(intptr_t)arg;
@@ -152,8 +162,6 @@ static void agg_timer_cb(void *arg) {
     s_agg[index].disconnected_mask = 0;
     s_agg[index].window_start_ms = 0;
     portEXIT_CRITICAL(&s_agg_lock);
-
-    const app_config_t *cfg = app_config_get();
 
     /* Masks already reflect final state (last event wins — connect clears disconnect
      * bit and vice versa), so no cancellation logic needed here. */
@@ -193,7 +201,7 @@ static void agg_timer_cb(void *arg) {
             }
         }
 
-        if ((cfg->toast_notify_mask & (1 << 0)) && !cfg->toast_instance_muted[index]) {
+        if (toast_allowed(index, 0)) {
             nina_toast_show(TOAST_SUCCESS, buf);
         }
         /* Voice has its own mask/gates; one grouped sentence for the burst. */
@@ -219,7 +227,7 @@ static void agg_timer_cb(void *arg) {
             if (i == EQ_SAFETY) sev = TOAST_ERROR;
             else if (seq_running) sev = TOAST_ERROR;
 
-            if ((cfg->toast_notify_mask & (1 << 1)) && !cfg->toast_instance_muted[index]) {
+            if (toast_allowed(index, 1)) {
                 ws_toast_fmt(index, sev, "%s disconnected", equipment_names[i]);
             }
             nina_event_log_add_fmt(sev == TOAST_ERROR ? EVENT_SEV_ERROR : EVENT_SEV_WARNING,
@@ -236,7 +244,7 @@ static void record_connect_event(int index, equipment_type_t eq) {
 
     // If aggregation disabled, show individual toast
     if (cfg->toast_aggregation_window_s == 0) {
-        if ((cfg->toast_notify_mask & (1 << 0)) && !cfg->toast_instance_muted[index]) {
+        if (toast_allowed(index, 0)) {
             ws_toast(index, TOAST_SUCCESS, equipment_names[eq]);
         }
         audio_alert_speak_event(0, index, (int)eq);
@@ -362,19 +370,12 @@ static void record_disconnect_event(int index, equipment_type_t eq) {
         }
     }
 
-    if ((cfg->toast_notify_mask & (1 << 1)) && !cfg->toast_instance_muted[index]) {
+    if (toast_allowed(index, 1)) {
         ws_toast_fmt(index, sev, "%s disconnected", equipment_names[eq]);
     }
     audio_alert_speak_event(1, index, (int)eq);
     nina_event_log_add_fmt(sev == TOAST_ERROR ? EVENT_SEV_ERROR : EVENT_SEV_WARNING,
                            index, "%s disconnected", equipment_names[eq]);
-}
-
-/* Check if a notification category is enabled for this instance */
-static bool toast_allowed(int index, int category_bit) {
-    const app_config_t *cfg = app_config_get();
-    return (cfg->toast_notify_mask & (1 << category_bit)) &&
-           !cfg->toast_instance_muted[index];
 }
 
 /**

--- a/main/settings_table.h
+++ b/main/settings_table.h
@@ -239,7 +239,9 @@
     /* -- Global audio mute (v77) -- */ \
     BOOL      (audio_muted,                  "audio_muted",                  false) /* silence EVERY sound (voice alerts, event phrases, connection announcements, boot jingle) at the audio_alert enqueue gate; the web test/preview endpoints bypass it so the speaker stays testable while muted */ \
     /* -- Anonymous telemetry (v78) -- */ \
-    BOOL      (telemetry_enabled,            "telemetry_enabled",            true)  /* one anonymous daily health report (fw version, uptime, crash counters, memory, feature bitmask; never URLs, names, coordinates or secrets). Fresh installs default ON; the v78 migration tail forces OFF for every upgrader (opt in) */
+    BOOL      (telemetry_enabled,            "telemetry_enabled",            true)  /* one anonymous daily health report (fw version, uptime, crash counters, memory, feature bitmask; never URLs, names, coordinates or secrets). Fresh installs default ON; the v78 migration tail forces OFF for every upgrader (opt in) */ \
+    /* -- NINA notification scope (v80) -- */ \
+    INT_RESET (nina_notify_scope,            "nina_notify_scope",            0,     0,     1)     /* which rigs may raise toasts, border flashes and spoken alerts: 0 = every online rig (default), 1 = only the rig whose page is on screen (Summary counts as every rig, any other page fires none). RESET, not clamp: an unknown value falls back to "every rig" */
 
 /* Apply every row's default value to *cfg. Called from set_defaults()
  * immediately after the memset(). Does not touch excluded/complex fields

--- a/main/ui/nina_alerts.c
+++ b/main/ui/nina_alerts.c
@@ -14,6 +14,7 @@
 
 #include "nina_alerts.h"
 #include "nina_dashboard_internal.h"
+#include "nina_dashboard.h"
 #include "themes.h"
 #include "display_defs.h"
 #include "ui_round.h"       /* ui_rim_radius (round alert ring) */
@@ -285,7 +286,7 @@ static void alert_eval_edge(alert_type_t type, int instance, float value, int ed
     /* Flash is attempted on every breached sample, exactly as before this
      * engine existed — nina_alert_trigger()'s 30 s per-type cooldown is what
      * actually paces it. */
-    if (breached && cfg->alert_flash_enabled) {
+    if (breached && cfg->alert_flash_enabled && nina_dashboard_instance_notifies(instance)) {
         nina_alert_trigger(type, instance, value);
     }
 

--- a/main/ui/nina_dashboard.c
+++ b/main/ui/nina_dashboard.c
@@ -1995,6 +1995,14 @@ int nina_dashboard_page_to_instance(int abs_page_idx) {
     return inst;
 }
 
+/* True when this rig may notify you right now: always when notifications are
+ * for every online rig, else only while its page or the Summary is on screen. */
+bool nina_dashboard_instance_notifies(int instance) {
+    if (app_config_get()->nina_notify_scope == 0) return true;
+    return active_page == PAGE_IDX_SUMMARY ||
+           nina_dashboard_page_to_instance(active_page) == instance;
+}
+
 /* Pure-offset inverse of page_to_instance. Returns the ABSOLUTE page index for
  * an instance, or -1 only for an out-of-range instance index. */
 int nina_dashboard_instance_to_page(int instance_idx) {

--- a/main/ui/nina_dashboard.h
+++ b/main/ui/nina_dashboard.h
@@ -263,6 +263,14 @@ bool nina_dashboard_thumbnail_visible(void);
 int nina_dashboard_page_to_instance(int abs_page_idx);
 
 /**
+ * @brief Whether a rig's toasts, voice and border flashes are wanted right now.
+ *
+ * True for every rig when nina_notify_scope is 0; otherwise only while that
+ * rig's page or the Summary is on screen. Plain read, no LVGL lock taken.
+ */
+bool nina_dashboard_instance_notifies(int instance);
+
+/**
  * @brief Map a NINA instance index to its ABSOLUTE page index.
  *
  * Pure offset (NINA_PAGE_OFFSET + instance) over the reserved NINA band; exact

--- a/main/web_handlers_config.c
+++ b/main/web_handlers_config.c
@@ -496,6 +496,7 @@ static const backup_field_t s_backup_fields[] = {
     {"boot_jingle_enabled",         "Startup Sound",           "Behavior", false, false},
     {"audio_muted",                 "Mute All Audio",          "Behavior", false, false},
     {"telemetry_enabled",           "Anonymous Telemetry",     "Behavior", false, false},
+    {"nina_notify_scope",           "Rig Notification Scope",  "Behavior", false, false},
     {"screen_sleep_enabled",        "Screen Sleep",             "Behavior", false, false},
     {"screen_sleep_timeout_s",      "Screen Sleep Timeout",     "Behavior", false, false},
 


### PR DESCRIPTION
### Summary
This PR introduces a setting that allows users to choose whether to receive notifications for all online rigs or only for the rig currently displayed on the dashboard. This helps users focus alerts on specific rigs they are actively monitoring.

### Changes
*   A new configuration setting, `nina_notify_scope`, is added to control whether notifications apply to all online rigs or only the rig currently displayed.
*   A "Notify for" selection menu is added to the Behavior tab's Notifications section in the web UI for this new setting.
*   A new predicate, `nina_dashboard_instance_notifies()`, is added to determine if a specific rig instance should trigger notifications.
*   This predicate now gates various alerts, including outage toasts, WebSocket toasts, live voice paths, and the dashboard border flash.
*   Event log entries continue to be recorded for all rigs, regardless of the notification scope setting.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-09-01T13:46:33.887Z | Generated by GitHub Actions</sub>