### PR TITLE
fix(net): reuse HTTPS connection per page

### DIFF
--- a/main/adsb_basemap.c
+++ b/main/adsb_basemap.c
@@ -140,7 +140,7 @@ bool adsb_basemap_poll(float rx_lat, float rx_lon, float range_nm)
 
     image_frame_t fresh;
     memset(&fresh, 0, sizeof(fresh));
-    if (image_fetch_custom(url, "", &fresh) != ESP_OK || fresh.buf == NULL) {
+    if (image_fetch_custom(url, "", &fresh, NULL) != ESP_OK || fresh.buf == NULL) {
         ESP_LOGW(TAG, "basemap fetch failed, backing off 60s");
         s_backoff_until_us = now_us + ADSB_BASEMAP_BACKOFF_US;
         return false;

--- a/main/goes_client.c
+++ b/main/goes_client.c
@@ -205,7 +205,7 @@ const char *goes_region_name(const char *code)
  * on a crop / dark-mode / Red Night change instead of re-downloading ~370 KB. */
 static esp_err_t fetch_image_into(const char *url, const char *label, image_frame_t *out,
                                   uint8_t **out_src, size_t *out_src_len,
-                                  const char *auth_header)
+                                  const char *auth_header, http_fetch_conn_t *conn)
 {
     if (!url || !out) return ESP_ERR_INVALID_ARG;
     if (out_src) { *out_src = NULL; *out_src_len = 0; }
@@ -234,6 +234,10 @@ static esp_err_t fetch_image_into(const char *url, const char *label, image_fram
         .shrink_to_fit = true,
         .user_agent = "NINA-Display/1.0 (ESP32-P4 dashboard)",
         .extra_header = (auth_header && auth_header[0] != '\0') ? auth_header : NULL,
+        /* NULL for every one-shot caller. A loop page passes its own slot so a
+         * run of frames from one host skips the per-request TCP+TLS setup; the
+         * slot's owner destroys it when the page parks. */
+        .conn = conn,
         .label = "image",
     };
 
@@ -311,7 +315,7 @@ esp_err_t image_fetch_goes(const char *region, image_frame_t *out)
     snprintf(url, sizeof(url),
              "https://cdn.star.nesdis.noaa.gov/GOES19/ABI/SECTOR/%s/GEOCOLOR/%s.jpg",
              region, size);
-    return fetch_image_into(url, goes_region_name(region), out, NULL, NULL, NULL);
+    return fetch_image_into(url, goes_region_name(region), out, NULL, NULL, NULL, NULL);
 }
 
 esp_err_t image_fetch_solar(uint8_t band, image_frame_t *out)
@@ -325,22 +329,24 @@ esp_err_t image_fetch_solar(uint8_t band, image_frame_t *out)
     }
     char url[256];
     solar_band_url(band, url, sizeof(url));
-    return fetch_image_into(url, solar_band_label(band), out, NULL, NULL, NULL);
+    return fetch_image_into(url, solar_band_label(band), out, NULL, NULL, NULL, NULL);
 }
 
-esp_err_t image_fetch_custom(const char *url, const char *auth_header, image_frame_t *out)
+esp_err_t image_fetch_custom(const char *url, const char *auth_header, image_frame_t *out,
+                             http_fetch_conn_t *conn)
 {
     if (!url || !url[0] || !out) return ESP_ERR_INVALID_ARG;
     /* No source word for the Custom page: the caption is the stamp alone. */
-    return fetch_image_into(url, "", out, NULL, NULL, auth_header);
+    return fetch_image_into(url, "", out, NULL, NULL, auth_header, conn);
 }
 
 esp_err_t image_fetch_custom_retain(const char *url, image_frame_t *out,
-                                    uint8_t **out_src, size_t *out_src_len)
+                                    uint8_t **out_src, size_t *out_src_len,
+                                    http_fetch_conn_t *conn)
 {
     if (!out_src || !out_src_len) return ESP_ERR_INVALID_ARG;
     *out_src = NULL;
     *out_src_len = 0;
     if (!url || !url[0] || !out) return ESP_ERR_INVALID_ARG;
-    return fetch_image_into(url, "", out, out_src, out_src_len, NULL);
+    return fetch_image_into(url, "", out, out_src, out_src_len, NULL, conn);
 }

--- a/main/goes_client.h
+++ b/main/goes_client.h
@@ -3,6 +3,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/semphr.h"
 #include "esp_err.h"
+#include "http_fetch.h"           /* http_fetch_conn_t (optional keep-alive slot) */
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
@@ -26,8 +27,16 @@ esp_err_t image_fetch_goes(const char *region, image_frame_t *out);
 esp_err_t image_fetch_solar(uint8_t band, image_frame_t *out);
 /* @p auth_header is an optional raw "Name: value" request header (the Custom
  * URL page's user-supplied header, e.g. "Authorization: Bearer xyz"); NULL or
- * "" sends none, which is the previous behaviour. */
-esp_err_t image_fetch_custom(const char *url, const char *auth_header, image_frame_t *out);
+ * "" sends none, which is the previous behaviour.
+ *
+ * @p conn is an optional keep-alive slot (see http_fetch.h): NULL is the
+ * one-shot behaviour every caller had before. A caller that fetches several
+ * images from ONE host in a row (the Cloud Cover loop) passes its own slot so
+ * only the first request pays TCP+TLS setup. The slot is owned by exactly one
+ * task and MUST be destroyed when that task stops fetching -- a parked slot
+ * holds an open socket against the board's ~9 connection ceiling. */
+esp_err_t image_fetch_custom(const char *url, const char *auth_header, image_frame_t *out,
+                             http_fetch_conn_t *conn);
 
 /* Same fetch+decode as image_fetch_custom(), but the COMPRESSED source bytes
  * survive the call so the caller can re-decode them later without re-fetching.
@@ -42,7 +51,8 @@ esp_err_t image_fetch_custom(const char *url, const char *auth_header, image_fra
  * re-downloading it. The other pages call image_fetch_custom() and the
  * compressed buffer is freed at decode time exactly as before. */
 esp_err_t image_fetch_custom_retain(const char *url, image_frame_t *out,
-                                    uint8_t **out_src, size_t *out_src_len);
+                                    uint8_t **out_src, size_t *out_src_len,
+                                    http_fetch_conn_t *conn);
 
 /* NESDIS sector code -> human-readable region name. Returns the code itself
  * when no match is found. Single source of truth for region labels. */

--- a/main/image_page_poll.c
+++ b/main/image_page_poll.c
@@ -362,6 +362,43 @@ void image_page_poll_init(void)
     if (!s_fetch_gate) s_fetch_gate = xSemaphoreCreateMutex();
 }
 
+/* PAGE-SCOPED KEEP-ALIVE, one slot per animated page. Every frame of one visit
+ * -- the newest, the 0..2 re-fetches and the whole history backfill, up to
+ * clouds_frames / radar_frames of them -- goes to the SAME host, and a one-shot
+ * client paid a fresh TCP+TLS handshake for each: Cloud Cover to GIBS or
+ * EUMETView (both halves of a date-line split included), radar map styles 1/2
+ * to the NCEP GeoServer, radar style 0 to radar.weather.gov (a fixed literal in
+ * radar_frame_url()). One slot per page covers all of them, because
+ * esp_http_client_set_url() closes the parked socket by itself when the host or
+ * port changes, so a satellite or map-style change just reconnects once.
+ *
+ * The worldwide radar source never reaches here (rainviewer_build_frame()
+ * returns earlier in anim_fetch_frame) and keeps its own tile-host slot inside
+ * rainviewer.c, closed by rainviewer_release() at the same park seam.
+ *
+ * OWNERSHIP: each page's own poll task only. It creates its slot inside
+ * anim_fetch_frame() and destroys it in anim_on_park(), which poll_loop_run()
+ * calls on that same task -- a drained-parked slot holds an OPEN socket, so it
+ * must not outlive the page's fetching against the ~9 connection ceiling. */
+static http_fetch_conn_t *s_anim_conn[IMG_SRC_COUNT];
+
+static http_fetch_conn_t *anim_conn_get(const image_page_t *p)
+{
+    if (s_anim_conn[p->src] == NULL) {
+        s_anim_conn[p->src] = http_fetch_conn_create();
+        if (s_anim_conn[p->src] != NULL) ESP_LOGI(TAG, "%s: keep-alive connection opened", p->name);
+    }
+    return s_anim_conn[p->src];   /* NULL on alloc failure = one-shot, still correct */
+}
+
+static void anim_conn_close(const image_page_t *p)
+{
+    if (s_anim_conn[p->src] == NULL) return;
+    http_fetch_conn_destroy(s_anim_conn[p->src]);
+    s_anim_conn[p->src] = NULL;
+    ESP_LOGI(TAG, "%s: keep-alive connection closed", p->name);
+}
+
 /* Hand a locally rendered Moon frame to the page (instant swap). */
 static void moon_commit(image_page_t *p, uint16_t *img, int w, int h)
 {
@@ -882,7 +919,7 @@ static bool clouds_fetch_split(image_page_t *p, const app_config_t *cfg,
             return false;
         }
         image_frame_t part = {0};
-        esp_err_t err = image_fetch_custom(url, NULL, &part);
+        esp_err_t err = image_fetch_custom(url, NULL, &part, anim_conn_get(p));
         if (err != ESP_OK || part.buf == NULL ||
             part.w != (uint16_t)sp->px_w[k] || part.h != (uint16_t)px) {
             if (part.buf) heap_caps_free(part.buf);
@@ -954,7 +991,9 @@ static bool anim_fetch_frame(image_page_t *p, const app_config_t *cfg, const cha
     }
     char url[RADAR_WMS_URL_MAX];
     if (!anim_frame_url(p, cfg, token, i, url, sizeof(url))) return false;
-    return image_fetch_custom_retain(url, out, src, src_len) == ESP_OK;
+    /* Both animated pages: every frame of this visit is another request to the
+     * host this URL already named, so the page's slot skips the handshake. */
+    return image_fetch_custom_retain(url, out, src, src_len, anim_conn_get(p)) == ESP_OK;
 }
 
 /* Fetch history frame @p i under generation @p gen and hand it to the ring
@@ -1320,7 +1359,7 @@ static bool net_poll_once(void *arg)
             } else {
                 /* Optional user-supplied request header (empty = none), for a
                  * source behind an API key or bearer token. */
-                err = image_fetch_custom(cfg->custom_image_url, cfg->custom_image_header, &fresh);
+                err = image_fetch_custom(cfg->custom_image_url, cfg->custom_image_header, &fresh, NULL);
             }
             break;
     }
@@ -1445,6 +1484,9 @@ static void anim_on_park(void *arg)
     /* The cached coastline map is another panel-sized PSRAM buffer, held for as
      * long as the ring is. Free it at the same seam. */
     if (p->src == IMG_SRC_RADAR) rainviewer_release();
+    /* A drained keep-alive slot parks its socket OPEN, so this page's frame
+     * connection must not survive the page going away. */
+    anim_conn_close(p);
 }
 
 /* ---- Moon ---- */

--- a/main/ota_github.c
+++ b/main/ota_github.c
@@ -23,13 +23,16 @@
 static const char *TAG = "ota_github";
 
 /* Releases endpoint, paginated. per_page=10 keeps each page's JSON under the
- * 128 KB MAX_RESPONSE_SIZE buffer (measured worst case ~93 KB). The full per-page
- * URL is composed by appending "&page=N" into a stack buffer (see fetch_releases_page). */
+ * 256 KB MAX_RESPONSE_SIZE buffer: a release entry with full notes runs about
+ * 15 KB, so 256 KB holds roughly 17 of them, comfortably above the 10 per page
+ * (issue 313: a page hit 132,672 bytes against the old 128 KB cap). The full
+ * per-page URL is composed by appending "&page=N" into a stack buffer (see
+ * fetch_releases_page). */
 #define GITHUB_API_URL    "https://api.github.com/repos/chvvkumar/ESP32-P4-NINA-Display/releases?per_page=10"
 #define MAX_RELEASE_PAGES 10       /* safety cap: 10 pages x per_page=10 = 100 releases (>2x current 43) */
 #define RELEASE_URL_BUF   256      /* generous bound for GITHUB_API_URL + "&page=NN" */
 #define OTA_BUF_SIZE      4096
-#define MAX_RESPONSE_SIZE (128 * 1024)
+#define MAX_RESPONSE_SIZE (256 * 1024)
 /* The square family keeps this asset name FOREVER: every fielded device matches
  * it with an exact strcmp, so changing it would stop the whole square fleet
  * seeing updates. The round family gets its own name, which is the first of the
@@ -470,7 +473,7 @@ static esp_err_t redirect_event_handler(esp_http_client_event_t *evt) {
  * parse it into a cJSON array. Returns the parsed array (caller owns it and must
  * cJSON_Delete it), or NULL on ANY failure: HTTP error, non-200 status, response
  * buffer overflow, or JSON parse failure. *overflow_out is set true only when the
- * 128 KB response buffer overflowed (so the caller can apply the history fail-safe);
+ * 256 KB response buffer overflowed (so the caller can apply the history fail-safe);
  * *rate_limited_out is set true only when GitHub answered 403/429 (quota exhausted);
  * both are left untouched on other failures. The helper frees its own response buffer.
  */

--- a/main/rainviewer.c
+++ b/main/rainviewer.c
@@ -76,6 +76,18 @@ static bool               s_base_valid;
 static int64_t            s_base_retry_us;  /* esp_timer time before which a failed
                                                basemap is not fetched again; 0 = now */
 
+/* PAGE-SCOPED KEEP-ALIVE for the tile host. A frame is 4 to 9 tiles from one
+ * server and a visit is several frames, and a one-shot client paid a fresh
+ * TCP+TLS handshake for every one of them: a New Zealand user's log shows 1.9
+ * to 3.1 s per tile, about 45 s before the page could show anything. Owned by
+ * the radar poll task alone (rainviewer_build_frame and rainviewer_release both
+ * run on it) and destroyed on park, because a drained slot parks its socket
+ * OPEN against this board's ~9 connection ceiling.
+ *
+ * NOT used for the basemap (a different host, GIBS) or for weather-maps.json
+ * (api.rainviewer.com, one request per poll): both stay one-shot. */
+static http_fetch_conn_t *s_tile_conn;
+
 bool radar_use_rainviewer(const app_config_t *c)
 {
     if (c == NULL) return false;
@@ -83,8 +95,26 @@ bool radar_use_rainviewer(const app_config_t *c)
                                c->weather_lat, c->weather_lon);
 }
 
+static http_fetch_conn_t *rv_tile_conn(void)
+{
+    if (s_tile_conn == NULL) {
+        s_tile_conn = http_fetch_conn_create();
+        if (s_tile_conn != NULL) ESP_LOGI(TAG, "tile keep-alive connection opened");
+    }
+    return s_tile_conn;   /* NULL on alloc failure = one-shot, still correct */
+}
+
+static void rv_tile_conn_close(void)
+{
+    if (s_tile_conn == NULL) return;
+    http_fetch_conn_destroy(s_tile_conn);
+    s_tile_conn = NULL;
+    ESP_LOGI(TAG, "tile keep-alive connection closed");
+}
+
 void rainviewer_release(void)
 {
+    rv_tile_conn_close();
     if (s_base != NULL) {
         heap_caps_free(s_base);
         s_base = NULL;
@@ -113,6 +143,10 @@ int rainviewer_refresh(const app_config_t *c, uint32_t *stamps, int max_out)
     if (c == NULL || stamps == NULL || max_out <= 0) return 0;
     if (max_out > RAINVIEWER_MAX_FRAMES) max_out = RAINVIEWER_MAX_FRAMES;
 
+    /* Declared before the failure goto below, which would otherwise jump over it. */
+    char prev_host[RAINVIEWER_HOST_MAX];
+    strlcpy(prev_host, s_host, sizeof(prev_host));
+
     http_fetch_opts_t opts = {
         .timeout_ms = RV_HTTP_TIMEOUT_MS,
         .use_tls_bundle = true,
@@ -129,6 +163,8 @@ int rainviewer_refresh(const app_config_t *c, uint32_t *stamps, int max_out)
     s_nframes = rainviewer_parse_maps(body, len, s_host, sizeof(s_host),
                                       s_frames, RAINVIEWER_MAX_FRAMES);
     heap_caps_free(body);
+    /* A parked socket points at the host it was opened to. */
+    if (strcmp(prev_host, s_host) != 0) rv_tile_conn_close();
     if (s_nframes == 0) {
         ESP_LOGW(TAG, "weather-maps.json had no usable radar frames");
         s_host[0] = '\0';
@@ -309,6 +345,7 @@ static bool rv_add_tile(uint16_t *frame, int frame_px, const app_config_t *c,
         .oversize = HTTP_BIN_OVERSIZE_REJECT,
         .shrink_to_fit = true,
         .user_agent = RV_USER_AGENT,
+        .conn = rv_tile_conn(),
         .label = "Radar tile",
     };
     uint8_t *png = NULL;


### PR DESCRIPTION
### Summary
This PR improves the loading speed of animated radar pages by reusing network connections for tiles and frames, reducing overall wait times. It also resolves an issue where devices could not check for new software updates because the GitHub releases page exceeded the buffer size.

### Changes
*   Animated radar pages, including RainViewer tiles and US RIDGE/WMS/GIBS frames, now reuse a single HTTPS connection while active to speed up loading times.
*   Connections are closed when an animated page is no longer displayed, managing network resources efficiently.
*   The buffer for fetching GitHub release information was increased to 256 KB, allowing devices to successfully check for updates when the release page is large.

---
<sub>Analyzed **1** commit(s) | Updated: 2026-09-05T13:22:37.101Z | Generated by GitHub Actions</sub>