### PR TITLE
fix: report actual system reset reason

### DIFF
--- a/main/fragment_behavior.html
+++ b/main/fragment_behavior.html
@@ -46,11 +46,13 @@
               <div class="field-hint">Animation used when Auto Cycle changes pages.</div>
             </div>
           </div>
-          <div class="toggle-row">
-            <span class="toggle-label" style="font-size:0.82rem;color:var(--text-muted)">Skip disconnected nodes</span>
-            <label class="toggle"><input type="checkbox" id="auto_rotate_skip"><span class="toggle-track"></span></label>
+          <div>
+            <div class="toggle-row">
+              <span class="toggle-label" style="font-size:0.82rem;color:var(--text-muted)">Skip disconnected nodes</span>
+              <label class="toggle"><input type="checkbox" id="auto_rotate_skip"><span class="toggle-track"></span></label>
+            </div>
+            <div class="field-hint" style="margin-top:4px">During Auto Cycle, skip NINA instance pages that are not connected.</div>
           </div>
-          <div class="field-hint">During Auto Cycle, skip NINA instance pages that are not connected.</div>
           <div class="pn-sub-divider"></div>
           <div>
             <div class="pn-section-label">Pages in Rotation</div>

--- a/main/web_handlers_system.c
+++ b/main/web_handlers_system.c
@@ -1454,10 +1454,18 @@ esp_err_t crash_get_handler(httpd_req_t *req)
         return ESP_FAIL;
     }
 
+    /* last_reset_reason is the reason for THIS boot (SW after an OTA or a
+     * web reboot, POWERON, PANIC, ...). last_crash_reason is the reason of the
+     * most recent abnormal reset since power-on, 0 (UNKNOWN) when there was
+     * none; it used to be reported under the last_reset_reason name, which
+     * read UNKNOWN on every healthy device. */
+    uint32_t reset_reason = power_mgmt_get_last_reset_reason();
     cJSON_AddNumberToObject(root, "crash_count", info.crash_count);
-    cJSON_AddStringToObject(root, "last_reset_reason",
+    cJSON_AddStringToObject(root, "last_reset_reason", reset_reason_to_str(reset_reason));
+    cJSON_AddNumberToObject(root, "last_reset_reason_code", reset_reason);
+    cJSON_AddStringToObject(root, "last_crash_reason",
                             reset_reason_to_str(info.last_crash_reason));
-    cJSON_AddNumberToObject(root, "last_reset_reason_code", info.last_crash_reason);
+    cJSON_AddNumberToObject(root, "last_crash_reason_code", info.last_crash_reason);
     cJSON_AddNumberToObject(root, "boot_count", info.boot_count);
     cJSON_AddNumberToObject(root, "uptime_s",
                             (double)esp_timer_get_time() / 1000000.0);


### PR DESCRIPTION
### Summary
This PR fixes a visual layout issue on the web interface and corrects how the system reports its reset reason. It ensures the `/api/crash` endpoint provides accurate information about why the device last booted, distinguishing it from crash-specific reasons.

### Changes
*   Corrects the vertical spacing of the hint text under the "Skip disconnected nodes" toggle on the web interface.
*   The `/api/crash` endpoint now reports the actual system reset reason for the current boot, such as software reset or power-on.
*   The crash-specific reset reason is now reported in new fields, `last_crash_reason` and `last_crash_reason_code`, on the `/api/crash` endpoint.

---
<sub>Analyzed **2** commit(s) | Updated: 2026-09-01T18:10:01.190Z | Generated by GitHub Actions</sub>